### PR TITLE
410 Integral Set 

### DIFF
--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -1,0 +1,353 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          discrete_interval.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_TERMINATION_INTERVAL_DISCRETE_INTERVAL_H
+#define INCLUDED_VT_TERMINATION_INTERVAL_DISCRETE_INTERVAL_H
+
+#include "vt/config.h"
+
+#include <algorithm>
+
+namespace vt { namespace term { namespace interval {
+
+/*
+ * Discrete interval tree for encoding non-overlapping integer ranges in a tree
+ */
+
+template <
+  typename DomainT,
+  typename CompareT = std::less<DomainT>,
+  DomainT sentinel = DomainT()
+>
+struct Interval {
+  using IntervalType = Interval<DomainT, CompareT, sentinel>;
+  using DomainType   = DomainT;
+
+  Interval() = default;
+  Interval(Interval const&) = default;
+  Interval(Interval&&) = default;
+  Interval& operator=(Interval const&) = default;
+
+  Interval(DomainT const& val) : lb_(val), ub_(val) { }
+  Interval(DomainT const& lb, DomainT const& ub) : lb_(lb), ub_(ub) { }
+
+public:
+  DomainT lower() const { return lb_; }
+  DomainT upper() const { return ub_; }
+  DomainT width() const { return (ub_-lb_)+1; }
+  bool    valid() const { lb_ <= ub_; }
+
+  template <typename DomainU>
+  bool in(DomainU&& val) const {
+    return val >= lb_ and val <= ub_;
+  }
+
+  void expandBy(DomainT const& val) {
+    if (val > 0) {
+      ub_ += val;
+    } else {
+      lb_ -= val;
+    }
+  }
+
+  enum struct PositionEnum : int {
+    TangentLeft = -1,
+    NotTangent   = 0,
+    TangentRight = 1
+  };
+
+  /*
+   * Determine if a input interval is tangent to this interval within a
+   * specified grap.
+   *
+   *        TangentLeft                   TangentRight
+   *       |------i-----| lb_        ub_ |------i-----|
+   *                      |----this----|
+   *                     ^              ^
+   *                    gap            gap
+   */
+
+  PositionEnum tangent(IntervalType const& i, DomainT gap = 1) {
+    if (lb_ == i.ub_ + gap) {
+      return PositionEnum::TangentLeft;
+    } else if (ub_ == i.lb_ - gap) {
+      return PositionEnum::TangentRight;
+    } else {
+      return PositionEnum::NotTangent;
+    }
+  }
+
+  void join(IntervalType const& i, PositionEnum pos) {
+    switch (pos) {
+    case PositionEnum::TangentLeft:
+      vtAssertExpr(lb_ == i.upper() + 1);
+      lb_ = std::min<DomainT>(lb_, i.lower());
+      break;
+    case PositionEnum::TangentRight:
+      vtAssertExpr(ub_ == i.lower() - 1);
+      ub_ = std::max<DomainT>(ub_, i.upper());
+      break;
+    default:
+      vtAssert(false, "Must have tangent position to join");
+    }
+  }
+
+public:
+  template <typename IntT, typename IntU>
+  static bool less(IntT&& i1, IntU&& i2) {
+    return i1.lower() <= i2.upper() and i2.lower() <= i1.upper();
+  }
+
+  friend bool operator<(IntervalType const& i1, IntervalType const& i2);
+
+private:
+  DomainT lb_ = sentinel;
+  DomainT ub_ = sentinel;
+};
+
+template <typename DomainT, typename CompareT, DomainT sentinel>
+bool operator<(
+  Interval<DomainT, CompareT, sentinel> const& i1,
+  Interval<DomainT, CompareT, sentinel> const& i2
+) {
+  return Interval<DomainT, CompareT, sentinel>::less(i1,i2);
+}
+
+template <typename DomainT>
+struct IntervalCompare {
+  using IntervalType = Interval<DomainT>;
+  bool operator()(IntervalType const& i1, IntervalType const& i2) const {
+    return IntervalType::less(i1,i2);
+  }
+};
+
+
+// template <typename T>
+// struct Node {
+//   template <typename T>
+//   using PtrType = std::unique_ptr<Node<T>>;
+
+//   Node() = default;
+//   explicit Node(T z) : x_(z), y_(z) { }
+
+//   bool inLocal(T z) const { return z >= x_ and z <= y; }
+
+//   bool in(T z) {
+//     if (inLocal(z)) {
+//       return true;
+//     } else {
+//       if (z < x_) {
+//         return c1_ ? c1_->in(z) : false;
+//       } else {
+//         return c2_ ? c2_->in(z) : false;
+//       }
+//     }
+//   }
+
+//   void insert(T z, bool new_insert = false) {
+//     if (inLocal(z)) {
+//       vtAssertInfo(
+//         not new_insert, "Element insertion in interval exists", z, x_, y_
+//       );
+//       return;
+//     }
+
+//     if (z < x_) {
+//       // test expand OR create node
+//       c1_->insert(z);
+//     } else {
+//       // test expand OR create node
+//       c2_->insert(z);
+//     }
+//   }
+
+//   bool hasChildren() const {
+//     return c1 != nullptr or c2 != nullptr;
+//   }
+
+//   void testInvariants() const {
+//     vtAssertExpr(x_ <= y_);
+//   }
+
+// private:
+//   T x_ = 0;
+//   T y_ = 0;
+//   PtrType c1_ = nullptr;
+//   PtrType c2_ = nullptr;
+// };
+
+template <
+  typename DomainT,
+  typename CompareT,
+  template <class, class> class IntervalT,
+  template <class, class> class OrderedSetT
+>
+struct IntervalSetBase {
+  using DomainType          = DomainT;
+  using IntervalType        = IntervalT<DomainT, CompareT>;
+  using IntervalCompareType = IntervalCompare<DomainT>;
+  using OrderedSetType      = OrderedSetT<IntervalType, IntervalCompareType>;
+  using IteratorType        = typename OrderedSetType::iterator;
+  using PositionType        = typename OrderedSetType::PositionEnum;
+
+  IntervalSetBase() : iter_(set_.end()) { }
+  IntervalSetBase(IntervalSetBase const&) = default;
+  IntervalSetBase(IntervalSetBase&&) = default;
+
+  template <
+    typename DomainU,
+    typename = std::enable_if_t<
+      std::is_same<std::remove_reference_t<DomainU>, DomainT>::value
+    >
+  >
+  IteratorType insert(DomainU&& val) {
+    IntervalType i(std::forward<DomainU>(val));
+
+    // Expand the global bounds in this interval set
+    updateGlobal(i);
+
+    return insertSet(iter_,std::move(i));
+  }
+
+  template <
+    typename DomainU,
+    typename = std::enable_if_t<
+      std::is_same<std::remove_reference_t<DomainU>, DomainT>::value
+    >
+  >
+  IteratorType insert(IteratorType it, DomainU&& val) {
+    vtAsserExpr(it not_eq set_.end());
+    IntervalType i(std::forward<DomainU>(val));
+
+    // Expand the global bounds in this interval set
+    updateGlobal(i);
+
+    // If the val is tangent to the hint iterator, directly update
+    auto pos = it->tangent(i);
+    if (pos not_eq PositionType::NotTangent) {
+      it->join(i, pos);
+      return it;
+    }
+
+    return insertSet(it,std::move(i));
+  }
+
+  void clear() {
+    set_.clear();
+    lb_ = ub_ = 0;
+    iter_ = set_.end();
+  }
+
+  DomainT range() const { return ub_ - lb_; }
+  DomainT lower() const { return lb_; }
+  DomainT upper() const { return ub_; }
+  bool    empty() const { return set_.size() == 0; }
+
+private:
+
+  template <
+    typename DomainU,
+    typename = std::enable_if_t<
+      std::is_same<std::remove_reference_t<DomainU>, DomainT>::value
+    >
+  >
+  IteratorType insertSet(IteratorType it, IntervalType i) {
+    // Insert into the set
+    auto ret = set_.emplace_hint(it,std::move(i));
+    vtAssert(ret.second,                  "Should be a valid insert");
+    vtAssert(ret.first not_eq set_.end(), "Must be valid insert---live iterator");
+
+    // Fuse interval set elements that are now tangent after this insertion
+    return iter_ = join(ret.first);
+  }
+
+  void updateGlobal(IntervalType const& i) {
+    // Expand the global bounds in this interval set
+    lb_ = std::min<DomainT>(lb_, i.lower());
+    ub_ = std::max<DomainT>(ub_, i.upper());
+  }
+
+  IteratorType join(IteratorType it) {
+    auto it2 = joinLeft(it);
+    return joinRight(it2);
+  }
+
+  IteratorType joinLeft(IteratorType it) {
+    vtAssertExpr(it not_eq set_.end());
+    if (it not_eq set_.begin()) {
+      auto prev = std::prev(it);
+      if (it->tangent(prev) == PositionType::TangentLeft) {
+        it->join(prev, PositionType::TangentLeft);
+        set_.erase(prev);
+      }
+    }
+    return it;
+  }
+
+  IteratorType joinRight(IteratorType it) {
+    vtAssertExpr(it not_eq set_.end());
+    auto next = std::next(it);
+    if (it not_eq set_.end()) {
+      if (it->tangent(next) == PositionType::TangentRight) {
+        it->join(next, PositionType::TangentRight);
+        set_.erase(next);
+      }
+    }
+    return it;
+  }
+
+private:
+  // The lower bound for the entire set
+  DomainT lb_         = 0;
+  // The upper bound for the entire set
+  DomainT ub_         = 0;
+  // The set of all the interval ranges
+  OrderedSetType set_ = {};
+  // The previous insert iterator for quick lookup
+  IteratorType iter_  = {};
+};
+
+}}} /* end namespace vt::term::interval */
+
+#endif /*INCLUDED_VT_TERMINATION_INTERVAL_DISCRETE_INTERVAL_H*/

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -172,17 +172,20 @@ struct IntervalCompare {
 
 template <
   typename DomainT,
-  typename CompareT,
-  template <class, class> class IntervalT,
-  template <class, class> class OrderedSetT
+  typename DomainCompareT,
+  DomainT sentinel,
+  template <class>                 class AllocatorT,
+  template <class, class, DomainT> class IntervalT,
+  template <class, class, class>   class OrderedSetT
 >
 struct IntervalSetBase {
   using DomainType          = DomainT;
-  using IntervalType        = IntervalT<DomainT, CompareT>;
-  using IntervalCompareType = IntervalCompare<DomainT>;
-  using OrderedSetType      = OrderedSetT<IntervalType, IntervalCompareType>;
+  using IntervalType        = IntervalT<DomainT, DomainCompareT, sentinel>;
+  using CompareType         = IntervalCompare<DomainT>;
+  using AllocType           = AllocatorT<IntervalType>;
+  using OrderedSetType      = OrderedSetT<IntervalType, CompareType, AllocType>;
   using IteratorType        = typename OrderedSetType::iterator;
-  using PositionType        = typename OrderedSetType::PositionEnum;
+  using PositionType        = typename IntervalType::PositionEnum;
 
   IntervalSetBase() : iter_(set_.end()) { }
   IntervalSetBase(IntervalSetBase const&) = default;
@@ -357,6 +360,18 @@ private:
   IteratorType iter_  = {};
 };
 
+
 }}} /* end namespace vt::term::interval */
