### PR TITLE
480 serialization reduce vec msg

### DIFF
--- a/src/vt/collective/reduce/operators/default_msg.h
+++ b/src/vt/collective/reduce/operators/default_msg.h
@@ -129,7 +129,7 @@ struct ReduceVecMsg : ReduceDataMsg<std::vector<T>> {
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
-    s | ReduceDataMsg<DataType>::val_;
+    ReduceDataMsg<std::vector<T>>::invokeSerialize(s);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/plus_op.h
+++ b/src/vt/collective/reduce/operators/functors/plus_op.h
@@ -65,6 +65,15 @@ struct PlusOp< std::vector<T> > {
   }
 };
 
+template <>
+struct PlusOp< std::vector<bool> > {
+  void operator()(std::vector<bool>& v1, std::vector<bool> const& v2) {
+    vtAssert(v1.size() == v2.size(), "Sizes of vectors in reduce must be equal");
+    for (size_t ii = 0; ii < v1.size(); ++ii)
+      v1[ii] = v1[ii] + v2[ii];
+  }
+};
+
 template <typename T, std::size_t N>
 struct PlusOp< std::array<T,N> > {
   void operator()(std::array<T,N>& v1, std::array<T,N> const& v2) {

--- a/tests/unit/collectives/test_collectives_reduce.cc
+++ b/tests/unit/collectives/test_collectives_reduce.cc
@@ -163,10 +163,7 @@ TEST_F(TestReduce, test_reduce_plus_default_op) {
 
   auto msg = makeSharedMessage<SysMsg>(my_node);
   debug_print(reduce, node, "msg->num={}\n", msg->getConstVal());
-  theCollective()->reduce<
-    SysMsg,
-    SysMsg::msgHandler<SysMsg, PlusOp<int>, Verify<ReduceOP::Plus> >
-  >(root, msg);
+  theCollective()->reduce<PlusOp<int>, Verify<ReduceOP::Plus>>(root, msg);
 }
 
 TEST_F(TestReduce, test_reduce_max_default_op) {
@@ -175,10 +172,7 @@ TEST_F(TestReduce, test_reduce_max_default_op) {
 
   auto msg = makeSharedMessage<SysMsg>(my_node);
   debug_print(reduce, node, "msg->num={}\n", msg->getConstVal());
-  theCollective()->reduce<
-    SysMsg,
-    SysMsg::msgHandler<SysMsg, MaxOp<int>, Verify<ReduceOP::Max> >
-  >(root, msg);
+  theCollective()->reduce<MaxOp<int>, Verify<ReduceOP::Max>>(root, msg);
 }
 
 TEST_F(TestReduce, test_reduce_min_default_op) {
@@ -187,10 +181,7 @@ TEST_F(TestReduce, test_reduce_min_default_op) {
 
   auto msg = makeSharedMessage<SysMsg>(my_node);
   debug_print(reduce, node, "msg->num={}\n", msg->getConstVal());
-  theCollective()->reduce<
-    SysMsg,
-    SysMsg::msgHandler<SysMsg, MinOp<int>, Verify<ReduceOP::Min> >
-  >(root, msg);
+  theCollective()->reduce<MinOp<int>, Verify<ReduceOP::Min>>(root, msg);
 }
 
 TEST_F(TestReduce, test_reduce_vec_bool_msg) {
@@ -200,13 +191,8 @@ TEST_F(TestReduce, test_reduce_vec_bool_msg) {
   vecOfBool.push_back(true);
 
   auto const root = 0;
-
   auto msg = makeSharedMessage<ReduceVecMsg<bool>>(vecOfBool);
-
-  theCollective()->reduce<
-    ReduceVecMsg<bool>,
-    ReduceVecMsg<bool>::msgHandler<ReduceVecMsg<bool>, PlusOp<std::vector<bool>>, Verify<ReduceOP::Plus> >
-  >(root, msg);
+  theCollective()->reduce<PlusOp<std::vector<bool>>, Verify<ReduceOP::Plus>>(root, msg);
 }
 
 TEST_F(TestReduce, test_reduce_vec_int_msg) {
@@ -218,13 +204,8 @@ TEST_F(TestReduce, test_reduce_vec_int_msg) {
   vecOfInt.push_back(3);
 
   auto const root = 0;
-
   auto msg = makeSharedMessage<ReduceVecMsg<int>>(vecOfInt);
-
-  theCollective()->reduce<
-    ReduceVecMsg<int>,
-    ReduceVecMsg<int>::msgHandler<ReduceVecMsg<int>, PlusOp<std::vector<int>>, Verify<ReduceOP::Plus> >
-  >(root, msg);
+  theCollective()->reduce<PlusOp<std::vector<int>>, Verify<ReduceOP::Plus>>(root, msg);
 }
 
 }}} // end namespace vt::tests::unit


### PR DESCRIPTION
ReduceVectorMsg is now serializable. 
A test has been added for vector of bool and vector of int.

The specialization `struct PlusOp< std::vector<bool> >` has been added because the general operation `v1[ii] += v2[ii];` doesn't work for std::vector of bool when `v1[ii] = v1[ii] + v2[ii];` works.

I think we can also change the operation from `v1[ii] += v2[ii];` to `v1[ii] = v1[ii] + v2[ii];` in the general PlusOp template but it's probably less optimized.