### PR TITLE
[#521] move 'pretty pring message' to cc

### DIFF
--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -45,7 +45,7 @@
 #if !defined INCLUDED_VT_CONFIGS_ARGUMENTS_ARGS_H
 #define INCLUDED_VT_CONFIGS_ARGUMENTS_ARGS_H
 
-#include "vt/config.h"
+// Do not pull in any VT dependencies here
 
 #include <string>
 

--- a/src/vt/configs/debug/debug_colorize.h
+++ b/src/vt/configs/debug/debug_colorize.h
@@ -46,7 +46,6 @@
 #define INCLUDED_VT_CONFIGS_DEBUG_DEBUG_COLORIZE_H
 
 #include "vt/configs/arguments/args.h"
-#include "vt/configs/types/types_type.h"
 
 #include <string>
 #include <unistd.h>

--- a/src/vt/configs/debug/debug_print.h
+++ b/src/vt/configs/debug/debug_print.h
@@ -45,6 +45,7 @@
 #if !defined INCLUDED_VT_CONFIGS_DEBUG_DEBUG_PRINT_H
 #define INCLUDED_VT_CONFIGS_DEBUG_DEBUG_PRINT_H
 
+#include "vt/configs/types/types_headers.h"
 #include "vt/configs/debug/debug_config.h"
 #include "vt/configs/debug/debug_colorize.h"
 #include "vt/configs/debug/debug_var_unused.h"

--- a/src/vt/configs/error/common.h
+++ b/src/vt/configs/error/common.h
@@ -45,7 +45,7 @@
 #if !defined INCLUDED_CONFIGS_ERROR_COMMON_H
 #define INCLUDED_CONFIGS_ERROR_COMMON_H
 
-#include "vt/configs/types/types_type.h"
+#include "vt/configs/types/types_headers.h"
 #include "vt/collective/basic.h"
 
 #include <tuple>

--- a/src/vt/configs/error/error.h
+++ b/src/vt/configs/error/error.h
@@ -45,8 +45,8 @@
 #if !defined INCLUDED_CONFIGS_ERROR_ERROR_H
 #define INCLUDED_CONFIGS_ERROR_ERROR_H
 
+#include "vt/configs/types/types_headers.h"
 #include "vt/configs/debug/debug_config.h"
-#include "vt/configs/types/types_type.h"
 #include "vt/configs/error/common.h"
 
 #include <string>

--- a/src/vt/configs/error/error.impl.h
+++ b/src/vt/configs/error/error.impl.h
@@ -45,8 +45,8 @@
 #if !defined INCLUDED_CONFIGS_ERROR_ERROR_IMPL_H
 #define INCLUDED_CONFIGS_ERROR_ERROR_IMPL_H
 
+#include "vt/configs/types/types_headers.h"
 #include "vt/configs/debug/debug_config.h"
-#include "vt/configs/types/types_type.h"
 #include "vt/configs/error/common.h"
 #include "vt/configs/error/error.h"
 #include "vt/configs/error/pretty_print_message.h"

--- a/src/vt/configs/error/hard_error.h
+++ b/src/vt/configs/error/hard_error.h
@@ -51,7 +51,6 @@
  */
 
 #include "vt/configs/debug/debug_config.h"
-#include "vt/configs/types/types_type.h"
 #include "vt/configs/error/common.h"
 #include "vt/configs/error/error.h"
 

--- a/src/vt/configs/error/pretty_print_message.cc
+++ b/src/vt/configs/error/pretty_print_message.cc
@@ -1,0 +1,97 @@
+#include "vt/configs/error/pretty_print_message.h"
+
+#include "vt/configs/error/common.h"
+#include "vt/configs/debug/debug_colorize.h"
+#include "vt/configs/generated/vt_git_revision.h"
+#include "vt/context/context.h"
+
+#include <string>
+#include <unistd.h> // gethostname
+
+#include "fmt/format.h"
+
+namespace vt { namespace debug {
+
+static std::string s_hostname = std::string();
+
+inline std::string& getCachedHostname() {
+  if (s_hostname.empty()) {
+    char temp[1024] = {0};
+    gethostname(temp, 1024);
+    s_hostname = std::string(temp);
+  }
+  return s_hostname;
+}
+
+std::string stringizeMessage(
+  std::string const& msg, std::string const& reason, std::string const& cond,
+  std::string const& file, int const line, std::string const& func,
+  ErrorCodeType error
+) {
+  auto node            = ::vt::debug::preNode();
+  auto nodes           = ::vt::debug::preNodes();
+  auto vt_pre          = ::vt::debug::vtPre();
+  auto node_str        = ::vt::debug::proc(node);
+  auto prefix          = vt_pre + node_str + " ";
+  auto green           = ::vt::debug::green();
+  auto blue            = ::vt::debug::blue();
+  auto reset           = ::vt::debug::reset();
+  auto bred            = ::vt::debug::bred();
+  auto red             = ::vt::debug::bred();
+  auto magenta         = ::vt::debug::magenta();
+  auto assert_reason   = reason != "" ? ::fmt::format(
+    "{}{:>20} {}{}{}\n", prefix, "Reason:", magenta, reason, reset
+  ) : "";
+  auto message         = ::fmt::format(
+    "{}{:>20} {}{}{}\n", prefix, "Type:", red, msg, reset
+  );
+  auto assert_cond     = cond != "" ? ::fmt::format(
+    "{}{:>20} {}({}){}\n", prefix, msg, bred, cond, reset
+  ) : message;
+
+  std::string dirty = "";
+  if (strncmp(vt_git_clean_status.c_str(), "DIRTY", 5) == 0) {
+    dirty = red + std::string("*dirty*") + reset;
+  } else {
+    dirty = green + std::string("clean") + reset;
+  }
+
+  std::string const& hostname = getCachedHostname();
+
+  auto assert_fail_str = ::fmt::format(
+    "{}\n"
+    "{}"
+    "{}"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}{:>20} {}\n"
+    "{}{:>20} {}{}{}\n"
+    "{}\n",
+    prefix,
+    assert_reason,
+    assert_cond,
+    prefix, "Node:",        blue,    node,              reset,
+    prefix, "Num Nodes:",   blue,    nodes,             reset,
+    prefix, "File:",        green,   file,              reset,
+    prefix, "Line:",        green,   line,              reset,
+    prefix, "Function:",    green,   func,              reset,
+    prefix, "Code:",        green,   error,             reset,
+    prefix, "Build SHA:",   magenta, vt_git_sha1,       reset,
+    prefix, "Build Ref:",   magenta, vt_git_refspec,    reset,
+    prefix, "Description:", magenta, vt_git_description,reset,
+    prefix, "GIT Repo:",    dirty,
+    prefix, "Hostname:",    magenta, hostname,          reset,
+    prefix
+  );
+  return assert_fail_str;
+}
+
+}} /* end namespace vt::debug */
+

