### PR TITLE
537 eliminate T-lambda in Auto Registry

### DIFF
--- a/src/vt/registry/auto/auto_registry_common.h
+++ b/src/vt/registry/auto/auto_registry_common.h
@@ -104,12 +104,14 @@ struct RegistrarGenInfoBase {
 };
 
 struct RegistrarGenInfo : RegistrarGenInfoBase {
-  RegistrarGenInfo() {
+
+  /// Create a new object.
+  /// Takes complete ownership of the supplied object (pointer).
+  static RegistrarGenInfo takeOwnership(RegistrarGenInfoBase *owned_proxy) {
+    return RegistrarGenInfo(owned_proxy);
   }
 
-  explicit RegistrarGenInfo(RegistrarGenInfoBase* owned_proxy)
-    : proxy_(owned_proxy)
-  {
+  RegistrarGenInfo() {
   }
 
   // Using unique_ptr; can expand later.
@@ -122,6 +124,12 @@ struct RegistrarGenInfo : RegistrarGenInfoBase {
   virtual HandlerType getRegisteredIndex() override {
     return proxy_->getRegisteredIndex();
   }
+
+private:
+  explicit RegistrarGenInfo(RegistrarGenInfoBase* owned_proxy)
+    : proxy_(owned_proxy)  {
+  }
+
 private:
   std::unique_ptr<RegistrarGenInfoBase> proxy_ = nullptr;
 };

--- a/src/vt/registry/auto/auto_registry_common.h
+++ b/src/vt/registry/auto/auto_registry_common.h
@@ -76,7 +76,7 @@ using AutoActiveIndexType         = std::size_t;
 using AutoActiveObjGroupType      = objgroup::ActiveObjAnyType;
 
 using HandlerManagerType = vt::HandlerManager;
-using AutoHandlerType = int32_t;
+using AutoHandlerType = HandlerType;
 using NumArgsType = int16_t;
 
 enum struct RegistryTypeEnum {
@@ -97,25 +97,54 @@ enum struct RegistryTypeEnum {
 static struct NumArgsTagType { } NumArgsTag { };
 #pragma GCC diagnostic pop
 
+struct RegistrarGenInfoBase {
+  /// Return the registered handler type.
+  virtual HandlerType getRegisteredIndex() = 0;
+  virtual ~RegistrarGenInfoBase() {}
+};
+
+struct RegistrarGenInfo : RegistrarGenInfoBase {
+  RegistrarGenInfo() {
+  }
+
+  explicit RegistrarGenInfo(RegistrarGenInfoBase* owned_proxy)
+    : proxy_(owned_proxy)
+  {
+  }
+
+  // Using unique_ptr; can expand later.
+  RegistrarGenInfo(RegistrarGenInfo const& in) = delete;
+
+  RegistrarGenInfo(RegistrarGenInfo&& in) {
+    proxy_.swap(in.proxy_);
+  }
+
+  virtual HandlerType getRegisteredIndex() {
+    return proxy_->getRegisteredIndex();
+  }
+private:
+  std::unique_ptr<RegistrarGenInfoBase> proxy_ = nullptr;
+};
+
 template <typename FnT>
 struct AutoRegInfo {
-  using GenFnType = std::function<AutoHandlerType()>;
-
   FnT activeFunT;
   NumArgsType args_ = 1;
   AutoHandlerType obj_idx_ = -1;
-  GenFnType gen_obj_idx_ = nullptr;
+  RegistrarGenInfo gen_obj_idx_;
 
   #if backend_check_enabled(trace_enabled)
     trace::TraceEntryIDType event_id;
     AutoRegInfo(
-      FnT const& in_active_fun_t, GenFnType in_gen,
+      FnT const& in_active_fun_t,
+      RegistrarGenInfo in_gen,
       trace::TraceEntryIDType const& in_event_id
-    ) : activeFunT(in_active_fun_t), gen_obj_idx_(in_gen), event_id(in_event_id)
+    ) : activeFunT(in_active_fun_t), gen_obj_idx_(std::move(in_gen)), event_id(in_event_id)
     { }
     AutoRegInfo(
       NumArgsTagType,
-      FnT const& in_active_fun_t, trace::TraceEntryIDType const& in_event_id,
+      FnT const& in_active_fun_t,
+      trace::TraceEntryIDType const& in_event_id,
       NumArgsType const& in_args
     ) : activeFunT(in_active_fun_t), args_(in_args), event_id(in_event_id)
     { }
@@ -123,19 +152,22 @@ struct AutoRegInfo {
       return event_id;
     }
   #else
-    explicit AutoRegInfo(FnT const& in_active_fun_t, GenFnType in_gen)
-      : activeFunT(in_active_fun_t), gen_obj_idx_(in_gen)
+    explicit AutoRegInfo(
+      FnT const& in_active_fun_t,
+      RegistrarGenInfo in_gen
+    ) : activeFunT(in_active_fun_t), gen_obj_idx_(std::move(in_gen))
     { }
     AutoRegInfo(
       NumArgsTagType,
-      FnT const& in_active_fun_t, NumArgsType const& in_args
+      FnT const& in_active_fun_t,
+      NumArgsType const& in_args
     ) : activeFunT(in_active_fun_t), args_(in_args)
     { }
   #endif
 
   AutoHandlerType getObjIdx() {
-    if (obj_idx_ == -1 and gen_obj_idx_ != nullptr) {
-      obj_idx_ = gen_obj_idx_();
+    if (obj_idx_ == -1) {
+      obj_idx_ = gen_obj_idx_.getRegisteredIndex();
     }
     return obj_idx_;
   }

--- a/src/vt/registry/auto/auto_registry_common.h
+++ b/src/vt/registry/auto/auto_registry_common.h
@@ -119,7 +119,7 @@ struct RegistrarGenInfo : RegistrarGenInfoBase {
     proxy_.swap(in.proxy_);
   }
 
-  virtual HandlerType getRegisteredIndex() {
+  virtual HandlerType getRegisteredIndex() override {
     return proxy_->getRegisteredIndex();
   }
 private:

--- a/src/vt/registry/auto/auto_registry_general_impl.h
+++ b/src/vt/registry/auto/auto_registry_general_impl.h
@@ -57,7 +57,7 @@ namespace vt { namespace auto_registry {
 
 template <typename RegObjTypeT>
 struct RegistrarGenInfoImpl : RegistrarGenInfoBase {
-  virtual HandlerType getRegisteredIndex() {
+  virtual HandlerType getRegisteredIndex() override {
     return objgroup::registry::makeObjIdx<RegObjTypeT>();
   }
 };

--- a/src/vt/registry/auto/auto_registry_general_impl.h
+++ b/src/vt/registry/auto/auto_registry_general_impl.h
@@ -68,7 +68,8 @@ RegistrarGen<ActFnT, RegT, InfoT, FnT>::RegistrarGen() {
   index = reg.size();
 
   FnT fn = reinterpret_cast<FnT>(ActFnT::getFunction());
-  RegistrarGenInfo indexAccessor{new RegistrarGenInfoImpl<typename ActFnT::ObjType>()};
+  RegistrarGenInfo indexAccessor = RegistrarGenInfo::takeOwnership(
+    new RegistrarGenInfoImpl<typename ActFnT::ObjType>());
 
   #if backend_check_enabled(trace_enabled)
   using Tn = typename ActFnT::ActFnType;


### PR DESCRIPTION
- Replace the T-lambda with a strong type-erased proxy.
  This avoids signifcant T-cost.

  Uses unique_ptr because shared_ptr is also T-costly.

  (Working on find a middle-ground with C++ and type-erasure
   as well.. Base + Proxy + Impl seems okay, if not verbose.)