### PR TITLE
Feature 325 build script fix

### DIFF
--- a/scripts/build_vt.pl
+++ b/scripts/build_vt.pl
@@ -132,9 +132,10 @@ if ($build_mode eq "coverage") {
    $CXX_FLAGS="\"-fprofile-arcs -ftest-coverage -fPIC\"";
    $C_FLAGS="\"-fprofile-arcs -ftest-coverage -fPIC\"";
 }
+my $cov_enabled = $coverage == 1 ? "enabled" : "disabled";
 
 print STDERR "=== Building vt ===\n";
-print STDERR  "\tCode coverage mode enabled\n" if $coverage == 1;
+print STDERR  "\tCode coverage mode $cov_enabled\n";
 print STDERR "\tBuild mode:$build_mode\n";
 print STDERR "\tRoot=$root\n";
 print STDERR "\tLibroot=$libroot\n";


### PR DESCRIPTION
The perl build script in vt was printing a error introduced by #264, merged PR as #268

```
"my" variable $str masks earlier declaration in same scope at ../virtual-transport/scripts/build_vt.pl line 182.
```

Also, this string was being printed as if having coverage off is an error:

```
Vt hasn't been correctly detected into a coverage mode
```