### PR TITLE
Feature 288 assert info output fix

### DIFF
--- a/src/vt/collective/collective_ops.cc
+++ b/src/vt/collective/collective_ops.cc
@@ -148,7 +148,7 @@ void CollectiveAnyOps<instance>::abort(
 template <RuntimeInstType instance>
 void CollectiveAnyOps<instance>::output(
   std::string const str, ErrorCodeType const code, bool error, bool decorate,
-  bool formatted
+  bool formatted, bool abort_out
 ) {
   auto tls_rt = curRT;
   auto rt = tls_rt ? tls_rt : ::vt::rt;
@@ -157,7 +157,7 @@ void CollectiveAnyOps<instance>::output(
   } else {
     ::fmt::print(str.c_str());
   }
-  if (error) {
+  if (error and abort_out) {
     vt::abort("Assertion Failed", 129);
   }
 }
@@ -175,9 +175,9 @@ void abort(std::string const str, ErrorCodeType const code) {
 
 void output(
   std::string const str, ErrorCodeType const code, bool error, bool decorate,
-  bool formatted
+  bool formatted, bool abort_out
 ) {
-  return CollectiveOps::output(str,code,error,decorate,formatted);
+  return CollectiveOps::output(str,code,error,decorate,formatted,abort_out);
 }
 
 } //end namespace vt

--- a/src/vt/collective/collective_ops.h
+++ b/src/vt/collective/collective_ops.h
@@ -76,7 +76,8 @@ struct CollectiveAnyOps {
   static void abort(std::string const str = "", ErrorCodeType const code = 0);
   static void output(
     std::string const str = "", ErrorCodeType const code = 1,
-    bool error = false, bool decorate = true, bool formatted = false
+    bool error = false, bool decorate = true, bool formatted = false,
+    bool abort_out = false
   );
 
   static HandlerType registerHandler(ActiveClosureFnType fn);
@@ -88,7 +89,7 @@ using CollectiveOps = CollectiveAnyOps<collective_default_inst>;
 void abort(std::string const str = "", ErrorCodeType const code = 1);
 void output(
   std::string const str = "", ErrorCodeType const code = 1, bool error = false,
-  bool decorate = true
+  bool decorate = true, bool abort_out = false
 );
 
 } //end namespace vt

--- a/src/vt/configs/error/assert_out.impl.h
+++ b/src/vt/configs/error/assert_out.impl.h
@@ -70,7 +70,7 @@ inline void assertOutExpr(
   auto msg = "Assertion failed:";
   auto reason = "";
   auto assert_fail_str = stringizeMessage(msg,reason,cond,file,line,func,error);
-  ::vt::output(assert_fail_str,error,true,true,true);
+  ::vt::output(assert_fail_str,error,true,true,true,fail);
   auto const& stack = ::vt::debug::stack::dumpStack();
   auto const& list_str = std::get<1>(stack);
 
@@ -89,7 +89,7 @@ assertOut(
 ) {
   auto msg = "Assertion failed:";
   auto assert_fail_str = stringizeMessage(msg,str,cond,file,line,func,error);
-  ::vt::output(assert_fail_str,error,true,true,true);
+  ::vt::output(assert_fail_str,error,true,true,true,fail);
   if (fail) {
     vtAbort("Assertion failed");
   }

--- a/src/vt/configs/error/assert_out_info.impl.h
+++ b/src/vt/configs/error/assert_out_info.impl.h
@@ -121,7 +121,7 @@ assertOutInfo(
     str_buf << cur;
   }
   str_buf << space << seperator << seperator;
-  ::vt::output(str_buf.str(),error,false,false,true);
+  ::vt::output(str_buf.str(),error,false,false,true,fail);
 
   if (fail) {
     vtAbort("Assertion failed");

--- a/src/vt/configs/error/common.h
+++ b/src/vt/configs/error/common.h
@@ -62,7 +62,9 @@ namespace vt {
 
 // Forward declare abort and output signatures, defined in collective ops
 void abort(std::string const str, ErrorCodeType const code);
-void output(std::string const str, ErrorCodeType const code, bool, bool, bool);
+void output(
+  std::string const str, ErrorCodeType const code, bool, bool, bool, bool
+);
 
 namespace debug {
 

--- a/src/vt/configs/error/error.impl.h
+++ b/src/vt/configs/error/error.impl.h
@@ -85,7 +85,7 @@ displayLoc(
 ) {
   auto msg = "vtAbort() Invoked";
   auto const inf = debug::stringizeMessage(msg,str,"",file,line,func,error);
-  return ::vt::output(inf,error,true,true,true);
+  return ::vt::output(inf,error,true,true,true,true);
 }
 
 template <typename... Args>
@@ -99,7 +99,7 @@ displayLoc(
   auto msg = "vtAbort() Invoked";
   std::string const buf = ::fmt::format(str,std::forward<Args>(args)...);
   auto const inf = debug::stringizeMessage(msg,buf,"",file,line,func,error);
-  return ::vt::output(inf,error,true,true,true);
+  return ::vt::output(inf,error,true,true,true,true);
 }
 
 }} /* end namespace vt::error */

--- a/src/vt/configs/error/soft_error.h
+++ b/src/vt/configs/error/soft_error.h
@@ -73,9 +73,9 @@ inline void warning(
   std::string const buf = ::fmt::format(str, std::forward<Args>(args)...);
   auto inf = debug::stringizeMessage(msg,buf,"",file,line,func,error);
   if (quit) {
-    return ::vt::output(inf,error,true,true,true);
+    return ::vt::output(inf,error,true,true,true,true);
   } else {
-    return ::vt::output(inf,error,false,true,true);
+    return ::vt::output(inf,error,false,true,true,true);
   }
 }
 


### PR DESCRIPTION
I think we need a bigger refactoring of the `vt::output` and assert framework. It's confusing.