### PR TITLE
517 remove extraneous commas

### DIFF
--- a/tests/unit/collection/test_broadcast.cc
+++ b/tests/unit/collection/test_broadcast.cc
@@ -148,7 +148,7 @@ using CollectionTestTypes = testing::Types<
 >;
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_bcast, TestBroadcast, CollectionTestTypes,
+  test_bcast, TestBroadcast, CollectionTestTypes
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_construct.cc
+++ b/tests/unit/collection/test_construct.cc
@@ -129,11 +129,11 @@ using CollectionTestDistTypes = testing::Types<
 >;
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_construct_simple, TestConstruct, CollectionTestTypes,
+  test_construct_simple, TestConstruct, CollectionTestTypes
 );
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_construct_distributed_simple, TestConstructDist, CollectionTestDistTypes,
+  test_construct_distributed_simple, TestConstructDist, CollectionTestDistTypes
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_construct_idx_fst.cc
+++ b/tests/unit/collection/test_construct_idx_fst.cc
@@ -90,7 +90,7 @@ using CollectionTestTypes = testing::Types<
 #if backend_check_enabled(detector) && backend_check_enabled(cons_multi_idx)
 
   INSTANTIATE_TYPED_TEST_CASE_P(
-    test_construct_idx_fst, TestConstruct, CollectionTestTypes,
+    test_construct_idx_fst, TestConstruct, CollectionTestTypes
   );
 
 #endif /*backend_check_enabled(detector)*/

--- a/tests/unit/collection/test_construct_idx_snd.cc
+++ b/tests/unit/collection/test_construct_idx_snd.cc
@@ -90,7 +90,7 @@ using CollectionTestTypes = testing::Types<
 #if backend_check_enabled(detector) && backend_check_enabled(cons_multi_idx)
 
   INSTANTIATE_TYPED_TEST_CASE_P(
-    test_construct_idx_snd, TestConstruct, CollectionTestTypes,
+    test_construct_idx_snd, TestConstruct, CollectionTestTypes
   );
 
 #endif /*backend_check_enabled(detector)*/

--- a/tests/unit/collection/test_construct_no_idx.cc
+++ b/tests/unit/collection/test_construct_no_idx.cc
@@ -86,11 +86,11 @@ using CollectionTestTypes = testing::Types<
 >;
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_construct_no_idx, TestConstruct, CollectionTestTypes,
+  test_construct_no_idx, TestConstruct, CollectionTestTypes
 );
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_construct_no_idx_dist, TestConstructDist, CollectionTestTypes,
+  test_construct_no_idx_dist, TestConstructDist, CollectionTestTypes
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_index_types.cc
+++ b/tests/unit/collection/test_index_types.cc
@@ -125,7 +125,7 @@ using CollectionTestTypes = testing::Types<
 >;
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_collection_index, TestCsollectionIndexTypes, CollectionTestTypes,
+  test_collection_index, TestCsollectionIndexTypes, CollectionTestTypes
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_send.cc
+++ b/tests/unit/collection/test_send.cc
@@ -196,10 +196,10 @@ using CollectionTestTypes = testing::Types<
 >;
 
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_collection_send, TestCollectionSend, CollectionTestTypes,
+  test_collection_send, TestCollectionSend, CollectionTestTypes
 );
 INSTANTIATE_TYPED_TEST_CASE_P(
-  test_collection_send_mem, TestCollectionSendMem, CollectionTestTypes,
+  test_collection_send_mem, TestCollectionSendMem, CollectionTestTypes
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/location/test_location.cc
+++ b/tests/unit/location/test_location.cc
@@ -387,7 +387,7 @@ REGISTER_TYPED_TEST_CASE_P /* NOLINT */ (
   test_route_entity, test_entity_cache_hits, test_entity_cache_migrated_entity
 );
 INSTANTIATE_TYPED_TEST_CASE_P /* NOLINT */ (
-  Message, TestLocationRoute, location::MsgType,
+  Message, TestLocationRoute, location::MsgType
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/memory/test_memory_active.cc
+++ b/tests/unit/memory/test_memory_active.cc
@@ -160,8 +160,8 @@ using MsgSerial = testing::Types<
   TestMemoryActiveMsg<TestStaticBytesSerialMsg>::TestMsgC
 >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_mem_short,  TestMemoryActive, MsgShort, );
-INSTANTIATE_TYPED_TEST_CASE_P(test_mem_normal, TestMemoryActive, MsgNormal, );
-INSTANTIATE_TYPED_TEST_CASE_P(test_mem_serial, TestMemoryActive, MsgSerial, );
+INSTANTIATE_TYPED_TEST_CASE_P(test_mem_short,  TestMemoryActive, MsgShort );
+INSTANTIATE_TYPED_TEST_CASE_P(test_mem_normal, TestMemoryActive, MsgNormal );
+INSTANTIATE_TYPED_TEST_CASE_P(test_mem_serial, TestMemoryActive, MsgSerial );
 
 }}} // end namespace vt::tests::unit


### PR DESCRIPTION
Issue #517. Removed the trailing comma in the argument list for `INSTANTIATE_TYPED_TEST_CASE_P`, which only takes 3 arguments.