### PR TITLE
274 Debug VT with LLDB on Linux

### DIFF
--- a/scripts/run_vt.pl
+++ b/scripts/run_vt.pl
@@ -107,7 +107,6 @@ LLDBPYTHON
         print $python_file $python_str;
         close $python_file;
 
-        print $tmphandle "file $binary\n";
         print $tmphandle "process attach --pid $pid\n";
         print $tmphandle "process handle --pass true --stop false --notify true SIGUSR1\n";
         print $tmphandle "process status\n";


### PR DESCRIPTION
Quick PR to fix the problem on linux that makes lldb process attachment failed on Linux.

It also still compatible with mac