### PR TITLE
507 LB add barriers to synchronize the hierlb tree setup

### DIFF
--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -299,7 +299,6 @@ NodeType BaseLB::objGetNode(ObjIDType const id) const {
 }
 
 void BaseLB::finishedStats() {
-  theCollective()->barrier();
   this->runLB();
 }
 

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -299,6 +299,7 @@ NodeType BaseLB::objGetNode(ObjIDType const id) const {
 }
 
 void BaseLB::finishedStats() {
+  theCollective()->barrier();
   this->runLB();
 }
 

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -693,7 +693,15 @@ std::size_t HierarchicalLB::clearObj(ObjSampleType& objs) {
 
 void HierarchicalLB::runLB() {
   setupTree(min_threshold);
-  theCollective()->barrier();
+
+  auto cb = vt::theCB()->makeBcast<
+    HierarchicalLB, SetupDoneMsg, &HierarchicalLB::setupDone
+  >(proxy);
+  auto msg = makeMessage<SetupDoneMsg>();
+  proxy.reduce(msg.get(),cb);
+}
+
+void HierarchicalLB::setupDone(SetupDoneMsg* msg) {
   loadStats();
 }
 

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -693,6 +693,7 @@ std::size_t HierarchicalLB::clearObj(ObjSampleType& objs) {
 
 void HierarchicalLB::runLB() {
   setupTree(min_threshold);
+  theCollective()->barrier();
   loadStats();
 }
 

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
@@ -101,6 +101,7 @@ private:
 
   void downTreeHandler(LBTreeDownMsg* msg);
   void lbTreeUpHandler(LBTreeUpMsg* msg);
+  void setupDone(SetupDoneMsg* msg);
 
   void downTreeSend(
     NodeType const node, NodeType const from, ObjSampleType const& excess,

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb_msgs.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb_msgs.h
@@ -123,6 +123,8 @@ private:
   bool final_child_ = 0;
 };
 
+struct SetupDoneMsg : vt::collective::ReduceNoneMsg { };
+
 }}}} /* end namespace vt::vrt::collection::lb */
 
 #endif /*INCLUDED_VRT_COLLECTION_BALANCE_HIERARCHICALLB_HIERLB_MSGS_H*/


### PR DESCRIPTION
Fixes a race condition in HierarchicalLB, occurring in EMPIRE runs on kahuna. For now, add barriers to synchronize the setup of the tree with the following use of it. In the future, this could become an asynchronous reduction.