### PR TITLE
registry: remove compile warning with tracing

### DIFF
--- a/src/vt/registry/auto/auto_registry.cc
+++ b/src/vt/registry/auto/auto_registry.cc
@@ -118,6 +118,7 @@ trace::TraceEntryIDType theTraceID(
   }
   default:
     assert(0 && "Should not be reachable");
+    return trace::TraceEntryIDType{};
     break;
   }
 }


### PR DESCRIPTION
Return in order to avoid warning in release mode.  Addresses #428