### PR TITLE
515 Fix memory use-after-free bug in unit test

### DIFF
--- a/tests/unit/active/test_active_bcast_put.cc
+++ b/tests/unit/active/test_active_bcast_put.cc
@@ -135,6 +135,11 @@ TEST_P(TestActiveBroadcastPut, test_type_safe_active_fn_bcast2) {
       }
     });
   }
+
+  // Spin here so test_vec does not go out of scope before the send completes
+  while (not vt::rt->isTerminated()) {
+    vt::runScheduler();
+  }
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -82,7 +82,9 @@ struct TestActiveSend : TestParallelHarness {
     auto size = msg->getPutSize();
     #if DEBUG_TEST_HARNESS_PRINT
       auto const& this_node = theContext()->getNode();
-      fmt::print("{}: test_handler_2: size={}, ptr={}\n", this_node, size, ptr);
+      fmt::print(
+        "{}: test_handler_2: size={}, ptr={}\n", this_node, size, print_ptr(ptr)
+      );
     #endif
     EXPECT_EQ(2 * sizeof(int), size);
     for (int i = 0; i < 2; i++) {
@@ -95,7 +97,9 @@ struct TestActiveSend : TestParallelHarness {
     auto size = msg->getPutSize();
     #if DEBUG_TEST_HARNESS_PRINT
       auto const& this_node = theContext()->getNode();
-      fmt::print("{}: test_handler_3: size={}, ptr={}\n", this_node, size, ptr);
+      fmt::print(
+        "{}: test_handler_3: size={}, ptr={}\n", this_node, size, print_ptr(ptr)
+      );
     #endif
     EXPECT_EQ(10 * sizeof(int), size);
     for (int i = 0; i < 10; i++) {
@@ -107,7 +111,7 @@ struct TestActiveSend : TestParallelHarness {
     auto const& this_node = theContext()->getNode();
 
     #if DEBUG_TEST_HARNESS_PRINT
-      fmt::print("{}: test_handler: cnt={}\n", this_node, ack_count);
+      fmt::print("{}: test_handler: cnt={}\n", this_node, handler_count);
     #endif
 
     handler_count++;

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -141,6 +141,11 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send) {
       EXPECT_EQ(handler_count, num_msg_sent);
     });
   }
+
+  // Spin here so test_vec does not go out of scope before the send completes
+  while (not vt::rt->isTerminated()) {
+    vt::runScheduler();
+  }
 }
 
 TEST_F(TestActiveSend, test_type_safe_active_fn_send_small_put) {
@@ -164,6 +169,11 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send_small_put) {
       );
     }
   }
+
+  // Spin here so test_vec does not go out of scope before the send completes
+  while (not vt::rt->isTerminated()) {
+    vt::runScheduler();
+  }
 }
 
 TEST_F(TestActiveSend, test_type_safe_active_fn_send_large_put) {
@@ -186,6 +196,11 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send_large_put) {
         1, msg
       );
     }
+  }
+
+  // Spin here so test_vec does not go out of scope before the send completes
+  while (not vt::rt->isTerminated()) {
+    vt::runScheduler();
   }
 }
 

--- a/tests/unit/active/test_active_send_put.cc
+++ b/tests/unit/active/test_active_send_put.cc
@@ -112,6 +112,11 @@ TEST_P(TestActiveSendPut, test_active_fn_send_put_param) {
     #endif
     theMsg()->sendMsg<PutTestMessage, test_handler>(1, msg);
   }
+
+  // Spin here so test_vec does not go out of scope before the send completes
+  while (not vt::rt->isTerminated()) {
+    vt::runScheduler();
+  }
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/tests/unit/active/test_active_send_put.cc
+++ b/tests/unit/active/test_active_send_put.cc
@@ -76,7 +76,9 @@ struct TestActiveSendPut : TestParameterHarnessNode {
     auto size = msg->getPutSize();
     #if DEBUG_TEST_HARNESS_PRINT
       auto const& this_node = theContext()->getNode();
-      fmt::print("{}: test_handler_2: size={}, ptr={}\n", this_node, size, ptr);
+      fmt::print(
+        "{}: test_handler_2: size={}, ptr={}\n", this_node, size, print_ptr(ptr)
+      );
     #endif
     EXPECT_EQ(msg->num_ints * sizeof(int), size);
     for (int i = 0; i < msg->num_ints; i++) {


### PR DESCRIPTION
This was causing an occasional test failure on Mutrino with Intel compilers.