### PR TITLE
457 gcc 9.x warnings and compiler error fixes

### DIFF
--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -119,7 +119,7 @@ function(link_target_with_vt)
     if (${ARG_DEBUG_LINK})
       message(STATUS "link_target_with_vt: fmt=${ARG_LINK_FMT}")
     endif()
-    target_compile_definitions(${ARG_TARGET} PUBLIC FMT_HEADER_ONLY=1)
+    target_compile_definitions(${ARG_TARGET} PUBLIC FMT_HEADER_ONLY=1 FMT_USE_USER_DEFINED_LITERALS=0)
     target_include_directories(${ARG_TARGET} PUBLIC
       $<BUILD_INTERFACE:${PROJECT_BASE_DIR}/lib/fmt>
       $<INSTALL_INTERFACE:include/fmt>

--- a/src/vt/parameterization/parameterization.h
+++ b/src/vt/parameterization/parameterization.h
@@ -157,7 +157,7 @@ struct Param {
     NodeType const& dest, Tuple tup,
     NonType<T, value> __attribute__((unused)) non = NonType<T,value>()
   ) {
-    auto const& han = auto_registry::makeAutoHandler<T,value>();
+    auto const& han = auto_registry::makeAutoHandlerParam<T,value>();
     return sendDataTuple(dest, han, std::forward<Tuple>(tup));
   }
 
@@ -166,7 +166,7 @@ struct Param {
     NodeType const& dest, DataMsg<std::tuple<Args...>>* msg,
     NonType<T, value> __attribute__((unused)) non = NonType<T,value>()
   ) {
-    auto const& han = auto_registry::makeAutoHandler<T,value>();
+    auto const& han = auto_registry::makeAutoHandlerParam<T,value>();
     msg->sub_han = han;
     return sendDataMsg(dest, han, msg);
   }
@@ -176,7 +176,7 @@ struct Param {
     NodeType const& dest, NonType<T, value> __attribute__((unused)) non,
     Args&&... a
   ) {
-    auto const& han = auto_registry::makeAutoHandler<T,value>();
+    auto const& han = auto_registry::makeAutoHandlerParam<T,value>();
 
     staticCheckCopyable<Args...>();
 

--- a/src/vt/registry/auto/auto_registry.h
+++ b/src/vt/registry/auto/auto_registry.h
@@ -74,7 +74,7 @@ template <typename MessageT, ActiveTypedFnType<MessageT>* f>
 HandlerType makeAutoHandler(MessageT* const msg);
 
 template <typename T, T value>
-HandlerType makeAutoHandler();
+HandlerType makeAutoHandlerParam();
 
 template <typename ObjT, typename MsgT, objgroup::ActiveObjType<MsgT, ObjT> f>
 void setHandlerTraceNameObjGroup(

--- a/src/vt/registry/auto/auto_registry_impl.h
+++ b/src/vt/registry/auto/auto_registry_impl.h
@@ -96,7 +96,7 @@ inline HandlerType makeAutoHandler(MessageT* const __attribute__((unused)) msg) 
 }
 
 template <typename T, T value>
-inline HandlerType makeAutoHandler() {
+inline HandlerType makeAutoHandlerParam() {
   using FunctorT = FunctorAdapter<T, value>;
   using ContainerType = AutoActiveContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveType>;
@@ -146,7 +146,7 @@ void setHandlerTraceName(std::string const& name, std::string const& parent) {
 template <typename T, T value>
 void setHandlerTraceName(std::string const& name, std::string const& parent) {
 #if backend_check_enabled(trace_enabled)
-  auto const handler = makeAutoHandler<T,value>();
+  auto const handler = makeAutoHandlerParam<T,value>();
   auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegGeneral);
   setTraceName(trace_id, name, parent);
 #endif

--- a/src/vt/registry/auto/auto_registry_interface.h
+++ b/src/vt/registry/auto/auto_registry_interface.h
@@ -55,7 +55,7 @@ template <typename MessageT, ActiveTypedFnType<MessageT>* f>
 HandlerType makeAutoHandler(MessageT* const msg);
 
 template <typename T, T value>
-HandlerType makeAutoHandler();
+HandlerType makeAutoHandlerParam();
 
 template <typename T, bool is_msg, typename... Args>
 HandlerType makeAutoHandlerFunctor();

--- a/src/vt/serialization/messaging/serialized_param_messenger.h
+++ b/src/vt/serialization/messaging/serialized_param_messenger.h
@@ -89,7 +89,7 @@ struct SerializedMessengerParam {
     NodeType const& dest, std::tuple<Args...> tup,
     SerializedNonType<T, value> __attribute__((unused)) non = SerializedNonType<T,value>()
   ) {
-    auto const& typed_handler = auto_registry::makeAutoHandler<T,value>();
+    auto const& typed_handler = auto_registry::makeAutoHandlerParam<T,value>();
 
     using TupleType = std::tuple<Args...>;
 

--- a/src/vt/utils/demangle/demangled_name.h
+++ b/src/vt/utils/demangle/demangled_name.h
@@ -53,10 +53,10 @@ namespace vt { namespace util { namespace demangle {
 
 struct DemangledName {
   DemangledName(
-    std::string const& in_ns, std::string const& in_func,
+    std::string const& in_ns, std::string const& in_fun,
     std::string const& in_args
-  ) : namespace_(in_ns), funcname_(in_func), params_(in_args),
-      func_with_params_(in_func + "(" + in_args + ")")
+  ) : namespace_(in_ns), funcname_(in_fun), params_(in_args),
+      func_with_params_(in_fun + "(" + in_args + ")")
   { }
 
   std::string getNamespace()  const { return namespace_       ; }


### PR DESCRIPTION
Added some commits for preventing warnings for GCC 9.x. Added a workaround for a GCC 9.X bug, and finally fixed an issue where epochs weren't being pushed when handling serialized messages