### PR TITLE
500 Non-heuristic termination hang detector, DOT epoch graphs, performance bugs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ set(
     termination
       termination/dijkstra-scholten
       termination/interval
-      termination/tree
+      termination/graph
     messaging/envelope messaging/message
     pool/static_sized pool/header
     rdma/channel rdma/collection rdma/group rdma/state

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,10 @@ set(
       pipe/callback/objgroup_bcast
       pipe/callback/anon
       pipe/callback/cb_union
-    termination/dijkstra-scholten
+    termination
+      termination/dijkstra-scholten
+      termination/interval
+      termination/tree
     messaging/envelope messaging/message
     pool/static_sized pool/header
     rdma/channel rdma/collection rdma/group rdma/state

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -93,6 +93,9 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_term_rooted_use_wave = false;
 /*static*/ bool        ArgConfig::vt_no_detect_hang     = false;
 /*static*/ int64_t     ArgConfig::vt_hang_freq          = 1024;
+/*static*/ bool        ArgConfig::vt_epoch_graph_on_hang= true;
+/*static*/ bool        ArgConfig::vt_epoch_graph_terse  = false;
+/*static*/ bool        ArgConfig::vt_print_no_progress  = true;
 
 /*static*/ bool        ArgConfig::vt_pause              = false;
 
@@ -390,15 +393,24 @@ namespace vt { namespace arguments {
   auto hang_freq    = "The number of tree traversals before a hang is detected";
   auto ds           = "Force use of Dijkstra-Scholten (DS) algorithm for rooted epoch termination detection";
   auto wave         = "Force use of 4-counter algorithm for rooted epoch termination detection";
+  auto graph_on     = "Output epoch graph to file (DOT) when hang is detected";
+  auto terse        = "Output epoch graph to file in terse mode";
+  auto progress     = "Print termination counts when progress is stalled";
   auto hfd          = 1024;
-  auto x  = app.add_flag("--vt_no_detect_hang",       vt_no_detect_hang,       hang);
-  auto x1 = app.add_flag("--vt_term_rooted_use_ds",   vt_term_rooted_use_ds,   ds);
-  auto x2 = app.add_flag("--vt_term_rooted_use_wave", vt_term_rooted_use_wave, wave);
-  auto y = app.add_option("--vt_hang_freq",           vt_hang_freq,      hang_freq, hfd);
+  auto x  = app.add_flag("--vt_no_detect_hang",        vt_no_detect_hang,       hang);
+  auto x1 = app.add_flag("--vt_term_rooted_use_ds",    vt_term_rooted_use_ds,   ds);
+  auto x2 = app.add_flag("--vt_term_rooted_use_wave",  vt_term_rooted_use_wave, wave);
+  auto x3 = app.add_option("--vt_epoch_graph_on_hang", vt_epoch_graph_on_hang,  graph_on, true);
+  auto x4 = app.add_flag("--vt_epoch_graph_terse",     vt_epoch_graph_terse,    terse);
+  auto x5 = app.add_option("--vt_print_no_progress",   vt_print_no_progress,    progress, true);
+  auto y = app.add_option("--vt_hang_freq",            vt_hang_freq,      hang_freq, hfd);
   auto debugTerm = "Termination";
   x->group(debugTerm);
   x1->group(debugTerm);
   x2->group(debugTerm);
+  x3->group(debugTerm);
+  x4->group(debugTerm);
+  x5->group(debugTerm);
   y->group(debugTerm);
 
   /*

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -93,6 +93,9 @@ public:
   static std::string vt_lb_stats_file;
 
   static bool vt_no_detect_hang;
+  static bool vt_print_no_progress;
+  static bool vt_epoch_graph_on_hang;
+  static bool vt_epoch_graph_terse;
   static bool vt_term_rooted_use_ds;
   static bool vt_term_rooted_use_wave;
   static int64_t vt_hang_freq;

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -233,6 +233,7 @@ EventType ActiveMessenger::sendMsgBytes(
 
   if (not is_term) {
     theTerm()->produce(epoch,1,dest);
+    theTerm()->hangDetectSend();
   }
 
   for (auto&& l : send_listen_) {
@@ -364,6 +365,7 @@ ActiveMessenger::SendDataRetType ActiveMessenger::sendData(
   // Assume that any raw data send/recv is paired with a message with an epoch
   // if required to inhibit early termination of that epoch
   theTerm()->produce(term::any_epoch_sentinel,1,dest);
+  theTerm()->hangDetectSend();
 
   for (auto&& l : send_listen_) {
     l->send(dest, num_bytes, false);
@@ -528,15 +530,16 @@ void ActiveMessenger::finishPendingDataMsgAsyncRecv(InProgressDataIRecv* irecv) 
     }
   };
 
-
   if (next == nullptr) {
     dealloc_buf();
     theTerm()->consume(term::any_epoch_sentinel,1,sender);
+    theTerm()->hangDetectRecv();
   } else {
     // If we have a continuation, schedule to run later
     auto run = [=]{
       next(RDMA_GetType{buf,num_probe_bytes}, dealloc_buf);
       theTerm()->consume(term::any_epoch_sentinel,1,sender);
+      theTerm()->hangDetectRecv();
     };
     theSched()->enqueue(irecv->priority, run);
   }
@@ -701,6 +704,7 @@ bool ActiveMessenger::deliverActiveMsg(
 
     if (not is_term) {
       theTerm()->consume(epoch,1,from_node);
+      theTerm()->hangDetectRecv();
     }
   } else {
     if (insert) {

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -515,6 +515,28 @@ void Runtime::printStartupBanner() {
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
   }
 
+  if (ArgType::vt_print_no_progress) {
+    auto f11 = fmt::format("Printing warnings when progress is stalls");
+    auto f12 = opt_on("--vt_print_no_progress", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
+  }
+
+  if (ArgType::vt_epoch_graph_terse) {
+    auto f11 = fmt::format("Printing terse epoch graphs when hang detected");
+    auto f12 = opt_on("--vt_epoch_graph_terse", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
+  } else {
+    auto f11 = fmt::format("Printing verbose epoch graphs when hang detected");
+    auto f12 = opt_inverse("--vt_epoch_graph_terse", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
+  }
+
+  if (ArgType::vt_epoch_graph_on_hang) {
+    auto f11 = fmt::format("Epoch graph output enabled if hang detected");
+    auto f12 = opt_on("--vt_epoch_graph_on_hang", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
+  }
+
   if (ArgType::vt_no_detect_hang) {
     auto f11 = fmt::format("Disabling termination hang detection");
     auto f12 = opt_on("--vt_no_detect_hang", f11);
@@ -528,7 +550,7 @@ void Runtime::printStartupBanner() {
   if (!ArgType::vt_no_detect_hang) {
     if (ArgType::vt_hang_freq != 0) {
       auto f11 = fmt::format(
-        "Detecting hang every {} tree traversals ", ArgType::vt_hang_freq
+        "Printing stall warning every {} tree traversals ", ArgType::vt_hang_freq
       );
       auto f12 = opt_on("--vt_hang_detect", f11);
       fmt::print("{}\t{}{}", vt_pre, f12, reset);

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1044,16 +1044,18 @@ void Runtime::initializeWorkers(WorkerCountType const num_workers) {
     // scheduler; register listeners to activate/deactivate that epoch
     theSched->registerTrigger(
       sched::SchedulerEvent::BeginIdleMinusTerm, []{
-        vt_print(
-          runtime, "setLocalTerminated: BeginIdle: true\n"
+        debug_print(
+          runtime, node,
+          "setLocalTerminated: BeginIdle: true\n"
         );
         vt::theTerm()->setLocalTerminated(true, false);
       }
     );
     theSched->registerTrigger(
       sched::SchedulerEvent::EndIdleMinusTerm, []{
-        vt_print(
-          runtime, "setLocalTerminated: EndIdle: false\n"
+        debug_print(
+          runtime, node,
+          "setLocalTerminated: EndIdle: false\n"
         );
         vt::theTerm()->setLocalTerminated(false, false);
       }

--- a/src/vt/scheduler/prioritized_work_unit.h
+++ b/src/vt/scheduler/prioritized_work_unit.h
@@ -52,8 +52,8 @@ namespace vt { namespace sched {
 struct PriorityUnit {
   using UnitActionType = ActionType;
 
-  PriorityUnit(PriorityType in_priority, UnitActionType in_work)
-    : work_(in_work), priority_(in_priority)
+  PriorityUnit(bool in_is_term, PriorityType in_priority, UnitActionType in_work)
+    : work_(in_work), priority_(in_priority), is_term_(in_is_term)
   { }
 
   void operator()() { execute(); }
@@ -67,9 +67,12 @@ struct PriorityUnit {
     return lhs.priority_ < rhs.priority_;
   }
 
+  bool isTerm() const { return is_term_; }
+
 private:
-  UnitActionType work_  = nullptr;
+  UnitActionType work_   = nullptr;
   PriorityType priority_ = no_priority;
+  bool is_term_          = false;
 };
 
 }} /* end namespace vt::sched */

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -61,9 +61,11 @@
 namespace vt { namespace sched {
 
 enum SchedulerEvent {
-  BeginIdle = 0,
-  EndIdle = 1,
-  SchedulerEventSize = 2
+  BeginIdle          = 0,
+  EndIdle            = 1,
+  BeginIdleMinusTerm = 2,
+  EndIdleMinusTerm   = 3,
+  SchedulerEventSize = 4
 };
 
 struct Scheduler {
@@ -105,6 +107,9 @@ struct Scheduler {
   std::size_t workQueueSize() const { return work_queue_.size(); }
   bool workQueueEmpty() const { return work_queue_.empty(); }
 
+  bool isIdle() const { return work_queue_.empty(); }
+  bool isIdleMinusTerm() const { return work_queue_.size() == num_term_msgs_; }
+
 private:
 
 # if backend_check_enabled(priorities)
@@ -113,8 +118,13 @@ private:
   Queue<UnitType> work_queue_;
 # endif
 
-  bool has_executed_ = false;
-  bool is_idle = false;
+  bool has_executed_      = false;
+  bool is_idle            = true;
+  bool is_idle_minus_term = true;
+
+  // The number of termination messages currently in the queue---they weakly
+  // imply idleness for the stake of termination
+  std::size_t num_term_msgs_ = 0;
 
   EventTriggerContType event_triggers;
   EventTriggerContType event_triggers_once;

--- a/src/vt/scheduler/scheduler.impl.h
+++ b/src/vt/scheduler/scheduler.impl.h
@@ -51,11 +51,17 @@ namespace vt { namespace sched {
 
 template <typename MsgT>
 void Scheduler::enqueue(MsgT* msg, ActionType action) {
+  bool const is_term = envelopeIsTerm(msg->env);
+
+  if (is_term) {
+    num_term_msgs_++;
+  }
+
 # if backend_check_enabled(priorities)
   auto priority = envelopeGetPriority(msg->env);
-  work_queue_.emplace(UnitType(priority, action));
+  work_queue_.emplace(UnitType(is_term, priority, action));
 # else
-  work_queue_.emplace(UnitType(action));
+  work_queue_.emplace(UnitType(is_term, action));
 # endif
 }
 

--- a/src/vt/scheduler/work_unit.h
+++ b/src/vt/scheduler/work_unit.h
@@ -54,8 +54,8 @@ namespace vt { namespace sched {
 struct Unit {
   using UnitActionType = ActionType;
 
-  explicit Unit(UnitActionType in_work)
-    : work_(in_work)
+  Unit(bool in_is_term, UnitActionType in_work)
+    : work_(in_work), is_term_(in_is_term)
   { }
 
   void operator()() { execute(); }
@@ -65,8 +65,11 @@ struct Unit {
     work_();
   }
 
+  bool isTerm() const { return is_term_; }
+
 private:
   UnitActionType work_ = nullptr;
+  bool is_term_        = false;
 };
 
 }} /* end namespace vt::sched */

--- a/src/vt/termination/dijkstra-scholten/ds.cc
+++ b/src/vt/termination/dijkstra-scholten/ds.cc
@@ -69,6 +69,7 @@ void TermDS<CommType>::terminated() {
     "terminated: epoch={:x}\n", epoch_
   );
 
+  is_terminated = true;
   CommType::rootTerminated(epoch_);
 }
 

--- a/src/vt/termination/dijkstra-scholten/ds.cc
+++ b/src/vt/termination/dijkstra-scholten/ds.cc
@@ -55,7 +55,7 @@ namespace vt { namespace term { namespace ds {
 
 template <typename CommType>
 TermDS<CommType>::TermDS(EpochType in_epoch, bool isRoot_, NodeType self_)
-  : EpochRelation(in_epoch, true),
+  : EpochDependency(in_epoch, true),
     parent(-1), self(self_), C(0), ackedArbitrary(0), ackedParent(0),
     reqedParent(0), engagementMessageCount(0), D(0), processedSum(C)
 {

--- a/src/vt/termination/dijkstra-scholten/ds.h
+++ b/src/vt/termination/dijkstra-scholten/ds.h
@@ -48,7 +48,7 @@
 #include "vt/config.h"
 #include "vt/termination/dijkstra-scholten/ack_request.h"
 #include "vt/termination/dijkstra-scholten/comm.fwd.h"
-#include "vt/termination/term_parent.h"
+#include "vt/termination/epoch_dependency.h"
 
 #include <cstdlib>
 #include <map>
@@ -76,7 +76,7 @@ namespace vt { namespace term { namespace ds {
  */
 
 template <typename CommType>
-struct TermDS : EpochRelation {
+struct TermDS : EpochDependency {
   using CountType = int64_t;
   using AckReqListType = std::list<AckRequest>;
 

--- a/src/vt/termination/dijkstra-scholten/ds.h
+++ b/src/vt/termination/dijkstra-scholten/ds.h
@@ -112,6 +112,8 @@ protected:
   CountType lC                      = 0;
   CountType lD                      = 0;
   AckReqListType outstanding        = {};
+public:
+  bool is_terminated                = false;
 };
 
 }}} /* end namespace vt::term::ds */

--- a/src/vt/termination/epoch_dependency.cc
+++ b/src/vt/termination/epoch_dependency.cc
@@ -67,6 +67,7 @@ void EpochDependency::addSuccessor(EpochType const in_successor) {
     // this epoch is live
     theTerm()->produce(in_successor,1);
     successors_.insert(in_successor);
+    theTerm()->addEpochStateDependency(in_successor);
   }
 }
 
@@ -86,6 +87,7 @@ EpochDependency::removeIntersection(SuccessorBagType successors) {
   );
   for (auto ep : intersection) {
     theTerm()->consume(ep,1);
+    theTerm()->removeEpochStateDependency(ep);
   }
   successors_ = remaining;
   return intersection;
@@ -129,6 +131,7 @@ void EpochDependency::clearSuccessors() {
     // Consume the successor epoch to release it so it can now possibly complete
     // since the child is terminated
     theTerm()->consume(successor,1);
+    theTerm()->removeEpochStateDependency(successor);
   }
 
   // Clear the successor list

--- a/src/vt/termination/epoch_dependency.cc
+++ b/src/vt/termination/epoch_dependency.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                term_parent.cc
+//                             epoch_dependency.cc
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -45,71 +45,102 @@
 #include "vt/config.h"
 #include "vt/termination/termination.h"
 
+#include <algorithm>
+
 namespace vt { namespace term {
 
-void EpochRelation::addParentEpoch(EpochType const in_parent) {
+void EpochDependency::addSuccessor(EpochType const in_successor) {
   if (is_ds_) {
     debug_print(
       termds, node,
-      "addParentEpoch: epoch_={:x}, parent={:x}\n", epoch_, in_parent
+      "addSuccessor: epoch_={:x}, successor={:x}\n", epoch_, in_successor
     );
   } else {
     debug_print(
       term, node,
-      "addParentEpoch: epoch_={:x}, parent={:x}\n", epoch_, in_parent
+      "addSuccessor: epoch_={:x}, successor={:x}\n", epoch_, in_successor
     );
   }
 
-  // Produce a single work unit for the parent epoch so it can not finish while
-  // this epoch is live
-  theTerm()->produce(in_parent,1);
-  parents_.insert(in_parent);
+  if (successors_.find(in_successor) == successors_.end()) {
+    // Produce a single work unit for the successor epoch so it can not finish while
+    // this epoch is live
+    theTerm()->produce(in_successor,1);
+    successors_.insert(in_successor);
+  }
 }
 
-void EpochRelation::clearParents() {
+EpochDependency::SuccessorBagType
+EpochDependency::removeIntersection(SuccessorBagType successors) {
+  SuccessorBagType intersection = {};
+  std::set_intersection(
+    successors.begin(), successors.end(),
+    successors_.begin(), successors_.end(),
+    std::inserter(intersection,intersection.begin())
+  );
+  SuccessorBagType remaining = {};
+  std::set_difference(
+    successors_.begin(), successors_.end(),
+    intersection.begin(), intersection.end(),
+    std::inserter(remaining,remaining.begin())
+  );
+  for (auto ep : intersection) {
+    theTerm()->consume(ep,1);
+  }
+  successors_ = remaining;
+  return intersection;
+}
+
+void EpochDependency::addIntersectingSuccessors(SuccessorBagType successors) {
+  for (auto&& ep : successors) {
+    successors_.insert(ep);
+  }
+}
+
+void EpochDependency::clearSuccessors() {
   if (is_ds_) {
     debug_print(
       termds, node,
-      "clearParents: epoch={:x}, parents_.size()={}\n", epoch_,
-      parents_.size()
+      "clearSuccessors: epoch={:x}, successors_.size()={}\n", epoch_,
+      successors_.size()
     );
   } else {
     debug_print(
       term, node,
-      "clearParents: epoch={:x}, parents_.size()={}\n", epoch_,
-      parents_.size()
+      "clearSuccessors: epoch={:x}, successors_.size()={}\n", epoch_,
+
+      successors_.size()
     );
   }
 
-  for (auto&& parent : parents_) {
+  for (auto&& successor : successors_) {
     if (is_ds_) {
       debug_print(
         termds, node,
-        "clearParents: epoch={:x}, parent={:x}\n", epoch_, parent
+        "clearSuccessors: epoch={:x}, successor={:x}\n", epoch_, successor
       );
     } else {
       debug_print(
         term, node,
-        "clearParents: epoch={:x}, parent={:x}\n", epoch_,parent
+        "clearSuccessors: epoch={:x}, successor={:x}\n", epoch_,successor
       );
     }
 
-    // Consume the parent epoch to release it so it can now possibly complete
+    // Consume the successor epoch to release it so it can now possibly complete
     // since the child is terminated
-    theTerm()->consume(parent,1);
+    theTerm()->consume(successor,1);
   }
 
-  // Clear the parent list
-  parents_.clear();
+  // Clear the successor list
+  successors_.clear();
 }
 
-bool EpochRelation::hasParent() const {
-  return parents_.size() > 0;
+bool EpochDependency::hasSuccessor() const {
+  return successors_.size() > 0;
 }
 
-std::size_t EpochRelation::numParents() const {
-  return parents_.size();
+std::size_t EpochDependency::numSuccessors() const {
+  return successors_.size();
 }
-
 
 }} /* end namespace vt::term */

--- a/src/vt/termination/epoch_dependency.h
+++ b/src/vt/termination/epoch_dependency.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                term_parent.h
+//                              epoch_dependency.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,28 +42,30 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_TERMINATION_TERM_PARENT_H
-#define INCLUDED_VT_TERMINATION_TERM_PARENT_H
+#if !defined INCLUDED_VT_TERMINATION_EPOCH_DEPENDENCY_H
+#define INCLUDED_VT_TERMINATION_EPOCH_DEPENDENCY_H
 
 #include "vt/config.h"
 #include "vt/epoch/epoch.h"
 
-#include <unordered_set>
+#include <set>
 
 namespace vt { namespace term {
 
-struct EpochRelation {
-  using ParentBagType = std::unordered_set<EpochType>;
+struct EpochDependency {
+  using SuccessorBagType = std::set<EpochType>;
 
-  EpochRelation(EpochType in_epoch, bool in_is_ds)
+  EpochDependency(EpochType in_epoch, bool in_is_ds)
     : epoch_(in_epoch), is_ds_(in_is_ds)
   { }
 
-  void addParentEpoch(EpochType const in_parent);
-  void clearParents();
-  bool hasParent() const;
-  std::size_t numParents() const;
-  ParentBagType const& getParents() const { return parents_; }
+  SuccessorBagType removeIntersection(SuccessorBagType successors);
+  void addIntersectingSuccessors(SuccessorBagType successors);
+  void addSuccessor(EpochType const in_successor);
+  void clearSuccessors();
+  bool hasSuccessor() const;
+  std::size_t numSuccessors() const;
+  SuccessorBagType const& getSuccessors() const { return successors_; }
 
 protected:
   // The epoch for the this relation
@@ -72,10 +74,10 @@ protected:
 private:
   // Is this a DS-epoch
   bool is_ds_ = false;
-  // The parent epochs for a given epoch
-  ParentBagType parents_ = {};
+  // The successor epochs for a given predecessor epoch
+  SuccessorBagType successors_ = {};
 };
 
 }} /* end namespace vt::term */
 
-#endif /*INCLUDED_VT_TERMINATION_TERM_PARENT_H*/
+#endif /*INCLUDED_VT_TERMINATION_EPOCH_DEPENDENCY_H*/

--- a/src/vt/termination/graph/epoch_graph.cc
+++ b/src/vt/termination/graph/epoch_graph.cc
@@ -1,0 +1,242 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                epoch_graph.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include "vt/config.h"
+#include "vt/termination/graph/epoch_graph.h"
+#include "vt/termination/term_common.h"
+#include "vt/epoch/epoch_headers.h"
+#include "vt/configs/arguments/args.h"
+
+#include <sys/stat.h>
+#include <cstdio>
+
+namespace vt { namespace termination { namespace graph {
+
+void EpochGraph::detectCyclesImpl(std::list<EpochType>& stack) {
+  bool cycle = false;
+  std::string cycle_diagnostic = "";
+  for (auto&& p : stack) {
+    // We have encountered the same epoch previously in the stack, thus a
+    // cycle
+    if (p == epoch_) {
+      cycle = true;
+    }
+    if (cycle) {
+      cycle_diagnostic += fmt::format("{:x}->", p);
+    }
+  }
+  if (cycle) {
+    cycle_diagnostic += fmt::format("{:x}", epoch_);
+    std::string cycle_print = fmt::format(
+      "Cycle detected in epoch graph:\nCycle: {}\n",
+      cycle_diagnostic
+    );
+    vtAbort(cycle_print);
+    return;
+  }
+
+  stack.push_back(epoch_);
+  for (auto const& s : successors_) {
+    s->detectCyclesImpl(stack);
+  }
+  vtAssert(stack.back() == epoch_, "Must match after pop!");
+  stack.pop_back();
+}
+
+void EpochGraph::detectCycles() {
+  // DFS on graph, maintaining a stack to detect any cycles (which are an
+  // error, and will cause a hang). This could be made more efficient by
+  // tracking visited nodes
+  std::list<EpochType> stack;
+  detectCyclesImpl(stack);
+}
+
+void EpochGraph::outputImpl(std::set<std::tuple<EpochType, EpochType>> &links)  {
+  for (auto const& s : successors_) {
+    links.insert(std::make_pair(epoch_, s->epoch_));
+    s->outputImpl(links);
+  }
+}
+
+EpochGraph::EpFormat EpochGraph::formatDOTEpoch(EpochType epoch) {
+  if (epoch == term::any_epoch_sentinel) {
+    return std::make_tuple(epoch, static_cast<NodeType>(-1), true, "Global");
+  } else {
+    if (epoch::EpochManip::isRooted(epoch)) {
+      auto const ds_epoch = epoch::eEpochCategory::DijkstraScholtenEpoch;
+      auto const epoch_category = epoch::EpochManip::category(epoch);
+      auto const is_ds = epoch_category == ds_epoch;
+      auto const ep_node = epoch::EpochManip::node(epoch);
+      auto const ep_seq = epoch::EpochManip::seq(epoch);
+      if (is_ds) {
+        auto str = fmt::format("{:x}-DS-{}", ep_seq, ep_node);
+        return std::make_tuple(epoch, ep_node, false, str);
+      } else {
+        auto str = fmt::format("{:x}-R-{}", ep_seq, ep_node);
+        return std::make_tuple(epoch, ep_node, false, str);
+      }
+    } else {
+      auto str = fmt::format("{:x}-C", epoch);
+      return std::make_tuple(epoch, static_cast<NodeType>(-1), true, str);
+    }
+  }
+}
+
+std::string EpochGraph::outputDOT(bool verbose) {
+  std::unordered_map<EpochType, EpFormat> eps;
+  std::set<std::tuple<EpochType, EpochType>> links;
+  std::string builder = "";
+  outputImpl(links);
+
+  for (auto&& elm : links) {
+    if (eps.find(std::get<0>(elm)) == eps.end()) {
+      eps[std::get<0>(elm)] = formatDOTEpoch(std::get<0>(elm));
+    }
+    if (eps.find(std::get<1>(elm)) == eps.end()) {
+      eps[std::get<1>(elm)] = formatDOTEpoch(std::get<1>(elm));
+    }
+  }
+
+  /*
+   * This is a very slow/inefficient std::string builder...but this is
+   * completely off the critical path
+   */
+  builder = "digraph graphname {\n";
+  builder += "\tlabelloc = \"b\"\n";
+  builder += "\trankdir = \"TB\"\n";
+  builder += "\tranksep = \"1\"\n";
+  builder += "\tedge[\n";
+  builder += "\t\t\tpenwidth=2\n";
+  builder += "\t]\n";
+  builder += "\tnode[\n";
+  builder += "\t\tfontname=Monaco,\n";
+  builder += "\t\tpenwidth=1,\n";
+  builder += "\t\tfontsize=10,\n";
+  if (verbose) {
+    builder += "\t\tmargin=.2,\n";
+  } else {
+    builder += "\t\tmargin=.3,\n";
+  }
+  builder += "\t\tshape=box,\n";
+  builder += "\t\tfillcolor=lightblue,\n";
+  builder += "\t\tstyle=\"rounded,filled\"\n";
+  builder += "\t]\n";
+  for (auto&& elm : eps) {
+    EpochType ep = std::get<0>(elm.second);
+    NodeType node = std::get<1>(elm.second);
+    bool collective = std::get<2>(elm.second);
+    std::string str = std::get<3>(elm.second);
+    if (not arguments::ArgConfig::vt_epoch_graph_terse or verbose) {
+      if (collective) {
+        builder += fmt::format(
+          "\t{:x} [shape=record height=1 label=\"{}|{} collective | {:x} {}\"]\n",
+          elm.first, str, "{", ep, "}"
+        );
+      } else {
+        builder += fmt::format(
+          "\t{:x} [shape=record height=1 label=\"{}|{} rooted | {:x} | node={} {}\"]\n",
+          elm.first, str, "{", ep, node, "}"
+        );
+      }
+    } else {
+      builder += fmt::format("\t{:x} [label=\"{}\"]\n", elm.first, str);
+    }
+  }
+  for (auto&& elm : links) {
+    builder += fmt::format("\t{:x}->{:x};\n", std::get<0>(elm), std::get<1>(elm));
+  }
+  builder += "}\n";
+  return builder;
+}
+
+void EpochGraph::writeToFile(std::string const& dot, bool global, std::string tag) {
+  auto const node = theContext()->getNode();
+  auto const base_file = "epoch_graph";
+  if (tag != "") {
+    tag = tag + ".";
+  }
+  std::string file = "";
+  if (global) {
+    file = fmt::format("{}.global.{}dot", base_file, tag);
+  } else {
+    file = fmt::format("{}.{}.{}dot", base_file, node, tag);
+  }
+  fmt::print("file={}\n", file);
+  auto fd = fopen(file.c_str(), "w+");
+  fmt::print("file desc={}\n", print_ptr(fd));
+  fprintf(fd, "%s", dot.c_str());
+  fclose(fd);
+}
+
+/*friend*/ EpochGraph operator+(EpochGraph a1, EpochGraph const& a2) {
+  vtAssert(a1.epoch_ == a2.epoch_, "Trees should match");
+  std::vector<std::shared_ptr<EpochGraph>> new_successors;
+  for (auto& c2 : a2.successors_) {
+    // This could be more efficient O(n) vs O(n^2) if this was stored with a
+    // constant time lookup data structure
+    std::shared_ptr<EpochGraph> c1_match = nullptr;
+    for (auto& c1 : a1.successors_) {
+      if (c1->epoch_ == c2->epoch_) {
+        c1_match = c1;
+        break;
+      }
+    }
+
+    if (c1_match != nullptr) {
+      // Recurse down this matching node, merging the matching successors
+      (*c1_match) = (*c1_match) + (*c2);
+    } else {
+      new_successors.push_back(c2);
+    }
+  }
+
+  // Add new successors that a1 did not have to a1's successors list
+  for (auto const& child : new_successors) {
+    a1.successors_.push_back(child);
+  }
+
+  return a1;
+}
+
+}}} /* end namespace vt::termination::graph */

--- a/src/vt/termination/graph/epoch_graph.h
+++ b/src/vt/termination/graph/epoch_graph.h
@@ -1,0 +1,282 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                epoch_graph.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_TERMINATION_GRAPH_EPOCH_GRAPH_H
+#define INCLUDED_VT_TERMINATION_GRAPH_EPOCH_GRAPH_H
+
+#include "vt/config.h"
+
+#include <vector>
+#include <memory>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <list>
+#include <set>
+
+namespace vt { namespace termination { namespace graph {
+
+struct EpochGraph {
+
+  EpochGraph() = default;
+  EpochGraph(EpochGraph&&) = default;
+  EpochGraph(EpochGraph const&) = default;
+  EpochGraph& operator=(EpochGraph const&) = default;
+
+  explicit EpochGraph(EpochType in_epoch)
+    : epoch_(in_epoch)
+  { }
+
+public:
+  bool hasSuccessors() const { return successors_.size() != 0; }
+  void addSuccessor(EpochGraph&& t) {
+    successors_.push_back(std::make_shared<EpochGraph>(std::move(t)));
+  }
+  void addSuccessor(std::shared_ptr<EpochGraph> t) {
+    successors_.push_back(t);
+  }
+
+private:
+
+  void detectCyclesImpl(std::list<EpochType>& stack) {
+    bool cycle = false;
+    std::string cycle_diagnostic = "";
+    for (auto&& p : stack) {
+      // We have encountered the same epoch previously in the stack, thus a
+      // cycle
+      if (p == epoch_) {
+        cycle = true;
+      }
+      if (cycle) {
+        cycle_diagnostic += fmt::format("{:x}->", p);
+      }
+    }
+    if (cycle) {
+      cycle_diagnostic += fmt::format("{:x}", epoch_);
+      std::string cycle_print = fmt::format(
+        "Cycle detected in epoch graph:\nCycle: {}\n",
+        cycle_diagnostic
+      );
+      vtAbort(cycle_print);
+      return;
+    }
+
+    stack.push_back(epoch_);
+    for (auto const& s : successors_) {
+      s->detectCyclesImpl(stack);
+    }
+    vtAssert(stack.back() == epoch_, "Must match after pop!");
+    stack.pop_back();
+  }
+
+public:
+
+  void detectCycles() {
+    // DFS on graph, maintaining a stack to detect any cycles (which are an
+    // error, and will cause a hang). This could be made more efficient by
+    // tracking visited nodes
+    std::list<EpochType> stack;
+    detectCyclesImpl(stack);
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | epoch_;
+    std::size_t nc = successors_.size();
+    s | nc;
+    for (std::size_t i = 0; i < nc; i++) {
+      // This is inefficient because it potentially serializes vertices multiple
+      // times (if the structure is not a tree). But, given that this only
+      // executes as a diagnostic, it's not worth the trouble of keeping a
+      // lookup table
+      if (s.isUnpacking()) {
+        EpochGraph et;
+        s | et;
+        successors_.push_back(std::make_shared<EpochGraph>(std::move(et)));
+      } else {
+        s | *successors_[i];
+      }
+    }
+  }
+
+private:
+  void outputImpl(std::set<std::tuple<EpochType, EpochType>> &links)  {
+    for (auto const& s : successors_) {
+      links.insert(std::make_pair(epoch_, s->epoch_));
+      s->outputImpl(links);
+    }
+  }
+
+  using EpFormat = std::tuple<EpochType, NodeType, bool, std::string>;
+
+  EpFormat formatDOTEpoch(EpochType epoch) {
+    if (epoch == term::any_epoch_sentinel) {
+      return std::make_tuple(epoch, static_cast<NodeType>(-1), true, "Global");
+    } else {
+      if (epoch::EpochManip::isRooted(epoch)) {
+        auto const ds_epoch = epoch::eEpochCategory::DijkstraScholtenEpoch;
+        auto const epoch_category = epoch::EpochManip::category(epoch);
+        auto const is_ds = epoch_category == ds_epoch;
+        auto const ep_node = epoch::EpochManip::node(epoch);
+        auto const ep_seq = epoch::EpochManip::seq(epoch);
+        if (is_ds) {
+          auto str = fmt::format("{:x}-DS-{}", ep_seq, ep_node);
+          return std::make_tuple(epoch, ep_node, false, str);
+        } else {
+          auto str = fmt::format("{:x}-R-{}", ep_seq, ep_node);
+          return std::make_tuple(epoch, ep_node, false, str);
+        }
+      } else {
+        auto str = fmt::format("{:x}-C", epoch);
+        return std::make_tuple(epoch, static_cast<NodeType>(-1), true, str);
+      }
+    }
+  }
+
+public:
+  std::string outputDOT(bool verbose = false) {
+    std::unordered_map<EpochType, EpFormat> eps;
+    std::set<std::tuple<EpochType, EpochType>> links;
+    std::string builder = "";
+    outputImpl(links);
+
+    for (auto&& elm : links) {
+      if (eps.find(std::get<0>(elm)) == eps.end()) {
+        eps[std::get<0>(elm)] = formatDOTEpoch(std::get<0>(elm));
+      }
+      if (eps.find(std::get<1>(elm)) == eps.end()) {
+        eps[std::get<1>(elm)] = formatDOTEpoch(std::get<1>(elm));
+      }
+    }
+
+    builder = "digraph graphname {\n";
+    builder += "\tlabelloc = \"b\"\n";
+    builder += "\trankdir = \"TB\"\n";
+    builder += "\tranksep = \"1\"\n";
+    builder += "\tedge[\n";
+    builder += "\t\t\tpenwidth=2\n";
+    builder += "\t]\n";
+    builder += "\tnode[\n";
+    builder += "\t\tfontname=Monaco,\n";
+    builder += "\t\tpenwidth=1,\n";
+    builder += "\t\tfontsize=10,\n";
+    if (verbose) {
+      builder += "\t\tmargin=.2,\n";
+    } else {
+      builder += "\t\tmargin=.3,\n";
+    }
+    builder += "\t\tshape=box,\n";
+    builder += "\t\tfillcolor=lightblue,\n";
+    builder += "\t\tstyle=\"rounded,filled\"\n";
+    builder += "\t]\n";
+    for (auto&& elm : eps) {
+      EpochType ep = std::get<0>(elm.second);
+      NodeType node = std::get<1>(elm.second);
+      bool collective = std::get<2>(elm.second);
+      std::string str = std::get<3>(elm.second);
+      if (verbose) {
+        if (collective) {
+          builder += fmt::format(
+            "\t{:x} [shape=record height=1 label=\"{}|{} collective | {:x} {}\"]\n",
+            elm.first, str, "{", ep, "}"
+          );
+        } else {
+          builder += fmt::format(
+            "\t{:x} [shape=record height=1 label=\"{}|{} rooted | {:x} | node={} {}\"]\n",
+            elm.first, str, "{", ep, node, "}"
+          );
+        }
+      } else {
+        builder += fmt::format("\t{:x} [label=\"{}\"]\n", elm.first, str);
+      }
+    }
+    for (auto&& elm : links) {
+      builder += fmt::format("\t{:x}->{:x};\n", std::get<0>(elm), std::get<1>(elm));
+    }
+    builder += "}\n";
+    return builder;
+  }
+
+public:
+  // Merge the EpochGraph `a2` with `a1` recursively to combine localized
+  // sub-graphs data up the reduction tree
+  friend EpochGraph operator+(EpochGraph a1, EpochGraph const& a2) {
+    vtAssert(a1.epoch_ == a2.epoch_, "Trees should match");
+    std::vector<std::shared_ptr<EpochGraph>> new_successors;
+    for (auto& c2 : a2.successors_) {
+      // This could be more efficient O(n) vs O(n^2) if this was stored with a
+      // constant time lookup data structure
+      std::shared_ptr<EpochGraph> c1_match = nullptr;
+      for (auto& c1 : a1.successors_) {
+        if (c1->epoch_ == c2->epoch_) {
+          c1_match = c1;
+          break;
+        }
+      }
+
+      if (c1_match != nullptr) {
+        // Recurse down this matching node, merging the matching successors
+        (*c1_match) = (*c1_match) + (*c2);
+      } else {
+        new_successors.push_back(c2);
+      }
+    }
+
+    // Add new successors that a1 did not have to a1's successors list
+    for (auto const& child : new_successors) {
+      a1.successors_.push_back(child);
+    }
+
+    return a1;
+  }
+
+
+private:
+  EpochType epoch_ = no_epoch;
+  std::vector<std::shared_ptr<EpochGraph>> successors_ = {};
+};
+
+}}} /* end namespace vt::termination::graph */
+
+#endif /*INCLUDED_VT_TERMINATION_GRAPH_EPOCH_GRAPH_H*/

--- a/src/vt/termination/graph/epoch_graph.h
+++ b/src/vt/termination/graph/epoch_graph.h
@@ -58,6 +58,7 @@
 namespace vt { namespace termination { namespace graph {
 
 struct EpochGraph {
+  using EpFormat = std::tuple<EpochType, NodeType, bool, std::string>;
 
   EpochGraph() = default;
   EpochGraph(EpochGraph&&) = default;
@@ -78,47 +79,23 @@ public:
   }
 
 private:
-
-  void detectCyclesImpl(std::list<EpochType>& stack) {
-    bool cycle = false;
-    std::string cycle_diagnostic = "";
-    for (auto&& p : stack) {
-      // We have encountered the same epoch previously in the stack, thus a
-      // cycle
-      if (p == epoch_) {
-        cycle = true;
-      }
-      if (cycle) {
-        cycle_diagnostic += fmt::format("{:x}->", p);
-      }
-    }
-    if (cycle) {
-      cycle_diagnostic += fmt::format("{:x}", epoch_);
-      std::string cycle_print = fmt::format(
-        "Cycle detected in epoch graph:\nCycle: {}\n",
-        cycle_diagnostic
-      );
-      vtAbort(cycle_print);
-      return;
-    }
-
-    stack.push_back(epoch_);
-    for (auto const& s : successors_) {
-      s->detectCyclesImpl(stack);
-    }
-    vtAssert(stack.back() == epoch_, "Must match after pop!");
-    stack.pop_back();
-  }
+  void detectCyclesImpl(std::list<EpochType>& stack);
 
 public:
+  void detectCycles();
 
-  void detectCycles() {
-    // DFS on graph, maintaining a stack to detect any cycles (which are an
-    // error, and will cause a hang). This could be made more efficient by
-    // tracking visited nodes
-    std::list<EpochType> stack;
-    detectCyclesImpl(stack);
-  }
+private:
+  void outputImpl(std::set<std::tuple<EpochType, EpochType>> &links);
+  EpFormat formatDOTEpoch(EpochType epoch);
+
+public:
+  std::string outputDOT(bool verbose = false);
+  void writeToFile(std::string const& dot, bool global = false, std::string tag = "");
+
+public:
+  // Merge the EpochGraph `a2` with `a1` recursively to combine localized
+  // sub-graphs data up the reduction tree
+  friend EpochGraph operator+(EpochGraph a1, EpochGraph const& a2);
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -139,138 +116,6 @@ public:
       }
     }
   }
-
-private:
-  void outputImpl(std::set<std::tuple<EpochType, EpochType>> &links)  {
-    for (auto const& s : successors_) {
-      links.insert(std::make_pair(epoch_, s->epoch_));
-      s->outputImpl(links);
-    }
-  }
-
-  using EpFormat = std::tuple<EpochType, NodeType, bool, std::string>;
-
-  EpFormat formatDOTEpoch(EpochType epoch) {
-    if (epoch == term::any_epoch_sentinel) {
-      return std::make_tuple(epoch, static_cast<NodeType>(-1), true, "Global");
-    } else {
-      if (epoch::EpochManip::isRooted(epoch)) {
-        auto const ds_epoch = epoch::eEpochCategory::DijkstraScholtenEpoch;
-        auto const epoch_category = epoch::EpochManip::category(epoch);
-        auto const is_ds = epoch_category == ds_epoch;
-        auto const ep_node = epoch::EpochManip::node(epoch);
-        auto const ep_seq = epoch::EpochManip::seq(epoch);
-        if (is_ds) {
-          auto str = fmt::format("{:x}-DS-{}", ep_seq, ep_node);
-          return std::make_tuple(epoch, ep_node, false, str);
-        } else {
-          auto str = fmt::format("{:x}-R-{}", ep_seq, ep_node);
-          return std::make_tuple(epoch, ep_node, false, str);
-        }
-      } else {
-        auto str = fmt::format("{:x}-C", epoch);
-        return std::make_tuple(epoch, static_cast<NodeType>(-1), true, str);
-      }
-    }
-  }
-
-public:
-  std::string outputDOT(bool verbose = false) {
-    std::unordered_map<EpochType, EpFormat> eps;
-    std::set<std::tuple<EpochType, EpochType>> links;
-    std::string builder = "";
-    outputImpl(links);
-
-    for (auto&& elm : links) {
-      if (eps.find(std::get<0>(elm)) == eps.end()) {
-        eps[std::get<0>(elm)] = formatDOTEpoch(std::get<0>(elm));
-      }
-      if (eps.find(std::get<1>(elm)) == eps.end()) {
-        eps[std::get<1>(elm)] = formatDOTEpoch(std::get<1>(elm));
-      }
-    }
-
-    builder = "digraph graphname {\n";
-    builder += "\tlabelloc = \"b\"\n";
-    builder += "\trankdir = \"TB\"\n";
-    builder += "\tranksep = \"1\"\n";
-    builder += "\tedge[\n";
-    builder += "\t\t\tpenwidth=2\n";
-    builder += "\t]\n";
-    builder += "\tnode[\n";
-    builder += "\t\tfontname=Monaco,\n";
-    builder += "\t\tpenwidth=1,\n";
-    builder += "\t\tfontsize=10,\n";
-    if (verbose) {
-      builder += "\t\tmargin=.2,\n";
-    } else {
-      builder += "\t\tmargin=.3,\n";
-    }
-    builder += "\t\tshape=box,\n";
-    builder += "\t\tfillcolor=lightblue,\n";
-    builder += "\t\tstyle=\"rounded,filled\"\n";
-    builder += "\t]\n";
-    for (auto&& elm : eps) {
-      EpochType ep = std::get<0>(elm.second);
-      NodeType node = std::get<1>(elm.second);
-      bool collective = std::get<2>(elm.second);
-      std::string str = std::get<3>(elm.second);
-      if (verbose) {
-        if (collective) {
-          builder += fmt::format(
-            "\t{:x} [shape=record height=1 label=\"{}|{} collective | {:x} {}\"]\n",
-            elm.first, str, "{", ep, "}"
-          );
-        } else {
-          builder += fmt::format(
-            "\t{:x} [shape=record height=1 label=\"{}|{} rooted | {:x} | node={} {}\"]\n",
-            elm.first, str, "{", ep, node, "}"
-          );
-        }
-      } else {
-        builder += fmt::format("\t{:x} [label=\"{}\"]\n", elm.first, str);
-      }
-    }
-    for (auto&& elm : links) {
-      builder += fmt::format("\t{:x}->{:x};\n", std::get<0>(elm), std::get<1>(elm));
-    }
-    builder += "}\n";
-    return builder;
-  }
-
-public:
-  // Merge the EpochGraph `a2` with `a1` recursively to combine localized
-  // sub-graphs data up the reduction tree
-  friend EpochGraph operator+(EpochGraph a1, EpochGraph const& a2) {
-    vtAssert(a1.epoch_ == a2.epoch_, "Trees should match");
-    std::vector<std::shared_ptr<EpochGraph>> new_successors;
-    for (auto& c2 : a2.successors_) {
-      // This could be more efficient O(n) vs O(n^2) if this was stored with a
-      // constant time lookup data structure
-      std::shared_ptr<EpochGraph> c1_match = nullptr;
-      for (auto& c1 : a1.successors_) {
-        if (c1->epoch_ == c2->epoch_) {
-          c1_match = c1;
-          break;
-        }
-      }
-
-      if (c1_match != nullptr) {
-        // Recurse down this matching node, merging the matching successors
-        (*c1_match) = (*c1_match) + (*c2);
-      } else {
-        new_successors.push_back(c2);
-      }
-    }
-
-    // Add new successors that a1 did not have to a1's successors list
-    for (auto const& child : new_successors) {
-      a1.successors_.push_back(child);
-    }
-
-    return a1;
-  }
-
 
 private:
   EpochType epoch_ = no_epoch;

--- a/src/vt/termination/graph/epoch_graph_reduce.h
+++ b/src/vt/termination/graph/epoch_graph_reduce.h
@@ -56,7 +56,7 @@ struct ReduceTMsg;
 
 namespace vt { namespace termination { namespace graph {
 
-// Must be templated (where T = tree::Epoch Tree) because of the circular
+// Must be templated (where T = graph::EpochGraph) because of the circular
 // dependency between termination.h and reduce.h
 template <typename T>
 struct EpochGraphMsg : collective::reduce::operators::ReduceTMsg<T> {

--- a/src/vt/termination/term_msgs.h
+++ b/src/vt/termination/term_msgs.h
@@ -90,13 +90,15 @@ private:
   bool finished_   = false;
 };
 
+struct HangCheckMsg : vt::ShortMessage { };
+
 struct TermCounterMsg : vt::ShortMessage {
   EpochType epoch = no_epoch;
   TermCounterType prod = 0, cons = 0;
 
   TermCounterMsg(
-    EpochType const& in_epoch, TermCounterType const& in_prod,
-    TermCounterType const& in_cons
+    EpochType const in_epoch,
+    TermCounterType const in_prod, TermCounterType const in_cons
   ) : ShortMessage(), epoch(in_epoch), prod(in_prod), cons(in_cons)
   { }
 };

--- a/src/vt/termination/term_msgs.h
+++ b/src/vt/termination/term_msgs.h
@@ -101,6 +101,8 @@ struct TermCounterMsg : vt::ShortMessage {
   { }
 };
 
+struct BuildGraphMsg : vt::ShortMessage { };
+
 }} //end namespace vt::term
 
 #endif /*INCLUDED_TERMINATION_TERM_MSGS_H*/

--- a/src/vt/termination/term_state.cc
+++ b/src/vt/termination/term_state.cc
@@ -114,6 +114,14 @@ void TermState::receiveContinueSignal(TermWaveType const& wave) {
   cur_wave_ = wave;
 }
 
+void TermState::incrementDependency() {
+  deps_++;
+}
+
+TermCounterType TermState::decrementDependency() {
+  return --deps_;
+}
+
 bool TermState::readySubmitParent(bool const needs_active) const {
   vtAssert(
     num_children_ != uninitialized_destination, "Children must be valid"
@@ -121,16 +129,17 @@ bool TermState::readySubmitParent(bool const needs_active) const {
 
   auto const ret = (epoch_active_ or not needs_active) and
     recv_child_count_ == num_children_ and local_terminated_ and
-    submitted_wave_ == cur_wave_ - 1 and not term_detected_;
+    submitted_wave_ == cur_wave_ - 1 and not term_detected_ and
+    deps_ == 0;
 
   debug_print_verbose(
     term, node,
     "readySubmitParent: epoch={:x}, active={}, local_ready={}, "
     "sub_wave={}, cur_wave_={}, recv_child={}, num_child={}, term={}:"
-    " ret={}\n",
+    " deps_={}, ret={}\n",
     epoch_, print_bool(epoch_active_), print_bool(local_terminated_),
     submitted_wave_, cur_wave_, recv_child_count_, num_children_,
-    print_bool(term_detected_), print_bool(ret)
+    print_bool(term_detected_), deps_, print_bool(ret)
   );
 
   return ret;

--- a/src/vt/termination/term_state.cc
+++ b/src/vt/termination/term_state.cc
@@ -139,8 +139,7 @@ bool TermState::readySubmitParent(bool const needs_active) const {
 TermState::TermState(
   EpochType const& in_epoch, bool const in_local_terminated, bool const active,
   NodeType const& children
-)
-  : EpochRelation(in_epoch, false),
+) : EpochDependency(in_epoch, false),
     local_terminated_(in_local_terminated), epoch_active_(active),
     num_children_(children)
 {
@@ -153,7 +152,7 @@ TermState::TermState(
 }
 
 TermState::TermState(EpochType const& in_epoch, NodeType const& children)
-  : EpochRelation(in_epoch, false), num_children_(children)
+  : EpochDependency(in_epoch, false), num_children_(children)
 {
   debug_print(
     term, node,

--- a/src/vt/termination/term_state.h
+++ b/src/vt/termination/term_state.h
@@ -73,6 +73,8 @@ struct TermState : EpochDependency {
   void setCurWave(TermWaveType const& wave);
   NodeType getNumChildren() const;
   bool noLocalUnits() const;
+  void incrementDependency();
+  TermCounterType decrementDependency();
 
   TermState(
     EpochType const& in_epoch, bool const in_local_terminated, bool const active,
@@ -101,6 +103,7 @@ private:
   bool local_terminated_                      = true;
   bool epoch_active_                          = true;
   bool term_detected_                         = false;
+  TermCounterType deps_                       = 0;
 
   EventCountType recv_child_count_            = 0;
   NodeType num_children_                      = uninitialized_destination;

--- a/src/vt/termination/term_state.h
+++ b/src/vt/termination/term_state.h
@@ -48,7 +48,7 @@
 #include "vt/config.h"
 #include "vt/context/context.h"
 #include "vt/termination/term_common.h"
-#include "vt/termination/term_parent.h"
+#include "vt/termination/epoch_dependency.h"
 
 #include <vector>
 #include <cstdlib>
@@ -56,7 +56,7 @@
 
 namespace vt { namespace term {
 
-struct TermState : EpochRelation {
+struct TermState : EpochDependency {
   using EventCountType = int32_t;
 
   void notifyChildReceive();

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -797,6 +797,23 @@ void TerminationDetector::addDependency(EpochType predecessor, EpochType success
   }
 }
 
+void TerminationDetector::removeEpochStateDependency(EpochType ep) {
+  if (not isDS(ep)) {
+    if (findOrCreateState(ep, true).decrementDependency() == 0) {
+      // Call propagate because this might have activated an epoch begin further
+      // propagated
+      maybePropagate();
+    }
+  }
+}
+
+void TerminationDetector::addEpochStateDependency(EpochType ep) {
+  if (not isDS(ep)) {
+    // Increment a dependency so the epoch stops sending messages
+    findOrCreateState(ep, true).incrementDependency();
+  }
+}
+
 void TerminationDetector::finishNoActivateEpoch(EpochType const& epoch) {
   auto ready_iter = epoch_ready_.find(epoch);
   if (ready_iter == epoch_ready_.end()) {

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -353,16 +353,30 @@ std::shared_ptr<TerminationDetector::EpochTree> TerminationDetector::makeTree() 
     // tree recursively by joining epoch nodes with their parent in the tree
     // data structure
 
-    // Collect all live epochs, both collective and rooted
+    // Collect live epochs, both collective and rooted (excluding rooted ones
+    // that did not originate on this node)
     std::unordered_map<EpochType, std::shared_ptr<EpochTree>> live_epochs;
     auto root = std::make_shared<EpochTree>(any_epoch_state_.getEpoch());
+    // Collect non-rooted epochs, just collective, excluding DS or other rooted
+    // epochs (info about them is localized on the creation node)
+    auto const this_node = theContext()->getNode();
     for (auto const& elm : epoch_state_) {
       if (not elm.second.isTerminated()) {
-        live_epochs[elm.first] = std::make_shared<EpochTree>(elm.first);
+        auto const ep = elm.first;
+        bool const rooted = epoch::EpochManip::isRooted(ep);
+        if (not rooted or (rooted and epoch::EpochManip::node(ep) == this_node)) {
+          live_epochs[ep] = std::make_shared<EpochTree>(ep);
+        }
       }
     }
     for (auto const& elm : term_) {
-      live_epochs[elm.first] = std::make_shared<EpochTree>(elm.first);
+      // Only include DS epochs that are created here. Other nodes do not have
+      // parentage data about the rooted, DS epochs
+      if (epoch::EpochManip::node(elm.first) == this_node) {
+        if (not elm.second.is_terminated) {
+          live_epochs[elm.first] = std::make_shared<EpochTree>(elm.first);
+        }
+      }
     }
 
     for (auto& live : live_epochs) {

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -67,6 +67,7 @@ static EpochType const arch_epoch_coll = 0ull;
 TerminationDetector::TerminationDetector()
   : collective::tree::Tree(collective::tree::tree_cons_tag_t),
   any_epoch_state_(any_epoch_sentinel, false, true, getNumChildren()),
+  hang_(no_epoch, true, false, getNumChildren()),
   epoch_coll_(std::make_unique<EpochWindow>(arch_epoch_coll))
 { }
 
@@ -130,17 +131,17 @@ TermCounterType TerminationDetector::getNumUnits() const {
 }
 
 void TerminationDetector::setLocalTerminated(
-  bool const local_terminated, bool const no_local
+  bool const local_terminated, bool const no_propagate
 ) {
   debug_print(
     term, node,
-    "setLocalTerminated: is_term={}, no_local_workers={}\n",
-    print_bool(local_terminated), print_bool(no_local)
+    "setLocalTerminated: is_term={}, no_propagate={}\n",
+    local_terminated, no_propagate
   );
 
   any_epoch_state_.notifyLocalTerminated(local_terminated);
 
-  if (local_terminated && !no_local) {
+  if (local_terminated && !no_propagate) {
     theTerm()->maybePropagate();
   }
 }
@@ -250,10 +251,12 @@ void TerminationDetector::produceConsume(
 }
 
 void TerminationDetector::maybePropagate() {
-  bool const ready = any_epoch_state_.readySubmitParent();
-
-  if (ready) {
+  if (any_epoch_state_.readySubmitParent()) {
     propagateEpoch(any_epoch_state_);
+  }
+
+  if (hang_.readySubmitParent()) {
+    propagateEpoch(hang_);
   }
 
   for (auto&& iter = epoch_state_.begin(); iter != epoch_state_.end(); ) {
@@ -305,6 +308,9 @@ void TerminationDetector::propagateEpochExternal(
 
   if (epoch == any_epoch_sentinel) {
     propagateEpochExternalState(any_epoch_state_, prod, cons);
+  } else if (epoch == no_epoch) {
+    // Dispatch to special hang detection epoch, demarcated as "no_epoch"
+    propagateEpochExternalState(hang_, prod, cons);
   } else {
     auto& state = findOrCreateState(epoch, false);
     propagateEpochExternalState(state, prod, cons);
@@ -420,6 +426,7 @@ bool TerminationDetector::propagateEpoch(TermStateType& state) {
   if (is_ready) {
     bool is_term = false;
 
+    // Update the global counters for a given epoch
     state.g_prod1 += state.l_prod;
     state.g_cons1 += state.l_cons;
 
@@ -458,6 +465,26 @@ bool TerminationDetector::propagateEpoch(TermStateType& state) {
         state.g_cons2, is_term
       );
 
+      if (not ArgType::vt_no_detect_hang) {
+        // Hang detection has confirmed a fatal hang---abort!
+        if (is_term and state.getEpoch() == no_epoch) {
+          vt_print(
+            term,
+            "Detected hang: write graph to file={}\n",
+            arguments::ArgConfig::vt_epoch_graph_on_hang
+          );
+          if (arguments::ArgConfig::vt_epoch_graph_on_hang) {
+            startEpochGraphBuild();
+            // After spawning the build, spin until the file gets written out so
+            // vtAbort does not exit too early
+            while (not has_printed_epoch_graph or not theSched()->isIdle()) {
+              vt::runScheduler();
+            }
+          }
+          vtAbort("Detected hang indicating no further progress is possible");
+        }
+      }
+
       if (is_term) {
         auto msg = makeSharedMessage<TermMsg>(state.getEpoch());
         theMsg()->setTermMessage(msg);
@@ -467,70 +494,14 @@ bool TerminationDetector::propagateEpoch(TermStateType& state) {
 
         epochTerminated(state.getEpoch());
       } else {
-        if (!ArgType::vt_no_detect_hang) {
-          // Counts are the same as previous iteration
-          if (state.g_prod2 == state.g_prod1 && state.g_cons2 == state.g_cons1) {
-            state.constant_count++;
-          } else {
-            state.constant_count = 0;
-          }
+        if (state.g_prod2 == state.g_prod1 and state.g_cons2 == state.g_cons1) {
+          state.constant_count++;
+        } else {
+          state.constant_count = 0;
+        }
 
-          if (
-            state.constant_count >= ArgType::vt_hang_freq and
-            state.constant_count %  ArgType::vt_hang_freq == 0
-          ) {
-            if (
-              state.num_print_constant == 0 or
-              std::log(static_cast<double>(state.constant_count)) >
-              state.num_print_constant
-            ) {
-              auto node            = ::vt::debug::preNode();
-              auto vt_pre          = ::vt::debug::vtPre();
-              auto node_str        = ::vt::debug::proc(node);
-              auto prefix          = vt_pre + node_str + " ";
-              auto reset           = ::vt::debug::reset();
-              auto bred            = ::vt::debug::bred();
-              auto magenta         = ::vt::debug::magenta();
-
-              // debug additional infos
-              auto const& current  = state.getEpoch();
-              bool const is_rooted = epoch::EpochManip::isRooted(current);
-              bool const has_categ = epoch::EpochManip::hasCategory(current);
-              bool const useDS = has_categ
-                and epoch::EpochManip::category(current) ==
-                    epoch::eEpochCategory::DijkstraScholtenEpoch;
-
-              auto f1 = fmt::format(
-                "{}Termination hang detected:{} {}traversals={} epoch={:x} "
-                "produced={}{} {}consumed={}{} rooted={}, ds={}\n",
-                bred, reset,
-                magenta, state.constant_count, state.getEpoch(), state.g_prod1,
-                reset, magenta, state.g_cons1, reset, is_rooted, useDS
-              );
-              vt_print(term, "{}", f1);
-              state.num_print_constant++;
-
-              #if !backend_check_enabled(production)
-                if (state.num_print_constant > 10) {
-                  static bool has_printed = false;
-                  if (not has_printed) {
-                    has_printed = true;
-                    // Broadcast to build local EpochGraph(s) and then merge them
-                    auto msg = makeMessage<BuildGraphMsg>();
-                    theMsg()->setTermMessage(msg.get());
-                    theMsg()->broadcastMsg<BuildGraphMsg, buildLocalGraphHandler>(msg.get());
-                    // Run build graph locally on root
-                    buildLocalGraphHandler(nullptr);
-                  }
-
-                  // vtAbort(
-                  //   "Hang detected (consumed != produced) for k tree "
-                  //   "traversals"
-                  // );
-                }
-              #endif
-            }
-          }
+        if (state.constant_count > 0) {
+          countsConstant(state);
         }
 
         state.g_prod2 = state.g_prod1;
@@ -566,24 +537,139 @@ bool TerminationDetector::propagateEpoch(TermStateType& state) {
   return is_ready;
 }
 
+void TerminationDetector::countsConstant(TermStateType& state) {
+  bool enter = not ArgType::vt_no_detect_hang or ArgType::vt_print_no_progress;
+  if (enter) {
+    bool is_global_epoch = state.getEpoch() == any_epoch_sentinel;
+    bool is_hang_detector = state.getEpoch() == no_epoch;
+
+    auto reset           = ::vt::debug::reset();
+    auto bred            = ::vt::debug::bred();
+    auto magenta         = ::vt::debug::magenta();
+
+    if (is_hang_detector) {
+      auto f1 = fmt::format(
+        "{}Progress has stalled, but hang detection implies messages are in"
+        " flight!{}\n",
+        bred, reset
+      );
+      vt_print(term, "{}", f1);
+      return;
+    }
+
+    if (
+      state.constant_count >= ArgType::vt_hang_freq and
+      state.constant_count %  ArgType::vt_hang_freq == 0
+    ) {
+      if (
+        state.num_print_constant == 0 or
+        std::log(static_cast<double>(state.constant_count)) >
+        state.num_print_constant
+      ) {
+        debug_print(
+          term, node,
+          "countsConstant: epoch={:x}, state.constant_count={}\n",
+          state.getEpoch(), state.constant_count
+        );
+
+        if (ArgType::vt_print_no_progress) {
+          auto const current  = state.getEpoch();
+          bool const is_rooted = epoch::EpochManip::isRooted(current);
+          bool const has_categ = epoch::EpochManip::hasCategory(current);
+          bool const useDS = has_categ and
+            epoch::EpochManip::category(current) ==
+            epoch::eEpochCategory::DijkstraScholtenEpoch;
+
+          auto f1 = fmt::format(
+            "{}Termination counts constant (no progress) for:{} {}traversals={} "
+            "epoch={:x} produced={}{} {}consumed={}{} rooted={}, ds={}\n",
+            bred, reset,
+            magenta, state.constant_count, state.getEpoch(), state.g_prod1,
+            reset, magenta, state.g_cons1, reset, is_rooted, useDS
+          );
+          vt_print(term, "{}", f1);
+        }
+
+        state.num_print_constant++;
+
+        if (state.num_print_constant == 10) {
+          if (is_global_epoch) {
+            // Start running final check to see if we are hung for sure
+            if (not ArgType::vt_no_detect_hang) {
+              auto msg = makeMessage<HangCheckMsg>();
+              theMsg()->setTermMessage(msg.get());
+              theMsg()->broadcastMsg<HangCheckMsg, hangCheckHandler>(msg.get());
+              hangCheckHandler(nullptr);
+            }
+          }
+        }
+      }
+    }
+  }
+
+}
+
+void TerminationDetector::startEpochGraphBuild() {
+  // Broadcast to build local EpochGraph(s), merge the graphs, and output to
+  // file
+  if (arguments::ArgConfig::vt_epoch_graph_on_hang) {
+    auto msg = makeMessage<BuildGraphMsg>();
+    theMsg()->setTermMessage(msg.get());
+    theMsg()->broadcastMsg<BuildGraphMsg, buildLocalGraphHandler>(msg.get());
+    buildLocalGraphHandler(nullptr);
+  }
+}
+
+/*static*/ void TerminationDetector::hangCheckHandler(HangCheckMsg* msg) {
+  fmt::print("{}:hangCheckHandler\n",theContext()->getNode());
+  theTerm()->hang_.activateEpoch();
+}
+
 /*static*/ void TerminationDetector::buildLocalGraphHandler(BuildGraphMsg*) {
   using MsgType  = EpochGraphMsg;
   using ReduceOp = collective::PlusOp<EpochGraph>;
+
+  debug_print(
+    term, node,
+    "buildLocalGraphHandler: building local epoch graph\n"
+  );
+
+  /*
+   * Make the local epoch graph on this node
+   */
+  auto graph = theTerm()->makeGraph();
+
+  /*
+   * Check for any cycles in the graph. If cycles are detected (will always
+   * cause a hang) `detectCycles` will abort and print the cycle that was found.
+   */
+  graph->detectCycles();
+
+  /*
+   * Generate the DOT file to output to file, reduce to create a global view of
+   * the epoch graph
+   */
+  auto str = graph->outputDOT();
+  graph->writeToFile(str);
+  auto msg = makeMessage<MsgType>(graph);
   NodeType root = 0;
   auto cb = vt::theCB()->makeSend<MsgType, epochGraphBuiltHandler>(root);
-  auto graph = theTerm()->makeGraph();
-  graph->detectCycles();
-  auto str = graph->outputDOT();
-  fmt::print("{}::::::\n{}\n",theContext()->getNode(), str);
-  auto msg = makeMessage<MsgType>(graph);
   theCollective()->reduce<ReduceOp>(root, msg.get(), cb);
+  if (theContext()->getNode() != root) {
+    theTerm()->has_printed_epoch_graph = true;
+  }
 }
 
 /*static*/ void TerminationDetector::epochGraphBuiltHandler(EpochGraphMsg* msg) {
-  fmt::print("epochGraphBuiltHandler\n");
+  debug_print(
+    term, node,
+    "epochGraphBuiltHandler: collected global, merged graph\n"
+  );
+
   auto graph = msg->getVal();
   auto str = graph.outputDOT();
-  fmt::print("{}\n",str);
+  graph.writeToFile(str, true);
+  theTerm()->has_printed_epoch_graph = true;
 }
 
 void TerminationDetector::cleanupEpoch(EpochType const& epoch) {
@@ -753,6 +839,8 @@ void TerminationDetector::epochContinue(
 
   if (epoch == any_epoch_sentinel) {
     any_epoch_state_.receiveContinueSignal(wave);
+  } else if (epoch == no_epoch) {
+    hang_.receiveContinueSignal(wave);
   } else {
     auto epoch_iter = epoch_state_.find(epoch);
     if (epoch_iter != epoch_state_.end()) {

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -789,6 +789,29 @@ void TerminationDetector::addDependency(EpochType predecessor, EpochType success
 
   if (has_successor) {
     if (not isEpochTerminated(predecessor)) {
+      /*
+       * Dependency optimization:
+       *
+       * Say that the current dependency structure looks like this:
+       *   where
+       *     succ successors are {c1, c2}
+       *     pred successors are {c1, c3}
+       *
+       *                       succ    pred
+       *                       /  \    /  \
+       *                      c1  c2  c1  c3
+       *
+       * Now that we have added a new dependency, pred -> succ, pred's c1
+       * dependency is carried through the transitive dependency. Thus, we
+       * transform this graph (LHS) to a simpler graph (RHS):
+       *
+       *                pred                    pred
+       *                / | \                   /  \
+       *               c1 c2 succ      ====>   c2  succ
+       *                     /  \                  /  \
+       *                    c1  c3                c1  c3
+       *
+       */
       auto pred = getEpochDep(predecessor);
       auto succ_successors = getEpochDep(successor)->getSuccessors();
       pred->removeIntersection(succ_successors);

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -342,6 +342,69 @@ void TerminationDetector::freeEpoch(EpochType const& epoch) {
   }
 }
 
+std::shared_ptr<TerminationDetector::EpochTree> TerminationDetector::makeTree() {
+  // Start at the global epoch root;
+  if (any_epoch_state_.isTerminated()) {
+    return nullptr;
+  } else {
+    // We can't traverse the tree from root to leaves naturally because the tree
+    // is stored inverted, with children only have pointers to their parents
+    // (not vice versa). Thus, we will extract all children and then build the
+    // tree recursively by joining epoch nodes with their parent in the tree
+    // data structure
+
+    // Collect all live epochs, both collective and rooted
+    std::unordered_map<EpochType, std::shared_ptr<EpochTree>> live_epochs;
+    auto root = std::make_shared<EpochTree>(any_epoch_state_.getEpoch());
+    for (auto const& elm : epoch_state_) {
+      if (not elm.second.isTerminated()) {
+        live_epochs[elm.first] = std::make_shared<EpochTree>(elm.first);
+      }
+    }
+    for (auto const& elm : term_) {
+      live_epochs[elm.first] = std::make_shared<EpochTree>(elm.first);
+    }
+
+    for (auto& live : live_epochs) {
+      auto const ep = live.first;
+      if (isDS(ep)) {
+        // DS-epoch case
+        auto parents = getDSTerm(ep)->getParents();
+        if (parents.size() == 0) {
+          root->addChild(live.second);
+        } else {
+          for (auto&& p : parents) {
+            auto pt = live_epochs.find(p);
+            if (pt != live_epochs.end()) {
+              pt->second->addChild(live.second);
+            } else {
+              vtAssert(false, "Parent epoch has terminated before its child!");
+            }
+          }
+        }
+      } else {
+        // Wave-based epoch case
+        auto parents = epoch_state_.find(ep)->second.getParents();
+        if (parents.size() == 0) {
+          root->addChild(live.second);
+        } else {
+          for (auto&& p : parents) {
+            auto pt = live_epochs.find(p);
+            if (pt != live_epochs.end()) {
+              pt->second->addChild(live.second);
+            } else {
+              vtAssert(false, "Parent epoch has terminated before its child!");
+            }
+          }
+        }
+      }
+    }
+
+    return root;
+  }
+}
+
+
 bool TerminationDetector::propagateEpoch(TermStateType& state) {
   bool const& is_ready = state.readySubmitParent();
   bool const& is_root = isRoot();

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -105,6 +105,8 @@ struct TerminationDetector :
   /***************************************************************************/
 
   friend struct ds::StateDS;
+  friend struct TermState;
+  friend struct EpochDependency;
 
   bool isRooted(EpochType epoch);
   bool isDS(EpochType epoch);
@@ -209,6 +211,8 @@ public:
 
 private:
   EpochDependency* getEpochDep(EpochType epoch);
+  void removeEpochStateDependency(EpochType ep);
+  void addEpochStateDependency(EpochType ep);
 
 private:
   static void makeRootedHandler(TermMsg* msg);

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -54,6 +54,7 @@
 #include "vt/termination/term_window.h"
 #include "vt/termination/term_parent.h"
 #include "vt/termination/dijkstra-scholten/ds_headers.h"
+#include "vt/termination/tree/epoch_tree.h"
 #include "vt/epoch/epoch.h"
 #include "vt/activefn/activefn.h"
 #include "vt/collective/tree/tree.h"
@@ -80,6 +81,7 @@ struct TerminationDetector :
   using WindowType         = std::unique_ptr<EpochWindow>;
   using ArgType            = vt::arguments::ArgConfig;
   using ParentBagType      = EpochRelation::ParentBagType;
+  using EpochTree          = termination::tree::EpochTree;
 
   TerminationDetector();
   virtual ~TerminationDetector() {}
@@ -182,6 +184,9 @@ public:
 public:
   // TermTerminated interface
   TermStatusEnum testEpochTerminated(EpochType epoch) override;
+
+public:
+  std::shared_ptr<EpochTree> makeTree();
 
 private:
   bool propagateEpoch(TermStateType& state);

--- a/src/vt/termination/tree/epoch_tree.h
+++ b/src/vt/termination/tree/epoch_tree.h
@@ -1,0 +1,120 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                    tree.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_TERMINATION_TREE_TREE_H
+#define INCLUDED_VT_TERMINATION_TREE_TREE_H
+
+#include "vt/config.h"
+
+#include <vector>
+#include <memory>
+#include <functional>
+#include <string>
+
+namespace vt { namespace termination { namespace tree {
+
+struct EpochTree {
+
+  explicit EpochTree(EpochType in_epoch)
+    : epoch_(in_epoch)
+  { }
+
+public:
+  bool hasChildren() const { return children_.size() != 0; }
+  void addChild(EpochTree&& t) {
+    children_.push_back(std::make_shared<EpochTree>(std::move(t)));
+  }
+  void addChild(std::shared_ptr<EpochTree> t) {
+    children_.push_back(t);
+  }
+
+  void traverse(std::function<void(EpochTree&)> fn) const {
+    for (auto& elm : children_) {
+      fn(*elm);
+    }
+  }
+
+private:
+  void pushContext(std::string& ctx, char c) const {
+    ctx.push_back(' ');
+    ctx.push_back(c);
+    ctx.push_back(' ');
+    ctx.push_back(' ');
+  }
+
+  void popContext(std::string& ctx) const {
+    for (int i = 0; i < 4; i++) {
+      ctx.pop_back();
+    }
+  }
+
+  void printImpl(std::string& builder, std::string& ctx) const {
+    builder += fmt::format("({:x})\n", epoch_);
+    std::size_t rem = children_.size();
+    for (auto const& child : children_) {
+      rem--;
+      bool const has_next = rem > 0;
+      builder += fmt::format("{} `--", ctx);
+      pushContext(ctx, has_next ? '|' : ' ');
+      child->printImpl(builder, ctx);
+      popContext(ctx);
+    }
+  }
+
+public:
+  std::string print() const {
+    std::string builder = "";
+    std::string ctx     = "";
+    printImpl(builder, ctx);
+    return builder;
+  }
+
+private:
+  EpochType epoch_ = no_epoch;
+  std::vector<std::shared_ptr<EpochTree>> children_ = {};
+};
+
+}}} /* end namespace vt::termination::tree */
+
+#endif /*INCLUDED_VT_TERMINATION_TREE_TREE_H*/

--- a/src/vt/termination/tree/epoch_tree.h
+++ b/src/vt/termination/tree/epoch_tree.h
@@ -56,6 +56,10 @@ namespace vt { namespace termination { namespace tree {
 
 struct EpochTree {
 
+  EpochTree() = default;
+  EpochTree(EpochTree&&) = default;
+  EpochTree(EpochTree const&) = default;
+
   explicit EpochTree(EpochType in_epoch)
     : epoch_(in_epoch)
   { }
@@ -108,6 +112,22 @@ public:
     std::string ctx     = "";
     printImpl(builder, ctx);
     return builder;
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | epoch_;
+    std::size_t nc = children_.size();
+    s | nc;
+    for (std::size_t i = 0; i < nc; i++) {
+      if (s.isUnpacking()) {
+        EpochTree et;
+        s | et;
+        children_.push_back(std::make_shared<EpochTree>(std::move(et)));
+      } else {
+        s | *children_[i];
+      }
+    }
   }
 
 private:

--- a/tests/unit/scheduler/test_priority_queue.cc
+++ b/tests/unit/scheduler/test_priority_queue.cc
@@ -56,12 +56,13 @@ TEST_F(TestPriorityQueue, test_priority_queue_1) {
 
   int seq = 1;
   vt::sched::PriorityQueue<PriorityUnit> queue;
+  bool const t = false;
 
-  queue.emplace(PriorityUnit(1, [&]{ EXPECT_EQ(seq, 5); seq++; }));
-  queue.emplace(PriorityUnit(2, [&]{ EXPECT_EQ(seq, 4); seq++; }));
-  queue.emplace(PriorityUnit(3, [&]{ EXPECT_EQ(seq, 3); seq++; }));
-  queue.emplace(PriorityUnit(4, [&]{ EXPECT_EQ(seq, 2); seq++; }));
-  queue.emplace(PriorityUnit(5, [&]{ EXPECT_EQ(seq, 1); seq++; }));
+  queue.emplace(PriorityUnit(t, 1, [&]{ EXPECT_EQ(seq, 5); seq++; }));
+  queue.emplace(PriorityUnit(t, 2, [&]{ EXPECT_EQ(seq, 4); seq++; }));
+  queue.emplace(PriorityUnit(t, 3, [&]{ EXPECT_EQ(seq, 3); seq++; }));
+  queue.emplace(PriorityUnit(t, 4, [&]{ EXPECT_EQ(seq, 2); seq++; }));
+  queue.emplace(PriorityUnit(t, 5, [&]{ EXPECT_EQ(seq, 1); seq++; }));
 
   EXPECT_EQ(seq, 1);
 
@@ -77,12 +78,13 @@ TEST_F(TestPriorityQueue, test_priority_queue_2) {
 
   int seq = 1;
   vt::sched::PriorityQueue<PriorityUnit> queue;
+  bool const t = false;
 
-  queue.emplace(PriorityUnit(2, [&]{ EXPECT_EQ(seq, 4); seq++; }));
-  queue.emplace(PriorityUnit(3, [&]{ EXPECT_EQ(seq, 3); seq++; }));
-  queue.emplace(PriorityUnit(1, [&]{ EXPECT_EQ(seq, 5); seq++; }));
-  queue.emplace(PriorityUnit(5, [&]{ EXPECT_EQ(seq, 1); seq++; }));
-  queue.emplace(PriorityUnit(4, [&]{ EXPECT_EQ(seq, 2); seq++; }));
+  queue.emplace(PriorityUnit(t, 2, [&]{ EXPECT_EQ(seq, 4); seq++; }));
+  queue.emplace(PriorityUnit(t, 3, [&]{ EXPECT_EQ(seq, 3); seq++; }));
+  queue.emplace(PriorityUnit(t, 1, [&]{ EXPECT_EQ(seq, 5); seq++; }));
+  queue.emplace(PriorityUnit(t, 5, [&]{ EXPECT_EQ(seq, 1); seq++; }));
+  queue.emplace(PriorityUnit(t, 4, [&]{ EXPECT_EQ(seq, 2); seq++; }));
 
   EXPECT_EQ(seq, 1);
 
@@ -99,25 +101,25 @@ TEST_F(TestPriorityQueue, test_priority_queue_3) {
 
   int seq = 1;
   vt::sched::PriorityQueue<PriorityUnit> queue;
-
+  bool const t = false;
 
 #if vt_feature_cmake_priority_bits_level == 1
-  queue.emplace(PriorityUnit(Priority::DepthFirst,   [&]{ EXPECT_EQ(seq, 2); seq++; }));
-  queue.emplace(PriorityUnit(Priority::BreadthFirst, [&]{ EXPECT_EQ(seq, 1); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::DepthFirst,   [&]{ EXPECT_EQ(seq, 2); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::BreadthFirst, [&]{ EXPECT_EQ(seq, 1); seq++; }));
 #elif vt_feature_cmake_priority_bits_level == 2
-  queue.emplace(PriorityUnit(Priority::Low,          [&]{ EXPECT_EQ(seq, 4); seq++; }));
-  queue.emplace(PriorityUnit(Priority::Medium,       [&]{ EXPECT_EQ(seq, 3); seq++; }));
-  queue.emplace(PriorityUnit(Priority::High,         [&]{ EXPECT_EQ(seq, 2); seq++; }));
-  queue.emplace(PriorityUnit(Priority::BreadthFirst, [&]{ EXPECT_EQ(seq, 1); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::Low,          [&]{ EXPECT_EQ(seq, 4); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::Medium,       [&]{ EXPECT_EQ(seq, 3); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::High,         [&]{ EXPECT_EQ(seq, 2); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::BreadthFirst, [&]{ EXPECT_EQ(seq, 1); seq++; }));
 #elif vt_feature_cmake_priority_bits_level == 3
-  queue.emplace(PriorityUnit(Priority::Lowest,       [&]{ EXPECT_EQ(seq, 8); seq++; }));
-  queue.emplace(PriorityUnit(Priority::Low,          [&]{ EXPECT_EQ(seq, 7); seq++; }));
-  queue.emplace(PriorityUnit(Priority::MediumLow,    [&]{ EXPECT_EQ(seq, 6); seq++; }));
-  queue.emplace(PriorityUnit(Priority::Medium,       [&]{ EXPECT_EQ(seq, 5); seq++; }));
-  queue.emplace(PriorityUnit(Priority::MediumHigh,   [&]{ EXPECT_EQ(seq, 4); seq++; }));
-  queue.emplace(PriorityUnit(Priority::High,         [&]{ EXPECT_EQ(seq, 3); seq++; }));
-  queue.emplace(PriorityUnit(Priority::Highest,      [&]{ EXPECT_EQ(seq, 2); seq++; }));
-  queue.emplace(PriorityUnit(Priority::BreadthFirst, [&]{ EXPECT_EQ(seq, 1); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::Lowest,       [&]{ EXPECT_EQ(seq, 8); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::Low,          [&]{ EXPECT_EQ(seq, 7); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::MediumLow,    [&]{ EXPECT_EQ(seq, 6); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::Medium,       [&]{ EXPECT_EQ(seq, 5); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::MediumHigh,   [&]{ EXPECT_EQ(seq, 4); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::High,         [&]{ EXPECT_EQ(seq, 3); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::Highest,      [&]{ EXPECT_EQ(seq, 2); seq++; }));
+  queue.emplace(PriorityUnit(t, Priority::BreadthFirst, [&]{ EXPECT_EQ(seq, 1); seq++; }));
 #else
   // Do nothing
 #endif


### PR DESCRIPTION
This PR provides:
- A non-heuristic hang detector, only detects a hang iff it's impossible for the system to make progress
  - Relies on work priorities, which provides a central queue
  - Term messages are marked as such, and tracked by the schduler
  - Two forms of "idleness" (term and non-term)
- Halt all progress on global epoch unless schedule is idle (minus term messages)
- Fixes a major performance bug in collective epochs
  - Create a new API call for creating epoch dependencies (instead of simply a produce/consume), which carry the semantic of the dependency for optimization purposes
  - Do not forward progress epochs that cannot finish due to a dependency
  - Optimizes the structure of epoch graphs, eliding redundant dependencies
- If a hang is *detected*, abort and output a DOT file of the hang
  - Local view of epochs for each node
  - Global view combining the all the local epoch graphs

Fixes #500 