### PR TITLE
#556 restore the original coloring logic

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -481,7 +481,11 @@ namespace vt { namespace arguments {
   } else if (vt_color) {
     colorize_output = true;
   } else { // assume auto-color
-    colorize_output = isatty(fileno(stdout));
+    if (vt_auto_color) {
+      colorize_output = isatty(fileno(stdout));
+    } else {
+      colorize_output = not vt_no_color;
+    }
   }
 
   /*

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -52,9 +52,8 @@
 
 namespace vt { namespace arguments {
 
-/*static*/ bool        ArgConfig::vt_color              = false;
+/*static*/ bool        ArgConfig::vt_color              = true;
 /*static*/ bool        ArgConfig::vt_no_color           = false;
-/*static*/ bool        ArgConfig::vt_auto_color         = true;
 /*static*/ bool        ArgConfig::vt_quiet              = false;
 
 /*static*/ bool        ArgConfig::colorize_output       = false;
@@ -161,20 +160,16 @@ namespace vt { namespace arguments {
    * Flags for controlling the colorization of output from vt
    */
   auto quiet  = "Quiet the output from vt (only errors, warnings)";
-  auto always = "Colorize output (overrides --vt_auto_color)";
-  auto never  = "Never colorize output (overrides --vt_color)";
-  auto maybe  = "Automatic colorization of output";
+  auto always = "Colorize output (default)";
+  auto never  = "Do not colorize output (overrides --vt_color)";
   auto a  = app.add_flag("-c,--vt_color",      vt_color,      always);
   auto b  = app.add_flag("-n,--vt_no_color",   vt_no_color,   never);
-  auto c  = app.add_flag("-a,--vt_auto_color", vt_auto_color, maybe);
   auto a1 = app.add_flag("-q,--vt_quiet",      vt_quiet,      quiet);
   auto outputGroup = "Output Control";
   a->group(outputGroup);
   b->group(outputGroup);
-  c->group(outputGroup);
   a1->group(outputGroup);
   b->excludes(a);
-  b->excludes(c);
 
   /*
    * Flags for controlling the signals that VT tries to catch
@@ -476,11 +471,9 @@ namespace vt { namespace arguments {
   // Determine the final colorization setting.
   if (vt_no_color) {
     colorize_output = false;
-  } else if (vt_color) {
-    colorize_output = true;
   } else {
-    // Otherwise, currently assume to colorize as VT runs within MPI.
-    // isatty in MPI is always false; mpc_isatty is a vendor extension.
+    // Otherwise, colorize.
+    // (Within MPI there is no good method to auto-detect.)
     colorize_output = true;
   }
 

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -48,8 +48,6 @@
 #include <string>
 #include <vector>
 
-#include <unistd.h>
-
 #include "CLI/CLI11.hpp"
 
 namespace vt { namespace arguments {
@@ -165,7 +163,7 @@ namespace vt { namespace arguments {
   auto quiet  = "Quiet the output from vt (only errors, warnings)";
   auto always = "Colorize output (overrides --vt_auto_color)";
   auto never  = "Never colorize output (overrides --vt_color)";
-  auto maybe  = "Automatic colorization of output (default, unnecessary)";
+  auto maybe  = "Automatic colorization of output";
   auto a  = app.add_flag("-c,--vt_color",      vt_color,      always);
   auto b  = app.add_flag("-n,--vt_no_color",   vt_no_color,   never);
   auto c  = app.add_flag("-a,--vt_auto_color", vt_auto_color, maybe);
@@ -480,12 +478,10 @@ namespace vt { namespace arguments {
     colorize_output = false;
   } else if (vt_color) {
     colorize_output = true;
-  } else { // assume auto-color
-    if (vt_auto_color) {
-      colorize_output = isatty(fileno(stdout));
-    } else {
-      colorize_output = true;
-    }
+  } else {
+    // Otherwise, currently assume to colorize as VT runs within MPI.
+    // isatty in MPI is always false; mpc_isatty is a vendor extension.
+    colorize_output = true;
   }
 
   /*

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -484,7 +484,7 @@ namespace vt { namespace arguments {
     if (vt_auto_color) {
       colorize_output = isatty(fileno(stdout));
     } else {
-      colorize_output = not vt_no_color;
+      colorize_output = true;
     }
   }
 

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -589,17 +589,23 @@ void Runtime::printStartupBanner() {
   }
 
   if (ArgType::vt_no_color) {
-    auto f11 = fmt::format("Disabling color output");
+    auto f11 = fmt::format("Color output Disabled");
     auto f12 = opt_on("--vt_no_color", f11);
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
   } else if (ArgType::vt_color) {
-    auto f11 = fmt::format("Color output enabled");
+    auto f11 = fmt::format("Color output Enabled");
     auto f12 = opt_on("--vt_color", f11);
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
   } else {
-    auto f11 = fmt::format("Automatically color output (if terminal)");
-    auto f12 = opt_inverse("--vt_no_color", f11);
-    fmt::print("{}\t{}{}", vt_pre, f12, reset);
+    if (ArgType::colorize_output) {
+      auto f11 = fmt::format("Automatically color output (colors Enabled)");
+      auto f12 = opt_inverse("--vt_no_color", f11);
+      fmt::print("{}\t{}{}", vt_pre, f12, reset);
+    } else {
+      auto f11 = fmt::format("Automatically color output (colors Disabled)");
+      auto f12 = opt_inverse("--vt_color", f11);
+      fmt::print("{}\t{}{}", vt_pre, f12, reset);
+    }
   }
 
   if (ArgType::vt_no_stack) {

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -589,23 +589,13 @@ void Runtime::printStartupBanner() {
   }
 
   if (ArgType::vt_no_color) {
-    auto f11 = fmt::format("Color output Disabled");
+    auto f11 = fmt::format("Color output disabled");
     auto f12 = opt_on("--vt_no_color", f11);
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
-  } else if (ArgType::vt_color) {
-    auto f11 = fmt::format("Color output Enabled");
-    auto f12 = opt_on("--vt_color", f11);
-    fmt::print("{}\t{}{}", vt_pre, f12, reset);
   } else {
-    if (ArgType::colorize_output) {
-      auto f11 = fmt::format("Automatically color output (colors Enabled)");
-      auto f12 = opt_inverse("--vt_no_color", f11);
-      fmt::print("{}\t{}{}", vt_pre, f12, reset);
-    } else {
-      auto f11 = fmt::format("Automatically color output (colors Disabled)");
-      auto f12 = opt_inverse("--vt_color", f11);
-      fmt::print("{}\t{}{}", vt_pre, f12, reset);
-    }
+    auto f11 = fmt::format("Color output enabled");
+    auto f12 = opt_inverse("--vt_color", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
   }
 
   if (ArgType::vt_no_stack) {

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -594,7 +594,7 @@ void Runtime::printStartupBanner() {
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
   } else {
     auto f11 = fmt::format("Color output enabled");
-    auto f12 = opt_inverse("--vt_color", f11);
+    auto f12 = opt_inverse("--vt_no_color", f11);
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
   }
 


### PR DESCRIPTION
#539, #544 caused color to *not* be output by default anymore on a my terminal (Mac). Restore the original logic (default on, not relying on `isatty`, unless `--vt_auto_color` is explicit to detect the termination type)

Fixes #556