### PR TITLE
#256: Remove disused Action arguments to {send,broadcast}Msg* functions

### DIFF
--- a/examples/jacobi1d_node.cc
+++ b/examples/jacobi1d_node.cc
@@ -157,7 +157,7 @@ static void boundaryFinished(bool const is_left) {
   if (wait_count == 0) {
     resid_val = kernel(cur_iter);
 
-    theRDMA()->putTypedData(jac_resid, &resid_val, 1, my_node, no_tag, no_action, []{
+    theRDMA()->putTypedData(jac_resid, &resid_val, 1, my_node, no_tag, []{
       theCollective()->barrierThen([]{
         if (cur_iter >= max_iterations) {
           finished();

--- a/examples/rdma_channel_sync.cc
+++ b/examples/rdma_channel_sync.cc
@@ -98,7 +98,7 @@ static void put_channel_setup(TestMsg* msg) {
       int const num_elm = 2;
 
       if (use_paired_sync) {
-        theRDMA()->putTypedData(handle, my_data, num_elm, no_byte, no_action, [=]{
+        theRDMA()->putTypedData(handle, my_data, num_elm, no_byte, [=]{
           TestMsg* back = makeSharedMessage<TestMsg>(handle);
           theMsg()->sendMsg<TestMsg, read_data_fn>(0, back);
         });

--- a/examples/rdma_simple_channel.cc
+++ b/examples/rdma_simple_channel.cc
@@ -79,9 +79,6 @@ static void put_channel_setup(TestMsg* msg) {
     theRDMA()->putTypedData(
       handle, my_data, num_elm, no_byte, no_tag,
       [=]{
-        fmt::print("{}: local put finished\n", my_node);
-      },
-      [=]{
         TestMsg* back = makeSharedMessage<TestMsg>(handle);
         theMsg()->sendMsg<TestMsg, read_data_fn>(0, back);
       }

--- a/examples/rdma_simple_put.cc
+++ b/examples/rdma_simple_put.cc
@@ -86,7 +86,6 @@ static void put_data_fn(TestMsg* msg) {
       (my_node-1)*local_data_len, no_tag, vt::rdma::rdma_default_byte_size,
       [=]{
         delete [] local_data;
-      }, [=]{
         fmt::print("{}: after put: sending msg back to 0\n", my_node);
         auto msg = makeSharedMessage<TestMsg>(my_node);
         msg->han = my_handle;

--- a/examples/rdma_simple_put_direct.cc
+++ b/examples/rdma_simple_put_direct.cc
@@ -80,7 +80,7 @@ static void putDataFn(TestMsg* msg) {
 
     int const num_elm = 2;
     int const offset = num_elm*(my_node-1);
-    theRDMA()->putTypedData(msg->han, my_data, num_elm, offset, no_action, [=]{
+    theRDMA()->putTypedData(msg->han, my_data, num_elm, offset, [=]{
       fmt::print(
         "{}: after put: sending msg back to 0: offset={}\n", my_node, offset
       );

--- a/examples/rdma_unsized_collection.cc
+++ b/examples/rdma_unsized_collection.cc
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
     // this message that causes a `get' races with the following `put'
     theMsg()->sendMsg<Msg, doGetHandler>(3, makeSharedMessage<Msg>());
     RDMACollectionManager::putElement(
-      my_handle, 1, test_data, serialize_put_fn, no_action, []{
+      my_handle, 1, test_data, serialize_put_fn, []{
         fmt::print("{}: put finished\n", my_node);
         theMsg()->sendMsg<Msg, doGetHandler>(1, makeSharedMessage<Msg>());
       }

--- a/src/vt/group/global/group_default.cc
+++ b/src/vt/group/global/group_default.cc
@@ -149,7 +149,7 @@ namespace vt { namespace group { namespace global {
 
 /*static*/ EventType DefaultGroup::broadcast(
   MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-  MsgSizeType const& size, bool const is_root, ActionType action
+  MsgSizeType const& size, bool const is_root
 ) {
   // By default use the default_group_->spanning_tree_
   auto const& msg = base.get();
@@ -168,17 +168,10 @@ namespace vt { namespace group { namespace global {
   );
 
   if (num_children > 0 || send_to_root) {
-    bool const& has_action = action != nullptr;
     EventRecordType* parent = nullptr;
     auto const& send_tag = static_cast<messaging::MPI_TagType>(
       messaging::MPITag::ActiveMsgTag
     );
-
-    if (has_action) {
-      event = theEvent()->createParentEvent(node);
-      auto& holder = theEvent()->getEventHolder(event);
-      parent = holder.get_event();
-    }
 
     // Send to child nodes in the spanning tree
     if (num_children > 0) {
@@ -194,11 +187,8 @@ namespace vt { namespace group { namespace global {
 
         if (send) {
           auto const put_event = theMsg()->sendMsgBytesWithPut(
-            child, base, size, send_tag, action
+            child, base, size, send_tag
           );
-          if (has_action) {
-            parent->addEventToList(put_event);
-          }
         }
       });
     }
@@ -214,11 +204,8 @@ namespace vt { namespace group { namespace global {
       );
 
       auto const put_event = theMsg()->sendMsgBytesWithPut(
-        root_node, base, size, send_tag, action
+        root_node, base, size, send_tag
       );
-      if (has_action) {
-        parent->addEventToList(put_event);
-      }
     }
   }
 

--- a/src/vt/group/global/group_default.h
+++ b/src/vt/group/global/group_default.h
@@ -76,7 +76,7 @@ struct DefaultGroup {
 public:
   static EventType broadcast(
     MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-    MsgSizeType const& size, bool const is_root, ActionType action
+    MsgSizeType const& size, bool const is_root
   );
 
 private:

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -158,13 +158,13 @@ private:
 
   EventType sendGroup(
     MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-    MsgSizeType const& size, bool const is_root, ActionType action,
+    MsgSizeType const& size, bool const is_root,
     bool* const deliver
   );
 
   EventType sendGroupCollective(
     MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-    MsgSizeType const& size, bool const is_root, ActionType action,
+    MsgSizeType const& size, bool const is_root,
     bool* const deliver
   );
 
@@ -176,7 +176,7 @@ public:
 private:
   static EventType groupHandler(
     MsgSharedPtr<BaseMsgType> const& msg, NodeType const& from,
-    MsgSizeType const& msg_size, bool const is_root, ActionType new_action,
+    MsgSizeType const& msg_size, bool const is_root,
     bool* const deliver
   );
 

--- a/src/vt/group/group_manager_active_attorney.cc
+++ b/src/vt/group/group_manager_active_attorney.cc
@@ -52,11 +52,11 @@ namespace vt { namespace group {
 
 /*static*/ EventType GroupActiveAttorney::groupHandler(
   MsgSharedPtr<BaseMsgType> const& msg, NodeType const& from,
-  MsgSizeType const& msg_size, bool const is_root, ActionType new_action,
+  MsgSizeType const& msg_size, bool const is_root,
   bool* const deliver
 ) {
   return GroupManager::groupHandler(
-    msg, from, msg_size, is_root, new_action, deliver
+    msg, from, msg_size, is_root, deliver
   );
 }
 

--- a/src/vt/group/group_manager_active_attorney.h
+++ b/src/vt/group/group_manager_active_attorney.h
@@ -61,7 +61,7 @@ struct GroupActiveAttorney {
 private:
   static EventType groupHandler(
     MsgSharedPtr<BaseMsgType> const& msg, NodeType const& from,
-    MsgSizeType const& msg_size, bool const is_root, ActionType new_action,
+    MsgSizeType const& msg_size, bool const is_root,
     bool* const deliver
   );
 };

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -115,7 +115,7 @@ struct ActiveMessenger {
   using EventRecordType      = event::AsyncEvent::EventRecordType;
   using SendDataRetType      = std::tuple<EventType, TagType>;
   using SendFnType           = std::function<
-    SendDataRetType(RDMA_GetType,NodeType,TagType,ActionType)
+    SendDataRetType(RDMA_GetType,NodeType,TagType)
   >;
   using UserSendFnType       = std::function<void(SendFnType)>;
   using ContainerPendingType = std::unordered_map<TagType,PendingRecvType>;
@@ -160,49 +160,45 @@ struct ActiveMessenger {
   template <typename MessageT>
   EventType sendMsgSz(
     NodeType const& dest, HandlerType const& han, MessageT* const msg,
-    ActionType next_action, ByteType const& msg_size
+    ByteType const& msg_size
+  );
+
+  template <typename MessageT>
+  EventType sendMsg(
+    NodeType const& dest, HandlerType const& han, MessageT* const msg
   );
 
   template <typename MessageT>
   EventType sendMsg(
     NodeType const& dest, HandlerType const& han, MessageT* const msg,
-    ActionType next_action = nullptr
+    TagType const& tag
   );
 
   template <typename MessageT>
   EventType sendMsg(
-    NodeType const& dest, HandlerType const& han, MessageT* const msg,
-    TagType const& tag, ActionType next_action = nullptr
+    HandlerType const& han, MessageT* const msg, TagType const& tag = no_tag
   );
 
-  template <typename MessageT>
+  template <typename MsgT>
   EventType sendMsg(
-    HandlerType const& han, MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    NodeType const& dest, HandlerType const& han, MsgSharedPtr<MsgT> const& msg
   );
 
   template <typename MsgT>
   EventType sendMsg(
     NodeType const& dest, HandlerType const& han, MsgSharedPtr<MsgT> const& msg,
-    ActionType next_action = nullptr
-  );
-
-  template <typename MsgT>
-  EventType sendMsg(
-    NodeType const& dest, HandlerType const& han, MsgSharedPtr<MsgT> const& msg,
-    TagType const& tag, ActionType next_action = nullptr
+    TagType const& tag
   );
 
   template <typename MsgT>
   EventType sendMsg(
     HandlerType const& han, MsgSharedPtr<MsgT> const& msg,
-    TagType const& tag = no_tag, ActionType next_action = nullptr
+    TagType const& tag = no_tag
   );
 
   template <typename MessageT>
   EventType sendMsgHan(
-    HandlerType const& han, MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    HandlerType const& han, MessageT* const msg, TagType const& tag = no_tag
   );
 
   /*
@@ -211,14 +207,13 @@ struct ActiveMessenger {
    */
   template <typename MessageT>
   EventType sendMsgAuto(
-    NodeType const& dest, HandlerType const& han, MessageT* const msg,
-    ActionType next_action = nullptr
+    NodeType const& dest, HandlerType const& han, MessageT* const msg
   );
 
   template <typename MessageT>
   EventType sendMsgAuto(
     NodeType const& dest, HandlerType const& han, MessageT* const msg,
-    TagType const& tag, ActionType next_action = nullptr
+    TagType const& tag
   );
 
   /*
@@ -245,33 +240,24 @@ struct ActiveMessenger {
 
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType broadcastMsgSz(
-    MessageT* const msg, ByteType const& msg_size, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    MessageT* const msg, ByteType const& msg_size, TagType const& tag = no_tag
   );
 
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType broadcastMsg(
-    MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    MessageT* const msg, TagType const& tag = no_tag
   );
 
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
-  EventType broadcastMsg(MessageT* const msg, ActionType act);
-
-  template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType sendMsg(
-    NodeType const& dest, MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    NodeType const& dest, MessageT* const msg, TagType const& tag = no_tag
   );
 
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType sendMsgSz(
     NodeType const& dest, MessageT* const msg, ByteType const& msg_size,
-    TagType const& tag = no_tag, ActionType next_action = nullptr
+    TagType const& tag = no_tag
   );
-
-  template <typename MessageT, ActiveTypedFnType<MessageT>* f>
-  EventType sendMsg(NodeType const& dest, MessageT* const msg, ActionType act);
 
   /*
    *  Auto method for dispatching to the serialization framework if required
@@ -279,20 +265,17 @@ struct ActiveMessenger {
    */
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType sendMsgAuto(
-    NodeType const& dest, MessageT* const msg, TagType const& tag,
-    ActionType next_action = nullptr
+    NodeType const& dest, MessageT* const msg, TagType const& tag
   );
 
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType sendMsgAuto(
-    NodeType const& dest, MessageT* const msg,
-    ActionType next_action = nullptr
+    NodeType const& dest, MessageT* const msg
   );
 
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType broadcastMsgAuto(
-    MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    MessageT* const msg, TagType const& tag = no_tag
   );
   /*
    *----------------------------------------------------------------------------
@@ -323,21 +306,16 @@ struct ActiveMessenger {
 
   template <ActiveFnType* f, typename MessageT>
   EventType broadcastMsg(
-    MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    MessageT* const msg, TagType const& tag = no_tag
   );
-
-  template <ActiveFnType* f, typename MessageT>
-  EventType broadcastMsg(MessageT* const msg, ActionType act);
 
   template <ActiveFnType* f, typename MessageT>
   EventType sendMsg(
-    NodeType const& dest, MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    NodeType const& dest, MessageT* const msg, TagType const& tag = no_tag
   );
 
   template <ActiveFnType* f, typename MessageT>
-  EventType sendMsg(NodeType const& dest, MessageT* const msg, ActionType act);
+  EventType sendMsg(NodeType const& dest, MessageT* const msg);
 
   /*
    *----------------------------------------------------------------------------
@@ -364,8 +342,7 @@ struct ActiveMessenger {
     typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
   EventType broadcastMsg(
-    MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    MessageT* const msg, TagType const& tag = no_tag
   );
 
   template <
@@ -373,29 +350,21 @@ struct ActiveMessenger {
     typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
   EventType broadcastMsgAuto(
-    MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    MessageT* const msg, TagType const& tag = no_tag
   );
 
   template <
     typename FunctorT,
     typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
-  EventType broadcastMsg(MessageT* const msg, ActionType act);
-
-  template <
-    typename FunctorT,
-    typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
-  >
-  EventType broadcastMsgAuto(MessageT* const msg, ActionType act);
+  EventType broadcastMsgAuto(MessageT* const msg);
 
   template <
     typename FunctorT,
     typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
   EventType sendMsg(
-    NodeType const& dest, MessageT* const msg, TagType const& tag = no_tag,
-    ActionType next_action = nullptr
+    NodeType const& dest, MessageT* const msg, TagType const& tag = no_tag
   );
 
   template <
@@ -403,22 +372,15 @@ struct ActiveMessenger {
     typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
   EventType sendMsgAuto(
-    NodeType const& dest, MessageT* const msg, TagType const& tag,
-    ActionType next_action = nullptr
+    NodeType const& dest, MessageT* const msg, TagType const& tag
   );
 
   template <
     typename FunctorT,
     typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
-  EventType sendMsg(NodeType const& dest, MessageT* const msg, ActionType act);
-
-  template <
-    typename FunctorT,
-    typename MessageT = typename util::FunctorExtractor<FunctorT>::MessageType
-  >
   EventType sendMsgAuto(
-    NodeType const& dest, MessageT* const msg, ActionType act = nullptr
+    NodeType const& dest, MessageT* const msg
   );
 
   /*
@@ -439,36 +401,32 @@ struct ActiveMessenger {
   template <typename MessageT>
   EventType sendMsg(
     NodeType const& dest, HandlerType const& han, MessageT* const msg,
-    UserSendFnType send_payload_fn, ActionType next_action = nullptr
+    UserSendFnType send_payload_fn
   );
 
   template <typename MessageT, ActiveTypedFnType<MessageT>* f>
   EventType sendMsg(
-    NodeType const& dest, MessageT* const msg, UserSendFnType send_payload_fn,
-    ActionType next_action = nullptr
+    NodeType const& dest, MessageT* const msg, UserSendFnType send_payload_fn
   );
 
   template <typename MessageT>
   EventType broadcastMsg(
-    HandlerType const& han, MessageT* const msg, ActionType act = nullptr
+    HandlerType const& han, MessageT* const msg
   );
 
   template <typename MessageT>
   EventType broadcastMsg(
-    HandlerType const& han, MessageT* const msg, TagType const& tag,
-    ActionType act = nullptr
+    HandlerType const& han, MessageT* const msg, TagType const& tag
   );
 
   template <typename MsgT>
   EventType broadcastMsg(
-    HandlerType const& han, MsgSharedPtr<MsgT> const& msg,
-    ActionType act = nullptr
+    HandlerType const& han, MsgSharedPtr<MsgT> const& msg
   );
 
   template <typename MsgT>
   EventType broadcastMsg(
-    HandlerType const& han, MsgSharedPtr<MsgT> const& msg, TagType const& tag,
-    ActionType act = nullptr
+    HandlerType const& han, MsgSharedPtr<MsgT> const& msg, TagType const& tag
   );
 
   /*
@@ -477,13 +435,12 @@ struct ActiveMessenger {
    */
   template <typename MessageT>
   EventType broadcastMsgAuto(
-    HandlerType const& han, MessageT* const msg, ActionType act = nullptr
+    HandlerType const& han, MessageT* const msg
   );
 
   template <typename MessageT>
   EventType broadcastMsgAuto(
-    HandlerType const& han, MessageT* const msg, TagType const& tag,
-    ActionType act = nullptr
+    HandlerType const& han, MessageT* const msg, TagType const& tag
   );
 
   /*
@@ -530,8 +487,7 @@ struct ActiveMessenger {
   );
 
   SendDataRetType sendData(
-    RDMA_GetType const& ptr, NodeType const& dest, TagType const& tag,
-    ActionType next_action = nullptr
+    RDMA_GetType const& ptr, NodeType const& dest, TagType const& tag
   );
 
   bool recvDataMsg(
@@ -552,8 +508,7 @@ struct ActiveMessenger {
   );
 
   EventType sendMsgSized(
-    MsgSharedPtr<BaseMsgType> const& msg, MsgSizeType const& msg_size,
-    ActionType next_action = nullptr
+    MsgSharedPtr<BaseMsgType> const& msg, MsgSizeType const& msg_size
   );
 
   void performTriggeredActions();
@@ -600,13 +555,12 @@ struct ActiveMessenger {
 
   EventType sendMsgBytes(
     NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base,
-    MsgSizeType const& msg_size, TagType const& send_tag,
-    ActionType next_action
+    MsgSizeType const& msg_size, TagType const& send_tag
   );
 
   EventType sendMsgBytesWithPut(
     NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base,
-    MsgSizeType const& msg_size, TagType const& send_tag, ActionType next_action
+    MsgSizeType const& msg_size, TagType const& send_tag
   );
 
   /*

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
@@ -111,7 +111,7 @@ void CallbackProxyBcastDirect::trigger(MsgT* msg, PipeType const& pipe) {
   } else {
     auto dispatcher = theCollection()->getDispatcher(vrt_dispatch_han_);
     auto const& proxy = proxy_;
-    dispatcher->broadcast(proxy,msg,handler_,member_,nullptr);
+    dispatcher->broadcast(proxy,msg,handler_,member_);
   }
 }
 

--- a/src/vt/rdma/collection/rdma_collection.cc
+++ b/src/vt/rdma/collection/rdma_collection.cc
@@ -151,7 +151,6 @@ namespace vt { namespace rdma {
   RDMA_ElmType const& elm,
   RDMA_PtrType const& ptr,
   RDMA_PutSerialize on_demand_put_serialize,
-  ActionType cont,
   ActionType action_after_put,
   TagType const& tag
 ) {
@@ -197,11 +196,7 @@ namespace vt { namespace rdma {
     );
 
     auto send_payload = [&](Active::SendFnType send){
-      auto ret = send(put_ret, put_node, no_tag, [=]{
-        if (cont != nullptr) {
-          cont();
-        }
-      });
+      auto ret = send(put_ret, put_node, no_tag);
       msg->mpi_tag_to_recv = std::get<1>(ret);
     };
 
@@ -227,9 +222,6 @@ namespace vt { namespace rdma {
         debug_print(
           rdma, node, "putElement: local data is put\n"
         );
-        if (cont) {
-          cont();
-        }
         if (action_after_put) {
           action_after_put();
         }

--- a/src/vt/rdma/collection/rdma_collection.h
+++ b/src/vt/rdma/collection/rdma_collection.h
@@ -76,7 +76,6 @@ struct RDMACollectionManager {
     RDMA_ElmType const& elm,
     RDMA_PtrType const& ptr,
     RDMA_PutSerialize on_demand_put_serialize = no_action,
-    ActionType cont = no_action,
     ActionType action_after_put = no_action,
     TagType const& tag = no_tag
   );

--- a/src/vt/rdma/rdma.h
+++ b/src/vt/rdma/rdma.h
@@ -101,35 +101,35 @@ struct RDMAManager {
   void putTypedData(
     RDMA_HandleType const& rdma_handle, T ptr,
     ByteType const& num_elems, ByteType const& offset, TagType const& tag,
-    ActionType cont = no_action, ActionType action_after_put = no_action
+    ActionType action_after_put = no_action
   ) {
     ByteType const num_bytes = num_elems == no_byte ? no_byte : sizeof(T)*num_elems;
     ByteType const byte_offset = offset == no_byte ? 0 : sizeof(T)*offset;
     return putData(
       rdma_handle, static_cast<RDMA_PtrType>(ptr), num_bytes, byte_offset, tag,
-      sizeof(T), cont, action_after_put
+      sizeof(T), action_after_put
     );
   }
 
   template <typename T>
   void putTypedData(
     RDMA_HandleType const& han, T ptr, ByteType const& num_elems = no_byte,
-    ByteType const& offset = no_byte, ActionType cont = no_action,
+    ByteType const& offset = no_byte,
     ActionType action_after_put = no_action
   ) {
     return putTypedData<T>(
-      han, ptr, num_elems, offset, no_tag, cont, action_after_put
+      han, ptr, num_elems, offset, no_tag, action_after_put
     );
   }
 
   void putData(
     RDMA_HandleType const& rdma_handle, RDMA_PtrType const& ptr,
-    ByteType const& num_bytes, ActionType cont = no_action,
+    ByteType const& num_bytes,
     ActionType action_after_put = no_action
   ) {
     return putData(
       rdma_handle, ptr, num_bytes, no_byte, no_tag, rdma_default_byte_size,
-      cont, action_after_put
+      action_after_put
     );
   }
 
@@ -137,7 +137,7 @@ struct RDMAManager {
     RDMA_HandleType const& rdma_handle, RDMA_PtrType const& ptr,
     ByteType const& num_bytes, ByteType const& offset, TagType const& tag,
     ByteType const& elm_size = rdma_default_byte_size,
-    ActionType cont = no_action, ActionType action_after_put = no_action,
+    ActionType action_after_put = no_action,
     NodeType const& collective_node = uninitialized_destination,
     bool const direct_message_send = false
   );
@@ -153,7 +153,7 @@ struct RDMAManager {
   void putDataIntoBufCollective(
     RDMA_HandleType const& rdma_handle, RDMA_PtrType const& ptr,
     ByteType const& num_bytes, ByteType const& elm_size, ByteType const& offset,
-    ActionType cont = no_action, ActionType after_put_action = no_action
+    ActionType after_put_action = no_action
   );
 
   void getDataIntoBufCollective(
@@ -169,7 +169,7 @@ struct RDMAManager {
 
   void putRegionTypeless(
     RDMA_HandleType const& rdma_handle, RDMA_PtrType const& ptr,
-    RDMA_RegionType const& region, ActionType cont, ActionType after_put_action
+    RDMA_RegionType const& region, ActionType after_put_action
   );
 
   template <typename T>
@@ -427,7 +427,7 @@ private:
   void sendDataChannel(
     RDMA_TypeType const& type, RDMA_HandleType const& han, RDMA_PtrType const& ptr,
     ByteType const& num_bytes, ByteType const& offset, NodeType const& target,
-    NodeType const& non_target, ActionType cont, ActionType action_after_put
+    NodeType const& non_target, ActionType action_after_put
   );
 
   void createDirectChannel(

--- a/src/vt/serialization/auto_dispatch/dispatch.h
+++ b/src/vt/serialization/auto_dispatch/dispatch.h
@@ -60,49 +60,48 @@ namespace vt { namespace serialization { namespace auto_dispatch {
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 struct Sender {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+    NodeType const& node, MsgT* msg, TagType const& tag
   );
 };
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 struct SenderSerialize {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+    NodeType const& node, MsgT* msg, TagType const& tag
   );
   static EventType sendMsgParserdes(
-    NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+    NodeType const& node, MsgT* msg, TagType const& tag
   );
 };
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 struct Broadcaster {
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag, ActionType action
+    MsgT* msg, TagType const& tag
   );
 };
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 struct BroadcasterSerialize {
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag, ActionType action
+    MsgT* msg, TagType const& tag
   );
   static EventType broadcastMsgParserdes(
-    MsgT* msg, TagType const& tag, ActionType action
+    MsgT* msg, TagType const& tag
   );
 };
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f, typename=void>
 struct RequiredSerialization {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    NodeType const& node, MsgT* msg, TagType const& tag = no_tag
   ) {
-    return Sender<MsgT,f>::sendMsg(node,msg,tag,action);
+    return Sender<MsgT,f>::sendMsg(node,msg,tag);
   }
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag = no_tag, ActionType action = nullptr
+    MsgT* msg, TagType const& tag = no_tag
   ) {
-    return Broadcaster<MsgT,f>::broadcastMsg(msg,tag,action);
+    return Broadcaster<MsgT,f>::broadcastMsg(msg,tag);
   }
 };
 
@@ -116,15 +115,14 @@ struct RequiredSerialization<
   >
 > {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    NodeType const& node, MsgT* msg, TagType const& tag = no_tag
   ) {
-    return SenderSerialize<MsgT,f>::sendMsg(node,msg,tag,action);
+    return SenderSerialize<MsgT,f>::sendMsg(node,msg,tag);
   }
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag = no_tag, ActionType action = nullptr
+    MsgT* msg, TagType const& tag = no_tag
   ) {
-    return BroadcasterSerialize<MsgT,f>::broadcastMsg(msg,tag,action);
+    return BroadcasterSerialize<MsgT,f>::broadcastMsg(msg,tag);
   }
 };
 
@@ -137,16 +135,15 @@ struct RequiredSerialization<
   >
 > {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    NodeType const& node, MsgT* msg, TagType const& tag = no_tag
   ) {
-    return SenderSerialize<MsgT,f>::sendMsgParserdes(node,msg,tag,action);
+    return SenderSerialize<MsgT,f>::sendMsgParserdes(node,msg,tag);
   }
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag = no_tag, ActionType action = nullptr
+    MsgT* msg, TagType const& tag = no_tag
   ) {
     return BroadcasterSerialize<MsgT,f>::broadcastMsgParserdes(
-      msg,tag,action
+      msg,tag
     );
   }
 };

--- a/src/vt/serialization/auto_dispatch/dispatch.impl.h
+++ b/src/vt/serialization/auto_dispatch/dispatch.impl.h
@@ -60,16 +60,16 @@ namespace vt { namespace serialization { namespace auto_dispatch {
  */
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 /*static*/ EventType Sender<MsgT,f>::sendMsg(
-  NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+  NodeType const& node, MsgT* msg, TagType const& tag
 ) {
-  return theMsg()->sendMsg<MsgT,f>(node,msg,tag,action);
+  return theMsg()->sendMsg<MsgT,f>(node,msg,tag);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 /*static*/ EventType Broadcaster<MsgT,f>::broadcastMsg(
-  MsgT* msg, TagType const& tag, ActionType action
+  MsgT* msg, TagType const& tag
 ) {
-  return theMsg()->broadcastMsg<MsgT,f>(msg,tag,action);
+  return theMsg()->broadcastMsg<MsgT,f>(msg,tag);
 }
 
 /*
@@ -78,7 +78,7 @@ template <typename MsgT, ActiveTypedFnType<MsgT>* f>
  */
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 /*static*/ EventType SenderSerialize<MsgT,f>::sendMsgParserdes(
-  NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+  NodeType const& node, MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::sendParserdesMsg<MsgT,f>(node,msg);
@@ -88,7 +88,7 @@ template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 /*static*/ EventType SenderSerialize<MsgT,f>::sendMsg(
-  NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+  NodeType const& node, MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::sendSerialMsg<MsgT,f>(node,msg);
@@ -99,7 +99,7 @@ template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 /*static*/ EventType BroadcasterSerialize<MsgT,f>::broadcastMsgParserdes(
-  MsgT* msg, TagType const& tag, ActionType action
+  MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::broadcastParserdesMsg<MsgT,f>(msg);
@@ -110,7 +110,7 @@ template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 /*static*/ EventType BroadcasterSerialize<MsgT,f>::broadcastMsg(
-  MsgT* msg, TagType const& tag, ActionType action
+  MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::broadcastSerialMsg<MsgT,f>(msg);

--- a/src/vt/serialization/auto_dispatch/dispatch_functor.h
+++ b/src/vt/serialization/auto_dispatch/dispatch_functor.h
@@ -61,34 +61,34 @@ namespace vt { namespace serialization { namespace auto_dispatch {
 template <typename FunctorT, typename MsgT>
 struct SenderFunctor {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+    NodeType const& node, MsgT* msg, TagType const& tag
   );
 };
 
 template <typename FunctorT, typename MsgT>
 struct SenderSerializeFunctor {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+    NodeType const& node, MsgT* msg, TagType const& tag
   );
   static EventType sendMsgParserdes(
-    NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+    NodeType const& node, MsgT* msg, TagType const& tag
   );
 };
 
 template <typename FunctorT, typename MsgT>
 struct BroadcasterFunctor {
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag, ActionType action
+    MsgT* msg, TagType const& tag
   );
 };
 
 template <typename FunctorT, typename MsgT>
 struct BroadcasterSerializeFunctor {
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag, ActionType action
+    MsgT* msg, TagType const& tag
   );
   static EventType broadcastMsgParserdes(
-    MsgT* msg, TagType const& tag, ActionType action
+    MsgT* msg, TagType const& tag
   );
 };
 
@@ -96,15 +96,14 @@ struct BroadcasterSerializeFunctor {
 template <typename FunctorT, typename MsgT, typename=void>
 struct RequiredSerializationFunctor {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    NodeType const& node, MsgT* msg, TagType const& tag = no_tag
   ) {
-    return SenderFunctor<FunctorT,MsgT>::sendMsg(node,msg,tag,action);
+    return SenderFunctor<FunctorT,MsgT>::sendMsg(node,msg,tag);
   }
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag = no_tag, ActionType action = nullptr
+    MsgT* msg, TagType const& tag = no_tag
   ) {
-    return BroadcasterFunctor<FunctorT,MsgT>::broadcastMsg(msg,tag,action);
+    return BroadcasterFunctor<FunctorT,MsgT>::broadcastMsg(msg,tag);
   }
 };
 
@@ -118,16 +117,15 @@ struct RequiredSerializationFunctor<
   >
 > {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    NodeType const& node, MsgT* msg, TagType const& tag = no_tag
   ) {
-    return SenderSerializeFunctor<FunctorT,MsgT>::sendMsg(node,msg,tag,action);
+    return SenderSerializeFunctor<FunctorT,MsgT>::sendMsg(node,msg,tag);
   }
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag = no_tag, ActionType action = nullptr
+    MsgT* msg, TagType const& tag = no_tag
   ) {
     return BroadcasterSerializeFunctor<FunctorT,MsgT>::broadcastMsg(
-      msg,tag,action
+      msg,tag
     );
   }
 };
@@ -140,18 +138,17 @@ struct RequiredSerializationFunctor<
   >
 > {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    NodeType const& node, MsgT* msg, TagType const& tag = no_tag
   ) {
     return SenderSerializeFunctor<FunctorT,MsgT>::sendMsgParserdes(
-      node,msg,tag,action
+      node,msg,tag
     );
   }
   static EventType broadcastMsg(
-    MsgT* msg, TagType const& tag = no_tag, ActionType action = nullptr
+    MsgT* msg, TagType const& tag = no_tag
   ) {
     return BroadcasterSerializeFunctor<FunctorT,MsgT>::broadcastMsgParserdes(
-      msg,tag,action
+      msg,tag
     );
   }
 };

--- a/src/vt/serialization/auto_dispatch/dispatch_functor.impl.h
+++ b/src/vt/serialization/auto_dispatch/dispatch_functor.impl.h
@@ -60,16 +60,16 @@ namespace vt { namespace serialization { namespace auto_dispatch {
  */
 template <typename FunctorT, typename MsgT>
 /*static*/ EventType SenderFunctor<FunctorT,MsgT>::sendMsg(
-  NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+  NodeType const& node, MsgT* msg, TagType const& tag
 ) {
-  return theMsg()->sendMsg<FunctorT,MsgT>(node,msg,tag,action);
+  return theMsg()->sendMsg<FunctorT,MsgT>(node,msg,tag);
 }
 
 template <typename FunctorT, typename MsgT>
 /*static*/ EventType BroadcasterFunctor<FunctorT,MsgT>::broadcastMsg(
-  MsgT* msg, TagType const& tag, ActionType action
+  MsgT* msg, TagType const& tag
 ) {
-  return theMsg()->broadcastMsg<FunctorT,MsgT>(msg,tag,action);
+  return theMsg()->broadcastMsg<FunctorT,MsgT>(msg,tag);
 }
 
 /*
@@ -78,7 +78,7 @@ template <typename FunctorT, typename MsgT>
  */
 template <typename FunctorT, typename MsgT>
 /*static*/ EventType SenderSerializeFunctor<FunctorT,MsgT>::sendMsgParserdes(
-  NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+  NodeType const& node, MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::sendParserdesMsg<FunctorT,MsgT>(node,msg);
@@ -88,7 +88,7 @@ template <typename FunctorT, typename MsgT>
 
 template <typename FunctorT, typename MsgT>
 /*static*/ EventType SenderSerializeFunctor<FunctorT,MsgT>::sendMsg(
-  NodeType const& node, MsgT* msg, TagType const& tag, ActionType action
+  NodeType const& node, MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::sendSerialMsg<FunctorT,MsgT>(node,msg);
@@ -100,7 +100,7 @@ template <typename FunctorT, typename MsgT>
 template <typename FunctorT, typename MsgT>
 /*static*/ EventType
  BroadcasterSerializeFunctor<FunctorT,MsgT>::broadcastMsgParserdes(
-  MsgT* msg, TagType const& tag, ActionType action
+  MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::broadcastParserdesMsg<FunctorT,MsgT>(msg);
@@ -111,7 +111,7 @@ template <typename FunctorT, typename MsgT>
 
 template <typename FunctorT, typename MsgT>
 /*static*/ EventType BroadcasterSerializeFunctor<FunctorT,MsgT>::broadcastMsg(
-  MsgT* msg, TagType const& tag, ActionType action
+  MsgT* msg, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::broadcastSerialMsg<FunctorT,MsgT>(msg);

--- a/src/vt/serialization/auto_dispatch/dispatch_handler.h
+++ b/src/vt/serialization/auto_dispatch/dispatch_handler.h
@@ -61,38 +61,34 @@ template <typename MsgT>
 struct SenderHandler {
   static EventType sendMsg(
     NodeType const& node, MsgT* msg, HandlerType const& handler,
-    TagType const& tag, ActionType action
+    TagType const& tag
   );
 };
 
 template <typename MsgT>
 struct SenderSerializeHandler {
   static EventType sendMsg(
-    NodeType const& node, MsgT* msg, HandlerType const& han, TagType const& tag,
-    ActionType action
+    NodeType const& node, MsgT* msg, HandlerType const& han, TagType const& tag
   );
   static EventType sendMsgParserdes(
-    NodeType const& node, HandlerType const& han, MsgT* msg, TagType const& tag,
-    ActionType action
+    NodeType const& node, HandlerType const& han, MsgT* msg, TagType const& tag
   );
 };
 
 template <typename MsgT>
 struct BroadcasterHandler {
   static EventType broadcastMsg(
-    MsgT* msg, HandlerType const& handler, TagType const& tag,
-    ActionType action
+    MsgT* msg, HandlerType const& handler, TagType const& tag
   );
 };
 
 template <typename MsgT>
 struct BroadcasterSerializeHandler {
   static EventType broadcastMsg(
-    MsgT* msg, HandlerType const& handler, TagType const& tag,
-    ActionType action
+    MsgT* msg, HandlerType const& handler, TagType const& tag
   );
   static EventType broadcastMsgParserdes(
-    MsgT* msg, HandlerType const& han, TagType const& tag, ActionType action
+    MsgT* msg, HandlerType const& han, TagType const& tag
   );
 };
 
@@ -100,15 +96,14 @@ template <typename MsgT, typename=void>
 struct RequiredSerializationHandler {
   static EventType sendMsg(
     NodeType const& node, MsgT* msg, HandlerType const& handler,
-    TagType const& tag = no_tag, ActionType action = nullptr
+    TagType const& tag = no_tag
   ) {
-    return SenderHandler<MsgT>::sendMsg(node,msg,handler,tag,action);
+    return SenderHandler<MsgT>::sendMsg(node,msg,handler,tag);
   }
   static EventType broadcastMsg(
-    MsgT* msg, HandlerType const& handler, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    MsgT* msg, HandlerType const& handler, TagType const& tag = no_tag
   ) {
-    return BroadcasterHandler<MsgT>::broadcastMsg(msg,handler,tag,action);
+    return BroadcasterHandler<MsgT>::broadcastMsg(msg,handler,tag);
   }
 };
 
@@ -123,15 +118,14 @@ struct RequiredSerializationHandler<
 > {
   static EventType sendMsg(
     NodeType const& node, MsgT* msg, HandlerType const& han,
-    TagType const& tag = no_tag, ActionType action = nullptr
+    TagType const& tag = no_tag
   ) {
-    return SenderSerializeHandler<MsgT>::sendMsg(node,msg,han,tag,action);
+    return SenderSerializeHandler<MsgT>::sendMsg(node,msg,han,tag);
   }
   static EventType broadcastMsg(
-    MsgT* msg, HandlerType const& han, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    MsgT* msg, HandlerType const& han, TagType const& tag = no_tag
   ) {
-    return BroadcasterSerializeHandler<MsgT>::broadcastMsg(msg,han,tag,action);
+    return BroadcasterSerializeHandler<MsgT>::broadcastMsg(msg,han,tag);
   }
 };
 
@@ -144,18 +138,17 @@ struct RequiredSerializationHandler<
 > {
   static EventType sendMsg(
     NodeType const& node, MsgT* msg, HandlerType const& han,
-    TagType const& tag = no_tag, ActionType action = nullptr
+    TagType const& tag = no_tag
   ) {
     return SenderSerializeHandler<MsgT>::sendMsgParserdes(
-      node,msg,han,tag,action
+      node,msg,han,tag
     );
   }
   static EventType broadcastMsg(
-    MsgT* msg, HandlerType const& han, TagType const& tag = no_tag,
-    ActionType action = nullptr
+    MsgT* msg, HandlerType const& han, TagType const& tag = no_tag
   ) {
     return BroadcasterSerializeHandler<MsgT>::broadcastMsgParserdes(
-      msg,han,tag,action
+      msg,han,tag
     );
   }
 };

--- a/src/vt/serialization/auto_dispatch/dispatch_handler.impl.h
+++ b/src/vt/serialization/auto_dispatch/dispatch_handler.impl.h
@@ -58,23 +58,22 @@ namespace vt { namespace serialization { namespace auto_dispatch {
 template <typename MsgT>
 /*static*/ EventType SenderHandler<MsgT>::sendMsg(
   NodeType const& node, MsgT* msg, HandlerType const& handler,
-  TagType const& tag, ActionType action
+  TagType const& tag
 ) {
-  return theMsg()->sendMsg<MsgT>(node,handler,msg,tag,action);
+  return theMsg()->sendMsg<MsgT>(node,handler,msg,tag);
 }
 
 template <typename MsgT>
 /*static*/ EventType BroadcasterHandler<MsgT>::broadcastMsg(
-  MsgT* msg, HandlerType const& handler, TagType const& tag,
-  ActionType action
+  MsgT* msg, HandlerType const& handler, TagType const& tag
 ) {
-  return theMsg()->broadcastMsg<MsgT>(handler,msg,tag,action);
+  return theMsg()->broadcastMsg<MsgT>(handler,msg,tag);
 }
 
 template <typename MsgT>
 /*static*/ EventType SenderSerializeHandler<MsgT>::sendMsgParserdes(
   NodeType const& node, HandlerType const& han, MsgT* msg,
-  TagType const& tag, ActionType action
+  TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::sendParserdesMsgHandler<MsgT>(node,han,msg);
@@ -85,7 +84,7 @@ template <typename MsgT>
 template <typename MsgT>
 /*static*/ EventType SenderSerializeHandler<MsgT>::sendMsg(
   NodeType const& node, MsgT* msg, HandlerType const& handler,
-  TagType const& tag, ActionType action
+  TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::sendSerialMsgHandler<MsgT>(node,msg,handler);
@@ -96,8 +95,7 @@ template <typename MsgT>
 template <typename MsgT>
 /*static*/ EventType
  BroadcasterSerializeHandler<MsgT>::broadcastMsgParserdes(
-   MsgT* msg, HandlerType const& handler, TagType const& tag,
-   ActionType action
+   MsgT* msg, HandlerType const& handler, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::broadcastParserdesMsgHandler<MsgT>(msg,handler);
@@ -107,8 +105,7 @@ template <typename MsgT>
 
 template <typename MsgT>
 /*static*/ EventType BroadcasterSerializeHandler<MsgT>::broadcastMsg(
-  MsgT* msg, HandlerType const& handler, TagType const& tag,
-  ActionType action
+  MsgT* msg, HandlerType const& handler, TagType const& tag
 ) {
   vtAssert(tag == no_tag, "Tagged messages serialized not implemented");
   SerializedMessenger::broadcastSerialMsgHandler<MsgT>(msg,handler);

--- a/src/vt/serialization/messaging/serialized_param_messenger.h
+++ b/src/vt/serialization/messaging/serialized_param_messenger.h
@@ -105,7 +105,7 @@ struct SerializedMessengerParam {
     });
 
     auto send_serialized = [&](Active::SendFnType send){
-      auto ret = send(RDMA_GetType{ptr, ptr_size}, dest, no_tag, no_action);
+      auto ret = send(RDMA_GetType{ptr, ptr_size}, dest, no_tag);
       meta_typed_data_msg->data_recv_tag = std::get<1>(ret);
     };
 

--- a/src/vt/topos/location/location.h
+++ b/src/vt/topos/location/location.h
@@ -144,27 +144,24 @@ struct EntityLocationCoord : LocationCoord {
 
   template <typename MessageT, ActiveTypedFnType<MessageT> *f>
   void routeMsgHandler(
-    EntityID const& id, NodeType const& home_node, MessageT *m,
-    ActionType action = nullptr
+    EntityID const& id, NodeType const& home_node, MessageT *m
   );
 
   template <typename MessageT, ActiveTypedFnType<MessageT> *f>
   void routeMsgSerializeHandler(
-    EntityID const& id, NodeType const& home_node, MsgSharedPtr<MessageT> msg,
-    ActionType action = nullptr
+    EntityID const& id, NodeType const& home_node, MsgSharedPtr<MessageT> msg
   );
 
   template <typename MessageT>
   void routeMsg(
     EntityID const& id, NodeType const& home_node, MsgSharedPtr<MessageT> msg,
-    ActionType action = nullptr, bool const serialize = false,
+    bool const serialize = false,
     NodeType from_node = uninitialized_destination
   );
 
   template <typename MessageT>
   void routeMsgSerialize(
-    EntityID const& id, NodeType const& home_node, MsgSharedPtr<MessageT> msg,
-    ActionType action = nullptr
+    EntityID const& id, NodeType const& home_node, MsgSharedPtr<MessageT> msg
   );
 
   void routeNonEagerAction(
@@ -185,14 +182,13 @@ private:
   template <typename MessageT>
   void routeMsgEager(
     bool const serialize, EntityID const& id, NodeType const& home_node,
-    MsgSharedPtr<MessageT> msg, ActionType action = nullptr
+    MsgSharedPtr<MessageT> msg
   );
 
   template <typename MessageT>
   void routeMsgNode(
     bool const serialize, EntityID const& id, NodeType const& home_node,
-    NodeType const& to_node, MsgSharedPtr<MessageT> msg,
-    ActionType action = nullptr
+    NodeType const& to_node, MsgSharedPtr<MessageT> msg
   );
 
   void insertPendingEntityAction(EntityID const& id, NodeActionType action);

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -146,7 +146,7 @@ void ComputeStats<ColT>::operator()(PhaseReduceMsg<ColT>* msg) {
   theCollection()->broadcastMsg<
     PhaseMsg<ColT>,
     ElementStats::computeStats<ColT>
-  >(proxy, phase_msg, nullptr, false);
+  >(proxy, phase_msg, false);
 }
 
 template <typename ColT>
@@ -215,7 +215,7 @@ void CollectedStats<ColT>::operator()(StatsMsg<ColT>* msg) {
 
   theCollection()->broadcastMsg<
     LoadStatsMsg<ColT>, ElementStats::statsIn<ColT>
-  >(msg->getProxy(), load_msg, nullptr, false);
+  >(msg->getProxy(), load_msg, false);
 }
 
 template <typename ColT>

--- a/src/vt/vrt/collection/broadcast/broadcastable.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.h
@@ -64,13 +64,13 @@ struct Broadcastable : BaseProxyT {
     typename MsgT,
     ActiveColTypedFnType<MsgT, typename MsgT::CollectionType> *f
   >
-  void broadcast(MsgT* msg, ActionType act = nullptr) const;
+  void broadcast(MsgT* msg) const;
 
   template <
     typename MsgT,
     ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
   >
-  void broadcast(MsgT* msg, ActionType act = nullptr) const;
+  void broadcast(MsgT* msg) const;
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -63,11 +63,9 @@ template <
   typename MsgT,
   ActiveColTypedFnType<MsgT, typename MsgT::CollectionType> *f
 >
-void Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(
-  MsgT* msg, ActionType cont
-) const {
+void Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(MsgT* msg) const {
   auto proxy = this->getProxy();
-  return theCollection()->broadcastMsg<MsgT, f>(proxy,msg,cont);
+  return theCollection()->broadcastMsg<MsgT, f>(proxy,msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -75,11 +73,9 @@ template <
   typename MsgT,
   ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
 >
-void Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(
-  MsgT* msg, ActionType cont
-) const {
+void Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(MsgT* msg) const {
   auto proxy = this->getProxy();
-  return theCollection()->broadcastMsg<MsgT, f>(proxy,msg,cont);
+  return theCollection()->broadcastMsg<MsgT, f>(proxy,msg);
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/dispatch/dispatch.h
+++ b/src/vt/vrt/collection/dispatch/dispatch.h
@@ -62,12 +62,10 @@ struct DispatchCollectionBase {
 
 public:
   virtual void broadcast(
-    VirtualProxyType proxy, void* msg, HandlerType han, bool member,
-    ActionType action
+    VirtualProxyType proxy, void* msg, HandlerType han, bool member
   ) = 0;
   virtual void send(
-    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member,
-    ActionType action
+    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
   ) = 0;
 
   template <typename=void>
@@ -84,12 +82,10 @@ template <typename ColT, typename MsgT>
 struct DispatchCollection final : DispatchCollectionBase {
 private:
   void broadcast(
-    VirtualProxyType proxy, void* msg, HandlerType han, bool member,
-    ActionType action
+    VirtualProxyType proxy, void* msg, HandlerType han, bool member
   ) override;
   void send(
-    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member,
-    ActionType action
+    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
   ) override;
 };
 

--- a/src/vt/vrt/collection/dispatch/dispatch.impl.h
+++ b/src/vt/vrt/collection/dispatch/dispatch.impl.h
@@ -57,21 +57,19 @@ namespace vt { namespace vrt { namespace collection {
 
 template <typename ColT, typename MsgT>
 void DispatchCollection<ColT,MsgT>::broadcast(
-  VirtualProxyType proxy, void* msg, HandlerType han, bool member,
-  ActionType action
+  VirtualProxyType proxy, void* msg, HandlerType han, bool member
 ) {
   using IdxT = typename ColT::IndexType;
   auto const msg_typed = reinterpret_cast<MsgT*>(msg);
   CollectionProxy<ColT,IdxT> typed_proxy{proxy};
   theCollection()->broadcastMsgWithHan<MsgT,ColT>(
-    typed_proxy,msg_typed,han,member,action,true
+    typed_proxy,msg_typed,han,member,true
   );
 }
 
 template <typename ColT, typename MsgT>
 void DispatchCollection<ColT,MsgT>::send(
-  VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member,
-  ActionType action
+  VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
 ) {
   using IdxT = typename ColT::IndexType;
   auto const msg_typed = reinterpret_cast<MsgT*>(msg);
@@ -79,7 +77,7 @@ void DispatchCollection<ColT,MsgT>::send(
   auto const& idx_typed_ref = *idx_typed;
   VrtElmProxy<ColT,IdxT> typed_proxy{proxy,idx_typed_ref};
   theCollection()->sendMsgWithHan<MsgT,ColT>(
-    typed_proxy,msg_typed,han,member,action
+    typed_proxy,msg_typed,han,member
   );
 }
 

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -280,34 +280,33 @@ public:
   >
   void sendMsgUntypedHandler(
     VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member, ActionType action,
+    HandlerType const& handler, bool const member,
     bool imm_context = true
   );
 
   template <typename MsgT, typename ColT>
   IsNotColMsgType<MsgT> sendMsgWithHan(
     VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member, ActionType action
+    HandlerType const& handler, bool const member
   );
 
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> sendMsgWithHan(
     VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member, ActionType action
+    HandlerType const& handler, bool const member
   );
 
   template <typename MsgT, typename ColT>
   void sendNormalMsg(
     VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member, ActionType action
+    HandlerType const& handler, bool const member
   );
 
   template <
     typename MsgT, ActiveColTypedFnType<MsgT,typename MsgT::CollectionType> *f
   >
   void sendMsg(
-    VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg,
-    ActionType act = nullptr
+    VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg
   );
 
   template <
@@ -315,18 +314,17 @@ public:
     ActiveColMemberTypedFnType<MsgT,typename MsgT::CollectionType> f
   >
   void sendMsg(
-    VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg,
-    ActionType act = nullptr
+    VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg
   );
 
   template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
   IsColMsgType<MsgT> sendMsg(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act = nullptr
+    VirtualElmProxyType<ColT> const& proxy, MsgT *msg
   );
 
   template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
   IsNotColMsgType<MsgT> sendMsg(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act = nullptr
+    VirtualElmProxyType<ColT> const& proxy, MsgT *msg
   );
 
   template <
@@ -335,7 +333,7 @@ public:
     ActiveColMemberTypedFnType<MsgT,ColT> f
   >
   IsColMsgType<MsgT> sendMsg(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act = nullptr
+    VirtualElmProxyType<ColT> const& proxy, MsgT *msg
   );
 
   template <
@@ -344,12 +342,12 @@ public:
     ActiveColMemberTypedFnType<MsgT,ColT> f
   >
   IsNotColMsgType<MsgT> sendMsg(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act = nullptr
+    VirtualElmProxyType<ColT> const& proxy, MsgT *msg
   );
 
   template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
   void sendMsgImpl(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act = nullptr
+    VirtualElmProxyType<ColT> const& proxy, MsgT *msg
   );
 
   template <
@@ -358,7 +356,7 @@ public:
     ActiveColMemberTypedFnType<MsgT,typename MsgT::CollectionType> f
   >
   void sendMsgImpl(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act = nullptr
+    VirtualElmProxyType<ColT> const& proxy, MsgT *msg
   );
 
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
@@ -419,28 +417,28 @@ public:
   IsNotColMsgType<MsgT> broadcastMsgWithHan(
     CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
     HandlerType const& handler, bool const member,
-    ActionType act = nullptr, bool instrument = true
+    bool instrument = true
   );
 
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> broadcastMsgWithHan(
     CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
     HandlerType const& handler, bool const member,
-    ActionType act = nullptr, bool instrument = true
+    bool instrument = true
   );
 
   template <typename MsgT, typename ColT>
   void broadcastNormalMsg(
     CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
     HandlerType const& handler, bool const member,
-    ActionType act = nullptr, bool instrument = true
+    bool instrument = true
   );
 
   template <typename MsgT, typename ColT, typename IdxT>
   void broadcastMsgUntypedHandler(
     CollectionProxyWrapType<ColT,IdxT> const& proxy, MsgT *msg,
     HandlerType const& handler, bool const member,
-    ActionType act, bool instrument
+    bool instrument
   );
 
   // CollectionMessage non-detecting broadcast
@@ -450,7 +448,7 @@ public:
   >
   void broadcastMsg(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <
@@ -459,19 +457,19 @@ public:
   >
   void broadcastMsg(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
   IsColMsgType<MsgT> broadcastMsg(
     CollectionProxyWrapType<ColT> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
   IsNotColMsgType<MsgT> broadcastMsg(
     CollectionProxyWrapType<ColT> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <
@@ -481,7 +479,7 @@ public:
   >
   IsColMsgType<MsgT> broadcastMsg(
     CollectionProxyWrapType<ColT> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <
@@ -491,13 +489,13 @@ public:
   >
   IsNotColMsgType<MsgT> broadcastMsg(
     CollectionProxyWrapType<ColT> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
   void broadcastMsgImpl(
     CollectionProxyWrapType<ColT> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <
@@ -507,7 +505,7 @@ public:
   >
   void broadcastMsgImpl(
     CollectionProxyWrapType<ColT> const& proxy,
-    MsgT *msg, ActionType act = nullptr, bool instrument = true
+    MsgT *msg, bool instrument = true
   );
 
   template <typename ColT, typename IndexT, typename MsgT>

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -736,10 +736,10 @@ template <
 >
 void CollectionManager::broadcastMsg(
   CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
-  MsgT *msg, ActionType act, bool instrument
+  MsgT *msg, bool instrument
 ) {
   using ColT = typename MsgT::CollectionType;
-  return broadcastMsg<MsgT,ColT,f>(proxy,msg,act,instrument);
+  return broadcastMsg<MsgT,ColT,f>(proxy,msg,instrument);
 }
 
 template <
@@ -748,29 +748,28 @@ template <
 >
 void CollectionManager::broadcastMsg(
   CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
-  MsgT *msg, ActionType act, bool instrument
+  MsgT *msg, bool instrument
 ) {
   using ColT = typename MsgT::CollectionType;
-  return broadcastMsg<MsgT,ColT,f>(proxy,msg,act,instrument);
+  return broadcastMsg<MsgT,ColT,f>(proxy,msg,instrument);
 }
 
 template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
 CollectionManager::IsColMsgType<MsgT>
 CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, ActionType act,
+  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
   bool instrument
 ) {
-  return broadcastMsgImpl<MsgT,ColT,f>(proxy,msg,act,instrument);
+  return broadcastMsgImpl<MsgT,ColT,f>(proxy,msg,instrument);
 }
 
 template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
 CollectionManager::IsNotColMsgType<MsgT>
 CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, ActionType act,
-  bool instrument
+  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, bool instrument
 ) {
   auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>(msg);
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,false,act,instrument);
+  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,false,instrument);
 }
 
 template <
@@ -780,10 +779,10 @@ template <
 >
 CollectionManager::IsColMsgType<MsgT>
 CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, ActionType act,
+  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
   bool instrument
  ) {
-  return broadcastMsgImpl<MsgT,ColT,f>(proxy,msg,act,instrument);
+  return broadcastMsgImpl<MsgT,ColT,f>(proxy,msg,instrument);
 }
 
 template <
@@ -793,11 +792,10 @@ template <
 >
 CollectionManager::IsNotColMsgType<MsgT>
 CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, ActionType act,
-  bool instrument
+  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, bool instrument
 ) {
   auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>(msg);
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,true,act,instrument);
+  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,true,instrument);
 }
 
 template <
@@ -806,52 +804,50 @@ template <
   ActiveColMemberTypedFnType<MsgT,ColT> f
 >
 void CollectionManager::broadcastMsgImpl(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, ActionType act,
-  bool inst
+  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, bool inst
 ) {
   // register the user's handler
   auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>(msg);
-  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,true,act,inst);
+  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,true,inst);
 }
 
 template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
 void CollectionManager::broadcastMsgImpl(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, ActionType act,
-  bool inst
+  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, bool inst
 ) {
   // register the user's handler
   auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>(msg);
-  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,false,act,inst);
+  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,false,inst);
 }
 
 template <typename MsgT, typename ColT>
 CollectionManager::IsColMsgType<MsgT>
 CollectionManager::broadcastMsgWithHan(
   CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& h, bool const mem, ActionType act, bool inst
+  HandlerType const& h, bool const mem, bool inst
 ) {
   using IdxT = typename ColT::IndexType;
-  return broadcastMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,h,mem,act,inst);
+  return broadcastMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,h,mem,inst);
 }
 
 template <typename MsgT, typename ColT>
 CollectionManager::IsNotColMsgType<MsgT>
 CollectionManager::broadcastMsgWithHan(
   CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& h, bool const mem, ActionType act, bool inst
+  HandlerType const& h, bool const mem, bool inst
 ) {
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,mem,act,inst);
+  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,mem,inst);
 }
 
 template <typename MsgT, typename ColT>
 void CollectionManager::broadcastNormalMsg(
   CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
   HandlerType const& handler, bool const member,
-  ActionType act, bool instrument
+  bool instrument
 ) {
   auto wrap_msg = makeSharedMessage<ColMsgWrap<ColT,MsgT>>(*msg);
   return broadcastMsgUntypedHandler<ColMsgWrap<ColT,MsgT>,ColT>(
-    proxy, wrap_msg, handler, member, act, instrument
+    proxy, wrap_msg, handler, member, instrument
   );
 }
 
@@ -879,7 +875,7 @@ template <typename MsgT>
 template <typename MsgT, typename ColT, typename IdxT>
 void CollectionManager::broadcastMsgUntypedHandler(
   CollectionProxyWrapType<ColT, IdxT> const& toProxy, MsgT *raw_msg,
-  HandlerType const& handler, bool const member, ActionType act, bool instrument
+  HandlerType const& handler, bool const member, bool instrument
 ) {
   auto const idx = makeVrtDispatch<MsgT,ColT>();
 
@@ -978,7 +974,7 @@ void CollectionManager::broadcastMsgUntypedHandler(
       );
       theMsg()->pushEpoch(cur_epoch);
       theCollection()->broadcastMsgUntypedHandler<MsgT,ColT,IdxT>(
-        toProxy, msg.get(), handler, member, act, instrument
+        toProxy, msg.get(), handler, member, instrument
       );
       theMsg()->popEpoch();
       theTerm()->consume(cur_epoch);
@@ -1158,29 +1154,29 @@ template <typename MsgT, typename ColT>
 CollectionManager::IsNotColMsgType<MsgT>
 CollectionManager::sendMsgWithHan(
   VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member, ActionType action
+  HandlerType const& handler, bool const member
 ) {
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,handler,member,action);
+  return sendNormalMsg<MsgT,ColT>(proxy,msg,handler,member);
 }
 
 template <typename MsgT, typename ColT>
 CollectionManager::IsColMsgType<MsgT>
 CollectionManager::sendMsgWithHan(
   VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member, ActionType action
+  HandlerType const& handler, bool const member
 ) {
   using IdxT = typename ColT::IndexType;
-  return sendMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,handler,member,action);
+  return sendMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,handler,member);
 }
 
 template <typename MsgT, typename ColT>
 void CollectionManager::sendNormalMsg(
   VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member, ActionType action
+  HandlerType const& handler, bool const member
 ) {
   auto wrap_msg = makeSharedMessage<ColMsgWrap<ColT,MsgT>>(*msg);
   return sendMsgUntypedHandler<ColMsgWrap<ColT,MsgT>,ColT>(
-    proxy, wrap_msg, handler, member, action
+    proxy, wrap_msg, handler, member
   );
 }
 
@@ -1188,11 +1184,10 @@ template <
   typename MsgT, ActiveColTypedFnType<MsgT,typename MsgT::CollectionType> *f
 >
 void CollectionManager::sendMsg(
-  VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg,
-  ActionType act
+  VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg
 ) {
   using ColT = typename MsgT::CollectionType;
-  return sendMsg<MsgT,ColT,f>(proxy,msg,act);
+  return sendMsg<MsgT,ColT,f>(proxy,msg);
 }
 
 template <
@@ -1200,28 +1195,27 @@ template <
   ActiveColMemberTypedFnType<MsgT,typename MsgT::CollectionType> f
 >
 void CollectionManager::sendMsg(
-  VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg,
-  ActionType act
+  VirtualElmProxyType<typename MsgT::CollectionType> const& proxy, MsgT *msg
 ) {
   using ColT = typename MsgT::CollectionType;
-  return sendMsg<MsgT,ColT,f>(proxy,msg,act);
+  return sendMsg<MsgT,ColT,f>(proxy,msg);
 }
 
 template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
 CollectionManager::IsColMsgType<MsgT>
 CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act
+  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
 ) {
-  return sendMsgImpl<MsgT,ColT,f>(proxy,msg,act);
+  return sendMsgImpl<MsgT,ColT,f>(proxy,msg);
 }
 
 template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
 CollectionManager::IsNotColMsgType<MsgT>
 CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act
+  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
 ) {
   auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>(msg);
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,false,act);
+  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,false);
 }
 
 template <
@@ -1231,9 +1225,9 @@ template <
 >
 CollectionManager::IsColMsgType<MsgT>
 CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act
+  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
 ) {
-  return sendMsgImpl<MsgT,ColT,f>(proxy,msg,act);
+  return sendMsgImpl<MsgT,ColT,f>(proxy,msg);
 }
 
 template <
@@ -1243,18 +1237,18 @@ template <
 >
 CollectionManager::IsNotColMsgType<MsgT>
 CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act
+  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
 ) {
   auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>(msg);
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,true,act);
+  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,true);
 }
 
 template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
 void CollectionManager::sendMsgImpl(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act
+  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
 ) {
   auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>(msg);
-  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,false,act);
+  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,false);
 }
 
 template <
@@ -1263,16 +1257,16 @@ template <
   ActiveColMemberTypedFnType<MsgT,typename MsgT::CollectionType> f
 >
 void CollectionManager::sendMsgImpl(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg, ActionType act
+  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
 ) {
   auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>(msg);
-  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,true,act);
+  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,true);
 }
 
 template <typename MsgT, typename ColT, typename IdxT>
 void CollectionManager::sendMsgUntypedHandler(
   VirtualElmProxyType<ColT> const& toProxy, MsgT *raw_msg,
-  HandlerType const& handler, bool const member, ActionType action,
+  HandlerType const& handler, bool const member,
   bool imm_context
 ) {
   // @todo: implement the action `action' after the routing is finished
@@ -1305,7 +1299,7 @@ void CollectionManager::sendMsgUntypedHandler(
     schedule<>([=]{
       theMsg()->pushEpoch(cur_epoch);
       theCollection()->sendMsgUntypedHandler<MsgT,ColT,IdxT>(
-        toProxy, msg.get(), handler, member, action, false
+        toProxy, msg.get(), handler, member, false
       );
       theMsg()->popEpoch();
       theTerm()->consume(cur_epoch);
@@ -1349,7 +1343,7 @@ void CollectionManager::sendMsgUntypedHandler(
     vtAssert(lm != nullptr, "LM must exist");
     lm->template routeMsgSerializeHandler<
       MsgT, collectionMsgTypedHandler<ColT,IdxT,MsgT>
-    >(toProxy, home_node, msg, action);
+    >(toProxy, home_node, msg);
 
     theMsg()->popEpoch();
   } else {
@@ -1375,7 +1369,7 @@ void CollectionManager::sendMsgUntypedHandler(
     iter->second.push_back([=](VirtualProxyType /*ignored*/){
       theMsg()->pushEpoch(cur_epoch);
       theCollection()->sendMsgUntypedHandler<MsgT,ColT,IdxT>(
-        toProxy, msg.get(), handler, member, action, false
+        toProxy, msg.get(), handler, member, false
       );
       theMsg()->popEpoch();
       theTerm()->consume(cur_epoch);
@@ -2750,7 +2744,7 @@ void CollectionManager::nextPhase(
     }
   );
   theCollection()->broadcastMsg<MsgType,ElementStats::syncNextPhase<ColT>>(
-    proxy, msg, nullptr, instrument
+    proxy, msg, instrument
   );
 }
 

--- a/src/vt/vrt/collection/send/sendable.h
+++ b/src/vt/vrt/collection/send/sendable.h
@@ -65,13 +65,13 @@ struct Sendable : BaseProxyT {
     typename MsgT,
     ActiveColTypedFnType<MsgT, typename MsgT::CollectionType> *f
   >
-  void send(MsgT* msg, ActionType act = nullptr) const;
+  void send(MsgT* msg) const;
 
   template <
     typename MsgT,
     ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
   >
-  void send(MsgT* msg, ActionType act = nullptr) const;
+  void send(MsgT* msg) const;
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/send/sendable.impl.h
+++ b/src/vt/vrt/collection/send/sendable.impl.h
@@ -69,9 +69,7 @@ template <
   typename MsgT,
   ActiveColTypedFnType<MsgT, typename MsgT::CollectionType> *f
 >
-void Sendable<ColT,IndexT,BaseProxyT>::send(
-  MsgT* msg, ActionType continuation
-) const {
+void Sendable<ColT,IndexT,BaseProxyT>::send(MsgT* msg) const {
   auto col_proxy = this->getCollectionProxy();
   auto elm_proxy = this->getElementProxy();
   auto proxy = VrtElmProxy<ColT, IndexT>(col_proxy,elm_proxy);
@@ -79,7 +77,7 @@ void Sendable<ColT,IndexT,BaseProxyT>::send(
    * @todo:
    *.  Directly reuse this proxy: static_cast<VrtElmProxy<IndexT>*>(this)
    */
-  return theCollection()->sendMsg<MsgT, f>(proxy, msg, continuation);
+  return theCollection()->sendMsg<MsgT, f>(proxy, msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -87,9 +85,7 @@ template <
   typename MsgT,
   ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
 >
-void Sendable<ColT,IndexT,BaseProxyT>::send(
-  MsgT* msg, ActionType continuation
-) const {
+void Sendable<ColT,IndexT,BaseProxyT>::send(MsgT* msg) const {
   auto col_proxy = this->getCollectionProxy();
   auto elm_proxy = this->getElementProxy();
   auto proxy = VrtElmProxy<ColT, IndexT>(col_proxy,elm_proxy);
@@ -97,7 +93,7 @@ void Sendable<ColT,IndexT,BaseProxyT>::send(
    * @todo:
    *.  Directly reuse this proxy: static_cast<VrtElmProxy<IndexT>*>(this)
    */
-  return theCollection()->sendMsg<MsgT, f>(proxy, msg, continuation);
+  return theCollection()->sendMsg<MsgT, f>(proxy, msg);
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/context/context_vrtmanager.h
+++ b/src/vt/vrt/context/context_vrtmanager.h
@@ -103,12 +103,12 @@ struct VirtualContextManager {
 
   template <typename VcT, typename MsgT, ActiveVrtTypedFnType<MsgT, VcT> *f>
   void sendMsg(
-    VirtualProxyType const& toProxy, MsgT *const msg, ActionType act = nullptr
+    VirtualProxyType const& toProxy, MsgT *const msg
   );
 
   template <typename VcT, typename MsgT, ActiveVrtTypedFnType<MsgT, VcT> *f>
   void sendSerialMsg(
-    VirtualProxyType const& toProxy, MsgT *const msg, ActionType act = nullptr
+    VirtualProxyType const& toProxy, MsgT *const msg
   );
 
 private:

--- a/src/vt/vrt/context/context_vrtmanager.impl.h
+++ b/src/vt/vrt/context/context_vrtmanager.impl.h
@@ -137,7 +137,7 @@ template <typename MsgT>
 
 template <typename VcT, typename MsgT, ActiveVrtTypedFnType<MsgT, VcT> *f>
 void VirtualContextManager::sendSerialMsg(
-  VirtualProxyType const& toProxy, MsgT *const msg, ActionType act
+  VirtualProxyType const& toProxy, MsgT *const msg
 ) {
   if (theContext()->getWorker() == worker_id_comm_thread) {
     NodeType const& home_node = VirtualProxyBuilder::getVirtualNode(toProxy);
@@ -165,7 +165,7 @@ void VirtualContextManager::sendSerialMsg(
         msg->setProxy(toProxy);
         theLocMan()->vrtContextLoc->routeMsgHandler<
           SerialMsgT, SerializedMessenger::payloadMsgHandler
-        >(toProxy, home_node, msg.get(), act);
+        >(toProxy, home_node, msg.get());
       },
       // custom data transfer lambda if above the eager threshold
       [=](ActionNodeType action){
@@ -176,7 +176,7 @@ void VirtualContextManager::sendSerialMsg(
     );
   } else {
     theWorkerGrp()->enqueueCommThread([=]{
-      theVirtualManager()->sendSerialMsg<VcT, MsgT, f>(toProxy, msg, act);
+      theVirtualManager()->sendSerialMsg<VcT, MsgT, f>(toProxy, msg);
     });
   }
 }
@@ -294,10 +294,8 @@ VirtualProxyType VirtualContextManager::makeVirtualMap(Args... args) {
 
 template <typename VcT, typename MsgT, ActiveVrtTypedFnType<MsgT, VcT> *f>
 void VirtualContextManager::sendMsg(
-  VirtualProxyType const& toProxy, MsgT *const raw_msg, ActionType act
+  VirtualProxyType const& toProxy, MsgT *const raw_msg
 ) {
-  // @todo: implement the action `act' after the routing is finished
-
   auto msg = promoteMsg(raw_msg);
 
   auto const& home_node = VirtualProxyBuilder::getVirtualNode(toProxy);
@@ -314,7 +312,7 @@ void VirtualContextManager::sendMsg(
   );
 
   // route the message to the destination using the location manager
-  theLocMan()->vrtContextLoc->routeMsg(toProxy, home_node, msg, act);
+  theLocMan()->vrtContextLoc->routeMsg(toProxy, home_node, msg);
 }
 
 }}  // end namespace vt::vrt

--- a/tests/unit/collection/test_broadcast.cc
+++ b/tests/unit/collection/test_broadcast.cc
@@ -131,7 +131,7 @@ TYPED_TEST_P(TestBroadcast, test_broadcast_1) {
     auto msg2 = makeSharedMessage<MsgType>(args);
     theCollection()->broadcastMsg<
       MsgType,BroadcastHandlers<ColType>::handler
-    >(proxy, msg2, nullptr);
+    >(proxy, msg2);
   }
 }
 

--- a/tests/unit/collection/test_index_types.cc
+++ b/tests/unit/collection/test_index_types.cc
@@ -107,7 +107,7 @@ TYPED_TEST_P(TestCsollectionIndexTypes, test_collection_index_1) {
         proxy[i].template send<MsgType,&ColType::handler>(msg);
       } else {
         theCollection()->sendMsg<MsgType,&ColType::handler>(
-          proxy[i], msg, nullptr
+          proxy[i], msg
         );
       }
     }

--- a/tests/unit/collection/test_send.cc
+++ b/tests/unit/collection/test_send.cc
@@ -150,7 +150,7 @@ TYPED_TEST_P(TestCollectionSend, test_collection_send_1) {
         proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg);
       } else {
         theCollection()->sendMsg<MsgType,SendHandlers<ColType>::handler>(
-          proxy[i], msg, nullptr
+          proxy[i], msg
         );
       }
     }
@@ -175,7 +175,7 @@ TYPED_TEST_P(TestCollectionSendMem, test_collection_send_ptm_1) {
         proxy[i].template send<MsgType,&ColType::handler>(msg);
       } else {
         theCollection()->sendMsg<MsgType,&ColType::handler>(
-          proxy[i], msg, nullptr
+          proxy[i], msg
         );
       }
     }


### PR DESCRIPTION
The Action arguments to every sort of message sending function were
originally used to support freeing messages once their transmission
was locally complete. This has been taken over by smart pointers
MsgSharedPtr in almost the entirety of the runtime, leaving the Action
arguments as mostly a distracting relic.