--- a/src/vt/configs/error/pretty_print_message.h
+++ b/src/vt/configs/error/pretty_print_message.h
@@ -45,89 +45,19 @@
 #if !defined INCLUDED_VT_CONFIGS_ERROR_PRETTY_PRINT_MESSAGE_H
 #define INCLUDED_VT_CONFIGS_ERROR_PRETTY_PRINT_MESSAGE_H
 
-#include "vt/configs/error/common.h"
-#include "vt/configs/types/types_type.h"
-#include "vt/configs/debug/debug_colorize.h"
-#include "vt/configs/generated/vt_git_revision.h"
-#include "vt/context/context.h"
+#include "vt/configs/types/types_headers.h"
 
 #include <string>
-#include <unistd.h>
 
 #include "fmt/format.h"
 
 namespace vt { namespace debug {
 
-inline std::string stringizeMessage(
+std::string stringizeMessage(
   std::string const& msg, std::string const& reason, std::string const& cond,
   std::string const& file, int const line, std::string const& func,
   ErrorCodeType error
-) {
-  auto node            = ::vt::debug::preNode();
-  auto nodes           = ::vt::debug::preNodes();
-  auto vt_pre          = ::vt::debug::vtPre();
-  auto node_str        = ::vt::debug::proc(node);
-  auto prefix          = vt_pre + node_str + " ";
-  auto green           = ::vt::debug::green();
-  auto blue            = ::vt::debug::blue();
-  auto reset           = ::vt::debug::reset();
-  auto bred            = ::vt::debug::bred();
-  auto red             = ::vt::debug::bred();
-  auto magenta         = ::vt::debug::magenta();
-  auto assert_reason   = reason != "" ? ::fmt::format(
-    "{}{:>20} {}{}{}\n", prefix, "Reason:", magenta, reason, reset
-  ) : "";
-  auto message         = ::fmt::format(
-    "{}{:>20} {}{}{}\n", prefix, "Type:", red, msg, reset
-  );
-  auto assert_cond     = cond != "" ? ::fmt::format(
-    "{}{:>20} {}({}){}\n", prefix, msg, bred, cond, reset
-  ) : message;
-
-  char hostname[1024];
-  gethostname(hostname, 1024);
-
-  std::string dirty = "";
-  if (strncmp(vt_git_clean_status.c_str(), "DIRTY", 5) == 0) {
-    dirty = red + std::string("*dirty*") + reset;
-  } else {
-    dirty = green + std::string("clean") + reset;
-  }
-
-  auto assert_fail_str = ::fmt::format(
-    "{}\n"
-    "{}"
-    "{}"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}{:>20} {}\n"
-    "{}{:>20} {}{}{}\n"
-    "{}\n",
-    prefix,
-    assert_reason,
-    assert_cond,
-    prefix, "Node:",        blue,    node,              reset,
-    prefix, "Num Nodes:",   blue,    nodes,             reset,
-    prefix, "File:",        green,   file,              reset,
-    prefix, "Line:",        green,   line,              reset,
-    prefix, "Function:",    green,   func,              reset,
-    prefix, "Code:",        green,   error,             reset,
-    prefix, "Build SHA:",   magenta, vt_git_sha1,       reset,
-    prefix, "Build Ref:",   magenta, vt_git_refspec,    reset,
-    prefix, "Description:", magenta, vt_git_description,reset,
-    prefix, "GIT Repo:",    dirty,
-    prefix, "Hostname:",    magenta, hostname,          reset,
-    prefix
-  );
-  return assert_fail_str;
-}
+);
 
 }} /* end namespace vt::debug */
 

