### PR TITLE
raise SIGTRAP to interrupt debugger when abort is called

### DIFF
--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -736,6 +736,7 @@ void Runtime::reset() {
 void Runtime::abort(std::string const abort_str, ErrorCodeType const code) {
   aborted_ = true;
   output(abort_str,code,true,true,false);
+  std::raise( SIGTRAP );
   if (theContext) {
     auto const comm = theContext->getComm();
     MPI_Abort(comm, 129);


### PR DESCRIPTION
Will have no effect if there is no debugger running

Implements #253 