+
+namespace vt {
+
+template <typename DomainT>
+using IntervalSet =
+  term::interval::IntervalSetBase<
+    DomainT, std::less<DomainT>, DomainT{}, std::allocator,
+    term::interval::Interval, std::set
+  >;
+
+} /* end namespace vt */
 
 #endif /*INCLUDED_VT_TERMINATION_INTERVAL_DISCRETE_INTERVAL_H*/

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -94,14 +94,6 @@ public:
     return val >= lb_ and val <= ub_;
   }
 
-  void expandBy(DomainT const& val) {
-    if (val > 0) {
-      ub_ += val;
-    } else {
-      lb_ -= val;
-    }
-  }
-
   enum struct PositionEnum : int {
     TangentLeft = -1,
     NotTangent   = 0,
@@ -304,12 +296,19 @@ private:
     bool is_lower = lb_ == val;
     bool is_upper = ub_ == val;
     if (is_lower) {
-      lb_++;
+      if (set_.size() > 0) {
+        lb_ = set_.begin()->lower();
+      } else {
+        lb_ = 0;
+      }
     }
     if (is_upper) {
-      ub_++;
+      if (set_.size() > 0) {
+        ub_ = std::prev(set_.end())->upper();
+      } else {
+        ub_ = 0;
+      }
     }
-    // @todo update the true valid range
   }
 
   void updateGlobal(IntervalType const& i) {

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -144,6 +144,9 @@ public:
     s | lb_ | ub_;
   }
 