--- a/src/vt/configs/types/types_size.h
+++ b/src/vt/configs/types/types_size.h
@@ -45,24 +45,22 @@
 #if !defined INCLUDED_TYPES_SIZE
 #define INCLUDED_TYPES_SIZE
 
-#include "vt/configs/debug/debug_masterconfig.h"
-#include "vt/configs/types/types_type.h"
-#include "vt/utils/bits/bits_common.h"
+#include "vt/utils/bits/bits_counter.h"
 
 namespace vt {
 
 static constexpr BitCountType const
-    node_num_bits = BitCounterType<NodeType>::value;
+    node_num_bits = utils::BitCounter<NodeType>::value;
 static constexpr BitCountType const
-    handler_num_bits = BitCounterType<HandlerType>::value;
+    handler_num_bits = utils::BitCounter<HandlerType>::value;
 static constexpr BitCountType const
-    ref_num_bits = BitCounterType<RefType>::value;
+    ref_num_bits = utils::BitCounter<RefType>::value;
 static constexpr BitCountType const
-    epoch_num_bits = BitCounterType<EpochType>::value;
+    epoch_num_bits = utils::BitCounter<EpochType>::value;
 static constexpr BitCountType const
-    tag_num_bits = BitCounterType<TagType>::value;
+    tag_num_bits = utils::BitCounter<TagType>::value;
 static constexpr BitCountType const
-    group_num_bits = BitCounterType<GroupType>::value;
+    group_num_bits = utils::BitCounter<GroupType>::value;
 
 }  // end namespace vt
 

--- a/src/vt/configs/types/types_type.h
+++ b/src/vt/configs/types/types_type.h
@@ -45,8 +45,6 @@
 #if !defined INCLUDED_TYPES_TYPE
 #define INCLUDED_TYPES_TYPE
 
-#include "vt/configs/debug/debug_masterconfig.h"
-
 #include <cstdint>
 #include <functional>
 

--- a/src/vt/event/event_id.cc
+++ b/src/vt/event/event_id.cc
@@ -43,6 +43,7 @@
 */
 
 #include "vt/event/event_id.h"
+#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace event {
 

--- a/src/vt/pipe/id/pipe_id.h
+++ b/src/vt/pipe/id/pipe_id.h
@@ -47,6 +47,7 @@
 
 #include "vt/config.h"
 #include "vt/pipe/pipe_common.h"
+#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace pipe {
 

--- a/src/vt/sequence/seq_closure.cc
+++ b/src/vt/sequence/seq_closure.cc
@@ -47,6 +47,7 @@
 #include "vt/sequence/seq_closure.h"
 #include "vt/sequence/seq_helpers.h"
 #include "vt/sequence/seq_node.h"
+#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace seq {
 

--- a/src/vt/termination/term_scope.cc
+++ b/src/vt/termination/term_scope.cc
@@ -47,6 +47,7 @@
 #include "vt/termination/term_common.h"
 #include "vt/scheduler/scheduler.h"
 #include "vt/messaging/active.h"
