### PR TITLE
519 fail on segfault

### DIFF
--- a/cmake/test_vt.cmake
+++ b/cmake/test_vt.cmake
@@ -108,5 +108,11 @@ macro(add_test_for_example_vt test_target test_exec test_list)
       TARGET_NAME                  vt:${test_name}_${PROC}
       TARGET_WORKING_DIRECTORY     ${CMAKE_CURRENT_BINARY_DIR}
     )
+
+    set_tests_properties(
+      vt:${test_name}_${PROC}
+      PROPERTIES
+      FAIL_REGULAR_EXPRESSION "Segmentation fault"
+    )
   endforeach()
 endmacro()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,15 +89,16 @@ if (${VT_HAS_GTEST} AND NOT ${VT_NO_BUILD_TESTS})
           TEST_LIST              ${CUR_TEST_LIST}
           EXECUTE_COMMAND        ${MPI_RUN_COMMAND} ${MPI_NUMPROC_FLAG} ${PROC}
         )
+
+        set_tests_properties(
+          ${${CUR_TEST_LIST}}
+          PROPERTIES TIMEOUT 60
+          FAIL_REGULAR_EXPRESSION "FAILED;should be deleted but never is;Segmentation fault"
+          PASS_REGULAR_EXPRESSION "PASSED"
+        )
+    endforeach()
       endforeach()
 
-      set_tests_properties(
-        ${${CUR_TEST_LIST}}
-        PROPERTIES TIMEOUT 60
-        FAIL_REGULAR_EXPRESSION "FAILED;should be deleted but never is"
-        PASS_REGULAR_EXPRESSION "PASSED"
-      )
-    endforeach()
   endforeach()
 else()
   if (${VT_NO_BUILD_TESTS})


### PR DESCRIPTION
Issue #519.  On Mutrino at least, ctest doesn't notice segfaults unless I have it grep for "Segmentation fault", potentially because of using srun to launch the tests.  With this improvement to the testing setup, I see that many unit tests and examples are segfaulting on Mutrino (whereas previously the segfaults were there but not brought to the user's attention). Note that I built with tracing and haven't checked to see how many of the segfaults are tracing-related.