### PR TITLE
[#521] perf. colorization code and unify color selection

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -48,14 +48,18 @@
 #include <string>
 #include <vector>
 
+#include <unistd.h>
+
 #include "CLI/CLI11.hpp"
 
 namespace vt { namespace arguments {
 
-/*static*/ bool        ArgConfig::vt_color              = true;
+/*static*/ bool        ArgConfig::vt_color              = false;
 /*static*/ bool        ArgConfig::vt_no_color           = false;
-/*static*/ bool        ArgConfig::vt_auto_color         = false;
+/*static*/ bool        ArgConfig::vt_auto_color         = true;
 /*static*/ bool        ArgConfig::vt_quiet              = false;
+
+/*static*/ bool        ArgConfig::colorize_output       = false;
 
 /*static*/ bool        ArgConfig::vt_no_sigint          = false;
 /*static*/ bool        ArgConfig::vt_no_sigsegv         = false;
@@ -155,9 +159,9 @@ namespace vt { namespace arguments {
    * Flags for controlling the colorization of output from vt
    */
   auto quiet  = "Quiet the output from vt (only errors, warnings)";
-  auto always = "Always colorize output";
-  auto never  = "Never colorize output";
-  auto maybe  = "Use isatty to determine colorization of output";
+  auto always = "Colorize output (overrides --vt_auto_color)";
+  auto never  = "Never colorize output (overrides --vt_color)";
+  auto maybe  = "Automatic colorization of output (default, unnecessary)";
   auto a  = app.add_flag("-c,--vt_color",      vt_color,      always);
   auto b  = app.add_flag("-n,--vt_no_color",   vt_no_color,   never);
   auto c  = app.add_flag("-a,--vt_auto_color", vt_auto_color, maybe);
@@ -444,6 +448,15 @@ namespace vt { namespace arguments {
     app.parse(args);
   } catch (CLI::Error &ex) {
     return app.exit(ex);
+  }
+
+  // Determine the final colorization setting.
+  if (vt_no_color) {
+    colorize_output = false;
+  } else if (vt_color) {
+    colorize_output = true;
+  } else { // assume auto-color
+    colorize_output = isatty(fileno(stdout));
   }
 
   /*

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -61,6 +61,9 @@ public:
   static bool vt_auto_color;
   static bool vt_quiet;
 
+  // Derived from vt_*_color arguments after parsing.
+  static bool colorize_output;
+
   static bool vt_no_sigint;
   static bool vt_no_sigsegv;
   static bool vt_no_terminate;

--- a/src/vt/configs/debug/debug_colorize.h
+++ b/src/vt/configs/debug/debug_colorize.h
@@ -49,44 +49,36 @@
 #include "vt/configs/types/types_type.h"
 
 #include <string>
-#include <unistd.h>
-// #include <sys/stat.h>
 
 namespace vt { namespace debug {
 
-inline auto istty() -> bool {
-  return isatty(fileno(stdout)) ? true : false;
+inline bool colorizeOutput() {
+  return arguments::ArgConfig::colorize_output;
 }
 
-inline auto ttyc() -> bool {
-  auto nocolor = arguments::ArgConfig::vt_no_color ? false : true;
-  auto tty = arguments::ArgConfig::vt_auto_color ? istty() : nocolor;
-  return tty;
-}
+inline std::string green()    { return colorizeOutput() ? "\033[32m"   : ""; }
+inline std::string bold()     { return colorizeOutput() ? "\033[1m"    : ""; }
+inline std::string magenta()  { return colorizeOutput() ? "\033[95m"   : ""; }
+inline std::string red()      { return colorizeOutput() ? "\033[31m"   : ""; }
+inline std::string bred()     { return colorizeOutput() ? "\033[31;1m" : ""; }
+inline std::string reset()    { return colorizeOutput() ? "\033[00m"   : ""; }
+inline std::string bd_green() { return colorizeOutput() ? "\033[32;1m" : ""; }
+inline std::string it_green() { return colorizeOutput() ? "\033[32;3m" : ""; }
+inline std::string un_green() { return colorizeOutput() ? "\033[32;4m" : ""; }
+inline std::string byellow()  { return colorizeOutput() ? "\033[33;1m" : ""; }
+inline std::string yellow()   { return colorizeOutput() ? "\033[33m"   : ""; }
+inline std::string blue()     { return colorizeOutput() ? "\033[34m"   : ""; }
 
-inline auto green()    -> std::string { return ttyc() ? "\033[32m"   : ""; }
-inline auto bold()     -> std::string { return ttyc() ? "\033[1m"   : ""; }
-inline auto magenta()  -> std::string { return ttyc() ? "\033[95m"   : ""; }
-inline auto red()      -> std::string { return ttyc() ? "\033[31m"  : ""; }
-inline auto bred()     -> std::string { return ttyc() ? "\033[31;1m" : ""; }
-inline auto reset()    -> std::string { return ttyc() ? "\033[00m"   : ""; }
-inline auto bd_green() -> std::string { return ttyc() ? "\033[32;1m" : ""; }
-inline auto it_green() -> std::string { return ttyc() ? "\033[32;3m" : ""; }
-inline auto un_green() -> std::string { return ttyc() ? "\033[32;4m" : ""; }
-inline auto byellow()  -> std::string { return ttyc() ? "\033[33;1m" : ""; }
-inline auto yellow()   -> std::string { return ttyc() ? "\033[33m"   : ""; }
-inline auto blue()     -> std::string { return ttyc() ? "\033[34m"   : ""; }
-
-inline auto emph(std::string str) -> std::string  {
+inline std::string emph(std::string str) {
   return magenta() + str + reset();
 }
-inline auto reg(std::string str) -> std::string  {
+inline std::string reg(std::string str) {
   return green() + str + reset();
 }
-inline auto vtPre() -> std::string  {
+inline std::string vtPre() {
   return bd_green() + std::string("vt") + reset() + ": ";
 }
-inline auto proc(vt::NodeType const& node) -> std::string  {
+inline std::string proc(vt::NodeType const& node)  {
   return blue() + "[" + std::to_string(node) + "]" + reset();
 }
 

--- a/src/vt/configs/debug/debug_print.h
+++ b/src/vt/configs/debug/debug_print.h
@@ -62,31 +62,28 @@
   debug_test(backend,line_file, "{}:{} ", )
 
 #define vt_type_print_colorize(debug_type)
-  vt_print_colorize_impl("\033[32m", debug_pretty_print(debug_type), ":")
+  vt_print_colorize_impl(::vt::debug::green(), debug_pretty_print(debug_type), ":")
 
 */
 
+/// Colorize the first string followed by the second in normal color.
+/// Honors colorization checks.
 #define vt_print_colorize_impl(color, str, str2)                        \
-  ((::vt::debug::ttyc()) ?                                              \
-   (std::string(color) + std::string(str) + std::string("\033[00m") +   \
+  (::vt::debug::colorizeOutput() ?                                      \
+   (color + std::string(str) + ::vt::debug::reset() +                   \
     std::string(str2)) :                                                \
    std::string(str) + std::string(str2))
 
-#define vt_print_colorize vt_print_colorize_impl("\033[32;1m", "vt", ":")
+#define vt_print_colorize                                               \
+  vt_print_colorize_impl(::vt::debug::bd_green(), "vt", ":")
 
-#define vt_proc_print_colorize(proc)                                     \
-  vt_print_colorize_impl("\033[34m", "[" + std::to_string(proc) + "]", "")
+#define vt_proc_print_colorize(proc)                                    \
+  vt_print_colorize_impl(::vt::debug::blue(), "[" + std::to_string(proc) + "]", "")
 
 #define debug_argument_option(opt)                                      \
   ::vt::arguments::ArgConfig::vt_debug_ ## opt
 
 #define debug_all_option ::vt::arguments::ArgConfig::vt_debug_all
-
-namespace vt { namespace runtime {
-struct Runtime;
-} /* end namespace runtime */
-extern runtime::Runtime* curRT;
-} /* end namespace vt */
 
 #define debug_print_impl(force, inconfig, inmode, cat, ctx, ...)        \
   vt::config::ApplyOp<                                                  \
@@ -150,11 +147,17 @@ extern runtime::Runtime* curRT;
 
 #define vt_option_check_enabled(mode, bit) ((mode & bit) not_eq 0)
 
+namespace vt { namespace runtime {
+struct Runtime;
+}} /* end namespace vt::runtime */
+
+namespace vt {
+extern runtime::Runtime* curRT;
+} /* end namespace vt */
+
 namespace vt { namespace debug {
-
 NodeType preNode();
-
-}} /* end naamespace vt::ctx */
+}} /* end namespace vt::debug */
 
 namespace vt { namespace config {
 
@@ -170,7 +173,7 @@ static inline void debugPrintImpl(NodeType node, Arg&& arg, Args&&... args) {
       "{} {} {} {}",
       vt_print_colorize,
       vt_proc_print_colorize(node),
-      vt_print_colorize_impl("\033[32m",  PrettyPrintCat<cat>::print(), ":"),
+      vt_print_colorize_impl(::vt::debug::green(), PrettyPrintCat<cat>::print(), ":"),
       user
     );
     if (vt_option_check_enabled(mod, ModeEnum::flush)) {

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -566,16 +566,14 @@ void Runtime::printStartupBanner() {
     auto f11 = fmt::format("Disabling color output");
     auto f12 = opt_on("--vt_no_color", f11);
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
+  } else if (ArgType::vt_color) {
+    auto f11 = fmt::format("Color output enabled");
+    auto f12 = opt_on("--vt_color", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
   } else {
-    if (ArgType::vt_auto_color) {
-      auto f11 = fmt::format("Automatic TTY detection for color output");
-      auto f12 = opt_on("--vt_auto_color", f11);
-      fmt::print("{}\t{}{}", vt_pre, f12, reset);
-    } else {
-      auto f11 = fmt::format("Color output enabled by default");
-      auto f12 = opt_inverse("--vt_no_color", f11);
-      fmt::print("{}\t{}{}", vt_pre, f12, reset);
-    }
+    auto f11 = fmt::format("Automatically color output (if terminal)");
+    auto f12 = opt_inverse("--vt_no_color", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
   }
 
   if (ArgType::vt_no_stack) {


### PR DESCRIPTION
- Rules for configuration are defined (AND followed..);
  logic happens immediately after parsing which ensures
  only one isatty check (ioctl) and centralized logic handling.

  Updated the setting/diagnostic messages to also align
  with the rules.

  Rules:
  - no-color DISABLES color
  - color ENABLES color
  - auto-color (assumed default) enables color in terminal

  (This makes VT consistent with tools like 'ls', or more so..)

- Removes unistd.h bleed - should be removed from other headers

- Consistently use defined colors and other minor formatting;
  swith to 'standard' functions.