### PR TITLE
540 perf. cleanup for demangler.cc

### DIFF
--- a/src/vt/utils/demangle/demangle.cc
+++ b/src/vt/utils/demangle/demangle.cc
@@ -42,19 +42,52 @@
 //@HEADER
 */
 
-
-#include "vt/config.h"
 #include "vt/utils/demangle/demangle.h"
-#include "vt/context/context.h"
 
 #include <vector>
 #include <string>
 #include <list>
 #include <cstring>
 
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+
 namespace vt { namespace util { namespace demangle {
 
-/*static*/ ActiveFunctionDemangler::StrParsedOutType
+//
+// DemanglerUtils
+//
+
+/*static*/ std::vector<std::string>
+DemanglerUtils::splitString(std::string const& str, char delim) {
+  std::stringstream ss;
+  ss.str(str);
+
+  std::string item;
+  std::vector<std::string> elems;
+  while (std::getline(ss, item, delim)) {
+    elems.push_back(item);
+  }
+  return elems;
+}
+
+/*static*/ std::string
+DemanglerUtils::removeSpaces(std::string const& str) {
+  std::string clean{str};
+
+  clean.erase(
+    std::remove(clean.begin(), clean.end(), ' '),
+    clean.end());
+
+  return clean;
+}
+
+//
+// ActiveFunctionDemangler
+//
+
+/*static*/ DemangledName
 ActiveFunctionDemangler::parseActiveFunctionName(std::string const& str) {
   using CountType = int32_t;
   using CharType = char;
@@ -333,7 +366,11 @@ ActiveFunctionDemangler::parseActiveFunctionName(std::string const& str) {
   return demangled;
 }
 
-/*static*/ ActiveFunctorDemangler::StrParsedOutType
+//
+// ActiveFunctorDemangler
+//
+
+/*static*/ DemangledName
 ActiveFunctorDemangler::parseActiveFunctorName(
   std::string const& name, std::string const& args
 ) {

--- a/src/vt/utils/demangle/demangle.h
+++ b/src/vt/utils/demangle/demangle.h
@@ -51,19 +51,14 @@
 #include "vt/utils/demangle/demangled_name.h"
 
 #include <string>
-#include <sstream>
 #include <vector>
 #include <cassert>
 #include <cstring>
-#include <iterator>
 #include <iosfwd>
-#include <regex>
 #include <cstdlib>
 #include <assert.h>
 
 namespace vt { namespace util { namespace demangle {
-
-using StrContainerType = std::vector<std::string>;
 
 struct DemanglerUtils {
   template <typename T>
@@ -72,34 +67,11 @@ struct DemanglerUtils {
     return s;
   }
 
-  template <typename StringOut>
-  static inline void splitString(
-    std::string const& s, char delim, StringOut result
-  ) {
-    std::stringstream ss;
-    ss.str(s);
-    std::string item;
-    while (std::getline(ss, item, delim)) {
-      *(result++) = item;
-    }
-  }
+  static std::vector<std::string>
+  splitString(std::string const& str, char delim);
 
-  static inline StrContainerType splitString(
-    std::string const& str, char delim
-  ) {
-    StrContainerType elems;
-    splitString(str, delim, std::back_inserter(elems));
-    return elems;
-  }
-
-  static inline std::string removeSpaces(std::string const& str) {
-    StrContainerType const& str_split = splitString(str, ' ');
-    std::stringstream clean;
-    for (auto&& x : str_split) {
-      clean << x;
-    }
-    return clean.str();
-  }
+  static std::string
+  removeSpaces(std::string const& str);
 };
 
 /*
@@ -115,17 +87,11 @@ struct DemanglerUtils {
  *  >
  */
 struct ActiveFunctionDemangler {
-  using StrParsedOutType = DemangledName;
-  using UtilType = DemanglerUtils;
-
-  static StrParsedOutType parseActiveFunctionName(std::string const& str);
+  static DemangledName parseActiveFunctionName(std::string const& str);
 };
 
 struct ActiveFunctorDemangler {
-  using StrParsedOutType = DemangledName;
-  using UtilType = DemanglerUtils;
-
-  static StrParsedOutType parseActiveFunctorName(
+  static DemangledName parseActiveFunctorName(
       std::string const& name, std::string const& args
   );
 };

--- a/src/vt/utils/demangle/demangled_name.h
+++ b/src/vt/utils/demangle/demangled_name.h
@@ -45,8 +45,6 @@
 #if !defined INCLUDED_UTILS_DEMANGLE_DEMANGLED_NAME_H
 #define INCLUDED_UTILS_DEMANGLE_DEMANGLED_NAME_H
 
-#include "vt/config.h"
-
 #include <string>
 
 namespace vt { namespace util { namespace demangle {


### PR DESCRIPTION
- Remove <regex> dependency; since this is gone from
  the header as well, saves many hundreds of ms per
  affected TU.. like, literally, 200ms+ per TU :|

- Moved non-effective inline functions to cc.

- Removed assorted aliases and converted to more idiomatic C++.