### PR TITLE
Feature 367 initialize argv break from copying loop

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -440,7 +440,7 @@ namespace vt { namespace arguments {
     for (auto ii = 0; ii < argc; ii++) {
       if (std::string(argv[ii]) == *iter) {
         ret_idx.push_back(ii);
-		break;
+        break;
       }
     }
     ret_args.push_back(*iter);


### PR DESCRIPTION
The copying loop needs to break when a match is found to avoid repetition of identical parameters.