### PR TITLE
Feature 363 objgroup warning fix

### DIFF
--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -147,7 +147,7 @@ struct ObjGroupManager {
    */
 
   template <typename ObjT>
-  ProxyType<ObjT> proxy(ObjT* obj);
+  ProxyType<ObjT> getProxy(ObjT* obj);
   template <typename ObjT>
   ProxyElmType<ObjT> proxyElm(ObjT* obj);
 

--- a/src/vt/objgroup/manager.impl.h
+++ b/src/vt/objgroup/manager.impl.h
@@ -266,7 +266,7 @@ void ObjGroupManager::update(ProxyType<ObjT> proxy, Args&&... args) {
 }
 
 template <typename ObjT>
-typename ObjGroupManager::ProxyType<ObjT> ObjGroupManager::proxy(ObjT* obj) {
+typename ObjGroupManager::ProxyType<ObjT> ObjGroupManager::getProxy(ObjT* obj) {
   auto map_iter = obj_to_proxy_.find(obj);
   vtAssert(map_iter != obj_to_proxy_.end(), "Object pointer does not exist");
   return ProxyType<ObjT>(map_iter->second);
@@ -274,7 +274,7 @@ typename ObjGroupManager::ProxyType<ObjT> ObjGroupManager::proxy(ObjT* obj) {
 
 template <typename ObjT>
 typename ObjGroupManager::ProxyElmType<ObjT> ObjGroupManager::proxyElm(ObjT* obj) {
-  return proxy<ObjT>(obj).operator()(theContext()->getNode());
+  return getProxy<ObjT>(obj).operator()(theContext()->getNode());
 }
 
 }} /* end namespace vt::objgroup */

--- a/tests/unit/objgroup/test_objgroup.cc
+++ b/tests/unit/objgroup/test_objgroup.cc
@@ -135,7 +135,7 @@ TEST_F(TestObjGroup, test_proxy_object_getter) {
 
   // check that retrieved proxy and the original one are really the same.
   auto proxy_ori_bits = proxy.getProxy();
-  auto proxy_get_bits = vt::theObjGroup()->proxy(obj_ori).getProxy();
+  auto proxy_get_bits = vt::theObjGroup()->getProxy(obj_ori).getProxy();
   EXPECT_EQ(proxy_ori_bits, proxy_get_bits);
 
   // check that creating multiple proxies from a same object group type


### PR DESCRIPTION
Fix shadow warning with GNU-6 that we missed in the objgroup code