### PR TITLE
336 tls warnings

### DIFF
--- a/cmake/load_threading_package.cmake
+++ b/cmake/load_threading_package.cmake
@@ -24,9 +24,4 @@ elseif(USE_OPENMP)
       "valid OpenMP in compiler"
     )
   endif()
-elseif(OpenMP_FOUND) #no default specified
-  config_for_openmp()
-else() #no default specified
-  message("OpenMP not found: using std::thread for workers")
-  config_for_std_thread()
 endif()

--- a/src/vt/configs/debug/debug_masterconfig.h
+++ b/src/vt/configs/debug/debug_masterconfig.h
@@ -65,7 +65,7 @@
 )
 #endif
 
-#define default_threading openmp
+#define default_threading
 
 #define backend_features backend_options_on(                             \
   default_threading, memory_pool, cmake_config_features                  \

--- a/src/vt/worker/worker_group.impl.h
+++ b/src/vt/worker/worker_group.impl.h
@@ -113,7 +113,7 @@ void WorkerGroupAny<WorkerT>::enqueueForWorker(
   WorkerIDType const& worker_id, WorkUnitType const& work_unit
 ) {
   vtAssert(initialized_, "Must be initialized to enqueue");
-  vtAssert(worker_id < workers_.size(), "Worker ID must be valid");
+  vtAssert((size_t)worker_id < workers_.size(), "Worker ID must be valid");
 
   this->enqueued();
   workers_[worker_id]->enqueue(work_unit);
@@ -162,7 +162,7 @@ void WorkerGroupAny<WorkerT>::spawnWorkers() {
     "WorkerGroup: spawnWorkers: num_workers_={}\n", num_workers_
   );
 
-  vtAssert(workers_.size() >= num_workers_, "Must be correct size");
+  vtAssert(workers_.size() >= (size_t)num_workers_, "Must be correct size");
 
   for (int i = 0; i < num_workers_; i++) {
     WorkerIDType const worker_id = i;

--- a/src/vt/worker/worker_seq.h
+++ b/src/vt/worker/worker_seq.h
@@ -53,7 +53,7 @@
 #include "vt/worker/worker_types.h"
 #include "vt/utils/container/concurrent_deque.h"
 
-#include <fcontext.h>
+#include <context/context.h>
 
 #include <functional>
 

--- a/tests/unit/atomic/test_atomic.cc
+++ b/tests/unit/atomic/test_atomic.cc
@@ -107,6 +107,8 @@ TEST_F(TestAtomic, basic_atomic_fetch_sub_single_thd) {
   }
 }
 
+#if !backend_no_threading
+
 using ::vt::util::mutex::MutexType;
 
 static constexpr WorkerCountType const num_workers = 8;
@@ -163,7 +165,6 @@ TEST_F(TestAtomic, basic_atomic_fetch_add_multi_thd) {
     }
   #endif
 
-  #if !backend_no_threading
   test_mutex.lock();
   for (auto&& elm : count) {
     EXPECT_EQ(elm, true);
@@ -171,7 +172,6 @@ TEST_F(TestAtomic, basic_atomic_fetch_add_multi_thd) {
   EXPECT_EQ(atomic_num.load(), 1);
   EXPECT_EQ(atomic_test_val.load(), num_workers);
   test_mutex.unlock();
-  #endif
 }
 
 TEST_F(TestAtomic, basic_atomic_cas_multi_thd) {
@@ -190,10 +190,10 @@ TEST_F(TestAtomic, basic_atomic_cas_multi_thd) {
     }
   #endif
 
-  #if !backend_no_threading
   EXPECT_EQ(atomic_test_slot.load(), num_workers);
   EXPECT_EQ(atomic_test_cas.load(), num_workers);
-  #endif
 }
+
+  #endif
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/tls/test_tls.cc
+++ b/tests/unit/tls/test_tls.cc
@@ -52,6 +52,8 @@
 
 #include "vt/transport.h"
 
+#if !backend_no_threading
+
 #if backend_check_enabled(openmp)
   #include <omp.h>
 #else
@@ -392,3 +394,5 @@ TEST_F(TestTLS, basic_tls_init_class_multi_thd_std) {
 #endif
 
 }}} // end namespace vt::tests::unit
+
+#endif

--- a/tests/unit/tls/test_tls.cc
+++ b/tests/unit/tls/test_tls.cc
@@ -256,7 +256,6 @@ TEST_F(TestTLS, basic_tls_init_multi_thd_openmp) {
 
   #pragma omp parallel num_threads(num_workers + 1)
   {
-    WorkerIDType const thd = omp_get_thread_num();
     testTLSMulti(false, true);
   }
 }
@@ -266,7 +265,6 @@ TEST_F(TestTLS, basic_tls_noinit_static_multi_thd_openmp) {
 
   #pragma omp parallel num_threads(num_workers + 1)
   {
-    WorkerIDType const thd = omp_get_thread_num();
     testTLSMulti(true, false);
   }
 }
@@ -276,7 +274,6 @@ TEST_F(TestTLS, basic_tls_init_static_multi_thd_openmp) {
 
   #pragma omp parallel num_threads(num_workers + 1)
   {
-    WorkerIDType const thd = omp_get_thread_num();
     testTLSMulti(true, true);
   }
 }
@@ -286,7 +283,6 @@ TEST_F(TestTLS, basic_tls_noinit_class_multi_thd_openmp) {
 
   #pragma omp parallel num_threads(num_workers + 1)
   {
-    WorkerIDType const thd = omp_get_thread_num();
     testTLSMulti(false, false, true);
   }
 }
@@ -296,7 +292,6 @@ TEST_F(TestTLS, basic_tls_init_class_multi_thd_openmp) {
 
   #pragma omp parallel num_threads(num_workers + 1)
   {
-    WorkerIDType const thd = omp_get_thread_num();
     testTLSMulti(false, true, true);
   }
 }


### PR DESCRIPTION
Looks like I forgot to put in the PR for this last week.  This turns off threading by default, disables the tls test, and fixes some warnings from within the test.  It should be reviewed carefully.