### PR TITLE
410 Dependent Epochs

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(
   PROJECT_EXAMPLES_LIST
   hello_world
+  dep_epoch
   ring
   comm_func
   rdma_simple_get

--- a/examples/dep_epoch.cc
+++ b/examples/dep_epoch.cc
@@ -103,6 +103,9 @@ static void testHan(HelloMsg* msg) {
 
   proxy[next].release(msg->ep);
 
+  // if (node == 0) {
+  //   cproxy.release(msg->ep);
+  // }
   for (int i = node * 10; i < (node+1)*10; i++) {
     cproxy[i].release(msg->ep);
   }

--- a/examples/dep_epoch.cc
+++ b/examples/dep_epoch.cc
@@ -82,12 +82,14 @@ vt::CollectionProxy<MyCol,vt::Index1D> cproxy;
 
 void MyCol::handlerA(HelloMsg2* msg) {
   auto node = vt::theContext()->getNode();
-  fmt::print("{}: MyCol::handlerA on from={}\n", node, msg->from);
+  auto idx = this->getIndex();
+  fmt::print("{}: {}: MyCol::handlerA on from={}\n", node, idx, msg->from);
 }
 
 void MyCol::handlerB(HelloMsg2* msg) {
   auto node = vt::theContext()->getNode();
-  fmt::print("{}: MyCol::handlerB on from={}\n", node, msg->from);
+  auto idx = this->getIndex();
+  fmt::print("{}: {}: MyCol::handlerB on from={}\n", node, idx, msg->from);
 }
 
 //vt::EpochType epoch = vt::no_epoch;

--- a/examples/dep_epoch.cc
+++ b/examples/dep_epoch.cc
@@ -1,0 +1,179 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                           dep_epoch.cc
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include "vt/transport.h"
+#include <cstdlib>
+
+struct HelloMsg : vt::Message {
+  HelloMsg(vt::NodeType in_from) : from(in_from) { }
+
+  vt::EpochType ep = vt::no_epoch;
+  vt::NodeType from = 0;
+};
+
+struct MyObjGroup {
+  void handlerA(HelloMsg* msg) {
+    auto node = vt::theContext()->getNode();
+    fmt::print("{}: MyObjGroup::handlerA on from={}\n", node, msg->from);
+  }
+  void handlerB(HelloMsg* msg) {
+    auto node = vt::theContext()->getNode();
+    fmt::print("{}: MyObjGroup::handlerB on from={}\n", node, msg->from);
+  }
+};
+
+struct HelloMsg2;
+
+struct MyCol : vt::Collection<MyCol,vt::Index1D> {
+  void handlerA(HelloMsg2* msg);
+  void handlerB(HelloMsg2* msg);
+};
+
+struct HelloMsg2 : vt::CollectionMessage<MyCol> {
+  HelloMsg2(vt::NodeType in_from) : from(in_from) { }
+
+  vt::EpochType ep = vt::no_epoch;
+  vt::NodeType from = 0;
+};
+
+vt::objgroup::proxy::Proxy<MyObjGroup> proxy;
+vt::CollectionProxy<MyCol,vt::Index1D> cproxy;
+
+void MyCol::handlerA(HelloMsg2* msg) {
+  auto node = vt::theContext()->getNode();
+  fmt::print("{}: MyCol::handlerA on from={}\n", node, msg->from);
+}
+
+void MyCol::handlerB(HelloMsg2* msg) {
+  auto node = vt::theContext()->getNode();
+  fmt::print("{}: MyCol::handlerB on from={}\n", node, msg->from);
+}
+
+//vt::EpochType epoch = vt::no_epoch;
+
+static void testHan(HelloMsg* msg) {
+  vt::NodeType num_nodes = vt::theContext()->getNumNodes();
+  vt::NodeType node = vt::theContext()->getNode();
+  vt::NodeType next = node + 1 < num_nodes ? node + 1 : 0;
+  fmt::print("{}: testHan from={}, epoch={:x}\n", node, msg->from, msg->ep);
+  vt::theTerm()->releaseEpoch(msg->ep);
+
+  proxy[next].release(msg->ep);
+
+  for (int i = node * 10; i < (node+1)*10; i++) {
+    cproxy[i].release(msg->ep);
+  }
+
+  if (node == 1) {
+    auto msg2 = vt::makeSharedMessage<HelloMsg>(node);
+    msg2->ep = msg->ep;
+    vt::theMsg()->sendMsg<HelloMsg, testHan>(0, msg2);
+  }
+
+  // vt::NodeType this_node = vt::theContext()->getNode();
+  // fmt::print(
+  //   "{}: testHan from node {}, epoch={:x}\n", this_node, msg->from, epoch
+  // );
+  // vt::theTerm()->releaseEpoch(epoch);
+}
+
+static void hello_world(HelloMsg* msg) {
+  vt::NodeType node = vt::theContext()->getNode();
+  fmt::print("{}: Hello from node {}\n", node, msg->from);
+}
+
+int main(int argc, char** argv) {
+  vt::initialize(argc, argv);
+
+  vt::NodeType this_node = vt::theContext()->getNode();
+  vt::NodeType num_nodes = vt::theContext()->getNumNodes();
+
+  if (num_nodes == 1) {
+    return vt::rerror("requires at least 2 nodes");
+  }
+
+  proxy = vt::theObjGroup()->makeCollective<MyObjGroup>();
+  cproxy = vt::theCollection()->constructCollective<MyCol>(vt::Index1D(num_nodes * 10));
+
+  if (this_node == 0) {
+    auto msg = vt::makeSharedMessage<HelloMsg>(static_cast<vt::NodeType>(100));
+    proxy.broadcast<HelloMsg,&MyObjGroup::handlerA>(msg);
+
+    auto msg2 = vt::makeSharedMessage<HelloMsg2>(static_cast<vt::NodeType>(100));
+    cproxy.broadcast<HelloMsg2,&MyCol::handlerA>(msg2);
+  }
+
+  //epoch = vt::theTerm()->makeEpochCollectiveDep();
+
+  if (this_node == 0) {
+    auto epoch = vt::theTerm()->makeEpochRootedDep();
+    vt::theMsg()->pushEpoch(epoch);
+
+    auto msg = vt::makeSharedMessage<HelloMsg>(this_node);
+    vt::theMsg()->broadcastMsg<HelloMsg, hello_world>(msg);
+
+    auto msg3 = vt::makeSharedMessage<HelloMsg>(static_cast<vt::NodeType>(101));
+    proxy.broadcast<HelloMsg,&MyObjGroup::handlerB>(msg3);
+
+    auto msg4 = vt::makeSharedMessage<HelloMsg2>(static_cast<vt::NodeType>(101));
+    cproxy.broadcast<HelloMsg2,&MyCol::handlerB>(msg4);
+
+    vt::theMsg()->popEpoch(epoch);
+    vt::theTerm()->finishedEpoch(epoch);
+
+    auto msg2 = vt::makeSharedMessage<HelloMsg>(this_node);
+    msg2->ep = epoch;
+    vt::theMsg()->broadcastMsg<HelloMsg, testHan>(msg2);
+  }
+
+  //vt::theTerm()->finishedEpoch(epoch);
+
+  while (!vt::rt->isTerminated()) {
+    vt::runScheduler();
+  }
+
+  vt::finalize();
+
+  return 0;
+}

--- a/examples/dep_epoch.cc
+++ b/examples/dep_epoch.cc
@@ -46,7 +46,7 @@
 #include <cstdlib>
 
 struct HelloMsg : vt::Message {
-  HelloMsg(vt::NodeType in_from) : from(in_from) { }
+  explicit HelloMsg(vt::NodeType in_from) : from(in_from) { }
 
   vt::EpochType ep = vt::no_epoch;
   vt::NodeType from = 0;
@@ -71,7 +71,7 @@ struct MyCol : vt::Collection<MyCol,vt::Index1D> {
 };
 
 struct HelloMsg2 : vt::CollectionMessage<MyCol> {
-  HelloMsg2(vt::NodeType in_from) : from(in_from) { }
+  explicit HelloMsg2(vt::NodeType in_from) : from(in_from) { }
 
   vt::EpochType ep = vt::no_epoch;
   vt::NodeType from = 0;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ set(
       vrt/collection/traits vrt/collection/defaults vrt/collection/constructor
       vrt/collection/send vrt/collection/destroy vrt/collection/broadcast
       vrt/collection/insert vrt/collection/reducable vrt/collection/mapped_node
-      vrt/collection/dispatch vrt/collection/gettable
+      vrt/collection/dispatch vrt/collection/gettable vrt/collection/release
       vrt/collection/staged_token
       vrt/collection/balance
         vrt/collection/balance/baselb

--- a/src/vt/collective/reduce/operators/default_op.impl.h
+++ b/src/vt/collective/reduce/operators/default_op.impl.h
@@ -57,7 +57,6 @@ template <typename MsgT, typename Op, typename ActOp>
   if (msg->isRoot()) {
     auto cb = msg->getCallback();
     debug_print(
-
       reduce, node,
       "ROOT: reduce root: valid={}, ptr={}\n", cb.valid(), print_ptr(msg)
     );

--- a/src/vt/epoch/epoch.h
+++ b/src/vt/epoch/epoch.h
@@ -91,7 +91,7 @@ static constexpr BitCountType const epoch_user_num_bits = 1;
 
 enum struct eEpochCategory : int8_t {
   NoCategoryEpoch       = 0x0,
-  InsertEpoch           = 0x1,
+  DependentEpoch        = 0x1,
   DijkstraScholtenEpoch = 0x2
 };
 

--- a/src/vt/epoch/epoch_manip.h
+++ b/src/vt/epoch/epoch_manip.h
@@ -115,6 +115,12 @@ struct EpochManip {
    */
   static eEpochCategory makeCat(eEpochCategory c1, eEpochCategory c2);
 
+  /*
+   * Test category bit w/o extracting whole category field (single |)
+   */
+  static bool isDS(EpochType epoch);
+  static bool isDep(EpochType epoch);
+
 private:
   static EpochType nextSlow(EpochType const& epoch);
   static EpochType nextFast(EpochType const& epoch);

--- a/src/vt/epoch/epoch_manip.h
+++ b/src/vt/epoch/epoch_manip.h
@@ -110,6 +110,11 @@ struct EpochManip {
   );
   static EpochType next(EpochType const& epoch);
 
+  /*
+   * Combine eEpochCategory elements
+   */
+  static eEpochCategory makeCat(eEpochCategory c1, eEpochCategory c2);
+
 private:
   static EpochType nextSlow(EpochType const& epoch);
   static EpochType nextFast(EpochType const& epoch);

--- a/src/vt/epoch/epoch_manip_get.h
+++ b/src/vt/epoch/epoch_manip_get.h
@@ -48,6 +48,7 @@
 #include "vt/config.h"
 #include "vt/epoch/epoch.h"
 #include "vt/epoch/epoch_manip.h"
+#include "vt/termination/term_common.h"
 #include "vt/utils/bits/bits_common.h"
 #include "vt/utils/bits/bits_packer.h"
 
@@ -83,6 +84,28 @@ namespace vt { namespace epoch {
   return BitPackerType::getField<
     eEpochLayout::EpochSequential, epoch_seq_num_bits, EpochType
   >(epoch);
+}
+
+/*static*/ inline bool EpochManip::isDS(EpochType epoch) {
+  using T = typename std::underlying_type<eEpochCategory>::type;
+  if (epoch == no_epoch or epoch == term::any_epoch_sentinel) {
+    return false;
+  }
+  static constexpr auto ds_bit = eEpochCategory::DijkstraScholtenEpoch;
+  auto const cat = epoch::EpochManip::category(epoch);
+  bool const is_ds = static_cast<T>(cat) & static_cast<T>(ds_bit);
+  return is_ds;
+}
+
+/*static*/ inline bool EpochManip::isDep(EpochType epoch) {
+  using T = typename std::underlying_type<eEpochCategory>::type;
+  if (epoch == no_epoch or epoch == term::any_epoch_sentinel) {
+    return false;
+  }
+  static constexpr auto dep_bit = eEpochCategory::DependentEpoch;
+  auto const cat = epoch::EpochManip::category(epoch);
+  bool const is_dep = static_cast<T>(cat) & static_cast<T>(dep_bit);
+  return is_dep;
 }
 
 }} /* end namespace vt::epoch */

--- a/src/vt/epoch/epoch_manip_make.h
+++ b/src/vt/epoch/epoch_manip_make.h
@@ -128,6 +128,14 @@ namespace vt { namespace epoch {
   return epoch + 1;
 }
 
+/*static*/ inline eEpochCategory EpochManip::makeCat(
+  eEpochCategory c1, eEpochCategory c2
+) {
+  using T = typename std::underlying_type<eEpochCategory>::type;
+  auto ret = static_cast<T>(c1) | static_cast<T>(c2);
+  return static_cast<eEpochCategory>(ret);
+}
+
 }} /* end namespace vt::epoch */
 
 #endif /*INCLUDED_EPOCH_EPOCH_MANIP_MAKE_H*/

--- a/src/vt/group/collective/group_collective_msg.h
+++ b/src/vt/group/collective/group_collective_msg.h
@@ -67,7 +67,9 @@ struct GroupCollectiveInfoMsg : MsgT {
   ) : MsgT(in_group, in_op), is_in_group(in_is_in_group),
       child_node_(in_child_node), subtree_size_(in_subtree),
       extra_nodes_(extra_nodes), level_(level)
-  { }
+  {
+    setSystemType(this->env);
+  }
 
   NodeType getChild() const { return child_node_; }
   NodeType getSubtreeSize() const { return subtree_size_; }

--- a/src/vt/group/msg/group_msg.h
+++ b/src/vt/group/msg/group_msg.h
@@ -61,14 +61,18 @@ struct GroupMsg : MsgT {
 
   GroupMsg(GroupType const& in_group, RemoteOperationIDType const& in_op)
     : MsgT(), group_(in_group), op_id_(in_op)
-  { }
+  {
+    setSystemType(this->env);
+  }
 
   GroupMsg(
     GroupType const& in_group, RemoteOperationIDType const& in_op,
     NodeType const& in_root, bool const& in_default_group
   ) : MsgT(), group_(in_group), op_id_(in_op), root_(in_root),
       default_group_(in_default_group)
-  { }
+  {
+    setSystemType(this->env);
+  }
 
   GroupType getGroup() const { return group_; }
   RemoteOperationIDType getOpID() const { return op_id_; }
@@ -99,7 +103,9 @@ struct GroupInfoMsg : MsgT {
   ) : MsgT(in_group, in_op), root_node_(in_root_node),
       num_nodes_(in_num_nodes), total_num_nodes_(in_total_num_nodes),
       parent_node_(in_parent_node)
-  { }
+  {
+    setSystemType(this->env);
+  }
 
   NodeType getRoot() const { return root_node_; }
   NodeType getCount() const { return num_nodes_; }
@@ -133,6 +139,7 @@ struct GroupListMsg : GroupInfoMsg<GroupMsg<::vt::PayloadMessage>> {
       in_range->getBound(),
       in_range->getSize() * sizeof(RangeType::BoundType)
     );
+    setSystemType(this->env);
   }
 
   RangeType getRange() {
@@ -157,7 +164,9 @@ struct GroupRangeMsg : GroupInfoMsg<GroupMsg<::vt::Message>> {
         in_parent_node
       ),
       group_range_(RangeDataType(*in_range))
-  { }
+  {
+    setSystemType(this->env);
+  }
 
   RangeType getRange() const { return group_range_.getRange(); }
 

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -578,15 +578,11 @@ bool ActiveMessenger::processActiveMsg(
   bool deliver = false;
   GroupActiveAttorney::groupHandler(base, from, size, false, &deliver);
 
-  auto const is_term = envelopeIsTerm(msg->env);
-
-  if (!is_term || backend_check_enabled(print_term_msgs)) {
-    debug_print(
-      active, node,
-      "processActiveMsg: msg={}, ref={}, deliver={}\n",
-      print_ptr(msg), envelopeGetRef(msg->env), print_bool(deliver)
-    );
-  }
+  debug_print_verbose(
+    active, node,
+    "handleActiveMsg: msg={}, ref={}, deliver={}\n",
+    print_ptr(msg), envelopeGetRef(msg->env), print_bool(deliver)
+  );
 
   return deliver ? deliverActiveMsg(base,from,insert) : false;
 }
@@ -598,54 +594,58 @@ bool ActiveMessenger::deliverActiveMsg(
   using MsgType = ShortMessage;
   auto msg = base.to<MsgType>().get();
 
-  auto const is_term = envelopeIsTerm(msg->env);
-  auto const is_bcast = envelopeIsBcast(msg->env);
-  auto const dest = envelopeGetDest(msg->env);
-  auto const handler = envelopeGetHandler(msg->env);
-  auto const epoch = envelopeIsEpochType(msg->env) ?
+  auto const is_term   = envelopeIsTerm(msg->env);
+  auto const is_bcast  = envelopeIsBcast(msg->env);
+  auto const dest      = envelopeGetDest(msg->env);
+  auto const handler   = envelopeGetHandler(msg->env);
+  auto const epoch     = envelopeIsEpochType(msg->env) ?
     envelopeGetEpoch(msg->env) : term::any_epoch_sentinel;
-  auto const is_tag = envelopeIsTagType(msg->env);
-  auto const tag = is_tag ? envelopeGetTag(msg->env) : no_tag;
+  auto const is_tag    = envelopeIsTagType(msg->env);
+  auto const tag       = is_tag ? envelopeGetTag(msg->env) : no_tag;
   auto const from_node = is_bcast ? dest : in_from_node;
 
-  ActiveFnPtrType active_fun = nullptr;
-
-  bool has_ex_handler = false;
-  bool const is_auto = HandlerManagerType::isHandlerAuto(handler);
-  bool const is_functor = HandlerManagerType::isHandlerFunctor(handler);
-  bool const is_obj = HandlerManagerType::isHandlerObjGroup(handler);
-
-  if (!is_term || backend_check_enabled(print_term_msgs)) {
-    debug_print(
-      active, node,
-      "deliverActiveMsg: msg={}, ref={}, is_bcast={}, epoch={:x}\n",
-      print_ptr(msg), envelopeGetRef(msg->env), print_bool(is_bcast),
-      epoch
-    );
-  }
-
-  if (is_auto and is_functor and not is_obj) {
-    active_fun = auto_registry::getAutoHandlerFunctor(handler);
-  } else if (is_auto and not is_obj) {
-    active_fun = auto_registry::getAutoHandler(handler);
-  } else if (not is_obj) {
-    auto ret = theRegistry()->getHandler(handler, tag);
-    if (ret != nullptr) {
-      has_ex_handler = true;
+  if (epoch != term::any_epoch_sentinel and epoch::EpochManip::isDep(epoch)) {
+    if (not theTerm()->epochReleased(epoch)) {
+      pending_epoch_msgs_[epoch].push_back(BufferedMsgType{base,from_node});
+      return false;
     }
   }
 
-  bool const has_handler = active_fun != no_action or has_ex_handler or is_obj;
+  ActiveFnPtrType active_fun = nullptr;
 
-  if (!is_term || backend_check_enabled(print_term_msgs)) {
-    debug_print(
-      active, node,
-      "deliverActiveMsg: msg={}, handler={:x}, tag={}, is_auto={}, "
-      "is_functor={}, is_obj_group={}, has_handler={}, insert={}\n",
-      print_ptr(msg), handler, tag, is_auto, is_functor, is_obj,
-      has_handler, insert
-    );
+  bool const is_auto    = HandlerManagerType::isHandlerAuto(handler);
+  bool const is_functor = HandlerManagerType::isHandlerFunctor(handler);
+  bool const is_obj     = HandlerManagerType::isHandlerObjGroup(handler);
+
+  debug_print_verbose(
+    active, node,
+    "deliverActiveMsg: msg={}, ref={}, is_bcast={}, epoch={:x}\n",
+    print_ptr(msg), envelopeGetRef(msg->env), print_bool(is_bcast),
+    epoch
+  );
+
+  bool has_handler = is_auto or is_functor or is_obj;
+
+  if (not has_handler) {
+    auto const manual_handler = theRegistry()->getHandler(handler, tag);
+    has_handler = manual_handler != nullptr;
   }
+
+  if (not is_obj) {
+    if (is_auto and is_functor) {
+      active_fun = auto_registry::getAutoHandlerFunctor(handler);
+    } else if (is_auto) {
+      active_fun = auto_registry::getAutoHandler(handler);
+    }
+  }
+
+  debug_print_verbose(
+    active, node,
+    "deliverActiveMsg: msg={}, handler={:x}, tag={}, is_auto={}, "
+    "is_functor={}, is_obj_group={}, has_handler={}, insert={}\n",
+    print_ptr(msg), handler, tag, is_auto, is_functor, is_obj,
+    has_handler, insert
+  );
 
   if (has_handler) {
     // the epoch_stack_ size after the epoch on the active message, if included
@@ -701,20 +701,22 @@ bool ActiveMessenger::deliverActiveMsg(
     }
   } else {
     if (insert) {
-      auto iter = pending_handler_msgs_.find(handler);
-      if (iter == pending_handler_msgs_.end()) {
-        pending_handler_msgs_.emplace(
-          std::piecewise_construct,
-          std::forward_as_tuple(handler),
-          std::forward_as_tuple(MsgContType{BufferedMsgType{base,from_node}})
-        );
-      } else {
-        iter->second.push_back(BufferedMsgType{base,from_node});
-      }
+      pending_handler_msgs_[handler].push_back(BufferedMsgType{base,from_node});
     }
   }
 
   return has_handler;
+}
+
+void ActiveMessenger::releaseEpochMsgs(EpochType epoch) {
+  auto iter = pending_epoch_msgs_.find(epoch);
+  if (iter != pending_epoch_msgs_.end()) {
+    auto msgs = std::move(iter->second);
+    pending_epoch_msgs_.erase(iter);
+    for (auto&& m : msgs) {
+      deliverActiveMsg(m.buffered_msg, m.from_node, true);
+    }
+  }
 }
 
 bool ActiveMessenger::tryProcessIncomingActiveMsg() {

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -609,7 +609,7 @@ bool ActiveMessenger::deliverActiveMsg(
 
   if (not is_any and not is_obj and epoch::EpochManip::isDep(epoch)) {
     if (not theTerm()->epochReleased(epoch)) {
-      pending_epoch_msgs_[epoch].push_back(BufferedMsgType{base,from_node});
+      pending_epoch_msgs_[epoch].push_back(BufferedMsgType{base,in_from_node});
       return false;
     }
   }
@@ -621,9 +621,9 @@ bool ActiveMessenger::deliverActiveMsg(
 
   debug_print_verbose(
     active, node,
-    "deliverActiveMsg: msg={}, ref={}, is_bcast={}, epoch={:x}\n",
+    "deliverActiveMsg: msg={}, ref={}, is_bcast={}, epoch={:x}, from={}\n",
     print_ptr(msg), envelopeGetRef(msg->env), print_bool(is_bcast),
-    epoch
+    epoch, in_from_node
   );
 
   bool has_handler = is_auto or is_functor or is_obj;
@@ -644,9 +644,9 @@ bool ActiveMessenger::deliverActiveMsg(
   debug_print_verbose(
     active, node,
     "deliverActiveMsg: msg={}, handler={:x}, tag={}, is_auto={}, "
-    "is_functor={}, is_obj_group={}, has_handler={}, insert={}\n",
+    "is_functor={}, is_obj_group={}, has_handler={}, insert={}, from={}\n",
     print_ptr(msg), handler, tag, is_auto, is_functor, is_obj,
-    has_handler, insert
+    has_handler, insert, in_from_node
   );
 
   if (has_handler) {
@@ -698,12 +698,12 @@ bool ActiveMessenger::deliverActiveMsg(
     }
 
     if (not is_term) {
-      theTerm()->consume(epoch,1,from_node);
+      theTerm()->consume(epoch,1,in_from_node);
       theTerm()->hangDetectRecv();
     }
   } else {
     if (insert) {
-      pending_handler_msgs_[handler].push_back(BufferedMsgType{base,from_node});
+      pending_handler_msgs_[handler].push_back(BufferedMsgType{base,in_from_node});
     }
   }
 

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -604,7 +604,10 @@ bool ActiveMessenger::deliverActiveMsg(
   auto const tag       = is_tag ? envelopeGetTag(msg->env) : no_tag;
   auto const from_node = is_bcast ? dest : in_from_node;
 
-  if (epoch != term::any_epoch_sentinel and epoch::EpochManip::isDep(epoch)) {
+  bool const is_any    = epoch == term::any_epoch_sentinel;
+  bool const is_obj    = HandlerManagerType::isHandlerObjGroup(handler);
+
+  if (not is_any and not is_obj and epoch::EpochManip::isDep(epoch)) {
     if (not theTerm()->epochReleased(epoch)) {
       pending_epoch_msgs_[epoch].push_back(BufferedMsgType{base,from_node});
       return false;
@@ -615,7 +618,6 @@ bool ActiveMessenger::deliverActiveMsg(
 
   bool const is_auto    = HandlerManagerType::isHandlerAuto(handler);
   bool const is_functor = HandlerManagerType::isHandlerFunctor(handler);
-  bool const is_obj     = HandlerManagerType::isHandlerObjGroup(handler);
 
   debug_print_verbose(
     active, node,

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -601,13 +601,14 @@ bool ActiveMessenger::deliverActiveMsg(
   auto const epoch     = envelopeIsEpochType(msg->env) ?
     envelopeGetEpoch(msg->env) : term::any_epoch_sentinel;
   auto const is_tag    = envelopeIsTagType(msg->env);
+  auto const is_sys    = envelopeIsSystemType(msg->env);
   auto const tag       = is_tag ? envelopeGetTag(msg->env) : no_tag;
   auto const from_node = is_bcast ? dest : in_from_node;
 
   bool const is_any    = epoch == term::any_epoch_sentinel;
   bool const is_obj    = HandlerManagerType::isHandlerObjGroup(handler);
 
-  if (not is_any and not is_obj and epoch::EpochManip::isDep(epoch)) {
+  if (not is_any and not is_obj and not is_sys and epoch::EpochManip::isDep(epoch)) {
     if (not theTerm()->epochReleased(epoch)) {
       pending_epoch_msgs_[epoch].push_back(BufferedMsgType{base,in_from_node});
       return false;

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -674,6 +674,7 @@ private:
   EpochType global_epoch_                                   = no_epoch;
   MaybeReadyType maybe_ready_tag_han_                       = {};
   ContWaitType pending_handler_msgs_                        = {};
+  EpochWaitType pending_epoch_msgs_                         = {};
   ContainerPendingType pending_recvs_                       = {};
   TagType cur_direct_buffer_tag_                            = starting_direct_buffer_tag;
   EpochStackType epoch_stack_;

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -167,6 +167,7 @@ struct ActiveMessenger {
   using ContainerPendingType = std::unordered_map<TagType,PendingRecvType>;
   using MsgContType          = std::list<BufferedMsgType>;
   using ContWaitType         = std::unordered_map<HandlerType, MsgContType>;
+  using EpochWaitType        = std::unordered_map<EpochType, MsgContType>;
   using ReadyHanTagType      = std::tuple<HandlerType, TagType>;
   using MaybeReadyType       = std::vector<ReadyHanTagType>;
   using HandlerManagerType   = HandlerManager;
@@ -637,6 +638,11 @@ struct ActiveMessenger {
     send_listen_.clear();
   }
 
+  /*
+   * Deliver messages that are now released with a dependent epoch
+   */
+  void releaseEpochMsgs(EpochType epoch);
+
 private:
   bool testPendingActiveMsgAsyncRecv();
   bool testPendingDataMsgAsyncRecv();
@@ -660,16 +666,16 @@ private:
     trace::UserEventIDType trace_isend     = 0;
   #endif
 
-  HandlerType current_handler_context_                    = uninitialized_handler;
-  NodeType current_node_context_                          = uninitialized_destination;
-  EpochType current_epoch_context_                        = no_epoch;
-  PriorityType current_priority_context_                  = no_priority;
-  PriorityLevelType current_priority_level_context_       = no_priority_level;
-  EpochType global_epoch_                                 = no_epoch;
-  MaybeReadyType maybe_ready_tag_han_                     = {};
-  ContWaitType pending_handler_msgs_                      = {};
-  ContainerPendingType pending_recvs_                     = {};
-  TagType cur_direct_buffer_tag_                          = starting_direct_buffer_tag;
+  HandlerType current_handler_context_                      = uninitialized_handler;
+  NodeType current_node_context_                            = uninitialized_destination;
+  EpochType current_epoch_context_                          = no_epoch;
+  PriorityType current_priority_context_                    = no_priority;
+  PriorityLevelType current_priority_level_context_         = no_priority_level;
+  EpochType global_epoch_                                   = no_epoch;
+  MaybeReadyType maybe_ready_tag_han_                       = {};
+  ContWaitType pending_handler_msgs_                        = {};
+  ContainerPendingType pending_recvs_                       = {};
+  TagType cur_direct_buffer_tag_                            = starting_direct_buffer_tag;
   EpochStackType epoch_stack_;
   std::vector<ListenerType> send_listen_                    = {};
   IRecvHolder<InProgressIRecv> in_progress_active_msg_irecv = {};

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -159,6 +159,12 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgSz(
   if (tag != no_tag) {
     envelopeSetTag(msg->env, tag);
   }
+
+  auto const is_epoch = envelopeIsEpochType(msg->env);
+  if (is_epoch) {
+    setupEpochMsg(msg);
+  }
+
   return sendMsgSz(this_node, han, msg, msg_size);
 }
 
@@ -200,6 +206,12 @@ ActiveMessenger::sendMsgSz(
   if (tag != no_tag) {
     envelopeSetTag(msg->env, tag);
   }
+
+  auto const is_epoch = envelopeIsEpochType(msg->env);
+  if (is_epoch) {
+    setupEpochMsg(msg);
+  }
+
   auto base = promoteMsg(msg).template to<BaseMsgType>();;
   return PendingSendType(base, msg_size);
 }

--- a/src/vt/messaging/envelope/envelope_set.h
+++ b/src/vt/messaging/envelope/envelope_set.h
@@ -75,6 +75,9 @@ template <typename Env>
 inline void setTagType(Env& env);
 
 template <typename Env>
+inline void setSystemType(Env& env);
+
+template <typename Env>
 inline void envelopeSetHandler(Env& env, HandlerType const& handler);
 
 template <typename Env>

--- a/src/vt/messaging/envelope/envelope_set.impl.h
+++ b/src/vt/messaging/envelope/envelope_set.impl.h
@@ -87,6 +87,11 @@ inline void setTagType(Env& env) {
 }
 
 template <typename Env>
+inline void setSystemType(Env& env) {
+  reinterpret_cast<Envelope*>(&env)->type |= 1 << eEnvType::EnvSystem;
+}
+
+template <typename Env>
 inline void envelopeSetHandler(Env& env, HandlerType const& handler) {
   reinterpret_cast<Envelope*>(&env)->han = handler;
 }

--- a/src/vt/messaging/envelope/envelope_test.h
+++ b/src/vt/messaging/envelope/envelope_test.h
@@ -70,6 +70,9 @@ inline bool envelopeIsEpochType(Env const& env);
 template <typename Env>
 inline bool envelopeIsTagType(Env const& env);
 
+template <typename Env>
+inline bool envelopeIsSystemType(Env const& env);
+
 }} //end namespace vt::messaging
 
 #include "vt/messaging/envelope/envelope_test.impl.h"

--- a/src/vt/messaging/envelope/envelope_test.impl.h
+++ b/src/vt/messaging/envelope/envelope_test.impl.h
@@ -88,6 +88,12 @@ inline bool envelopeIsTagType(Env const& env) {
     (1 << eEnvType::EnvTagType);
 }
 
+template <typename Env>
+inline bool envelopeIsSystemType(Env const& env) {
+  return reinterpret_cast<Envelope const*>(&env)->type &
+    (1 << eEnvType::EnvSystem);
+}
+
 }} //end namespace vt::messaging
 
 #endif /*INCLUDED_MESSAGING_ENVELOPE_ENVELOPE_TEST_IMPL_H*/

--- a/src/vt/messaging/envelope/envelope_type.h
+++ b/src/vt/messaging/envelope/envelope_type.h
@@ -64,7 +64,8 @@ enum eEnvelopeType {
   EnvBroadcast = 3,
   EnvEpochType = 4,
   EnvTagType   = 5,
-  EnvPackedPut = 6
+  EnvPackedPut = 6,
+  EnvSystem    = 7
 };
 
 static constexpr BitCountType const envelope_num_bits = 8;

--- a/src/vt/messaging/pending_send.cc
+++ b/src/vt/messaging/pending_send.cc
@@ -53,8 +53,26 @@ void PendingSend::sendMsg() {
   } else {
     send_action_(msg_);
   }
+  produceConsumeMsg(PendingTermEnum::Consume);
   msg_ = nullptr;
   send_action_ = nullptr;
+}
+
+void PendingSend::produceConsumeMsg(PendingTermEnum op) {
+  if (msg_ != nullptr) {
+    auto const is_epoch = envelopeIsEpochType(msg_->env);
+    auto const is_term = envelopeIsTerm(msg_->env);
+    if (is_epoch and not is_term) {
+      auto ep = envelopeGetEpoch(msg_->env);
+      if (ep != no_epoch and ep != term::any_epoch_sentinel) {
+        if (op == PendingTermEnum::Produce) {
+          theTerm()->produce(ep,1);
+        } else {
+          theTerm()->consume(ep,1);
+        }
+      }
+    }
+  }
 }
 
 }}

--- a/src/vt/messaging/pending_send.cc
+++ b/src/vt/messaging/pending_send.cc
@@ -63,10 +63,12 @@ void PendingSend::produceConsumeMsg(PendingTermEnum op) {
     auto const is_epoch = envelopeIsEpochType(msg_->env);
     auto const is_term = envelopeIsTerm(msg_->env);
     if (is_epoch and not is_term) {
-      auto ep = envelopeGetEpoch(msg_->env);
+      bool const is_produce = op == PendingTermEnum::Produce;
+      auto const ep = is_produce ? envelopeGetEpoch(msg_->env) : epoch_produced_;
       if (ep != no_epoch and ep != term::any_epoch_sentinel) {
-        if (op == PendingTermEnum::Produce) {
+        if (is_produce) {
           theTerm()->produce(ep,1);
+          epoch_produced_ = ep;
         } else {
           theTerm()->consume(ep,1);
         }

--- a/src/vt/messaging/pending_send.h
+++ b/src/vt/messaging/pending_send.h
@@ -56,16 +56,24 @@ namespace vt { namespace messaging {
 struct PendingSend final {
   using SendActionType = std::function<void(MsgVirtualPtr<BaseMsgType>)>;
 
+  enum PendingTermEnum { Produce, Consume };
+
   PendingSend(MsgSharedPtr<BaseMsgType> const& in_msg, ByteType const& in_msg_size)
     : msg_(in_msg.template toVirtual<BaseMsgType>())
     , msg_size_(in_msg_size)
-  { }
+  {
+    produceConsumeMsg(PendingTermEnum::Produce);
+  }
   template <typename MsgT>
   PendingSend(MsgSharedPtr<MsgT> in_msg, SendActionType const& in_action)
     : msg_(in_msg.template toVirtual<BaseMsgType>())
     , msg_size_(sizeof(MsgT))
     , send_action_(in_action)
-  { }
+  {
+    produceConsumeMsg(PendingTermEnum::Produce);
+  }
+
+  void produceConsumeMsg(PendingTermEnum op);
 
   explicit PendingSend(std::nullptr_t) { }
   PendingSend(PendingSend&& in)

--- a/src/vt/messaging/pending_send.h
+++ b/src/vt/messaging/pending_send.h
@@ -79,7 +79,8 @@ struct PendingSend final {
   PendingSend(PendingSend&& in)
     : msg_(std::move(in.msg_)),
       msg_size_(std::move(in.msg_size_)),
-      send_action_(std::move(in.send_action_))
+      send_action_(std::move(in.send_action_)),
+      epoch_produced_(std::move(in.epoch_produced_))
   {
     in.msg_ = nullptr;
     in.send_action_ = nullptr;
@@ -105,6 +106,7 @@ private:
   MsgVirtualPtr<BaseMsgType> msg_ = nullptr;
   ByteType msg_size_ = no_byte;
   SendActionType send_action_ = nullptr;
+  EpochType epoch_produced_ = no_epoch;
 };
 
 }} /* end namespace vt::messaging */

--- a/src/vt/objgroup/dispatch/dispatch.h
+++ b/src/vt/objgroup/dispatch/dispatch.h
@@ -50,6 +50,8 @@
 #include "vt/objgroup/dispatch/dispatch_base.h"
 #include "vt/messaging/message/smart_ptr.h"
 
+#include <functional>
+
 namespace vt { namespace objgroup { namespace dispatch {
 
 template <typename ObjT>
@@ -59,13 +61,23 @@ struct Dispatch final : DispatchBase {
   Dispatch(Dispatch&&) = default;
 
   Dispatch(ObjGroupProxyType in_proxy, ObjT* in_obj)
-    : DispatchBase(in_proxy), obj_(in_obj)
+    : DispatchBase(
+        in_proxy,
+        std::bind(&Dispatch<ObjT>::release, this, std::placeholders::_1)
+      ),
+      obj_(in_obj)
   { }
 
   virtual ~Dispatch() = default;
 
-  void run(HandlerType han, BaseMessage* msg) override;
+
   void* objPtr() const override  { return obj_; }
+
+  void release(MsgVirtualPtrAny msg) {
+    run(envelopeGetHandler(msg->env),msg);
+  }
+
+  void run(HandlerType han, MsgVirtualPtrAny msg) override;
 
 private:
   ObjT* obj_ = nullptr;

--- a/src/vt/objgroup/manager.cc
+++ b/src/vt/objgroup/manager.cc
@@ -79,7 +79,7 @@ void ObjGroupManager::dispatch(MsgVirtualPtrAny msg, HandlerType han) {
     }
     pending_[proxy].push_back(msg);
   } else {
-    dispatch_iter->second->run(han,msg.get());
+    dispatch_iter->second->run(han,msg);
   }
 }
 

--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -53,6 +53,7 @@
 #include "vt/objgroup/holder/holder_user.h"
 #include "vt/objgroup/holder/holder_basic.h"
 #include "vt/objgroup/dispatch/dispatch.h"
+#include "vt/objgroup/system_msg.h"
 #include "vt/messaging/message/message.h"
 #include "vt/messaging/message/smart_ptr.h"
 
@@ -143,6 +144,19 @@ struct ObjGroupManager {
   EpochType reduce(
     ProxyType<ObjT> proxy, MsgSharedPtr<MsgT> msg, EpochType epoch, TagType tag
   );
+
+  /*
+   * Manage dependent epochs for a given element
+   */
+
+  template <typename ObjT>
+  bool isReleased(ProxyElmType<ObjT> proxy, EpochType const& epoch);
+  template <typename ObjT>
+  void whenReleased(ProxyElmType<ObjT> proxy, EpochType const& epoch, ActionType act);
+  template <typename ObjT>
+  void release(ProxyElmType<ObjT> proxy, EpochType const& epoch);
+  template <typename ObjT>
+  static void releaseHan(ReleaseMsg<ObjT>* msg);
 
   /*
    * Get access to the local instance of a particular object group

--- a/src/vt/objgroup/manager.impl.h
+++ b/src/vt/objgroup/manager.impl.h
@@ -313,10 +313,12 @@ void ObjGroupManager::release(ProxyElmType<ObjT> elm, EpochType const& epoch) {
   if (node == this_node) {
     auto iter = dispatch_.find(proxy);
     vtAssert(iter != dispatch_.end(), "Dispatcher must exist");
-    iter->second->release(epoch);
+    iter->second->releaseEpoch(epoch);
   } else {
     auto msg = makeMessage<ReleaseMsg<ObjT>>(elm,epoch);
-    theMsg()->sendMsg<ReleaseMsg<ObjT>,ObjGroupManager::releaseHan<ObjT>>(node,msg);
+    theMsg()->sendMsg<ReleaseMsg<ObjT>,ObjGroupManager::releaseHan<ObjT>>(
+      node,msg.get()
+    );
   }
 }
 

--- a/src/vt/objgroup/proxy/proxy_objgroup_elm.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup_elm.h
@@ -88,6 +88,13 @@ struct ProxyElm {
   ObjGroupProxyType getProxy() const { return proxy_; }
   NodeType getNode() const { return node_; }
 
+  /*
+   * Proxy operations for releasing dependent epochs
+   */
+  bool isReleased(EpochType const& epoch);
+  void whenReleased(EpochType const& epoch, ActionType action);
+  void release(EpochType const& epoch);
+
 public:
   template <typename SerializerT>
   void serialize(SerializerT& s);

--- a/src/vt/objgroup/proxy/proxy_objgroup_elm.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup_elm.impl.h
@@ -90,6 +90,24 @@ ObjT* ProxyElm<ObjT>::get() const {
   return theObjGroup()->get<ObjT>(proxy);
 }
 
+template <typename ObjT>
+bool ProxyElm<ObjT>::isReleased(EpochType const& epoch) {
+  auto proxy = ProxyElm<ObjT>(*this);
+  return theObjGroup()->isReleased<ObjT>(proxy,epoch);
+}
+
+template <typename ObjT>
+void ProxyElm<ObjT>::whenReleased(EpochType const& epoch, ActionType action) {
+  auto proxy = ProxyElm<ObjT>(*this);
+  return theObjGroup()->whenReleased<ObjT>(proxy,epoch,action);
+}
+
+template <typename ObjT>
+void ProxyElm<ObjT>::release(EpochType const& epoch) {
+  auto proxy = ProxyElm<ObjT>(*this);
+  return theObjGroup()->release<ObjT>(proxy,epoch);
+}
+
 }}} /* end namespace vt::objgroup::proxy */
 
 #endif /*INCLUDED_VT_OBJGROUP_PROXY_PROXY_OBJGROUP_ELM_IMPL_H*/

--- a/src/vt/objgroup/system_msg.h
+++ b/src/vt/objgroup/system_msg.h
@@ -1,0 +1,68 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          system_msg.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_OBJGROUP_SYSTEM_MSG_H
+#define INCLUDED_VT_OBJGROUP_SYSTEM_MSG_H
+
+#include "vt/config.h"
+#include "vt/messaging/message/message.h"
+#include "vt/objgroup/proxy/proxy_objgroup_elm.h"
+
+namespace vt { namespace objgroup {
+
+template <typename ObjT>
+struct ReleaseMsg : vt::Message {
+
+  ReleaseMsg() = default;
+  ReleaseMsg(proxy::ProxyElm<ObjT> in_proxy, EpochType in_epoch)
+    : proxy_(in_proxy), epoch_(in_epoch)
+  { }
+
+  proxy::ProxyElm<ObjT> proxy_ = {};
+  EpochType epoch_ = no_epoch;
+};
+
+}} /* end namespace vt::objgroup */
+
+#endif /*INCLUDED_VT_OBJGROUP_SYSTEM_MSG_H*/

--- a/src/vt/termination/interval/category_map.h
+++ b/src/vt/termination/interval/category_map.h
@@ -1,0 +1,88 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          category_map.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_TERMINATION_INTERVAL_CATEGORY_MAP_H
+#define INCLUDED_VT_TERMINATION_INTERVAL_CATEGORY_MAP_H
+
+#include "vt/config.h"
+#include "vt/epoch/epoch.h"
+
+namespace vt { namespace term { namespace interval {
+
+struct CategoryMap {
+
+  CategoryMap() = default;
+
+  EpochType categorize(EpochType const& epoch) const {
+    auto cat_epoch = epoch;
+    epoch::EpochManip::setSeq(cat_epoch,0);
+    return cat_epoch;
+  }
+
+  vt::IntegralSet<EpochType>& get(EpochType const& epoch) {
+    auto cat = categorize(epoch);
+    return map_[cat];
+  }
+
+  void cleanup(EpochType const& epoch) {
+    auto cat = categorize(epoch);
+    auto iter = map_.find(cat);
+    if (iter != map_.end() and iter->second.empty()) {
+      map_.erase(iter);
+    }
+  }
+
+private:
+  std::unordered_map<EpochType, vt::IntegralSet<EpochType>> map_ = {};
+};
+
+}}} /* end namespace vt::term::interval */
+
+namespace vt {
+
+using EpochCategoryMap = term::interval::CategoryMap;
+
+} /* end namespace vt */
+
+#endif /*INCLUDED_VT_TERMINATION_INTERVAL_CATEGORY_MAP_H*/

--- a/src/vt/termination/interval/category_map.h
+++ b/src/vt/termination/interval/category_map.h
@@ -83,6 +83,11 @@ struct CategoryMap {
     }
   }
 
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | map_;
+  }
+
 private:
   std::unordered_map<EpochType, vt::IntegralSet<EpochType>> map_ = {};
 };

--- a/src/vt/termination/interval/category_map.h
+++ b/src/vt/termination/interval/category_map.h
@@ -62,7 +62,17 @@ struct CategoryMap {
 
   vt::IntegralSet<EpochType>& get(EpochType const& epoch) {
     auto cat = categorize(epoch);
-    return map_[cat];
+    auto iter = map_.find(cat);
+    if (iter == map_.end()) {
+      map_.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(cat),
+        std::forward_as_tuple(vt::IntegralSet<EpochType>(cat))
+      );
+      iter = map_.find(cat);
+    }
+    vtAssertExpr(iter != map_.end());
+    return iter->second;
   }
 
   void cleanup(EpochType const& epoch) {

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -69,12 +69,21 @@ struct EpochReleaseSet {
   void release(EpochType const& epoch) {
     debug_print(
       gen, node,
-      "release: epoch={:x}\n",
-      epoch
+      "({}): release: epoch={:x}\n",
+      print_ptr(this), epoch
     );
 
-    // Insert into integral set
-    map_.get(epoch).insert(epoch);
+    auto exists = map_.get(epoch).exists(epoch);
+    if (not exists) {
+      // Insert into integral set
+      map_.get(epoch).insert(epoch);
+    } else {
+      debug_print(
+        gen, node,
+        "({}): release: trying to release epoch={:x} again!\n",
+        print_ptr(this), epoch
+      );
+    }
 
     // Trigger functions on the buffered messages with released epoch
     auto iter = wait_.find(epoch);

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -64,6 +64,12 @@ struct EpochReleaseSet {
   explicit EpochReleaseSet(ReleaseFnType in_fn) : release_fn_(in_fn) { }
 
   void release(EpochType const& epoch) {
+    debug_print(
+      gen, node,
+      "release: epoch={:x}\n",
+      epoch
+    );
+
     // Insert into integral set
     map_.get(epoch).insert(epoch);
 
@@ -73,6 +79,12 @@ struct EpochReleaseSet {
       auto lst = std::move(iter->second);
       wait_.erase(iter);
       for (auto&& msg : lst) {
+        debug_print(
+          gen, node,
+          "release: epoch={:x}, running msg={}, consume\n",
+          epoch, print_ptr(msg.get())
+        );
+
         release_fn_(msg);
         theTerm()->consume(epoch);
       }
@@ -132,6 +144,12 @@ struct EpochReleaseSet {
   }
 
   void buffer(EpochType const& epoch, MsgVirtualPtrAny msg) {
+    debug_print(
+      gen, node,
+      "buffer: epoch={:x}, buffering msg={}, produce, num={}\n",
+      epoch, print_ptr(msg.get()), wait_[epoch].size()
+    );
+
     theTerm()->produce(epoch);
     wait_[epoch].push_back(msg);
   }

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -64,6 +64,8 @@ struct EpochReleaseSet {
   EpochReleaseSet() = default;
   explicit EpochReleaseSet(ReleaseFnType in_fn) : release_fn_(in_fn) { }
 
+  void setReleaseFn(ReleaseFnType in_fn) { release_fn_ = in_fn; }
+
   void release(EpochType const& epoch) {
     debug_print(
       gen, node,

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -1,0 +1,141 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          epoch_release_set.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_TERMINATION_INTERVAL_EPOCH_RELEASE_SET_H
+#define INCLUDED_VT_TERMINATION_INTERVAL_EPOCH_RELEASE_SET_H
+
+#include "vt/config.h"
+#include "vt/termination/interval/integral_set.h"
+#include "vt/termination/interval/category_map.h"
+#include "vt/termination/termination.h"
+#include "vt/epoch/epoch.h"
+
+#include <tuple>
+#include <unordered_map>
+#include <list>
+#include <functional>
+
+namespace vt { namespace term { namespace interval {
+
+struct EpochReleaseSet {
+  using ReleaseFnType = std::function<void(MsgVirtualPtrAny)>;
+
+  explicit EpochReleaseSet(ReleaseFnType in_fn) : release_fn_(in_fn) { }
+
+  void release(EpochType const& epoch) {
+    // Insert into integral set
+    map_.get(epoch).insert(epoch);
+
+    // Trigger functions on the buffered messages with released epoch
+    auto iter = wait_.find(epoch);
+    if (iter != wait_.end()) {
+      auto lst = std::move(iter->second);
+      wait_.erase(iter);
+      for (auto&& msg : lst) {
+        release_fn_(msg);
+        theTerm()->consume(epoch);
+      }
+    }
+
+    // Trigger actions waiting for epoch release
+    auto iter2 = action_.find(epoch);
+    if (iter2 != action_.end()) {
+      auto lst = std::move(iter2->second);
+      action_.erase(iter2);
+      for (auto&& fn : lst) { fn(); }
+    }
+
+    // Add an action for cleaning up the epoch after termination
+    theTerm()->addAction(epoch, [this,epoch]{ notifyTerminated(epoch); });
+  }
+
+  bool isReleased(EpochType const& epoch) {
+    bool const is_dep = epoch::EpochManip::isDep(epoch);
+    if (is_dep) {
+      bool const is_term = theTerm()->isTerm(epoch);
+      if (is_term) {
+        return true;
+      } else {
+        return map_.get(epoch).exists(epoch);
+      }
+    } else {
+      return true;
+    }
+  }
+
+  void notifyTerminated(EpochType const& epoch) {
+    map_.get(epoch).erase(epoch);
+    map_.cleanup(epoch);
+  }
+
+  void buffer(EpochType const& epoch, MsgVirtualPtrAny msg) {
+    theTerm()->produce(epoch);
+    wait_[epoch].push_back(msg);
+  }
+
+  void whenReleased(EpochType const& epoch, ActionType action) {
+    if (isReleased(epoch)) {
+      action();
+    } else {
+      action_[epoch].push_back(action);
+    }
+  }
+
+private:
+  vt::EpochCategoryMap                                      map_        = {};
+  std::unordered_map<EpochType,std::list<MsgVirtualPtrAny>> wait_       = {};
+  std::unordered_map<EpochType,std::list<ActionType>>       action_     = {};
+  ReleaseFnType                                             release_fn_ = {};
+};
+
+}}} /* end namespace vt::term::interval */
+
+namespace vt {
+
+using EpochReleaseSet = term::interval::EpochReleaseSet;
+
+} /* end namespace vt */
+
+
+#endif /*INCLUDED_VT_TERMINATION_INTERVAL_EPOCH_RELEASE_SET_H*/

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -61,6 +61,7 @@ namespace vt { namespace term { namespace interval {
 struct EpochReleaseSet {
   using ReleaseFnType = std::function<void(MsgVirtualPtrAny)>;
 
+  EpochReleaseSet() = default;
   explicit EpochReleaseSet(ReleaseFnType in_fn) : release_fn_(in_fn) { }
 
   void release(EpochType const& epoch) {
@@ -159,6 +160,18 @@ struct EpochReleaseSet {
       action();
     } else {
       action_[epoch].push_back(action);
+    }
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    if (not s.isUnpacking()) {
+      vtAssertExpr(wait_.size() == 0);
+      vtAssertExpr(action_.size() == 0);
+    }
+    s | map_;
+    if (s.isUnpacking()) {
+      release_fn_ = nullptr;
     }
   }
 

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -92,12 +92,34 @@ struct EpochReleaseSet {
 
   bool isReleased(EpochType const& epoch) {
     bool const is_dep = epoch::EpochManip::isDep(epoch);
+
+    debug_print(
+      gen, node,
+      "isReleased: epoch={:x}, is_dep={}\n",
+      epoch, is_dep
+    );
+
     if (is_dep) {
       bool const is_term = theTerm()->isTerm(epoch);
+
+      debug_print(
+        gen, node,
+        "isReleased: epoch={:x}, is_dep={}, is_term={}\n",
+        epoch, is_dep, is_term
+      );
+
       if (is_term) {
         return true;
       } else {
-        return map_.get(epoch).exists(epoch);
+        auto exists = map_.get(epoch).exists(epoch);
+
+        debug_print(
+          gen, node,
+          "isReleased: epoch={:x}, is_dep={}, exists={}\n",
+          epoch, is_dep, exists
+        );
+
+        return exists;
       }
     } else {
       return true;

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -151,7 +151,10 @@ struct EpochReleaseSet {
   }
 
   void notifyTerminated(EpochType const& epoch) {
-    map_.get(epoch).erase(epoch);
+    auto exists = map_.get(epoch).exists(epoch);
+    if (exists) {
+      map_.get(epoch).erase(epoch);
+    }
     map_.cleanup(epoch);
   }
 

--- a/src/vt/termination/interval/epoch_release_set.h
+++ b/src/vt/termination/interval/epoch_release_set.h
@@ -66,7 +66,7 @@ struct EpochReleaseSet {
 
   void setReleaseFn(ReleaseFnType in_fn) { release_fn_ = in_fn; }
 
-  void release(EpochType const& epoch) {
+  void release(EpochType epoch) {
     debug_print(
       gen, node,
       "({}): release: epoch={:x}\n",

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -138,7 +138,7 @@ struct IntegralSetBase {
     debug_print(
       gen, node,
       "OrderedSet: insertInterval: bounds=[{:x},{:x}] elms_={}, i={}, is_end={}\n",
-      lb_, ub_, elms_, i, hint_ == set_.end()
+      lb_, ub_, elms_, i.lower(), hint_ == set_.end()
     );
 
     auto iter = elms_ == 0 ? set_.end() : hint_;
@@ -184,7 +184,7 @@ struct IntegralSetBase {
     debug_print(
       gen, node,
       "OrderedSet: erase: bounds=[{:x},{:x}] size={}, comp={}, val={}, in={}\n",
-      lb_, ub_, size(), compressedSize(), j, in_set
+      lb_, ub_, size(), compressedSize(), j.lower(), in_set
     );
     vtAssert(in_set, "The element must exist in a interval bucket");
     if (in_set) {
@@ -269,7 +269,7 @@ private:
     debug_print(
       gen, node,
       "OrderedSet: insertSet: bounds=[{:x},{:x}] elms_={}, i={}, is_end={}\n",
-      lb_, ub_, elms_, i, it == set_.end()
+      lb_, ub_, elms_, i.lower(), it == set_.end()
     );
 
     // Insert into the set
@@ -309,8 +309,8 @@ private:
   void insertGlobal(IntervalType const& i) {
     debug_print(
       gen, node,
-      "OrderedSet: insertGlobal: bounds=[{:x},{:x}] elms_={}, i={}\n",
-      lb_, ub_, elms_, i
+      "OrderedSet: insertGlobal: bounds=[{:x},{:x}] elms_={}\n",
+      lb_, ub_, elms_
     );
 
     if (elms_ == 0) {

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -1154,7 +1154,7 @@ void TerminationDetector::runReleaseEpochActions(EpochType epoch) {
 void TerminationDetector::onReleaseEpoch(EpochType epoch, ActionType action) {
   // Run an action if an epoch has been released
   bool const is_dep = isDep(epoch);
-  if (not is_dep or (is_dep and epochReleased(epoch))) {
+  if (not is_dep or  epochReleased(epoch)) {
     action();
   } else {
     epoch_release_action_[epoch].push_back(action);

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -107,9 +107,15 @@ EpochType TerminationDetector::getArchetype(EpochType const& epoch) const {
 }
 
 EpochWindow* TerminationDetector::getWindow(EpochType const& epoch) {
-  auto const is_rooted = epoch::EpochManip::isRooted(epoch);
-  if (is_rooted) {
-    auto const& arch_epoch = getArchetype(epoch);
+  auto const arch_epoch = getArchetype(epoch);
+
+  debug_print_verbose(
+    term, node,
+    "getWindow: epoch={:x}, rooted={}, isDep={}, arch_epoch={:x}\n",
+    epoch, isRooted(epoch), isDep(epoch), arch_epoch
+  );
+
+  if (arch_epoch != 0) {
     auto iter = epoch_arch_.find(arch_epoch);
     if (iter == epoch_arch_.end()) {
       epoch_arch_.emplace(
@@ -1164,6 +1170,11 @@ bool TerminationDetector::epochReleased(EpochType epoch) {
   if (not is_dep) {
     return true;
   }
+
+  debug_print(
+    term, node,
+    "epochReleased: epoch={:x}, is_dep={}\n", epoch, is_dep
+  );
 
   // Terminated epochs are always released
   bool const is_term = getWindow(epoch)->isTerminated(epoch);

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -1205,6 +1205,10 @@ TerminationDetector::getParents(EpochType epoch) {
   }
 }
 
+bool TerminationDetector::isTerm(EpochType epoch) {
+  return getWindow(epoch)->isTerminated(epoch);
+}
+
 void TerminationDetector::cleanupReleasedEpoch(EpochType epoch) {
   bool const is_dep = isDep(epoch);
   if (is_dep) {

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -116,6 +116,7 @@ struct TerminationDetector :
   bool isRooted(EpochType epoch) const;
   bool isDS(EpochType epoch) const;
   bool isDep(EpochType epoch) const;
+  bool isTerm(EpochType epoch);
 
   TermStateDSType* getDSTerm(EpochType epoch, bool is_root = false);
 

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -110,8 +110,13 @@ struct TerminationDetector :
   friend struct TermState;
   friend struct EpochDependency;
 
-  bool isRooted(EpochType epoch);
-  bool isDS(EpochType epoch);
+  /*
+   * Test different types of epochs
+   */
+  bool isRooted(EpochType epoch) const;
+  bool isDS(EpochType epoch) const;
+  bool isDep(EpochType epoch) const;
+
   TermStateDSType* getDSTerm(EpochType epoch, bool is_root = false);
 
   void resetGlobalTerm();

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -144,15 +144,15 @@ public:
    * Interface for making epochs for termination detection
    */
   EpochType makeEpochRooted(
-    bool useDS = false, bool child = true, EpochType parent = no_epoch,
-    bool is_dep = false
+    bool useDS = false, bool child = true, EpochType successor = no_epoch,
+    bool dep_epoch = false
   );
   EpochType makeEpochCollective(
-    bool child = true, EpochType parent = no_epoch, bool is_dep = false
+    bool has_dep = true, EpochType successor = no_epoch, bool dep_epoch = false
   );
   EpochType makeEpoch(
     bool is_coll, bool useDS = false, bool child = true,
-    EpochType parent = no_epoch, bool is_dep = false
+    EpochType successor = no_epoch, bool dep_epoch = false
   );
 
   /*
@@ -167,10 +167,10 @@ public:
    *
    */
   EpochType makeEpochRootedDep(
-    bool useDS = true, bool child = true, EpochType parent = no_epoch
+    bool useDS = true, bool has_dep = true, EpochType successor = no_epoch
   );
   EpochType makeEpochCollectiveDep(
-    bool child = true, EpochType parent = no_epoch
+    bool has_dep = true, EpochType successor = no_epoch
   );
 
   /*
@@ -198,17 +198,16 @@ public:
   void finishNoActivateEpoch(EpochType const& epoch);
 
 private:
-  ParentBagType const& getParents(EpochType epoch);
   void cleanupReleasedEpoch(EpochType epoch);
   void runReleaseEpochActions(EpochType epoch);
-  bool epochParentReleased(EpochType epoch);
+  bool epochSuccessorReleased(EpochType epoch);
 
 public:
   /*
    * Directly call into a specific type of rooted epoch, can not be overridden
    */
-  EpochType makeEpochRootedWave(bool child, EpochType parent, bool dep = false);
-  EpochType makeEpochRootedDS(bool child, EpochType parent, bool dep = false);
+  EpochType makeEpochRootedWave(bool has_dep, EpochType successor, bool dep_epoch = false);
+  EpochType makeEpochRootedDS(bool has_dep, EpochType successor, bool dep_epoch = false);
 
 private:
   enum CallFromEnum { Root, NonRoot };

--- a/src/vt/termination/termination.impl.h
+++ b/src/vt/termination/termination.impl.h
@@ -67,20 +67,20 @@ inline void TerminationDetector::consume(
   return produceConsume(in_epoch, num_units, false, node);
 }
 
-inline bool TerminationDetector::isRooted(EpochType epoch) {
+inline bool TerminationDetector::isRooted(EpochType epoch) const {
   bool const is_sentinel = epoch == any_epoch_sentinel or epoch == no_epoch;
   return is_sentinel ? false : epoch::EpochManip::isRooted(epoch);
 }
 
-inline bool TerminationDetector::isDS(EpochType epoch) {
-  if (isRooted(epoch)) {
-    auto const ds_epoch = epoch::eEpochCategory::DijkstraScholtenEpoch;
-    auto const epoch_category = epoch::EpochManip::category(epoch);
-    auto const is_ds = epoch_category == ds_epoch;
-    return is_ds;
-  } else {
+inline bool TerminationDetector::isDS(EpochType epoch) const {
+  if (not isRooted(epoch)) {
     return false;
   }
+  return epoch::EpochManip::isDS(epoch);
+}
+
+inline bool TerminationDetector::isDep(EpochType epoch) const {
+  return epoch::EpochManip::isDep(epoch);
 }
 
 }} /* end namespace vt::term */

--- a/src/vt/topos/location/location.impl.h
+++ b/src/vt/topos/location/location.impl.h
@@ -171,6 +171,7 @@ void EntityLocationCoord<EntityID>::registerEntity(
       auto msg = makeSharedMessage<LocMsgType>(
         this_inst, id, no_location_event_id, ask_node, home
       );
+      setSystemType(msg->env);
       msg->setResolvedNode(this_node);
       theMsg()->sendMsg<LocMsgType, updateLocation>(home, msg);
     }
@@ -360,6 +361,7 @@ void EntityLocationCoord<EntityID>::getLocation(
         auto msg = makeSharedMessage<LocMsgType>(
           this_inst, id, event_id, this_node, home_node
         );
+        setSystemType(msg->env);
         theMsg()->sendMsg<LocMsgType, getLocationHandler>(home_node, msg);
         // save a pending action when information about location arrives
         pending_actions_.emplace(
@@ -715,6 +717,7 @@ template <typename EntityID>
         auto msg2 = makeSharedMessage<LocMsgType>(
           inst, entity, event_id, ask_node, home_node
         );
+        setSystemType(msg2->env);
         msg2->setResolvedNode(node);
         theMsg()->sendMsg<LocMsgType, updateLocation>(ask_node, msg2);
       });

--- a/src/vt/vrt/collection/broadcast/broadcastable.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.h
@@ -79,6 +79,8 @@ struct Broadcastable : BaseProxyT {
     typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
   >
   messaging::PendingSend broadcast(Args&&... args) const;
+
+  void release(EpochType const& epoch) const;
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -113,6 +113,7 @@ void Broadcastable<ColT,IndexT,BaseProxyT>::release(EpochType const& epoch) cons
   vt::CollectionProxy<ColT, IndexT> base{untyped_proxy};
   auto msg = makeMessage<MsgT>(epoch);
   setSystemType(msg->env);
+  msg->setSystem(true);
   base.template broadcast<MsgT, BaseT::template releaseHandler<MsgT, ColT>>(msg);
 }
 

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -98,7 +98,6 @@ messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(Args&&..
   return broadcast<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
-
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
 messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(MsgT* msg) const {
@@ -110,11 +109,11 @@ template <typename ColT, typename IndexT, typename BaseProxyT>
 void Broadcastable<ColT,IndexT,BaseProxyT>::release(EpochType const& epoch) const {
   auto untyped_proxy = this->getProxy();
   using BaseT = CollectionBase<ColT, IndexT>;
-  using MsgT  = ReleaseMsg<BaseT>;
-  vt::CollectionProxy<BaseT, IndexT> base{untyped_proxy};
+  using MsgT  = ReleaseMsg<ColT>;
+  vt::CollectionProxy<ColT, IndexT> base{untyped_proxy};
   auto msg = makeMessage<MsgT>(epoch);
   setSystemType(msg->env);
-  base.template broadcast<MsgT, &BaseT::template releaseHandler<MsgT>>(msg);
+  base.template broadcast<MsgT, BaseT::template releaseHandler<MsgT, ColT>>(msg);
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -195,13 +195,13 @@ struct CollectionManager {
     typename ColT,  mapping::ActiveMapTypedFnType<typename ColT::IndexType> fn
   >
   CollectionProxyWrapType<ColT> constructCollective(
-    typename ColT::IndexType range, DistribConstructFn<ColT> cons_fn,
+    typename ColT::IndexType range, DistribConstructFn<ColT> cons_fn = nullptr,
     TagType const& tag = no_tag
   );
 
   template <typename ColT>
   CollectionProxyWrapType<ColT> constructCollective(
-    typename ColT::IndexType range, DistribConstructFn<ColT> cons_fn,
+    typename ColT::IndexType range, DistribConstructFn<ColT> cons_fn = nullptr,
     TagType const& tag = no_tag
   );
 
@@ -816,6 +816,26 @@ private:
     HandlerType const& map_han
   );
 
+public:
+
+  /*
+   * Manage dependent epochs for a given element
+   */
+
+  template <typename ColT>
+  bool isReleased(VirtualElmProxyType<ColT> proxy, EpochType const& epoch);
+
+  template <typename ColT>
+  void whenReleased(
+    VirtualElmProxyType<ColT> proxy, EpochType const& epoch, ActionType act
+  );
+
+  template <typename ColT>
+  void release(VirtualElmProxyType<ColT> proxy, EpochType const& epoch);
+
+  template <typename ColT>
+  static void releaseHan(ReleaseMsg<ColT>* msg);
+
 private:
   template <typename MsgT>
   static EpochType getCurrentEpoch(MsgT* msg);
@@ -885,6 +905,7 @@ namespace details
 #include "vt/vrt/collection/staged_token/token.impl.h"
 #include "vt/vrt/collection/types/base.impl.h"
 #include "vt/vrt/collection/balance/proxy/lbable.impl.h"
+#include "vt/vrt/collection/release/releaseable.impl.h"
 
 #include "vt/pipe/callback/proxy_bcast/callback_proxy_bcast.impl.h"
 #include "vt/pipe/callback/proxy_send/callback_proxy_send.impl.h"

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -488,7 +488,7 @@ template <typename ColT, typename IndexT, typename MsgT>
             std::make_unique<balance::LBListener>(
               [&](NodeType dest, MsgSizeType size, bool bcast){
                 auto& stats = base->getStats();
-                stats.recvToNode(dest, elm_id, size, bcast);
+                stats.recvToNode(dest, perm_elm_id, temp_elm_id, size, bcast);
               }
             );
           theMsg()->addSendListener(std::move(listener));
@@ -3188,23 +3188,6 @@ template <typename always_void>
 DispatchBasePtrType
 CollectionManager::getDispatcher(DispatchHandlerType const& han) {
   return getDispatch(han);
-}
-
-template <typename always_void>
-void CollectionManager::schedule(ActionType action) {
-  work_units_.push_back(action);
-}
-
-template <typename always_void>
-bool CollectionManager::scheduler() {
-  if (work_units_.size() == 0) {
-    return false;
-  } else {
-    auto unit = work_units_.back();
-    work_units_.pop_back();
-    unit();
-    return true;
-  }
 }
 
 template <typename ColT>

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3262,7 +3262,7 @@ void CollectionManager::release(
     } else {
       using IdxT  = typename ColT::IndexType;
       using BaseT = CollectionBase<ColT, IdxT>;
-      using MsgT  = ReleaseMsg<BaseT>;
+      using MsgT  = ReleaseMsg<ColT>;
       auto msg = makeMessage<MsgT>(epoch);
       setSystemType(msg->env);
       proxy.template send<MsgT, BaseT::template releaseHandler<MsgT, ColT>>(msg);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -445,6 +445,7 @@ template <typename ColT, typename IndexT, typename MsgT>
         "broadcast: apply to element: epoch={}, bcast_epoch={}\n",
         msg->bcast_epoch_, base->cur_bcast_epoch_
       );
+
       vtAssert(base != nullptr, "Must be valid pointer");
       base->cur_bcast_epoch_++;
 
@@ -703,6 +704,11 @@ template <typename ColT, typename IndexT, typename MsgT>
     sub_handler, member, cur_epoch, idx, exists
   );
 
+  auto pmsg = promoteMsg(msg);
+  if (not col_ptr->release_.isReleased(cur_epoch)) {
+    col_ptr->release_.buffer(cur_epoch,pmsg);
+    return;
+  }
 
   #if backend_check_enabled(lblite)
     debug_print(

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3266,6 +3266,7 @@ void CollectionManager::release(
       using MsgT  = ReleaseMsg<BaseT>;
       vt::CollectionProxy<BaseT, IdxT> base{col_proxy};
       auto msg = makeMessage<MsgT>(epoch);
+      setSystemType(msg->env);
       base[idx].template send<MsgT, &BaseT::template releaseHandler<MsgT>>(msg);
     }
   } else {

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -450,8 +450,9 @@ template <typename ColT, typename IndexT, typename MsgT>
       vtAssert(base != nullptr, "Must be valid pointer");
       base->cur_bcast_epoch_++;
 
+      auto is_sys = envelopeIsSystemType(msg->env);
       auto pmsg = promoteMsg(msg);
-      if (not base->release_.isReleased(msg_epoch)) {
+      if (not is_sys and not base->release_.isReleased(msg_epoch)) {
         base->release_.buffer(msg_epoch,pmsg.template toVirtual<ShortMessage>());
       } else {
 
@@ -711,8 +712,9 @@ template <typename ColT, typename IndexT, typename MsgT>
     sub_handler, member, cur_epoch, idx, exists
   );
 
+  auto is_sys = envelopeIsSystemType(msg->env);
   auto pmsg = promoteMsg(msg);
-  if (not col_ptr->release_.isReleased(cur_epoch)) {
+  if (not is_sys and not col_ptr->release_.isReleased(cur_epoch)) {
     col_ptr->release_.buffer(cur_epoch,pmsg.template toVirtual<ShortMessage>());
     return;
   }

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3260,16 +3260,12 @@ void CollectionManager::release(
     if (exists) {
       return elm_holder->lookup(idx).getCollection()->releaseEpoch(epoch);
     } else {
-      // Must downcast to the base collection type (and recreate the proxy) so
-      // the proxy does not mismatch the derived user type with base type when
-      // building the active member handler for the collection type
       using IdxT  = typename ColT::IndexType;
       using BaseT = CollectionBase<ColT, IdxT>;
       using MsgT  = ReleaseMsg<BaseT>;
-      vt::CollectionProxy<BaseT, IdxT> base{col_proxy};
       auto msg = makeMessage<MsgT>(epoch);
       setSystemType(msg->env);
-      base[idx].template send<MsgT, &BaseT::template releaseHandler<MsgT>>(msg);
+      proxy.template send<MsgT, BaseT::template releaseHandler<MsgT, ColT>>(msg);
     }
   } else {
     buffered_sends_[col_proxy].push_back([=](VirtualProxyType) {

--- a/src/vt/vrt/collection/messages/fetch_msg.h
+++ b/src/vt/vrt/collection/messages/fetch_msg.h
@@ -1,0 +1,64 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          fetch_msg.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_VRT_COLLECTION_MESSAGES_FETCH_MSG_H
+#define INCLUDED_VT_VRT_COLLECTION_MESSAGES_FETCH_MSG_H
+
+#include "vt/config.h"
+#include "vt/messaging/message/message.h"
+#include "vt/vrt/collection/proxy.h"
+#include "vt/vrt/vrt_common.h"
+
+namespace vt { namespace vrt { namespace collection {
+
+template <typename ColT>
+using RoutedMessageType = LocationRoutedMsg<VirtualElmProxyType<ColT>, Message>;
+
+template <typename ColT>
+struct CollectionMessage : RoutedMessageType<ColT> {
+};
+
+}}} /* end namespace vt::vrt::collection */
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_MESSAGES_FETCH_MSG_H*/

--- a/src/vt/vrt/collection/messages/release_msg.h
+++ b/src/vt/vrt/collection/messages/release_msg.h
@@ -1,0 +1,66 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          release_msg.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_VRT_COLLECTION_MESSAGES_RELEASE_MSG_H
+#define INCLUDED_VT_VRT_COLLECTION_MESSAGES_RELEASE_MSG_H
+
+#include "vt/config.h"
+#include "vt/vrt/collection/messages/user.h"
+
+namespace vt { namespace vrt { namespace collection {
+
+template <typename ColT>
+struct ReleaseMsg : CollectionMessage<ColT> {
+
+  ReleaseMsg() = default;
+  explicit ReleaseMsg(EpochType in_epoch)
+    : epoch_(in_epoch)
+  { }
+
+  EpochType epoch_ = no_epoch;
+};
+
+}}} /* end namespace vt::vrt::collection */
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_MESSAGES_RELEASE_MSG_H*/

--- a/src/vt/vrt/collection/messages/user.h
+++ b/src/vt/vrt/collection/messages/user.h
@@ -109,6 +109,9 @@ struct CollectionMessage :
   bool getWrap() const;
   void setWrap(bool const& wrap);
 
+  bool getSystem() const;
+  void setSystem(bool const is_system);
+
   #if backend_check_enabled(lblite)
     bool lbLiteInstrument() const;
     void setLBLiteInstrument(bool const& val);
@@ -137,6 +140,7 @@ private:
   NodeType from_node_ = uninitialized_destination;
   bool member_ = false;
   bool is_wrap_ = false;
+  bool is_system_ = false;
 
   #if backend_check_enabled(lblite)
     /*

--- a/src/vt/vrt/collection/messages/user.impl.h
+++ b/src/vt/vrt/collection/messages/user.impl.h
@@ -128,6 +128,7 @@ void CollectionMessage<ColT, BaseMsgT>::serializeThis(SerializerT& s) {
   s | bcast_epoch_;
   s | member_;
   s | is_wrap_;
+  s | is_system_;
 
   #if backend_check_enabled(lblite)
     s | lb_lite_instrument_;
@@ -155,6 +156,16 @@ bool CollectionMessage<ColT,BaseMsgT>::getWrap() const {
 template <typename ColT, typename BaseMsgT>
 void CollectionMessage<ColT,BaseMsgT>::setWrap(bool const& wrap) {
   is_wrap_ = wrap;
+}
+
+template <typename ColT, typename BaseMsgT>
+bool CollectionMessage<ColT,BaseMsgT>::getSystem() const {
+  return is_system_;
+}
+
+template <typename ColT, typename BaseMsgT>
+void CollectionMessage<ColT,BaseMsgT>::setSystem(bool const is_system) {
+  is_system_ = is_system;
 }
 
 #if backend_check_enabled(lblite)

--- a/src/vt/vrt/collection/proxy_traits/proxy_elm_traits.h
+++ b/src/vt/vrt/collection/proxy_traits/proxy_elm_traits.h
@@ -53,13 +53,17 @@
 #include "vt/vrt/collection/gettable/gettable.h"
 #include "vt/vrt/collection/insert/insertable.h"
 #include "vt/vrt/collection/balance/proxy/lbable.h"
+#include "vt/vrt/collection/release/releaseable.h"
 
 namespace vt { namespace vrt { namespace collection {
 
 namespace elm_proxy {
 
 template <typename ColT, typename IndexT>
-using Chain4 = LBable<ColT,IndexT,BaseCollectionElmProxy<ColT,IndexT>>;
+using Chain5 = Releaseable<ColT,IndexT,BaseCollectionElmProxy<ColT,IndexT>>;
+
+template <typename ColT, typename IndexT>
+using Chain4 = LBable<ColT,IndexT,Chain5<ColT,IndexT>>;
 
 template <typename ColT, typename IndexT>
 using Chain3 = Gettable<ColT,IndexT,Chain4<ColT,IndexT>>;

--- a/src/vt/vrt/collection/release/releaseable.h
+++ b/src/vt/vrt/collection/release/releaseable.h
@@ -1,0 +1,73 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          releaseable.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_VRT_COLLECTION_RELEASE_RELEASEABLE_H
+#define INCLUDED_VT_VRT_COLLECTION_RELEASE_RELEASEABLE_H
+
+#include "vt/config.h"
+
+namespace vt { namespace vrt { namespace collection {
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+struct Releaseable : BaseProxyT {
+  Releaseable() = default;
+  Releaseable(
+    typename BaseProxyT::ProxyType const& in_proxy,
+    typename BaseProxyT::ElementProxyType const& in_elm
+  );
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s);
+
+  /*
+   * Proxy operations for releasing dependent epochs
+   */
+  bool isReleased(EpochType const& epoch);
+  void whenReleased(EpochType const& epoch, ActionType action);
+  void release(EpochType const& epoch);
+};
+
+}}} /* end namespace vt::vrt::collection */
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_RELEASE_RELEASEABLE_H*/

--- a/src/vt/vrt/collection/release/releaseable.impl.h
+++ b/src/vt/vrt/collection/release/releaseable.impl.h
@@ -1,0 +1,93 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          releaseable.impl.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_VRT_COLLECTION_RELEASE_RELEASEABLE_IMPL_H
+#define INCLUDED_VT_VRT_COLLECTION_RELEASE_RELEASEABLE_IMPL_H
+
+#include "vt/config.h"
+
+namespace vt { namespace vrt { namespace collection {
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+Releaseable<ColT,IndexT,BaseProxyT>::Releaseable(
+  typename BaseProxyT::ProxyType const& in_proxy,
+  typename BaseProxyT::ElementProxyType const& in_elm
+) : BaseProxyT(in_proxy, in_elm)
+{ }
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename SerializerT>
+void Releaseable<ColT,IndexT,BaseProxyT>::serialize(SerializerT& s) {
+  BaseProxyT::serialize(s);
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+bool Releaseable<ColT,IndexT,BaseProxyT>::isReleased(EpochType const& epoch) {
+  auto col_proxy = this->getCollectionProxy();
+  auto elm_proxy = this->getElementProxy();
+  auto proxy = VrtElmProxy<ColT, IndexT>(col_proxy,elm_proxy);
+  return theCollection()->isReleased<ColT>(proxy,epoch);
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+void Releaseable<ColT,IndexT,BaseProxyT>::whenReleased(
+  EpochType const& epoch, ActionType action
+) {
+  auto col_proxy = this->getCollectionProxy();
+  auto elm_proxy = this->getElementProxy();
+  auto proxy = VrtElmProxy<ColT, IndexT>(col_proxy,elm_proxy);
+  return theCollection()->whenReleased<ColT>(proxy,epoch,action);
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+void Releaseable<ColT,IndexT,BaseProxyT>::release(EpochType const& epoch) {
+  auto col_proxy = this->getCollectionProxy();
+  auto elm_proxy = this->getElementProxy();
+  auto proxy = VrtElmProxy<ColT, IndexT>(col_proxy,elm_proxy);
+  return theCollection()->release<ColT>(proxy,epoch);
+}
+
+}}} /* end namespace vt::vrt::collection */
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_RELEASE_RELEASEABLE_IMPL_H*/

--- a/src/vt/vrt/collection/types/base.h
+++ b/src/vt/vrt/collection/types/base.h
@@ -92,7 +92,9 @@ struct CollectionBase : Indexable<ColT, IndexT> {
 
   friend struct CollectionManager;
 
-  void releaseHandler(ReleaseMsg<ColT>* msg) { releaseEpoch(msg->epoch_); }
+  template <typename MsgT>
+  void releaseHandler(MsgT* msg) { releaseEpoch(msg->epoch_); }
+
   bool isReleased(EpochType const& ep) { return release_.isReleased(ep); }
   void releaseEpoch(EpochType const& ep) { return release_.release(ep); }
   void whenReleased(EpochType const& ep, ActionType act) {

--- a/src/vt/vrt/collection/types/base.h
+++ b/src/vt/vrt/collection/types/base.h
@@ -55,6 +55,7 @@
 #include "vt/vrt/collection/manager.fwd.h"
 #include "vt/vrt/proxy/collection_proxy.h"
 #include "vt/termination/interval/epoch_release_set.h"
+#include "vt/vrt/collection/messages/release_msg.h"
 
 namespace vt { namespace vrt { namespace collection {
 
@@ -91,11 +92,13 @@ struct CollectionBase : Indexable<ColT, IndexT> {
 
   friend struct CollectionManager;
 
+  void releaseHandler(ReleaseMsg<ColT>* msg) { releaseEpoch(msg->epoch_); }
   bool isReleased(EpochType const& ep) { return release_.isReleased(ep); }
   void releaseEpoch(EpochType const& ep) { return release_.release(ep); }
   void whenReleased(EpochType const& ep, ActionType act) {
     release_.whenReleased(ep,act);
   }
+  EpochReleaseSet& getEpochRelease() { return release_; }
 
 protected:
   VirtualElmCountType numElems_ = no_elms;

--- a/src/vt/vrt/collection/types/base.h
+++ b/src/vt/vrt/collection/types/base.h
@@ -54,6 +54,7 @@
 #include "vt/vrt/collection/types/untyped.h"
 #include "vt/vrt/collection/manager.fwd.h"
 #include "vt/vrt/proxy/collection_proxy.h"
+#include "vt/termination/interval/epoch_release_set.h"
 
 namespace vt { namespace vrt { namespace collection {
 
@@ -90,11 +91,18 @@ struct CollectionBase : Indexable<ColT, IndexT> {
 
   friend struct CollectionManager;
 
+  bool isReleased(EpochType const& ep) { return release_.isReleased(ep); }
+  void releaseEpoch(EpochType const& ep) { return release_.release(ep); }
+  void whenReleased(EpochType const& ep, ActionType act) {
+    release_.whenReleased(ep,act);
+  }
+
 protected:
   VirtualElmCountType numElems_ = no_elms;
   EpochType cur_bcast_epoch_ = 0;
   bool hasStaticSize_ = true;
   bool elmsFixedAtCreation_ = true;
+  EpochReleaseSet release_;
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/types/base.h
+++ b/src/vt/vrt/collection/types/base.h
@@ -92,8 +92,10 @@ struct CollectionBase : Indexable<ColT, IndexT> {
 
   friend struct CollectionManager;
 
-  template <typename MsgT>
-  void releaseHandler(MsgT* msg) { releaseEpoch(msg->epoch_); }
+  template <typename MsgT, typename ColU>
+  static void releaseHandler(MsgT* msg, ColU* col) {
+    col->releaseEpoch(msg->epoch_);
+  }
 
   bool isReleased(EpochType const& ep) { return release_.isReleased(ep); }
   void releaseEpoch(EpochType const& ep) { return release_.release(ep); }

--- a/src/vt/vrt/collection/types/base.impl.h
+++ b/src/vt/vrt/collection/types/base.impl.h
@@ -111,6 +111,7 @@ void CollectionBase<ColT, IndexT>::serialize(Serializer& s) {
   s | elmsFixedAtCreation_;
   s | cur_bcast_epoch_;
   s | numElems_;
+  s | release_;
 }
 
 template <typename ColT, typename IndexT>

--- a/tests/unit/epoch/test_epoch.cc
+++ b/tests/unit/epoch/test_epoch.cc
@@ -140,7 +140,7 @@ TEST_P(TestEpochParam, basic_test_epoch_category_1) {
   EpochType const start_seq  = GetParam();
   auto const epoch           = epoch::EpochManip::makeEpoch(
     start_seq, false, uninitialized_destination, false,
-    epoch::eEpochCategory::InsertEpoch
+    epoch::eEpochCategory::DependentEpoch
   );
   auto const is_rooted       = epoch::EpochManip::isRooted(epoch);
   auto const is_user         = epoch::EpochManip::isUser(epoch);
@@ -157,14 +157,14 @@ TEST_P(TestEpochParam, basic_test_epoch_category_1) {
   EXPECT_EQ(get_seq, start_seq);
   EXPECT_EQ(ep_node, 0);
   EXPECT_EQ(next_seq, start_seq + 1);
-  EXPECT_EQ(cat, epoch::eEpochCategory::InsertEpoch);
+  EXPECT_EQ(cat, epoch::eEpochCategory::DependentEpoch);
 }
 
 TEST_P(TestEpochParam, basic_test_epoch_all_1) {
   auto const& n              = 48;
   EpochType const start_seq  = GetParam();
   auto const epoch           = epoch::EpochManip::makeEpoch(
-    start_seq, true, n, true, epoch::eEpochCategory::InsertEpoch
+    start_seq, true, n, true, epoch::eEpochCategory::DependentEpoch
   );
   auto const is_rooted       = epoch::EpochManip::isRooted(epoch);
   auto const is_user         = epoch::EpochManip::isUser(epoch);
@@ -181,7 +181,7 @@ TEST_P(TestEpochParam, basic_test_epoch_all_1) {
   EXPECT_EQ(get_seq, start_seq);
   EXPECT_EQ(ep_node, n);
   EXPECT_EQ(next_seq, start_seq + 1);
-  EXPECT_EQ(cat, epoch::eEpochCategory::InsertEpoch);
+  EXPECT_EQ(cat, epoch::eEpochCategory::DependentEpoch);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/tests/unit/termination/test_term_dep_epoch_active.cc
+++ b/tests/unit/termination/test_term_dep_epoch_active.cc
@@ -1,0 +1,129 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                   test_term_dep_epoch_active.cc
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "data_message.h"
+
+#include "vt/transport.h"
+#include "vt/messaging/collection_chain_set.h"
+
+namespace vt { namespace tests { namespace unit {
+
+using namespace vt;
+using namespace vt::tests::unit;
+
+struct TestTermDepEpochActive : TestParallelHarness { };
+
+struct TestMsg : vt::Message { };
+
+struct TestDep {
+  static void depHandler(TestMsg* msg) {
+    //auto const& node = theContext()->getNode();
+    num_dep++;
+    //fmt::print("{}: depHandler: num_dep={}\n", node, num_dep);
+    EXPECT_EQ(num_non_dep, 1);
+  }
+
+  static void nonDepHandler(TestMsg* msg) {
+    //auto const& node = theContext()->getNode();
+    num_non_dep++;
+    //fmt::print("{}: nonDepHandler: num_non_dep={}\n", node, num_non_dep);
+    EXPECT_EQ(num_dep, 0);
+  }
+
+  static int num_dep;
+  static int num_non_dep;
+};
+
+/*static*/ int TestDep::num_dep = 0;
+/*static*/ int TestDep::num_non_dep = 0;
+
+TEST_F(TestTermDepEpochActive, test_term_dep_epoch_active) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+  bool const bcast = true;
+  int const k = 10;
+
+  TestDep::num_dep = 0;
+  TestDep::num_non_dep = 0;
+  vt::theCollective()->barrier();
+
+  auto epoch = vt::theTerm()->makeEpochCollectiveDep();
+  vt::theMsg()->pushEpoch(epoch);
+  if (bcast) {
+    for (int i = 0; i < k; i++) {
+      auto msg = vt::makeSharedMessage<TestMsg>();
+      vt::theMsg()->broadcastMsg<TestMsg, TestDep::depHandler>(msg);
+    }
+  } else {
+  }
+  vt::theMsg()->popEpoch(epoch);
+  vt::theTerm()->finishedEpoch(epoch);
+
+  auto chain = std::make_unique<vt::messaging::CollectionChainSet<NodeType>>();
+  chain->addIndex(this_node);
+
+  chain->nextStep([=](NodeType node) {
+    auto const next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto msg = vt::makeSharedMessage<TestMsg>();
+    return vt::theMsg()->sendMsg<TestMsg, TestDep::nonDepHandler>(next,msg);
+  });
+
+  chain->nextStep([=](NodeType node) {
+    auto msg = vt::makeMessage<TestMsg>();
+    return vt::messaging::PendingSend(msg, [=](MsgVirtualPtr<vt::BaseMsgType>){
+      EXPECT_EQ(TestDep::num_dep, 0);
+      theTerm()->releaseEpoch(epoch);
+    });
+  });
+
+  vt::theTerm()->addAction([=]{
+    EXPECT_EQ(TestDep::num_non_dep, 1);
+    EXPECT_EQ(TestDep::num_dep, (num_nodes - 1)*k);
+  });
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_term_dep_epoch_collection.cc
+++ b/tests/unit/termination/test_term_dep_epoch_collection.cc
@@ -1,0 +1,153 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                test_term_dep_epoch_collection.cc
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "data_message.h"
+
+#include "vt/transport.h"
+#include "vt/messaging/collection_chain_set.h"
+
+namespace vt { namespace tests { namespace unit {
+
+using namespace vt;
+using namespace vt::tests::unit;
+
+struct TestTermDepEpochCollection : TestParallelHarness { };
+
+struct TestDep : vt::Collection<TestDep,vt::Index1D> {
+  struct TestMsg : vt::CollectionMessage<TestDep> {
+    int k = 0;
+    int r = 0;
+  };
+
+  void depHandler(TestMsg* msg) {
+    auto const& node = theContext()->getNode();
+    auto idx = this->getIndex();
+    num_dep++;
+    fmt::print("{}: {}: depHandler: num_dep={}\n", node, idx, num_dep);
+    EXPECT_EQ(num_non_dep, 1);
+  }
+
+  void nonDepHandler(TestMsg* msg) {
+    auto const& node = theContext()->getNode();
+    auto idx = this->getIndex();
+    num_non_dep++;
+    fmt::print("{}: {}: nonDepHandler: num_non_dep={}\n", node, idx, num_non_dep);
+    EXPECT_EQ(num_dep, 0);
+  }
+
+  void check(TestMsg* msg) {
+    auto const num_nodes = vt::theContext()->getNumNodes();
+    EXPECT_EQ(num_non_dep, 1);
+    EXPECT_EQ(num_dep, num_nodes*msg->k);
+  }
+
+  int num_dep = 0;
+  int num_non_dep = 0;
+};
+
+using TestMsg = typename TestDep::TestMsg;
+
+TEST_F(TestTermDepEpochCollection, test_term_dep_epoch_collection) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+  bool const bcast = true;
+  int const k = 10;
+  int const r = 48;
+
+  auto range = vt::Index1D(r);
+  auto proxy = vt::theCollection()->constructCollective<TestDep>(range);
+  vt::theCollective()->barrier();
+
+  auto epoch = vt::theTerm()->makeEpochCollectiveDep();
+  vt::theMsg()->pushEpoch(epoch);
+  if (bcast) {
+    for (int i = 0; i < k; i++) {
+      auto msg = vt::makeSharedMessage<TestMsg>();
+      //vt::envelopeSetEpoch(msg->env, epoch);
+      proxy.template broadcast<TestMsg, &TestDep::depHandler>(msg);
+    }
+  } else {
+  }
+  vt::theMsg()->popEpoch(epoch);
+  vt::theTerm()->finishedEpoch(epoch);
+
+  auto chain = std::make_unique<vt::messaging::CollectionChainSet<vt::Index1D>>();
+
+  for (int i = 0; i < r; i++) {
+    if (i % num_nodes == this_node) {
+      chain->addIndex(vt::Index1D(i));
+    }
+  }
+
+  chain->nextStep([=](vt::Index1D idx) {
+    auto msg = vt::makeMessage<TestMsg>();
+    return vt::messaging::PendingSend(msg, [=](MsgVirtualPtr<vt::BaseMsgType>){
+      auto msg2 = vt::makeSharedMessage<TestMsg>();
+      proxy[idx].send<TestMsg, &TestDep::nonDepHandler>(msg2);
+    });
+  });
+
+  chain->nextStep([=](vt::Index1D idx) {
+    auto msg = vt::makeMessage<TestMsg>();
+    return vt::messaging::PendingSend(msg, [=](MsgVirtualPtr<vt::BaseMsgType>){
+      fmt::print("release: {}\n", idx);
+      proxy[idx].release(epoch);
+    });
+  });
+
+  vt::theTerm()->addAction([=]{
+    auto const node = vt::theContext()->getNode();
+    if (node == 0) {
+      auto msg = vt::makeSharedMessage<TestMsg>();
+      msg->k = k;
+      msg->r = r;
+      proxy.template broadcast<TestMsg, &TestDep::check>(msg);
+    }
+  });
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_term_dep_epoch_collection.cc
+++ b/tests/unit/termination/test_term_dep_epoch_collection.cc
@@ -64,18 +64,18 @@ struct TestDep : vt::Collection<TestDep,vt::Index1D> {
   };
 
   void depHandler(TestMsg* msg) {
-    auto const& node = theContext()->getNode();
-    auto idx = this->getIndex();
+    // auto const& node = theContext()->getNode();
+    // auto idx = this->getIndex();
     num_dep++;
-    fmt::print("{}: {}: depHandler: num_dep={}\n", node, idx, num_dep);
+    // fmt::print("{}: {}: depHandler: num_dep={}\n", node, idx, num_dep);
     EXPECT_EQ(num_non_dep, 1);
   }
 
   void nonDepHandler(TestMsg* msg) {
-    auto const& node = theContext()->getNode();
-    auto idx = this->getIndex();
+    // auto const& node = theContext()->getNode();
+    // auto idx = this->getIndex();
     num_non_dep++;
-    fmt::print("{}: {}: nonDepHandler: num_non_dep={}\n", node, idx, num_non_dep);
+    // fmt::print("{}: {}: nonDepHandler: num_non_dep={}\n", node, idx, num_non_dep);
     EXPECT_EQ(num_dep, 0);
   }
 
@@ -107,7 +107,6 @@ TEST_F(TestTermDepEpochCollection, test_term_dep_epoch_collection) {
   if (bcast) {
     for (int i = 0; i < k; i++) {
       auto msg = vt::makeSharedMessage<TestMsg>();
-      //vt::envelopeSetEpoch(msg->env, epoch);
       proxy.template broadcast<TestMsg, &TestDep::depHandler>(msg);
     }
   } else {

--- a/tests/unit/termination/test_term_dep_epoch_collection.cc
+++ b/tests/unit/termination/test_term_dep_epoch_collection.cc
@@ -123,11 +123,7 @@ TEST_F(TestTermDepEpochCollection, test_term_dep_epoch_collection) {
   }
 
   chain->nextStep([=](vt::Index1D idx) {
-    auto msg = vt::makeMessage<TestMsg>();
-    return vt::messaging::PendingSend(msg, [=](MsgVirtualPtr<vt::BaseMsgType>){
-      auto msg2 = vt::makeSharedMessage<TestMsg>();
-      proxy[idx].send<TestMsg, &TestDep::nonDepHandler>(msg2);
-    });
+    return proxy[idx].send<TestMsg, &TestDep::nonDepHandler>();
   });
 
   chain->nextStep([=](vt::Index1D idx) {

--- a/tests/unit/termination/test_term_dep_epoch_objgroup.cc
+++ b/tests/unit/termination/test_term_dep_epoch_objgroup.cc
@@ -1,0 +1,129 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                 test_term_dep_epoch_objgroup.cc
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "data_message.h"
+
+#include "vt/transport.h"
+#include "vt/messaging/collection_chain_set.h"
+
+namespace vt { namespace tests { namespace unit {
+
+using namespace vt;
+using namespace vt::tests::unit;
+
+struct TestTermDepEpochObjGroup : TestParallelHarness { };
+
+struct TestMsg : vt::Message { };
+
+struct TestDep {
+  void depHandler(TestMsg* msg) {
+    //auto const& node = theContext()->getNode();
+    num_dep++;
+    //fmt::print("{}: depHandler: num_dep={}\n", node, num_dep);
+    EXPECT_EQ(num_non_dep, 1);
+  }
+
+  void nonDepHandler(TestMsg* msg) {
+    //auto const& node = theContext()->getNode();
+    num_non_dep++;
+    //fmt::print("{}: nonDepHandler: num_non_dep={}\n", node, num_non_dep);
+    EXPECT_EQ(num_dep, 0);
+  }
+
+  int num_dep = 0;
+  int num_non_dep = 0;
+};
+
+TEST_F(TestTermDepEpochObjGroup, test_term_dep_epoch_objgroup) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+  bool const bcast = true;
+  int const k = 10;
+
+  auto proxy = vt::theObjGroup()->makeCollective<TestDep>();
+  vt::theCollective()->barrier();
+
+  auto epoch = vt::theTerm()->makeEpochCollectiveDep();
+  vt::theMsg()->pushEpoch(epoch);
+  if (bcast) {
+    for (int i = 0; i < k; i++) {
+      auto msg = vt::makeSharedMessage<TestMsg>();
+      proxy.template broadcast<TestMsg, &TestDep::depHandler>(msg);
+    }
+  } else {
+  }
+  vt::theMsg()->popEpoch(epoch);
+  vt::theTerm()->finishedEpoch(epoch);
+
+  auto chain = std::make_unique<vt::messaging::CollectionChainSet<NodeType>>();
+  chain->addIndex(this_node);
+
+  chain->nextStep([=](NodeType node) {
+    auto msg = vt::makeMessage<TestMsg>();
+    return vt::messaging::PendingSend(msg, [=](MsgVirtualPtr<vt::BaseMsgType>){
+      auto const next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+      auto msg2 = vt::makeSharedMessage<TestMsg>();
+      proxy[next].send<TestMsg, &TestDep::nonDepHandler>(msg2);
+    });
+  });
+
+  chain->nextStep([=](NodeType node) {
+    auto msg = vt::makeMessage<TestMsg>();
+    return vt::messaging::PendingSend(msg, [=](MsgVirtualPtr<vt::BaseMsgType>){
+      EXPECT_EQ(proxy[node].get()->num_dep, 0);
+      proxy[node].release(epoch);
+    });
+  });
+
+  vt::theTerm()->addAction([=]{
+    auto const node = vt::theContext()->getNode();
+    EXPECT_EQ(proxy[node].get()->num_non_dep, 1);
+    EXPECT_EQ(proxy[node].get()->num_dep, num_nodes*k);
+  });
+}
+
+}}} // end namespace vt::tests::unit


### PR DESCRIPTION
This is the full implementation of dependent epochs. TD dump prints on hang could be improved.

- Added a bit to envelope for marking system messages
- Implemented dependent epochs for:
  - General active message handlers;
  - Virtual Collection Elements (with whole collection release)
    - Release, check release, add action on release occurs on indexed proxy
  - ObjGroups
- Integration/Unit Tests for Dependent Epochs
  - General active message handler test
  - *added* ObjGroup test
  - *added* Virtual Collection test