+#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace term {
 

--- a/src/vt/trace/trace_event.cc
+++ b/src/vt/trace/trace_event.cc
@@ -44,6 +44,7 @@
 
 
 #include "vt/trace/trace_event.h"
+#include "vt/utils/bits/bits_common.h"
 
 #include <string>
 

--- a/src/vt/utils/bits/bits_common.h
+++ b/src/vt/utils/bits/bits_common.h
@@ -45,7 +45,6 @@
 #if !defined INCLUDED_BITS_COMMON
 #define INCLUDED_BITS_COMMON
 
-#include "vt/config.h"
 #include "vt/utils/bits/bits_counter.h"
 #include "vt/utils/bits/bits_packer.h"
 
@@ -53,6 +52,7 @@ namespace vt {
 
 template <typename T>
 using BitCounterType = utils::BitCounter<T>;
+
 using BitPackerType = utils::BitPacker;
 
 }  // end namespace vt

--- a/src/vt/utils/bits/bits_counter.h
+++ b/src/vt/utils/bits/bits_counter.h
@@ -45,7 +45,7 @@
 #if !defined INCLUDED_BITS_COUNTER
 #define INCLUDED_BITS_COUNTER
 
-#include "vt/config.h"
+// Do not pull in other VT dependencies here
 
 namespace vt { namespace utils {
 
@@ -54,6 +54,6 @@ struct BitCounter {
   static constexpr BitCountType const value = sizeof(BitField) * 8;
 };
 
-}}  // end namespace vt::utils
+}} // end namespace vt::utils
 
 #endif  /*INCLUDED_BITS_COUNTER*/

--- a/src/vt/utils/bits/bits_packer.h
+++ b/src/vt/utils/bits/bits_packer.h
@@ -88,6 +88,10 @@ private:
 
 }}  // end namespace vt::utils
 
+namespace vt {
+  using BitPackerType = utils::BitPacker;
+}  // end namespace vt
+
 #include "vt/utils/bits/bits_packer.impl.h"
 
 #endif  /*INCLUDED_BITS_PACKER*/

--- a/src/vt/vrt/collection/balance/proc_stats.h
+++ b/src/vt/vrt/collection/balance/proc_stats.h
@@ -54,10 +54,6 @@
 
 #include <vector>
 #include <unordered_map>
-#include <tuple>
-#include <functional>
-#include <cstdio>
-#include <cstdlib>
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 

--- a/src/vt/vrt/collection/proxy_builder/elm_proxy_builder.cc
+++ b/src/vt/vrt/collection/proxy_builder/elm_proxy_builder.cc
@@ -44,6 +44,7 @@
 
 #include "vt/config.h"
 #include "vt/vrt/collection/proxy_builder/elm_proxy_builder.h"
+#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace vrt { namespace collection {
 

--- a/src/vt/vrt/collection/proxy_builder/elm_proxy_builder.h
+++ b/src/vt/vrt/collection/proxy_builder/elm_proxy_builder.h
@@ -46,6 +46,7 @@
 #define INCLUDED_VRT_COLLECTION_PROXY_BUILDER_ELM_PROXY_BUILDER_H
 
 #include "vt/config.h"
+#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace vrt { namespace collection {
 

--- a/src/vt/vrt/proxy/proxy_bits.h
+++ b/src/vt/vrt/proxy/proxy_bits.h
@@ -47,6 +47,7 @@
 
 #include "vt/config.h"
 #include "vt/vrt/context/context_vrt_fwd.h"
+#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace vrt {
 

--- a/src/vt/worker/worker_seq.cc
+++ b/src/vt/worker/worker_seq.cc
@@ -51,6 +51,7 @@
 #include "vt/collective/collective_ops.h"
 #include "vt/worker/worker_common.h"
 #include "vt/worker/worker_seq.h"
+#include "vt/utils/bits/bits_common.h"
 
 #include <memory>
 #include <functional>


### PR DESCRIPTION
- Code does not have benefit being in header so..
  moved to compile-once-CC-file.

  And then FIXED a number of headers/code that broke
  due to having the transitive dependency spider web
  removed.

- Removed last gobal usage of unistd.h and cstdio
  from headers - should add wiki note about the 'allowed headers'
  that may be included in .h files.. so much global pollution.

- As added bonus, uses cached std::string hostname.

- Fix broken header includes exposed when headers stopped
  being included from 'pretty_print_message.h'

  Now 'types_headers.h' should be resolveable at the TOP of the header graph;
  updated bits_counter to accomodate.