### PR TITLE
382 build: use cmake variable to check compiler version

### DIFF
--- a/cmake-modules/SetCXXCompilerFlags.cmake
+++ b/cmake-modules/SetCXXCompilerFlags.cmake
@@ -7,9 +7,7 @@ set(CXX_STANDARD_FLAGS)
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   # 4.9.3 complains about std::min not being constexpr
   set(CXX_STANDARD_FLAGS -std=c++1y)
-  execute_process(
-  COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-  if (NOT (GCC_VERSION VERSION_GREATER 5 OR GCC_VERSION VERSION_EQUAL 5))
+  if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5))
     message("${PROJECT_NAME} currently requires g++ 5 or greater.  If you need it to work with 4.9, please complain.")
   endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")


### PR DESCRIPTION
Addresses #382 to avoid an error when cuda is used.