### PR TITLE
529 LB fix double-counted migration count

### DIFF
--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -253,11 +253,10 @@ void BaseLB::migrateObjectTo(ObjIDType const obj_id, NodeType const to) {
     obj_id, from, to, iter != migrator.end()
   );
 
-  local_migration_count_++;
-
   if (iter == migrator.end()) {
     off_node_migrate_[from].push_back(std::make_tuple(obj_id,to));
   } else {
+    local_migration_count_++;
     iter->second(to);
   }
 }


### PR DESCRIPTION
The global migration count after LB runs is currently incorrect---this fixes the double counting on the number of migrations.