### PR TITLE
552 add tracing of mpi calls

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -70,6 +70,7 @@ namespace vt { namespace arguments {
 /*static*/ int32_t     ArgConfig::vt_stack_mod          = 0;
 
 /*static*/ bool        ArgConfig::vt_trace              = false;
+/*static*/ bool        ArgConfig::vt_trace_mpi          = false;
 /*static*/ std::string ArgConfig::vt_trace_file         = "";
 /*static*/ std::string ArgConfig::vt_trace_dir          = "";
 /*static*/ int32_t     ArgConfig::vt_trace_mod          = 0;
@@ -215,16 +216,20 @@ namespace vt { namespace arguments {
   /*
    * Flags to control tracing output
    */
-  auto trace  = "Enable tracing (must be compiled with trace_enabled)";
-  auto tfile  = "Name of trace files";
-  auto tdir   = "Name of directory for trace files";
-  auto tmod   = "Output trace file if (node % vt_stack_mod) == 0";
-  auto n = app.add_flag("--vt_trace",           vt_trace,           trace);
-  auto o = app.add_option("--vt_trace_file",    vt_trace_file,      tfile, "");
-  auto p = app.add_option("--vt_trace_dir",     vt_trace_dir,       tdir,  "");
-  auto q = app.add_option("--vt_trace_mod",     vt_trace_mod,       tmod,  1);
+  auto trace     = "Enable tracing (must be compiled with trace_enabled)";
+  auto trace_mpi = "Enable tracing of MPI calls (must be compiled with "
+                   "trace_enabled)";
+  auto tfile     = "Name of trace files";
+  auto tdir      = "Name of directory for trace files";
+  auto tmod      = "Output trace file if (node % vt_stack_mod) == 0";
+  auto n  = app.add_flag("--vt_trace",           vt_trace,           trace);
+  auto nm = app.add_flag("--vt_trace_mpi",       vt_trace_mpi,       trace_mpi);
+  auto o  = app.add_option("--vt_trace_file",    vt_trace_file,      tfile, "");
+  auto p  = app.add_option("--vt_trace_dir",     vt_trace_dir,       tdir,  "");
+  auto q  = app.add_option("--vt_trace_mod",     vt_trace_mod,       tmod,  1);
   auto traceGroup = "Tracing Configuration";
   n->group(traceGroup);
+  nm->group(traceGroup);
   o->group(traceGroup);
   p->group(traceGroup);
   q->group(traceGroup);

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -74,6 +74,7 @@ public:
   static int32_t vt_stack_mod;
 
   static bool vt_trace;
+  static bool vt_trace_mpi;
   static std::string vt_trace_file;
   static std::string vt_trace_dir;
   static int32_t vt_trace_mod;

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -50,6 +50,7 @@
 #include <mpi.h>
 
 #include "vt/config.h"
+#include "vt/configs/arguments/args.h"
 #include "vt/activefn/activefn.h"
 #include "vt/messaging/active.fwd.h"
 #include "vt/messaging/message/smart_ptr.h"
@@ -61,6 +62,10 @@
 #include "vt/registry/auto/auto_registry_interface.h"
 #include "vt/trace/trace_common.h"
 #include "vt/utils/static_checks/functor.h"
+
+#if backend_check_enabled(trace_enabled)
+  #include "vt/trace/trace_headers.h"
+#endif
 
 #include <type_traits>
 #include <tuple>
@@ -163,6 +168,7 @@ struct ActiveMessenger {
   using EpochStackType       = std::stack<EpochType>;
   using PendingSendType      = PendingSend;
   using ListenerType         = std::unique_ptr<Listener>;
+  using ArgType              = vt::arguments::ArgConfig;
 
   ActiveMessenger();
 
@@ -627,6 +633,8 @@ private:
 
   #if backend_check_enabled(trace_enabled)
     trace::TraceEventIDType current_trace_context_ = trace::no_trace_event;
+    trace::UserEventIDType trace_irecv     = 0;
+    trace::UserEventIDType trace_isend     = 0;
   #endif
 
   HandlerType current_handler_context_           = uninitialized_handler;

--- a/src/vt/messaging/irecv_holder.h
+++ b/src/vt/messaging/irecv_holder.h
@@ -46,6 +46,11 @@
 #define INCLUDED_VT_MESSAGING_IRECV_HOLDER_H
 
 #include "vt/config.h"
+#include "vt/configs/arguments/args.h"
+
+#if backend_check_enabled(trace_enabled)
+  #include "vt/trace/trace_headers.h"
+#endif
 
 #include <vector>
 
@@ -53,6 +58,8 @@ namespace vt { namespace messaging {
 
 template <typename T>
 struct IRecvHolder {
+  using ArgType = vt::arguments::ArgConfig;
+
   IRecvHolder() = default;
 
   template <typename U>
@@ -88,6 +95,15 @@ struct IRecvHolder {
         MPI_Status stat;
         MPI_Test(&e.req, &flag, &stat);
         if (flag == 1) {
+          #if backend_check_enabled(trace_enabled)
+            if (ArgType::vt_trace_mpi) {
+              auto tr_note = fmt::format(
+                "Irecv completed: from={}", stat.MPI_SOURCE
+              );
+              trace::addUserNote(tr_note);
+            }
+          #endif
+
           c(&e);
           progress_made = true;
           e.valid = false;

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -905,11 +905,13 @@ void Runtime::initializeComponents() {
   theEvent = std::make_unique<event::AsyncEvent>();
   thePool = std::make_unique<pool::Pool>();
 
+  // Initialize tracing, when it is enabled; used in the AM constructor
+  initializeTrace();
+
   // Core components: enables more complex subsequent initialization
   theObjGroup = std::make_unique<objgroup::ObjGroupManager>();
   theMsg = std::make_unique<messaging::ActiveMessenger>();
   theSched = std::make_unique<sched::Scheduler>();
-  initializeTrace();
   theTerm = std::make_unique<term::TerminationDetector>();
   theCollective = std::make_unique<collective::CollectiveAlg>();
   theGroup = std::make_unique<group::GroupManager>();
@@ -923,6 +925,10 @@ void Runtime::initializeComponents() {
   theLocMan = std::make_unique<location::LocationManager>();
   theVirtualManager = std::make_unique<vrt::VirtualContextManager>();
   theCollection = std::make_unique<vrt::collection::CollectionManager>();
+
+  #if backend_check_enabled(trace_enabled)
+    theTrace->initialize();
+  #endif
 
   debug_print(runtime, node, "end: initializeComponents\n");
 }

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -58,13 +58,9 @@ namespace vt { namespace trace {
 Trace::Trace(std::string const& in_prog_name, std::string const& in_trace_name)
   : prog_name_(in_prog_name), trace_name_(in_trace_name),
     start_time_(getCurrentTime())
-{
-  initialize();
-}
+{ }
 
-Trace::Trace() {
-  initialize();
-}
+Trace::Trace() { }
 
 /*static*/ void Trace::traceBeginIdleTrigger() {
   #if backend_check_enabled(trace_enabled)


### PR DESCRIPTION
Issue #552.  I have created this PR for merging into 1.0.0 because that's where I branched off.  I don't think it's appropriate to merge directly into 1.0.0, so I have marked this as WIP.  However, this is complete and **ready for review** as far as I am concerned.

This adds tracing of MPI_Isend, MPI_Irecv, and the completion of MPI_Irecv when the new --vt_trace_mpi option is used.  I implemented it differently than @lifflander did in the past due to the conditional (so couldn't use scoping) and the desire to include the message size as a note associated with the MPI_Irecv event itself rather than as a precursor note.