+  bool operator==(IntervalType const& i) const { return i.lb_ == lb_ and i.ub_ == ub_; }
+  bool operator!=(IntervalType const& i) const { return !(*this == i); }
+
 public:
   template <typename IntT, typename IntU>
   static bool intersects(IntT&& i1, IntU&& i2) {

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -163,6 +163,12 @@ public:
 
   friend bool operator<(IntervalType const& i1, IntervalType const& i2);
 
+  template <typename T, typename U, DomainT v>
+  friend std::ostream& operator<<(std::ostream& os, Interval<T,U,v> const& i) {
+    os << "itv[" << i.lower() << "," << i.upper() << "]";
+    return os;
+  }
+
 private:
   DomainT lb_ = sentinel;
   DomainT ub_ = sentinel;

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -500,6 +500,9 @@ private:
 
 namespace vt {
 
+template <typename DomainT, typename CompareT = std::less<DomainT>>
+using Interval = term::interval::Interval<DomainT, CompareT>;
+
 template <typename DomainT>
 using IntervalSet =
   term::interval::IntervalSetBase<

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -345,8 +345,8 @@ private:
     vtAssertExpr(it not_eq set_.end());
     if (it not_eq set_.begin()) {
       auto prev = std::prev(it);
-      if (it->tangent(prev) == PositionType::TangentLeft) {
-        it->join(prev, PositionType::TangentLeft);
+      if (it->tangent(*prev) == PositionType::TangentLeft) {
+        it->join(*prev, PositionType::TangentLeft);
         set_.erase(prev);
       }
     }
@@ -357,8 +357,8 @@ private:
     vtAssertExpr(it not_eq set_.end());
     auto next = std::next(it);
     if (it not_eq set_.end()) {
-      if (it->tangent(next) == PositionType::TangentRight) {
-        it->join(next, PositionType::TangentRight);
+      if (it->tangent(*next) == PositionType::TangentRight) {
+        it->join(*next, PositionType::TangentRight);
         set_.erase(next);
       }
     }

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -111,7 +111,7 @@ public:
    *                    gap            gap
    */
 
-  PositionEnum tangent(IntervalType const& i, DomainT gap = 1) {
+  PositionEnum tangent(IntervalType const& i, DomainT gap = 1) const {
     if (lb_ == i.ub_ + gap) {
       return PositionEnum::TangentLeft;
     } else if (ub_ == i.lb_ - gap) {

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -329,7 +329,7 @@ private:
   IteratorType insertSet(IteratorType it, IntervalType&& i) {
     // Insert into the set
     auto ret = set_.emplace_hint(it,std::move(i));
-    vtAssert(ret != it,             "Should be a valid insert");
+    vtAssert(ret not_eq it,         "Should be a valid insert");
     vtAssert(ret not_eq set_.end(), "Must be valid insert---live iterator");
 
     // Fuse interval set elements that are now tangent after this insertion

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -348,7 +348,8 @@ private:
       if (it->tangent(*prev) == PositionType::TangentLeft) {
         auto tmp = *prev;
         set_.erase(prev);
-        it->join(tmp, PositionType::TangentLeft);
+        auto& to_fuse = const_cast<IntervalType&>(*it);
+        to_fuse.join(tmp, PositionType::TangentLeft);
       }
     }
     return it;
@@ -361,7 +362,8 @@ private:
       if (it->tangent(*next) == PositionType::TangentRight) {
         auto tmp = *next;
         set_.erase(next);
-        it->join(tmp, PositionType::TangentRight);
+        auto& to_fuse = const_cast<IntervalType&>(*it);
+        to_fuse.join(tmp, PositionType::TangentRight);
       }
     }
     return it;

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -452,6 +452,8 @@ public:
       return *this;
     }
 
+    Iter operator++(int) { Iter ret = *this; ++(*this); return ret; }
+    Iter operator--(int) { Iter ret = *this; --(*this); return ret; }
     bool operator==(Iter i) const { return i.impl_ == impl_ and i.cur_ == cur_; }
     bool operator!=(Iter i) const { return !(*this == i); }
     pointer operator*() const { return impl_->get(cur_); }

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -296,11 +296,11 @@ private:
   IteratorType insertSet(IteratorType it, IntervalType&& i) {
     // Insert into the set
     auto ret = set_.emplace_hint(it,std::move(i));
-    vtAssert(ret.second,                  "Should be a valid insert");
-    vtAssert(ret.first not_eq set_.end(), "Must be valid insert---live iterator");
+    vtAssert(ret != it,             "Should be a valid insert");
+    vtAssert(ret not_eq set_.end(), "Must be valid insert---live iterator");
 
     // Fuse interval set elements that are now tangent after this insertion
-    return hint_ = join(ret.first);
+    return hint_ = join(ret);
   }
 
   bool existsGlobal(DomainT const& val) const {

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -346,8 +346,9 @@ private:
     if (it not_eq set_.begin()) {
       auto prev = std::prev(it);
       if (it->tangent(*prev) == PositionType::TangentLeft) {
-        it->join(*prev, PositionType::TangentLeft);
+        auto tmp = *prev;
         set_.erase(prev);
+        it->join(tmp, PositionType::TangentLeft);
       }
     }
     return it;
@@ -358,8 +359,9 @@ private:
     auto next = std::next(it);
     if (it not_eq set_.end()) {
       if (it->tangent(*next) == PositionType::TangentRight) {
-        it->join(*next, PositionType::TangentRight);
+        auto tmp = *next;
         set_.erase(next);
+        it->join(tmp, PositionType::TangentRight);
       }
     }
     return it;

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -467,10 +467,17 @@ public:
   using ForwardIter  = IntervalSetIter<IteratorType>;
   using ReverseIter  = std::reverse_iterator<ForwardIter>;
 
+  // Per-element iterators
   ForwardIter begin()  { return ForwardIter(set_.begin(),0); }
   ForwardIter end()    { return ForwardIter(set_.end(),0); }
   ReverseIter rbegin() { return ReverseIter(end()); }
   ReverseIter rend()   { return ReverseIter(begin()); }
+
+  // Per-interval iterators
+  IteratorType ibegin()  { return set_.begin(); }
+  IteratorType iend()    { return set_.end(); }
+  IteratorType irbegin() { return set_.rbegin(); }
+  IteratorType irend()   { return set_.rend(); }
 
 private:
   // The lower bound for the entire set

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -311,6 +311,19 @@ struct IntervalSetBase {
     }
   }
 
+  void dumpState() const {
+    debug_print(
+      gen, node,
+      "OrderedSet: bounds=[{},{}] size={}, compressedSize={}, compression={}\n",
+      lb_, ub_, size(), compressedSize(), compression()
+    );
+    std::size_t c = 0;
+    for (auto&& i : set_) {
+      debug_print(gen, node, "\t interval {} : {}\n", c, i);
+      c++;
+    }
+  }
+
 private:
 
   IteratorType insertSet(IteratorType it, IntervalType&& i) {

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -143,6 +143,20 @@ public:
 
 public:
   template <typename IntT, typename IntU>
+  static bool intersects(IntT&& i1, IntU&& i2) {
+    bool ret = i1.lower() <= i2.upper() and i2.lower() <= i1.upper();
+    debug_print(
+      gen, node,
+      "Interval intersects: i1={}, i2={}, op:{}<={}={} and {}<={}={} => {}\n",
+      i1, i2,
+      i1.lower(), i2.upper(), i1.lower() <= i2.upper(),
+      i2.lower(), i1.upper(), i2.lower() <= i1.upper(),
+      ret
+    );
+    return ret;
+  }
+
+  template <typename IntT, typename IntU>
   static bool less(IntT&& i1, IntU&& i2) {
     return i1.lower() <= i2.upper() and i2.lower() <= i1.upper();
   }

--- a/src/vt/termination/interval/discrete_interval.h
+++ b/src/vt/termination/interval/discrete_interval.h
@@ -158,7 +158,7 @@ public:
 
   template <typename IntT, typename IntU>
   static bool less(IntT&& i1, IntU&& i2) {
-    return i1.lower() <= i2.upper() and i2.lower() <= i1.upper();
+    return i1.lower() < i2.lower() and i1.upper() < i2.lower();
   }
 
   friend bool operator<(IntervalType const& i1, IntervalType const& i2);

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -50,6 +50,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <set>
 
 namespace vt { namespace term { namespace interval {
 

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -135,13 +135,16 @@ struct IntegralSetBase {
           hint_ = ret;
         }
       } else if (iter->upper() == val) {
-        iter->setUpper(iter->upper() - 1);
+        auto& to_split = const_cast<IntervalType&>(*iter);
+        to_split.setUpper(iter->upper() - 1);
       } else if (iter->lower() == val) {
-        iter->setLower(iter->lower() + 1);
+        auto& to_split = const_cast<IntervalType&>(*iter);
+        to_split.setLower(iter->lower() + 1);
       } else {
         // Splice the interval into two pieces
         vtAssert(iter->width() > 2, "Interval width must be greater than 2");
-        iter->setUpper(val - 1);
+        auto& to_split = const_cast<IntervalType&>(*iter);
+        to_split.setUpper(val - 1);
         IntervalType i(val+1, iter->upper());
         insertSet(iter,std::move(i));
       }

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -88,7 +88,13 @@ struct IntegralSetBase {
     : lb_(base),
       ub_(base),
       hint_(set_.end())
-  { }
+  {
+    debug_print(
+      gen, node,
+      "OrderedSet: construct: bounds=[{:x},{:x}] elms_={}, is_end={}\n",
+      lb_, ub_, elms_, hint_ == set_.end()
+    );
+ }
 
   template <
     typename DomainU,
@@ -99,6 +105,11 @@ struct IntegralSetBase {
     >
   >
   IteratorType insert(DomainU&& val) {
+    debug_print(
+      gen, node,
+      "OrderedSet: insert: bounds=[{:x},{:x}] elms_={}, is_end={}\n",
+      lb_, ub_, elms_, hint_ == set_.end()
+    );
     return insertInterval(IntervalType(std::forward<DomainU>(val)));
   }
 
@@ -124,6 +135,12 @@ struct IntegralSetBase {
     >
   >
   IteratorType insertInterval(IntervalU&& i) {
+    debug_print(
+      gen, node,
+      "OrderedSet: insertInterval: bounds=[{:x},{:x}] elms_={}, i={}, is_end={}\n",
+      lb_, ub_, elms_, i, hint_ == set_.end()
+    );
+
     // Expand the global bounds in this interval set
     insertGlobal(i);
 
@@ -161,7 +178,7 @@ struct IntegralSetBase {
     bool in_set = iter != set_.end();
     debug_print(
       gen, node,
-      "OrderedSet: erase: bounds=[{},{}] size={}, comp={}, val={}, in={}\n",
+      "OrderedSet: erase: bounds=[{:x},{:x}] size={}, comp={}, val={}, in={}\n",
       lb_, ub_, size(), compressedSize(), j, in_set
     );
     vtAssert(in_set, "The element must exist in a interval bucket");
@@ -230,7 +247,7 @@ struct IntegralSetBase {
   void dumpState() const {
     debug_print(
       gen, node,
-      "OrderedSet: bounds=[{},{}] size={}, compressedSize={}, compression={}\n",
+      "OrderedSet: bounds=[{:x},{:x}] size={}, compressedSize={}, compression={}\n",
       lb_, ub_, size(), compressedSize(), compression()
     );
     std::size_t c = 0;
@@ -243,6 +260,12 @@ struct IntegralSetBase {
 private:
 
   IteratorType insertSet(IteratorType it, IntervalType&& i) {
+    debug_print(
+      gen, node,
+      "OrderedSet: insertSet: bounds=[{:x},{:x}] elms_={}, i={}, is_end={}\n",
+      lb_, ub_, elms_, i, it == set_.end()
+    );
+
     // Insert into the set
     auto ret = set_.emplace_hint(it,std::move(i));
     vtAssert(ret not_eq it,         "Should be a valid insert");
@@ -278,6 +301,12 @@ private:
   }
 
   void insertGlobal(IntervalType const& i) {
+    debug_print(
+      gen, node,
+      "OrderedSet: insertGlobal: bounds=[{:x},{:x}] elms_={}, i={}\n",
+      lb_, ub_, elms_, i
+    );
+
     if (elms_ == 0) {
       lb_ = i.lower();
       ub_ = i.upper();
@@ -291,6 +320,12 @@ private:
   }
 
   IteratorType join(IteratorType it) {
+    debug_print(
+      gen, node,
+      "OrderedSet: join: bounds=[{:x},{:x}] elms_={}\n",
+      lb_, ub_, elms_
+    );
+
     auto it2 = joinLeft(it);
     return joinRight(it2);
   }

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -210,6 +210,7 @@ struct IntegralSetBase {
     }
   }
 
+  bool contains(DomainT const& val) const { return exists(val); }
   bool exists(DomainT const& val) const {
     if (not existsGlobal(val)) {
       return false;

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -92,12 +92,7 @@ struct IntegralSetBase {
     >
   >
   IteratorType insert(DomainU&& val) {
-    IntervalType i(std::forward<DomainU>(val));
-
-    // Expand the global bounds in this interval set
-    insertGlobal(i);
-
-    return insertSet(hint_,std::move(i));
+    return insertInterval(IntervalType(std::forward<DomainU>(val)));
   }
 
   template <
@@ -110,8 +105,34 @@ struct IntegralSetBase {
   >
   IteratorType insert(IteratorType it, DomainU&& val) {
     vtAsserExpr(it not_eq set_.end());
-    IntervalType i(std::forward<DomainU>(val));
+    return insertInterval(IntervalType(std::forward<DomainU>(val)));
+  }
 
+  template <
+    typename IntervalU,
+    typename = std::enable_if_t<
+      std::is_same<
+        std::remove_const_t<std::remove_reference_t<IntervalU>>, IntervalType
+      >::value
+    >
+  >
+  IteratorType insertInterval(IntervalU&& i) {
+    // Expand the global bounds in this interval set
+    insertGlobal(i);
+
+    // Insert interval into the compressed tree
+    return insertSet(hint_,std::move(i));
+  }
+
+  template <
+    typename IntervalU,
+    typename = std::enable_if_t<
+      std::is_same<
+        std::remove_const_t<std::remove_reference_t<IntervalU>>, IntervalType
+      >::value
+    >
+  >
+  IteratorType insertInterval(IteratorType it, IntervalU&& i) {
     // Expand the global bounds in this interval set
     insertGlobal(i);
 
@@ -122,6 +143,7 @@ struct IntegralSetBase {
       return it;
     }
 
+    // Insert interval into the compressed tree
     return insertSet(it,std::move(i));
   }
 

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -86,7 +86,9 @@ struct IntegralSetBase {
   template <
     typename DomainU,
     typename = std::enable_if_t<
-      std::is_same<std::remove_reference_t<DomainU>, DomainT>::value
+      std::is_same<
+        std::remove_const_t<std::remove_reference_t<DomainU>>, DomainT
+      >::value
     >
   >
   IteratorType insert(DomainU&& val) {
@@ -101,7 +103,9 @@ struct IntegralSetBase {
   template <
     typename DomainU,
     typename = std::enable_if_t<
-      std::is_same<std::remove_reference_t<DomainU>, DomainT>::value
+      std::is_same<
+        std::remove_const_t<std::remove_reference_t<DomainU>>, DomainT
+      >::value
     >
   >
   IteratorType insert(IteratorType it, DomainU&& val) {

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -123,8 +123,14 @@ struct IntegralSetBase {
 
   void erase(DomainT const& val) {
     vtAssert(existsGlobal(val), "This element must exist in the set");
-    auto iter = set_.find(val);
+    IntervalType j(val);
+    auto iter = set_.find(j);
     bool in_set = iter != set_.end();
+    debug_print(
+      gen, node,
+      "OrderedSet: erase: bounds=[{},{}] size={}, comp={}, val={}, in={}\n",
+      lb_, ub_, size(), compressedSize(), j, in_set
+    );
     vtAssert(in_set, "The element must exist in a interval bucket");
     if (in_set) {
       eraseGlobal(val);
@@ -143,9 +149,10 @@ struct IntegralSetBase {
       } else {
         // Splice the interval into two pieces
         vtAssert(iter->width() > 2, "Interval width must be greater than 2");
+        auto ub = iter->upper();
         auto& to_split = const_cast<IntervalType&>(*iter);
         to_split.setUpper(val - 1);
-        IntervalType i(val+1, iter->upper());
+        IntervalType i(val+1, ub);
         insertSet(iter,std::move(i));
       }
     }
@@ -155,7 +162,8 @@ struct IntegralSetBase {
     if (not existsGlobal(val)) {
       return false;
     }
-    auto iter = set_.find(val);
+    IntervalType i(val);
+    auto iter = set_.find(i);
     bool in_set = iter != set_.end();
     if (in_set) {
       vtAssert(iter->in(val), "Value must exists in range");

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -159,7 +159,6 @@ struct IntegralSetBase {
     );
     vtAssert(in_set, "The element must exist in a interval bucket");
     if (in_set) {
-      eraseGlobal(val);
       if (iter->width() == 1) {
         bool invalid_hint = iter == hint_;
         auto ret = set_.erase(iter);
@@ -181,6 +180,7 @@ struct IntegralSetBase {
         IntervalType i(val+1, ub);
         insertSet(iter,std::move(i));
       }
+      eraseGlobal(val);
     }
   }
 

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -249,10 +249,15 @@ private:
   }
 
   void insertGlobal(IntervalType const& i) {
-    // Expand the global bounds in this interval set
-    lb_ = std::min<DomainT>(lb_, i.lower());
-    ub_ = std::max<DomainT>(ub_, i.upper());
-    // Decrement count of non-compressed elements
+    if (elms_ == 0) {
+      lb_ = i.lower();
+      ub_ = i.upper();
+    } else {
+      // Expand the global bounds in this interval set
+      lb_ = std::min<DomainT>(lb_, i.lower());
+      ub_ = std::max<DomainT>(ub_, i.upper());
+    }
+    // Increment count of non-compressed elements
     elms_++;
   }
 

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -162,6 +162,9 @@ struct IntegralSetBase {
     // Expand the global bounds in this interval set
     insertGlobal(i);
 
+    // Must be valid iterator to call this overload
+    vtAssert(it != set_.end(), "Must be valid iterator");
+
     // If the val is tangent to the hint iterator, directly update
     auto pos = it->tangent(i);
     if (pos not_eq PositionType::NotTangent) {

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -64,16 +64,16 @@ namespace vt { namespace term { namespace interval {
 
 template <
   typename DomainT,
-  typename DomainCompareT,
   DomainT sentinel,
   template <class>                 class AllocatorT,
-  template <class, class, DomainT> class IntervalT,
-  template <class, class, class>   class OrderedSetT
+  template <class, DomainT>        class IntervalT,
+  template <class, class, class>   class OrderedSetT,
+  template <class>                 class IntervalCompareT
 >
 struct IntegralSetBase {
   using DomainType          = DomainT;
-  using IntervalType        = IntervalT<DomainT, DomainCompareT, sentinel>;
-  using CompareType         = IntervalCompare<DomainT>;
+  using IntervalType        = IntervalT<DomainT, sentinel>;
+  using CompareType         = IntervalCompareT<DomainT>;
   using AllocType           = AllocatorT<IntervalType>;
   using OrderedSetType      = OrderedSetT<IntervalType, CompareType, AllocType>;
   using IteratorType        = typename OrderedSetType::iterator;
@@ -492,8 +492,12 @@ namespace vt {
 template <typename DomainT>
 using IntegralSet =
   term::interval::IntegralSetBase<
-    DomainT, std::less<DomainT>, DomainT{}, std::allocator,
-    term::interval::Interval, std::set
+    DomainT,
+    DomainT{},
+    std::allocator,
+    term::interval::Interval,
+    std::set,
+    IntervalCompare
   >;
 
 } /* end namespace vt */

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -82,6 +82,13 @@ struct IntegralSetBase {
   IntegralSetBase() : hint_(set_.end()) { }
   IntegralSetBase(IntegralSetBase const&) = default;
   IntegralSetBase(IntegralSetBase&&) = default;
+  IntegralSetBase& operator=(IntegralSetBase const&) = default;
+
+  explicit IntegralSetBase(DomainT base)
+    : lb_(base),
+      ub_(base),
+      hint_(set_.end())
+  { }
 
   template <
     typename DomainU,

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -218,7 +218,7 @@ struct IntegralSetBase {
     auto iter = set_.find(i);
     bool in_set = iter != set_.end();
     if (in_set) {
-      vtAssert(iter->in(val), "Value must exists in range");
+      vtAssert(iter->contains(val), "Value must be contained in range");
     }
     return in_set;
   }

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -191,7 +191,7 @@ struct IntegralSetBase {
 
   float compression() const {
     if (set_.size() > 0) {
-      return static_cast<double>(elms_) / static_cast<double>(set_.size());
+      return static_cast<float>(elms_) / static_cast<float>(set_.size());
     } else {
       vtAssert(elms_ == 0, "Number of elements must be zero is set is empty");
       return 1.0f;

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -137,7 +137,7 @@ struct IntegralSetBase {
       } else if (iter->upper() == val) {
         iter->setUpper(iter->upper() - 1);
       } else if (iter->lower() == val) {
-        iter->setUpper(iter->lower() + 1);
+        iter->setLower(iter->lower() + 1);
       } else {
         // Splice the interval into two pieces
         vtAssert(iter->width() > 2, "Interval width must be greater than 2");

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -147,7 +147,7 @@ struct IntegralSetBase {
         auto& to_split = const_cast<IntervalType&>(*iter);
         to_split.setLower(iter->lower() + 1);
       } else {
-        // Splice the interval into two pieces
+        // Slice the interval into two interval nodes
         vtAssert(iter->width() > 2, "Interval width must be greater than 2");
         auto ub = iter->upper();
         auto& to_split = const_cast<IntervalType&>(*iter);

--- a/src/vt/termination/interval/integral_set.h
+++ b/src/vt/termination/interval/integral_set.h
@@ -141,11 +141,13 @@ struct IntegralSetBase {
       lb_, ub_, elms_, i, hint_ == set_.end()
     );
 
+    auto iter = elms_ == 0 ? set_.end() : hint_;
+
     // Expand the global bounds in this interval set
     insertGlobal(i);
 
     // Insert interval into the compressed tree
-    return insertSet(hint_,std::move(i));
+    return insertSet(iter,std::move(i));
   }
 
   template <
@@ -267,7 +269,7 @@ private:
     );
 
     // Insert into the set
-    auto ret = set_.emplace_hint(it,std::move(i));
+    auto ret = set_.insert(it,std::move(i));
     vtAssert(ret not_eq it,         "Should be a valid insert");
     vtAssert(ret not_eq set_.end(), "Must be valid insert---live iterator");
 

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -75,7 +75,7 @@ public:
   DomainT lower() const { return lb_; }
   DomainT upper() const { return ub_; }
   DomainT width() const { return (ub_-lb_)+1; }
-  bool    valid() const { return lb_ != sentinel and ub != sentinel and lb_ <= ub_; }
+  bool    valid() const { return lb_ != sentinel and ub_ != sentinel and lb_ <= ub_; }
 
   DomainT get(std::size_t i) const {
     vtAssert(lb_ not_eq sentinel, "Lower bound must be valid");

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -103,7 +103,7 @@ public:
 
   /*
    * Determine if a input interval is tangent to this interval within a
-   * specified grap.
+   * specified gap.
    *
    *        TangentLeft                   TangentRight
    *       |------i-----| lb_        ub_ |------i-----|

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -75,10 +75,12 @@ public:
   DomainT lower() const { return lb_; }
   DomainT upper() const { return ub_; }
   DomainT width() const { return (ub_-lb_)+1; }
-  bool    valid() const { return lb_ <= ub_; }
+  bool    valid() const { return lb_ != sentinel and ub != sentinel and lb_ <= ub_; }
 
   DomainT get(std::size_t i) const {
-    vtAssert(lb_ + i <= ub_, "Must be in interval range");
+    vtAssert(lb_ not_eq sentinel, "Lower bound must be valid");
+    vtAssert(ub_ not_eq sentinel, "Upper bound must be valid");
+    vtAssert(lb_ + i <= ub_,      "Must be in interval range");
     return lb_ + i;
   }
 
@@ -134,11 +136,11 @@ public:
     switch (pos) {
     case PositionEnum::TangentLeft:
       vtAssertExpr(lb_ == i.upper() + 1);
-      lb_ = std::min<DomainT>(lb_, i.lower());
+      lb_ = i.lower();
       break;
     case PositionEnum::TangentRight:
       vtAssertExpr(ub_ == i.lower() - 1);
-      ub_ = std::max<DomainT>(ub_, i.upper());
+      ub_ = i.upper();
       break;
     default:
       vtAssert(false, "Must have tangent position to join");

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -54,13 +54,9 @@ namespace vt { namespace term { namespace interval {
  * representation.
  */
 
-template <
-  typename DomainT,
-  typename CompareT = std::less<DomainT>,
-  DomainT sentinel = DomainT()
->
+template <typename DomainT, DomainT sentinel = DomainT()>
 struct Interval {
-  using IntervalType = Interval<DomainT, CompareT, sentinel>;
+  using IntervalType = Interval<DomainT, sentinel>;
   using DomainType   = DomainT;
 
   Interval() = default;
@@ -189,8 +185,8 @@ public:
 
   friend bool operator<(IntervalType const& i1, IntervalType const& i2);
 
-  template <typename T, typename U, DomainT v>
-  friend std::ostream& operator<<(std::ostream& os, Interval<T,U,v> const& i) {
+  template <typename T, DomainT v>
+  friend std::ostream& operator<<(std::ostream& os, Interval<T,v> const& i) {
     os << "itv[" << i.lower() << "," << i.upper() << "]";
     return os;
   }
@@ -200,12 +196,11 @@ private:
   DomainT ub_ = sentinel;
 };
 
-template <typename DomainT, typename CompareT, DomainT sentinel>
+template <typename DomainT, DomainT sentinel>
 bool operator<(
-  Interval<DomainT, CompareT, sentinel> const& i1,
-  Interval<DomainT, CompareT, sentinel> const& i2
+  Interval<DomainT, sentinel> const& i1, Interval<DomainT, sentinel> const& i2
 ) {
-  return Interval<DomainT, CompareT, sentinel>::less(i1,i2);
+  return Interval<DomainT, sentinel>::less(i1,i2);
 }
 
 template <typename DomainT>
@@ -220,8 +215,11 @@ struct IntervalCompare {
 
 namespace vt {
 
-template <typename DomainT, typename CompareT = std::less<DomainT>>
-using Interval = term::interval::Interval<DomainT, CompareT>;
+template <typename DomainT>
+using IntervalCompare = term::interval::IntervalCompare<DomainT>;
+
+template <typename DomainT>
+using Interval = term::interval::Interval<DomainT>;
 
 } /* end namespace vt */
 

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -94,6 +94,11 @@ public:
     vtAssert(valid(),    "Interval must remain valid");
   }
 
+  void set(DomainT const& lo, DomainT const& hi) {
+    setLower(lo);
+    setUpper(hi);
+  }
+
   bool contains(DomainT const& val) const {
     return val >= lb_ and val <= ub_;
   }

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -1,0 +1,206 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                          interval.h
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_TERMINATION_INTERVAL_INTERVAL_H
+#define INCLUDED_VT_TERMINATION_INTERVAL_INTERVAL_H
+
+#include "vt/config.h"
+
+namespace vt { namespace term { namespace interval {
+
+/*
+ * Discrete interval for encoding compressed sets (DIETs). Inclusive in
+ * representation.
+ */
+
+template <
+  typename DomainT,
+  typename CompareT = std::less<DomainT>,
+  DomainT sentinel = DomainT()
+>
+struct Interval {
+  using IntervalType = Interval<DomainT, CompareT, sentinel>;
+  using DomainType   = DomainT;
+
+  Interval() = default;
+  Interval(Interval const&) = default;
+  Interval(Interval&&) = default;
+  Interval& operator=(Interval const&) = default;
+
+  Interval(DomainT const& val) : lb_(val), ub_(val) { }
+  Interval(DomainT const& lb, DomainT const& ub) : lb_(lb), ub_(ub) { }
+
+public:
+  DomainT lower() const { return lb_; }
+  DomainT upper() const { return ub_; }
+  DomainT width() const { return (ub_-lb_)+1; }
+  bool    valid() const { lb_ <= ub_; }
+
+  DomainT get(std::size_t i) const { return lb_ + i; }
+
+  void setUpper(DomainT const& val) {
+    ub_ = val;
+    vtAssert(val >= lb_, "Upper must be greater than lower bound");
+    vtAssert(valid(),    "Interval must remain valid");
+  }
+
+  void setLower(DomainT const& val) {
+    lb_ = val;
+    vtAssert(ub_ >= val, "Lower must be less than upper bound");
+    vtAssert(valid(),    "Interval must remain valid");
+  }
+
+  bool in(DomainT const& val) const {
+    return val >= lb_ and val <= ub_;
+  }
+
+  enum struct PositionEnum : int {
+    TangentLeft = -1,
+    NotTangent   = 0,
+    TangentRight = 1
+  };
+
+  /*
+   * Determine if a input interval is tangent to this interval within a
+   * specified grap.
+   *
+   *        TangentLeft                   TangentRight
+   *       |------i-----| lb_        ub_ |------i-----|
+   *                      |----this----|
+   *                     ^              ^
+   *                    gap            gap
+   */
+
+  PositionEnum tangent(IntervalType const& i, DomainT gap = 1) const {
+    if (lb_ == i.ub_ + gap) {
+      return PositionEnum::TangentLeft;
+    } else if (ub_ == i.lb_ - gap) {
+      return PositionEnum::TangentRight;
+    } else {
+      return PositionEnum::NotTangent;
+    }
+  }
+
+  void join(IntervalType const& i, PositionEnum pos) {
+    switch (pos) {
+    case PositionEnum::TangentLeft:
+      vtAssertExpr(lb_ == i.upper() + 1);
+      lb_ = std::min<DomainT>(lb_, i.lower());
+      break;
+    case PositionEnum::TangentRight:
+      vtAssertExpr(ub_ == i.lower() - 1);
+      ub_ = std::max<DomainT>(ub_, i.upper());
+      break;
+    default:
+      vtAssert(false, "Must have tangent position to join");
+    }
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | lb_ | ub_;
+  }
+
+  bool operator==(IntervalType const& i) const { return i.lb_ == lb_ and i.ub_ == ub_; }
+  bool operator!=(IntervalType const& i) const { return !(*this == i); }
+
+public:
+  template <typename IntT, typename IntU>
+  static bool intersects(IntT&& i1, IntU&& i2) {
+    bool ret = i1.lower() <= i2.upper() and i2.lower() <= i1.upper();
+    debug_print(
+      gen, node,
+      "Interval intersects: i1={}, i2={}, op:{}<={}={} and {}<={}={} => {}\n",
+      i1, i2,
+      i1.lower(), i2.upper(), i1.lower() <= i2.upper(),
+      i2.lower(), i1.upper(), i2.lower() <= i1.upper(),
+      ret
+    );
+    return ret;
+  }
+
+  template <typename IntT, typename IntU>
+  static bool less(IntT&& i1, IntU&& i2) {
+    return i1.lower() < i2.lower() and i1.upper() < i2.lower();
+  }
+
+  friend bool operator<(IntervalType const& i1, IntervalType const& i2);
+
+  template <typename T, typename U, DomainT v>
+  friend std::ostream& operator<<(std::ostream& os, Interval<T,U,v> const& i) {
+    os << "itv[" << i.lower() << "," << i.upper() << "]";
+    return os;
+  }
+
+private:
+  DomainT lb_ = sentinel;
+  DomainT ub_ = sentinel;
+};
+
+template <typename DomainT, typename CompareT, DomainT sentinel>
+bool operator<(
+  Interval<DomainT, CompareT, sentinel> const& i1,
+  Interval<DomainT, CompareT, sentinel> const& i2
+) {
+  return Interval<DomainT, CompareT, sentinel>::less(i1,i2);
+}
+
+template <typename DomainT>
+struct IntervalCompare {
+  using IntervalType = Interval<DomainT>;
+  bool operator()(IntervalType const& i1, IntervalType const& i2) const {
+    return IntervalType::less(i1,i2);
+  }
+};
+
+}}} /* end namespace vt::term::interval */
+
+namespace vt {
+
+template <typename DomainT, typename CompareT = std::less<DomainT>>
+using Interval = term::interval::Interval<DomainT, CompareT>;
+
+} /* end namespace vt */
+
+#endif /*INCLUDED_VT_TERMINATION_INTERVAL_INTERVAL_H*/

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -77,7 +77,10 @@ public:
   DomainT width() const { return (ub_-lb_)+1; }
   bool    valid() const { return lb_ <= ub_; }
 
-  DomainT get(std::size_t i) const { return lb_ + i; }
+  DomainT get(std::size_t i) const {
+    vtAssert(lb_ + i <= ub_, "Must be in interval range");
+    return lb_ + i;
+  }
 
   void setUpper(DomainT const& val) {
     ub_ = val;

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -154,6 +154,18 @@ public:
   bool operator!=(IntervalType const& i) const { return !(*this == i); }
 
 public:
+  /*
+   * Determine if two intervals intersect:
+   *
+   *
+   *.         [i1.lower(), ..., i1.upper()]
+   *                           ^          ^
+   *                           |          |
+   *                           [i2.lower(), ...,  i2.upper()]
+   *
+   * Two intervals intersect iff:
+   *      (i2.lower() <= i1.upper()) && (i1.lower() <= i2.upper())
+   */
   template <typename IntT, typename IntU>
   static bool intersects(IntT&& i1, IntU&& i2) {
     bool ret = i1.lower() <= i2.upper() and i2.lower() <= i1.upper();

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -94,7 +94,7 @@ public:
     vtAssert(valid(),    "Interval must remain valid");
   }
 
-  bool in(DomainT const& val) const {
+  bool contains(DomainT const& val) const {
     return val >= lb_ and val <= ub_;
   }
 

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -68,7 +68,7 @@ struct Interval {
   Interval(Interval&&) = default;
   Interval& operator=(Interval const&) = default;
 
-  Interval(DomainT const& val) : lb_(val), ub_(val) { }
+  explicit Interval(DomainT const& val) : lb_(val), ub_(val) { }
   Interval(DomainT const& lb, DomainT const& ub) : lb_(lb), ub_(ub) { }
 
 public:

--- a/src/vt/termination/interval/interval.h
+++ b/src/vt/termination/interval/interval.h
@@ -75,7 +75,7 @@ public:
   DomainT lower() const { return lb_; }
   DomainT upper() const { return ub_; }
   DomainT width() const { return (ub_-lb_)+1; }
-  bool    valid() const { lb_ <= ub_; }
+  bool    valid() const { return lb_ <= ub_; }
 
   DomainT get(std::size_t i) const { return lb_ + i; }
 

--- a/src/vt/termination/term_window.cc
+++ b/src/vt/termination/term_window.cc
@@ -115,24 +115,30 @@ void EpochWindow::addEpoch(EpochType const& epoch) {
 void EpochWindow::closeEpoch(EpochType const& epoch) {
   debug_print_verbose(
     term, node,
-    "closeEpoch: (before) epoch={:x}, unresolved: first={:x}, last={:x}\n",
-    epoch, active_.lower(), active_.upper()
+    "closeEpoch: (before) epoch={:x}, first={:x}, last={:x}, num={}, "
+    "compression={}\n",
+    epoch, active_.lower(), active_.upper(), active_.size(),
+    active_.compression()
   );
 
   active_.erase(epoch);
 
   debug_print(
     term, node,
-    "closeEpoch: (after) epoch={:x}, unresolved: first={:x}, last={:x}\n",
-    epoch, active_.lower(), active_.upper()
+    "closeEpoch: (after) epoch={:x}, first={:x}, last={:x}, num={}, "
+    "compression={}\n",
+    epoch, active_.lower(), active_.upper(), active_.size(),
+    active_.compression()
   );
 }
 
 bool EpochWindow::isTerminated(EpochType const& epoch) const {
   debug_print(
     term, node,
-    "isTerminated: epoch={:x}, first={:x}, last={:x}\n",
-    epoch, active_.lower(), active_.upper()
+    "isTerminated: epoch={:x}, first={:x}, last={:x}, num={}, "
+    "compression={}\n",
+    epoch, active_.lower(), active_.upper(), active_.size(),
+    active_.compression()
   );
 
   return not active_.exists(epoch);

--- a/src/vt/termination/term_window.cc
+++ b/src/vt/termination/term_window.cc
@@ -103,7 +103,7 @@ void EpochWindow::addEpoch(EpochType const& epoch) {
     "addEpoch: (after) epoch={:x}, first={:x}, last={:x}, num={}, "
     "compression={}\n",
     epoch, terminated_epochs_.lower(), terminated_epochs_.upper(),
-    terminated_epochs_.size(), termin_.compression()
+    terminated_epochs_.size(), terminated_epochs_.compression()
   );
 }
 
@@ -132,8 +132,8 @@ bool EpochWindow::isTerminated(EpochType const& epoch) const {
     term, node,
     "isTerminated: epoch={:x}, first={:x}, last={:x}, num={}, "
     "compression={}\n",
-    epoch, terminated_epochs_.lower(), terminated_epochs_.upper(), term_.size(),
-    terminated_epochs_.compression()
+    epoch, terminated_epochs_.lower(), terminated_epochs_.upper(),
+    terminated_epochs_.size(), terminated_epochs_.compression()
   );
 
   return terminated_epochs_.contains(epoch);

--- a/src/vt/termination/term_window.cc
+++ b/src/vt/termination/term_window.cc
@@ -93,7 +93,7 @@ void EpochWindow::addEpoch(EpochType const& epoch) {
 
   // We should possibly perform some error checking once we wrap around in case
   // of pending actions
-  if (term_.exists(epoch)) {
+  if (term_.contains(epoch)) {
     term_.erase(epoch);
   }
 
@@ -135,7 +135,7 @@ bool EpochWindow::isTerminated(EpochType const& epoch) const {
     term_.compression()
   );
 
-  return term_.exists(epoch);
+  return term_.contains(epoch);
 }
 
 }} /* end namespace vt::term */

--- a/src/vt/termination/term_window.cc
+++ b/src/vt/termination/term_window.cc
@@ -48,7 +48,7 @@
 namespace vt { namespace term {
 
 EpochWindow::EpochWindow(EpochType const& epoch)
-  : term_(epoch)
+  : terminated_epochs_(epoch)
  {
   auto arch_epoch = epoch;
   /*
@@ -80,29 +80,30 @@ void EpochWindow::addEpoch(EpochType const& epoch) {
     term, node,
     "addEpoch: (before) epoch={:x}, first={:x}, last={:x}, num={}, "
     "compression={}\n",
-    epoch, term_.lower(), term_.upper(), term_.size(),
-    term_.compression()
+    epoch, terminated_epochs_.lower(), terminated_epochs_.upper(),
+    terminated_epochs_.size(), terminated_epochs_.compression()
   );
 
   auto is_epoch_arch = isArchetypal(epoch);
 
   vtAssertExprInfo(
     is_epoch_arch, epoch, is_epoch_arch, archetype_epoch_,
-    term_.lower(), term_.upper(), term_.size()
+    terminated_epochs_.lower(), terminated_epochs_.upper(),
+    terminated_epochs_.size()
   );
 
   // We should possibly perform some error checking once we wrap around in case
   // of pending actions
-  if (term_.contains(epoch)) {
-    term_.erase(epoch);
+  if (terminated_epochs_.contains(epoch)) {
+    terminated_epochs_.erase(epoch);
   }
 
   debug_print(
     term, node,
     "addEpoch: (after) epoch={:x}, first={:x}, last={:x}, num={}, "
     "compression={}\n",
-    epoch, term_.lower(), term_.upper(), term_.size(),
-    term_.compression()
+    epoch, terminated_epochs_.lower(), terminated_epochs_.upper(),
+    terminated_epochs_.size(), termin_.compression()
   );
 }
 
@@ -111,18 +112,18 @@ void EpochWindow::closeEpoch(EpochType const& epoch) {
     term, node,
     "closeEpoch: (before) epoch={:x}, first={:x}, last={:x}, num={}, "
     "compression={}\n",
-    epoch, term_.lower(), term_.upper(), term_.size(),
-    term_.compression()
+    epoch, terminated_epochs_.lower(), terminated_epochs_.upper(),
+    terminated_epochs_.size(), terminated_epochs_.compression()
   );
 
-  term_.insert(epoch);
+  terminated_epochs_.insert(epoch);
 
   debug_print(
     term, node,
     "closeEpoch: (after) epoch={:x}, first={:x}, last={:x}, num={}, "
     "compression={}\n",
-    epoch, term_.lower(), term_.upper(), term_.size(),
-    term_.compression()
+    epoch, terminated_epochs_.lower(), terminated_epochs_.upper(),
+    terminated_epochs_.size(), terminated_epochs_.compression()
   );
 }
 
@@ -131,11 +132,11 @@ bool EpochWindow::isTerminated(EpochType const& epoch) const {
     term, node,
     "isTerminated: epoch={:x}, first={:x}, last={:x}, num={}, "
     "compression={}\n",
-    epoch, term_.lower(), term_.upper(), term_.size(),
-    term_.compression()
+    epoch, terminated_epochs_.lower(), terminated_epochs_.upper(), term_.size(),
+    terminated_epochs_.compression()
   );
 
-  return term_.contains(epoch);
+  return terminated_epochs_.contains(epoch);
 }
 
 }} /* end namespace vt::term */

--- a/src/vt/termination/term_window.h
+++ b/src/vt/termination/term_window.h
@@ -53,19 +53,56 @@ namespace vt { namespace term {
 
 struct EpochWindow {
 
+  /*
+   * Holds the set of terminated epochs for a given archetype. An archetype is
+   * an epoch that belongs to a certain category. The window tracks the state of
+   * all the epochs in that category. Because only one category of epoch (high
+   * bits the same) are in a single category the window will eventually be
+   * contiguous.
+   *
+   * The wrap around case happens when an epoch exists in the window and then is
+   * re-activated. This case is handled in `addEpoch` by checking for existence
+   * in the integral set before using it.
+   */
+
   explicit EpochWindow(EpochType const& in_epoch);
 
 private:
+  /*
+   * Does a given epoch match the archetype that this window holds
+   */
   inline bool isArchetypal(EpochType const& epoch);
 
 public:
+  /*
+   * Initialize the window for a given archetype: category of an epoch based on
+   * high bits.
+   */
   void initialize(EpochType const& epoch);
 
+  /*
+   * Get the first terminated epoch in the window
+   */
   EpochType getFirst() const { return terminated_epochs_.lower(); }
+  /*
+   * Get the last terminated epoch in the window
+   */
   EpochType getLast()  const { return terminated_epochs_.upper(); }
 
+  /*
+   * Check if an epoch is terminated or not: exists in the set
+   */
   bool isTerminated(EpochType const& epoch) const;
+
+  /*
+   * Activate an epoch: goes from the state terminated to non-terminated if the
+   * epoch has wrapped around
+   */
   void addEpoch(EpochType const& epoch);
+
+  /*
+   * Terminated an active epoch by adding it to the sett
+   */
   void closeEpoch(EpochType const& epoch);
 
 private:

--- a/src/vt/termination/term_window.h
+++ b/src/vt/termination/term_window.h
@@ -47,8 +47,7 @@
 
 #include "vt/config.h"
 #include "vt/epoch/epoch_manip.h"
-
-#include <set>
+#include "vt/termination/interval/integral_set.h"
 
 namespace vt { namespace term {
 
@@ -64,15 +63,12 @@ private:
 public:
   void initialize(EpochType const& epoch);
 
-  EpochType getFirst() const { return first_unresolved_epoch_; }
-  EpochType getLast()  const { return last_unresolved_epoch_; }
+  EpochType getFirst() const { return active_.lower(); }
+  EpochType getLast()  const { return active_.upper(); }
 
-  bool inWindow(EpochType const& epoch) const;
   bool isTerminated(EpochType const& epoch) const;
   void addEpoch(EpochType const& epoch);
   void closeEpoch(EpochType const& epoch);
-
-  void clean(EpochType const& epoch);
 
 private:
   // The archetypical epoch for this window container (category,rooted,user,..)
@@ -81,12 +77,8 @@ private:
   bool initialized_                       = false;
   // Should the epoch conform to an archetype?
   bool conform_archetype_                 = true;
-  // The first unresolved epoch in the window: all epoch <= this are terminated
-  EpochType first_unresolved_epoch_       = no_epoch;
-  // The last unresolved epoch in the current window
-  EpochType last_unresolved_epoch_        = no_epoch;
   // The set of epochs terminated that are not represented by the window
-  std::set<EpochType> terminated_         = {};
+  vt::IntegralSet<EpochType> active_      = {};
 };
 
 }} /* end namespace vt::term */

--- a/src/vt/termination/term_window.h
+++ b/src/vt/termination/term_window.h
@@ -61,8 +61,8 @@ private:
 public:
   void initialize(EpochType const& epoch);
 
-  EpochType getFirst() const { return active_.lower(); }
-  EpochType getLast()  const { return active_.upper(); }
+  EpochType getFirst() const { return term_.lower(); }
+  EpochType getLast()  const { return term_.upper(); }
 
   bool isTerminated(EpochType const& epoch) const;
   void addEpoch(EpochType const& epoch);
@@ -71,8 +71,8 @@ public:
 private:
   // The archetypical epoch for this window container (category,rooted,user,..)
   EpochType archetype_epoch_              = no_epoch;
-  // The set of epochs terminated that are not represented by the window
-  vt::IntegralSet<EpochType> active_      = {};
+  // The set of epochs terminated
+  vt::IntegralSet<EpochType> term_;
 };
 
 }} /* end namespace vt::term */

--- a/src/vt/termination/term_window.h
+++ b/src/vt/termination/term_window.h
@@ -53,9 +53,7 @@ namespace vt { namespace term {
 
 struct EpochWindow {
 
-  explicit EpochWindow(bool const in_conform = true)
-    : initialized_(!in_conform), conform_archetype_(in_conform)
-  { }
+  explicit EpochWindow(EpochType const& in_epoch);
 
 private:
   inline bool isArchetypal(EpochType const& epoch);
@@ -73,10 +71,6 @@ public:
 private:
   // The archetypical epoch for this window container (category,rooted,user,..)
   EpochType archetype_epoch_              = no_epoch;
-  // Has this window been initialized with an archetype?
-  bool initialized_                       = false;
-  // Should the epoch conform to an archetype?
-  bool conform_archetype_                 = true;
   // The set of epochs terminated that are not represented by the window
   vt::IntegralSet<EpochType> active_      = {};
 };

--- a/src/vt/termination/term_window.h
+++ b/src/vt/termination/term_window.h
@@ -61,8 +61,8 @@ private:
 public:
   void initialize(EpochType const& epoch);
 
-  EpochType getFirst() const { return term_.lower(); }
-  EpochType getLast()  const { return term_.upper(); }
+  EpochType getFirst() const { return terminated_epochs_.lower(); }
+  EpochType getLast()  const { return terminated_epochs_.upper(); }
 
   bool isTerminated(EpochType const& epoch) const;
   void addEpoch(EpochType const& epoch);
@@ -72,7 +72,7 @@ private:
   // The archetypical epoch for this window container (category,rooted,user,..)
   EpochType archetype_epoch_              = no_epoch;
   // The set of epochs terminated
-  vt::IntegralSet<EpochType> term_;
+  vt::IntegralSet<EpochType> terminated_epochs_;
 };
 
 }} /* end namespace vt::term */

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -324,9 +324,6 @@ void TerminationDetector::freeEpoch(EpochType const& epoch) {
     }
   }
 
-  auto window = getWindow(epoch);
-  window->clean(epoch);
-
   // Clean up any actions lambdas associated with epoch
   {
     auto iter = epoch_actions_.find(epoch);

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -61,10 +61,12 @@
 
 namespace vt { namespace term {
 
+static EpochType const arch_epoch_coll = 0ull;
+
 TerminationDetector::TerminationDetector()
   : collective::tree::Tree(collective::tree::tree_cons_tag_t),
   any_epoch_state_(any_epoch_sentinel, false, true, getNumChildren()),
-  epoch_coll_(std::make_unique<EpochWindow>())
+  epoch_coll_(std::make_unique<EpochWindow>(arch_epoch_coll))
 { }
 
 /*static*/ void TerminationDetector::makeRootedHandler(TermMsg* msg) {
@@ -111,10 +113,9 @@ EpochWindow* TerminationDetector::getWindow(EpochType const& epoch) {
       epoch_arch_.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(arch_epoch),
-        std::forward_as_tuple(std::make_unique<EpochWindow>(true))
+        std::forward_as_tuple(std::make_unique<EpochWindow>(arch_epoch))
       );
       iter = epoch_arch_.find(arch_epoch);
-      iter->second->initialize(epoch);
     }
     return iter->second.get();
   } else {

--- a/tests/unit/termination/test_integral_set.cc
+++ b/tests/unit/termination/test_integral_set.cc
@@ -1,0 +1,170 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                      test_integral_set.cc
+//                     vt (Virtual Transport)
+//                  Copyright (C) 2018 NTESS, LLC
+//
+// Under the terms of Contract DE-NA-0003525 with NTESS, LLC,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "data_message.h"
+
+#include "vt/transport.h"
+#include "vt/termination/interval/integral_set.h"
+
+namespace vt { namespace tests { namespace unit {
+
+using namespace vt;
+using namespace vt::tests::unit;
+
+struct TestIntegralSet : TestParallelHarness { };
+
+TEST_F(TestIntegralSet, test_interval_set) {
+  std::vector<int> elms{6,9,2,13,8,14,10,7,5};
+  std::vector<int> comp{1,2,3,4 ,4,4 ,4 ,3,3};
+  vt::IntegralSet<int> i = {};
+  std::set<int> t = {};
+  int cur = 0;
+  for (auto&& e : elms) {
+    i.insert(e);
+    t.insert(e);
+    EXPECT_EQ(i.compressedSize(), comp[cur]);
+    cur++;
+    fmt::print(
+      "size={}, compressed size={}, ratio={}\n",
+      i.size(), i.compressedSize(), i.compression()
+    );
+    //i.dumpState();
+  }
+
+  EXPECT_EQ(i.size(), 9);
+
+  for (auto&& e : elms) {
+    EXPECT_EQ(i.exists(e), true);
+  }
+
+  for (int k = 0; k < 20; k++) {
+    auto in_t = t.find(k) != t.end();
+    EXPECT_EQ(i.exists(k), in_t);
+  }
+
+  auto ti = t.begin();
+  for (auto&& e : i) {
+    EXPECT_EQ(e, *ti);
+    ++ti;
+  }
+  auto tr = t.rbegin();
+  for (auto iter = i.rbegin(); iter != i.rend(); ++iter) {
+    auto const& e = *iter;
+    EXPECT_EQ(e, *tr);
+    ++tr;
+  }
+
+  auto in = i.ibegin();
+  EXPECT_EQ(*in, vt::Interval<int>(2,2));
+  ++in;
+  EXPECT_EQ(*in, vt::Interval<int>(5,10));
+  ++in;
+  EXPECT_EQ(*in, vt::Interval<int>(13,14));
+}
+
+TEST_F(TestIntegralSet, test_interval_set_2) {
+  vt::IntegralSet<int> i = {};
+
+  int num = 0;
+  for (int k = 0; k < 10000; k += 2) {
+    i.insert(k);
+    EXPECT_TRUE(i.exists(k));
+    num++;
+  }
+
+  EXPECT_EQ(num, i.size());
+  EXPECT_EQ(num, i.compressedSize());
+
+  fmt::print(
+    "size={}, compressed size={}, ratio={}\n",
+    i.size(), i.compressedSize(), i.compression()
+  );
+
+  for (int k = 1; k < 10000; k += 2) {
+    i.insert(k);
+    EXPECT_TRUE(i.exists(k));
+    num++;
+  }
+
+  EXPECT_EQ(num, i.size());
+  EXPECT_EQ(1, i.compressedSize());
+
+  fmt::print(
+    "size={}, compressed size={}, ratio={}\n",
+    i.size(), i.compressedSize(), i.compression()
+  );
+
+  for (int k = 1; k < 10000; k += 2) {
+    i.erase(k);
+    EXPECT_FALSE(i.exists(k));
+    num--;
+  }
+
+  EXPECT_EQ(num, i.size());
+  EXPECT_EQ(num, i.compressedSize());
+
+  fmt::print(
+    "size={}, compressed size={}, ratio={}\n",
+    i.size(), i.compressedSize(), i.compression()
+  );
+
+  for (int k = 1; k < 10000; k += 2) {
+    i.insert(k);
+    EXPECT_TRUE(i.exists(k));
+    num++;
+  }
+
+  EXPECT_EQ(num, i.size());
+  EXPECT_EQ(1, i.compressedSize());
+
+  fmt::print(
+    "size={}, compressed size={}, ratio={}\n",
+    i.size(), i.compressedSize(), i.compression()
+  );
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_integral_set.cc
+++ b/tests/unit/termination/test_integral_set.cc
@@ -72,6 +72,7 @@ TEST_F(TestIntegralSet, test_interval_set) {
       "size={}, compressed size={}, ratio={}\n",
       i.size(), i.compressedSize(), i.compression()
     );
+    EXPECT_EQ(i.size(), t.size());
     //i.dumpState();
   }
 
@@ -91,12 +92,15 @@ TEST_F(TestIntegralSet, test_interval_set) {
     EXPECT_EQ(e, *ti);
     ++ti;
   }
+  EXPECT_EQ(ti, t.end());
+
   auto tr = t.rbegin();
   for (auto iter = i.rbegin(); iter != i.rend(); ++iter) {
     auto const& e = *iter;
     EXPECT_EQ(e, *tr);
     ++tr;
   }
+  EXPECT_EQ(tr, t.rend());
 
   auto in = i.ibegin();
   EXPECT_EQ(*in, vt::Interval<int>(2,2));
@@ -104,6 +108,8 @@ TEST_F(TestIntegralSet, test_interval_set) {
   EXPECT_EQ(*in, vt::Interval<int>(5,10));
   ++in;
   EXPECT_EQ(*in, vt::Interval<int>(13,14));
+  ++in;
+  EXPECT_EQ(in, i.iend());
 }
 
 TEST_F(TestIntegralSet, test_interval_set_2) {

--- a/tests/unit/termination/test_integral_set.cc
+++ b/tests/unit/termination/test_integral_set.cc
@@ -79,12 +79,12 @@ TEST_F(TestIntegralSet, test_interval_set) {
   EXPECT_EQ(i.size(), 9);
 
   for (auto&& e : elms) {
-    EXPECT_EQ(i.exists(e), true);
+    EXPECT_EQ(i.contains(e), true);
   }
 
   for (int k = 0; k < 20; k++) {
     auto in_t = t.find(k) != t.end();
-    EXPECT_EQ(i.exists(k), in_t);
+    EXPECT_EQ(i.contains(k), in_t);
   }
 
   auto ti = t.begin();
@@ -118,7 +118,7 @@ TEST_F(TestIntegralSet, test_interval_set_2) {
   int num = 0;
   for (int k = 0; k < 10000; k += 2) {
     i.insert(k);
-    EXPECT_TRUE(i.exists(k));
+    EXPECT_TRUE(i.contains(k));
     num++;
   }
 
@@ -132,7 +132,7 @@ TEST_F(TestIntegralSet, test_interval_set_2) {
 
   for (int k = 1; k < 10000; k += 2) {
     i.insert(k);
-    EXPECT_TRUE(i.exists(k));
+    EXPECT_TRUE(i.contains(k));
     num++;
   }
 
@@ -146,7 +146,7 @@ TEST_F(TestIntegralSet, test_interval_set_2) {
 
   for (int k = 1; k < 10000; k += 2) {
     i.erase(k);
-    EXPECT_FALSE(i.exists(k));
+    EXPECT_FALSE(i.contains(k));
     num--;
   }
 
@@ -160,7 +160,7 @@ TEST_F(TestIntegralSet, test_interval_set_2) {
 
   for (int k = 1; k < 10000; k += 2) {
     i.insert(k);
-    EXPECT_TRUE(i.exists(k));
+    EXPECT_TRUE(i.contains(k));
     num++;
   }
 


### PR DESCRIPTION
- Implemented new integral set vt::IntegralSet, that makes epoch alloc/dealloc far more efficient
    - Uses a sorted, non-overlapping interval tree to implement automatic compaction
    - Holes in the release set of epochs no longer inhibit wrap around (a major problem for tree-structured epochs)