### PR TITLE
#561 implement new file spec with LB-specific params

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -81,6 +81,7 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_lb_quiet           = false;
 /*static*/ std::string ArgConfig::vt_lb_file_name       = "balance.in";
 /*static*/ std::string ArgConfig::vt_lb_name            = "NoLB";
+/*static*/ std::string ArgConfig::vt_lb_args            = "";
 /*static*/ int32_t     ArgConfig::vt_lb_interval        = 1;
 /*static*/ bool        ArgConfig::vt_lb_stats           = false;
 /*static*/ std::string ArgConfig::vt_lb_stats_dir       = "vt_lb_stats";
@@ -346,6 +347,7 @@ namespace vt { namespace arguments {
 
   auto lb            = "Enable load balancing";
   auto lb_file       = "Enable reading LB configuration from file";
+  auto lb_args       = "Arguments pass to LB: \"x=0 y=1 test=2\"";
   auto lb_quiet      = "Silence load balancing output";
   auto lb_file_name  = "LB configuration file to read";
   auto lb_name       = "Name of the load balancer to use";
@@ -358,11 +360,13 @@ namespace vt { namespace arguments {
   auto lbf = "balance.in";
   auto lbd = "vt_lb_stats";
   auto lbs = "stats";
+  auto lba = "";
   auto s  = app.add_flag("--vt_lb",              vt_lb,             lb);
   auto t  = app.add_flag("--vt_lb_file",         vt_lb_file,        lb_file);
   auto t1 = app.add_flag("--vt_lb_quiet",        vt_lb_quiet,       lb_quiet);
   auto u  = app.add_option("--vt_lb_file_name",  vt_lb_file_name,   lb_file_name, lbf);
   auto v  = app.add_option("--vt_lb_name",       vt_lb_name,        lb_name,      lbn);
+  auto v1 = app.add_option("--vt_lb_args",       vt_lb_args,        lb_args,      lba);
   auto w  = app.add_option("--vt_lb_interval",   vt_lb_interval,    lb_interval,  lbi);
   auto ww = app.add_flag("--vt_lb_stats",        vt_lb_stats,       lb_stats);
   auto wx = app.add_option("--vt_lb_stats_dir",  vt_lb_stats_dir,   lb_stats_dir, lbd);
@@ -373,6 +377,7 @@ namespace vt { namespace arguments {
   t1->group(debugLB);
   u->group(debugLB);
   v->group(debugLB);
+  v1->group(debugLB);
   w->group(debugLB);
   ww->group(debugLB);
   wx->group(debugLB);

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -79,7 +79,7 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_lb                 = false;
 /*static*/ bool        ArgConfig::vt_lb_file            = false;
 /*static*/ bool        ArgConfig::vt_lb_quiet           = false;
-/*static*/ std::string ArgConfig::vt_lb_file_name       = "balance.in";
+/*static*/ std::string ArgConfig::vt_lb_file_name       = "";
 /*static*/ std::string ArgConfig::vt_lb_name            = "NoLB";
 /*static*/ std::string ArgConfig::vt_lb_args            = "";
 /*static*/ int32_t     ArgConfig::vt_lb_interval        = 1;
@@ -357,7 +357,7 @@ namespace vt { namespace arguments {
   auto lb_stats_file = "Load balancing statistics output file name";
   auto lbn = "NoLB";
   auto lbi = 1;
-  auto lbf = "balance.in";
+  auto lbf = "";
   auto lbd = "vt_lb_stats";
   auto lbs = "stats";
   auto lba = "";

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -87,6 +87,7 @@ public:
   static bool vt_lb_quiet;
   static std::string vt_lb_file_name;
   static std::string vt_lb_name;
+  static std::string vt_lb_args;
   static int32_t vt_lb_interval;
   static bool vt_lb_stats;
   static std::string vt_lb_stats_dir;

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -424,11 +424,20 @@ void Runtime::printStartupBanner() {
     auto f9 = opt_on("--vt_lb", "Load balancing enabled");
     fmt::print("{}\t{}{}", vt_pre, f9, reset);
     if (ArgType::vt_lb_file) {
-      auto f10 = opt_on("--vt_lb_file", "Reading LB config from file");
-      fmt::print("{}\t{}{}", vt_pre, f10, reset);
-      auto f12 = fmt::format("Reading file \"{}\"", ArgType::vt_lb_file_name);
-      auto f11 = opt_on("--vt_lb_file_name", f12);
-      fmt::print("{}\t{}{}", vt_pre, f11, reset);
+      if (ArgType::vt_lb_file_name == "") {
+        auto warn_lb_file = fmt::format(
+          "{}Warning:{} {}{}{} has no effect: compile-time"
+          " option {}{}{} is empty{}\n", red, reset, magenta, "--vt_lb_file",
+          reset, magenta, "--vt_lb_file_name", reset, reset
+        );
+        fmt::print("{}\t{}{}", vt_pre, warn_lb_file, reset);
+      } else {
+        auto f10 = opt_on("--vt_lb_file", "Reading LB config from file");
+        fmt::print("{}\t{}{}", vt_pre, f10, reset);
+        auto f12 = fmt::format("Reading file \"{}\"", ArgType::vt_lb_file_name);
+        auto f11 = opt_on("--vt_lb_file_name", f12);
+        fmt::print("{}\t{}{}", vt_pre, f11, reset);
+      }
     } else {
       auto a3 = fmt::format("Load balancer name: \"{}\"", ArgType::vt_lb_name);
       auto a4 = opt_on("--vt_lb_name", a3);

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -51,6 +51,7 @@
 #include "vt/vrt/collection/balance/baselb/baselb_msgs.h"
 #include "vt/vrt/collection/balance/proc_stats.h"
 #include "vt/vrt/collection/balance/lb_comm.h"
+#include "vt/vrt/collection/balance/read_lb.h"
 #include "vt/objgroup/headers.h"
 
 #include <set>
@@ -106,38 +107,32 @@ struct BaseLB {
   void transferMigrations(TransferMsg<TransferVecType>* msg);
   void finalize(CountMsg* msg);
 
+  virtual void inputParams(balance::SpecEntry* spec) = 0;
   virtual void runLB() = 0;
 
 private:
   balance::LoadData reduceVec(std::vector<balance::LoadData>&& vec) const;
   bool isCollectiveComm(balance::CommCategory cat) const;
   void computeStatisticsOver(Statistic stats);
-  void readLB(PhaseType phase);
+  void getArgs(PhaseType phase);
 
 protected:
-  virtual double getDefaultMinThreshold()  const = 0;
-  virtual double getDefaultMaxThreshold()  const = 0;
-  virtual bool   getDefaultAutoThreshold() const = 0;
-
-protected:
-  double max_threshold                  = 0.0f;
-  double min_threshold                  = 0.0f;
-  bool auto_threshold                   = true;
-  double start_time_                    = 0.0f;
-  int32_t bin_size_                     = 10;
-  ObjSampleType obj_sample              = {};
-  LoadType this_load                    = 0.0f;
-  ElementLoadType const* load_data      = nullptr;
-  ElementCommType const* comm_data      = nullptr;
-  StatisticMapType stats                = {};
-  EpochType migration_epoch_            = no_epoch;
-  TransferType off_node_migrate_        = {};
-  objgroup::proxy::Proxy<BaseLB> proxy_ = {};
-  int32_t local_migration_count_        = 0;
-  PhaseType phase_                      = 0;
-  int32_t num_reduce_stats_             = 0;
-  bool comm_aware_                      = false;
-  bool comm_collectives_                = false;
+  double start_time_                              = 0.0f;
+  int32_t bin_size_                               = 10;
+  ObjSampleType obj_sample                        = {};
+  LoadType this_load                              = 0.0f;
+  ElementLoadType const* load_data                = nullptr;
+  ElementCommType const* comm_data                = nullptr;
+  StatisticMapType stats                          = {};
+  EpochType migration_epoch_                      = no_epoch;
+  TransferType off_node_migrate_                  = {};
+  objgroup::proxy::Proxy<BaseLB> proxy_           = {};
+  int32_t local_migration_count_                  = 0;
+  PhaseType phase_                                = 0;
+  int32_t num_reduce_stats_                       = 0;
+  bool comm_aware_                                = false;
+  bool comm_collectives_                          = false;
+  std::unique_ptr<balance::SpecEntry> spec_entry_ = nullptr;
 };
 
 }}}} /* end namespace vt::vrt::collection::balance::lb */

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -56,6 +56,9 @@ void GossipLB::init(objgroup::proxy::Proxy<GossipLB> in_proxy) {
   proxy = in_proxy;
 }
 
+void GossipLB::inputParams(balance::SpecEntry* spec) {
+}
+
 void GossipLB::runLB() {
   this->inform();
 }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -64,10 +64,7 @@ public: // ctors
 public:
   void init(objgroup::proxy::Proxy<GossipLB> in_proxy);
   void runLB() override;
-
-  double getDefaultMinThreshold()  const override { return 0.0;  }
-  double getDefaultMaxThreshold()  const override { return 0.0;  }
-  bool   getDefaultAutoThreshold() const override { return true; }
+  void inputParams(balance::SpecEntry* spec) override;
 
 protected:
   void inform();

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -72,6 +72,12 @@ void GreedyLB::init(objgroup::proxy::Proxy<GreedyLB> in_proxy) {
   proxy = scatter_proxy = in_proxy;
 }
 
+void GreedyLB::inputParams(balance::SpecEntry* spec) {
+  min_threshold = spec->getOrDefault<double>("min", greedy_threshold_p);
+  max_threshold = spec->getOrDefault<double>("max", greedy_max_threshold_p);
+  auto_threshold = spec->getOrDefault<bool>("auto", greedy_auto_threshold_p);
+}
+
 void GreedyLB::runLB() {
   loadStats();
 }

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.h
@@ -74,16 +74,7 @@ struct GreedyLB : BaseLB {
 
   void init(objgroup::proxy::Proxy<GreedyLB> in_proxy);
   void runLB() override;
-
-  double getDefaultMinThreshold()  const override {
-    return greedy_threshold_p;
-  }
-  double getDefaultMaxThreshold()  const override {
-    return greedy_max_threshold_p;
-  }
-  bool   getDefaultAutoThreshold() const override {
-    return greedy_auto_threshold_p;
-  }
+  void inputParams(balance::SpecEntry* spec) override;
 
 private:
   double getAvgLoad() const;
@@ -116,6 +107,9 @@ private:
   ObjSampleType load_over;
   std::size_t load_over_size = 0;
   objgroup::proxy::Proxy<GreedyLB> proxy = {};
+  double max_threshold = 0.0f;
+  double min_threshold = 0.0f;
+  bool auto_threshold = true;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -72,6 +72,12 @@ void HierarchicalLB::init(objgroup::proxy::Proxy<HierarchicalLB> in_proxy) {
   proxy = in_proxy;
 }
 
+void HierarchicalLB::inputParams(balance::SpecEntry* spec) {
+  min_threshold = spec->getOrDefault<double>("min", hierlb_threshold_p);
+  max_threshold = spec->getOrDefault<double>("max", hierlb_max_threshold_p);
+  auto_threshold = spec->getOrDefault<bool>("auto", hierlb_auto_threshold_p);
+}
+
 void HierarchicalLB::setupTree(double const threshold) {
   vtAssert(
     tree_setup == false,

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
@@ -78,16 +78,7 @@ struct HierarchicalLB : BaseLB {
 
   void init(objgroup::proxy::Proxy<HierarchicalLB> in_proxy);
   void runLB() override;
-
-  double getDefaultMinThreshold()  const override {
-    return hierlb_threshold_p;
-  }
-  double getDefaultMaxThreshold()  const override {
-    return hierlb_max_threshold_p;
-  }
-  bool   getDefaultAutoThreshold() const override {
-    return hierlb_auto_threshold_p;
-  }
+  void inputParams(balance::SpecEntry* spec) override;
 
   void setupTree(double const threshold);
   void calcLoadOver(HeapExtractEnum const extract);
@@ -145,6 +136,9 @@ private:
   int64_t migrates_expected = 0, transfer_count = 0;
   TransferType transfers;
   objgroup::proxy::Proxy<HierarchicalLB> proxy = {};
+  double max_threshold = 0.0f;
+  double min_threshold = 0.0f;
+  bool auto_threshold = true;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -80,9 +80,6 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
   }
 
   if (ArgType::vt_lb_file and try_file) {
-    auto const file_name = ArgType::vt_lb_file_name;
-    ReadLBSpec::openFile(file_name);
-    ReadLBSpec::readFile();
     bool const has_spec = ReadLBSpec::hasSpec();
     if (has_spec) {
       the_lb = ReadLBSpec::getLB(phase);

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -46,6 +46,7 @@
 #include "vt/context/context.h"
 #include "vt/vrt/collection/balance/read_lb.h"
 #include "vt/vrt/collection/balance/lb_type.h"
+#include "vt/configs/arguments/args.h"
 
 #include <string>
 #include <fstream>
@@ -57,18 +58,37 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 
 /*static*/ std::string ReadLBSpec::filename = {};
 /*static*/ SpecIndex ReadLBSpec::num_entries_ = 0;
-/*static*/ std::unordered_map<SpecIndex,SpecEntry> ReadLBSpec::spec_ = {};
-/*static*/ bool ReadLBSpec::has_spec_ = false;
+/*static*/ typename ReadLBSpec::SpecMapType ReadLBSpec::spec_mod_ = {};
+/*static*/ typename ReadLBSpec::SpecMapType ReadLBSpec::spec_exact_ = {};
+/*static*/ std::vector<SpecIndex> ReadLBSpec::spec_prec_ = {};
 /*static*/ bool ReadLBSpec::read_complete_ = false;
+
+/*static*/ bool ReadLBSpec::hasSpec() {
+  if (not ArgType::vt_lb_file) {
+    return false;
+  }
+  if (read_complete_) {
+    return true;
+  } else {
+    auto const file_name = ArgType::vt_lb_file_name;
+    if (file_name == "") {
+      return false;
+    } else {
+      return openFile(file_name);
+    }
+  }
+}
 
 /*static*/ bool ReadLBSpec::openFile(std::string const name) {
   std::ifstream file(name);
   filename = name;
-  has_spec_ = file.good();
   return file.good();
 }
 
 /*static*/ LBType ReadLBSpec::getLB(SpecIndex const& idx) {
+  if (not read_complete_) {
+    readFile();
+  }
   auto const lb = entry(idx);
   if (lb) {
     return lb->getLB();
@@ -77,118 +97,180 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
   }
 }
 
-/*static*/ SpecEntry const* ReadLBSpec::entry(SpecIndex const& idx) {
-  auto spec_iter = spec_.find(idx);
-  debug_print(
-    lb, node,
-    "idx={},idx-mod={},found={},size={},num_entries={}\n",
-    idx,
-    idx % num_entries_,
-    spec_iter != spec_.end(),
-    spec_.size(),
-    num_entries_
-  );
-  if (spec_iter == spec_.end()) {
-    auto idx2 = idx;
-    if (idx2 > num_entries_) {
-      auto const div = (idx2 - num_entries_) / num_entries_;
-      idx2 -= div;
-    }
-    while (idx2 > num_entries_) {
-      idx2 -= num_entries_;
-    }
-    spec_iter = spec_.find(idx2/* % num_entries_*/);
-    if (spec_iter != spec_.end()) {
-      return &spec_iter->second;
-    }
-  } else {
+/*static*/ SpecEntry* ReadLBSpec::entry(SpecIndex const& idx) {
+  // First, search the exact iter spec for this iteration: it has the highest
+  // precedence
+  auto spec_iter = spec_exact_.find(idx);
+  if (spec_iter != spec_exact_.end()) {
     return &spec_iter->second;
   }
+
+  // Second, walk through the spec precedence map for the mod overloads
+  for (auto mod : spec_prec_) {
+    auto iter = spec_mod_.find(mod);
+    if (iter != spec_mod_.end()) {
+      // Check if this mod is applicable to the idx
+      if (idx % mod == 0) {
+        auto iter_mod = spec_mod_.find(mod);
+        if (iter_mod != spec_mod_.end()) {
+          return &iter_mod->second;
+        }
+      }
+    }
+  }
+
+  // Else, return nullptr---no applicable entry found
   return nullptr;
 }
 
+int eatWhitespace(std::ifstream& file) {
+  while (not file.eof() and std::isspace(file.peek())) {
+    file.get();
+  }
+  return file.eof() ? 0 : file.peek();
+}
+
 /*static*/ void ReadLBSpec::readFile() {
-  if (read_complete_ || !has_spec_) {
+  if (read_complete_) {
     return;
   }
 
   std::ifstream file(filename);
   vtAssert(file.good(), "must be valid");
 
-  constexpr int64_t const max_num_times = 100000;
-  int64_t max_entry = 0;
-  int64_t num_times = 0;
-  std::string cur_line;
   while (!file.eof()) {
-    double lb_min = 0.0f, lb_max = 0.0f;
-    int64_t lb_iter = -1;
+    bool is_mod = false;
+    int64_t mod = -1;
     std::string lb_name;
+    std::vector<std::string> params;
 
-    if (std::isalpha(file.peek())) {
-      file >> lb_name;
-      lb_iter = max_entry;
-      max_entry++;
-    } else {
-      file >> lb_iter;
-      file >> lb_name;
-      max_entry = std::max(max_entry, lb_iter);
-    }
-    if (file.peek() != '\n') {
-      file >> lb_min;
-    }
-    if (file.peek() != '\n') {
-      file >> lb_max;
+    int c = eatWhitespace(file);
+
+    /*
+     * Parse an entry that starts with an LB: "% ..."
+     */
+    if (static_cast<char>(c) == '%') {
+      is_mod = true;
+      // Eat up the '%', move to next
+      file.get();
+      c = eatWhitespace(file);
     }
 
+    /*
+     * Parse entry starting LB iter/mod: "[%] 10 GreedyLB ..."
+     */
+    if (std::isdigit(c)) {
+      file >> mod;
+    }
+
+    c = eatWhitespace(file);
+
+    /*
+     * Parse the name of the LB: "GreedyLB ..."
+     */
+    if (std::isalpha(c)) {
+      file >> lb_name;
+    }
+
+    c = eatWhitespace(file);
+
+    /*
+     * Parse out all the parameters for the LB: "x=1 y=2 test=3 ..."
+     */
+    while (file.peek() != '\n' and not file.eof()) {
+      std::string param;
+      file >> param;
+      params.push_back(param);
+    }
+
+    eatWhitespace(file);
+
+    /*
+     * Split params into 'key=value'
+     */
+    auto const param_map = parseParams(params);
+
+    /*
+     * Check to make sure we have a valid LB name
+     */
     bool valid_lb_found = false;
     for (auto&& elm : lb_names_) {
       if (lb_name == elm.second) {
         valid_lb_found = true;
       }
     }
+    if (not valid_lb_found) {
+      auto err_msg = fmt::format("Valid LB not found: \"name={}\"\n", lb_name);
+      vtAbort(err_msg);
+    }
 
-    if (valid_lb_found) {
-      auto spec_index = static_cast<SpecIndex>(lb_iter);
-      spec_.emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(spec_index),
-        std::forward_as_tuple(SpecEntry{spec_index,lb_name,lb_min,lb_max})
-      );
-      debug_print(
-        lb, node,
-        "{}: insert: idx={},size={},name={},min={},max={}\n",
-        theContext()->getNode(),
-        spec_index,
-        spec_.size(),
-        lb_name,
-        lb_min,
-        lb_max
-      );
-    } else {
-      auto const& this_node = theContext()->getNode();
-      if (this_node == 0 && lb_name != "") {
-        vt_print(
-          lb,
-          "valid LB not found: \"name={},iter={},min={},max={}\"\n",
-          this_node, lb_name, lb_iter, lb_min, lb_max
-        );
+    /*
+     * If the line is specified as a mod '%' or not line is specified (assume
+     * mod 1)
+     */
+    SpecMapType* map = nullptr;
+    if (is_mod or mod == -1) {
+      if (mod == -1) {
+        mod = 1;
       }
+      spec_prec_.push_back(mod);
+      map = &spec_mod_;
+    } else {
+      map = &spec_exact_;
     }
 
-    num_times++;
-
-    if (num_times > max_num_times) {
-      break;
+    if (map->find(mod) != map->end()) {
+      auto err_msg = fmt::format(
+        "Iter {} specified twice: name={}, mod={}\n", mod, lb_name, is_mod
+      );
+      vtAbort(err_msg);
     }
-  }
 
-  num_entries_ = spec_.size();
-
-  for (auto&& elm : spec_) {
-    num_entries_ = std::max(num_entries_, elm.second.getIdx());
+    map->emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(mod),
+      std::forward_as_tuple(SpecEntry{mod, lb_name, param_map})
+    );
   }
 
   read_complete_ = true;
+}
+
+/*static*/ typename ReadLBSpec::ParamMapType
+ReadLBSpec::parseParams(std::vector<std::string> params) {
+  ParamMapType param_map;
+
+  /*
+   * Split params into 'key=value'
+   */
+  for (auto&& p : params) {
+    std::string key, value;
+    bool found = false;
+    for (int i = 0; i < p.size(); i++) {
+      if (p[i] == '=') {
+        key = p.substr(0, i);
+        value = p.substr(i + 1, p.length() - 1);
+        param_map[key] = value;
+        found = true;
+      }
+    }
+  }
+
+  return param_map;
+}
+
+/*static*/ SpecEntry ReadLBSpec::makeSpecFromParams(std::string param_str) {
+  std::istringstream stream(param_str);
+  std::vector<std::string> params;
+  while (not stream.eof()) {
+    std::string param;
+    stream >> param;
+    params.push_back(param);
+  }
+
+  auto param_map = parseParams(params);
+
+  return SpecEntry{0, "", param_map};
 }
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -249,6 +249,15 @@ int eatWhitespace(std::ifstream& file) {
   read_complete_ = true;
 }
 
+/*static*/ void ReadLBSpec::clear() {
+  read_complete_ = false;
+  filename = "";
+  num_entries_ = 0;
+  spec_mod_.clear();
+  spec_exact_.clear();
+  spec_prec_.clear();
+}
+
 /*static*/ typename ReadLBSpec::ParamMapType
 ReadLBSpec::parseParams(std::vector<std::string> params) {
   ParamMapType param_map;

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -276,6 +276,10 @@ ReadLBSpec::parseParams(std::vector<std::string> params) {
         found = true;
       }
     }
+    if (not found) {
+      auto err = fmt::format("LB file reader: could not parse param: \"{}\"", p);
+      vtAbort(err);
+    }
   }
 
   return param_map;

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -266,6 +266,9 @@ ReadLBSpec::parseParams(std::vector<std::string> params) {
    * Split params into 'key=value'
    */
   for (auto&& p : params) {
+    if (p == "") {
+      continue;
+    }
     std::string key, value;
     bool found = false;
     for (std::size_t i = 0; i < p.size(); i++) {

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -72,9 +72,18 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
   } else {
     auto const file_name = ArgType::vt_lb_file_name;
     if (file_name == "") {
+      vtAbort(
+        "--vt_lb_file enabled but no file name is specified: --vt_lb_file_name"
+      );
       return false;
     } else {
-      return openFile(file_name);
+      bool good = openFile(file_name);
+      if (not good) {
+        auto str =
+          fmt::format("--vt_lb_file_name={} is not a valid file", file_name);
+        vtAbort(str);
+      }
+      return good;
     }
   }
 }

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -268,7 +268,7 @@ ReadLBSpec::parseParams(std::vector<std::string> params) {
   for (auto&& p : params) {
     std::string key, value;
     bool found = false;
-    for (int i = 0; i < p.size(); i++) {
+    for (std::size_t i = 0; i < p.size(); i++) {
       if (p[i] == '=') {
         key = p.substr(0, i);
         value = p.substr(i + 1, p.length() - 1);

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -124,7 +124,7 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 }
 
 int eatWhitespace(std::ifstream& file) {
-  while (not file.eof() and std::isspace(file.peek())) {
+  while (not file.eof() and std::isspace(file.peek()) and file.peek() != '\n') {
     file.get();
   }
   return file.eof() ? 0 : file.peek();
@@ -184,6 +184,10 @@ int eatWhitespace(std::ifstream& file) {
     }
 
     eatWhitespace(file);
+
+    while (file.peek() == '\n') {
+      file.get();
+    }
 
     /*
      * Split params into 'key=value'

--- a/src/vt/vrt/collection/balance/read_lb.h
+++ b/src/vt/vrt/collection/balance/read_lb.h
@@ -156,6 +156,7 @@ struct ReadLBSpec {
   static LBType getLB(SpecIndex const& idx);
   static ParamMapType parseParams(std::vector<std::string> params);
   static SpecEntry makeSpecFromParams(std::string params);
+  static void clear();
 
 private:
   static bool read_complete_;

--- a/src/vt/vrt/collection/balance/read_lb.h
+++ b/src/vt/vrt/collection/balance/read_lb.h
@@ -76,7 +76,6 @@ struct Converter<double> {
 template <>
 struct Converter<bool> {
   static bool convert(std::string val, bool default_) {
-    fmt::print("convert bool: val=\"{}\"\n", val);
     if (val == "1" or val == "true" or val == "t") {
       return true;
     }

--- a/src/vt/vrt/collection/balance/read_lb.h
+++ b/src/vt/vrt/collection/balance/read_lb.h
@@ -147,7 +147,7 @@ struct ReadLBSpec {
   using SpecMapType  = std::unordered_map<SpecIndex,SpecEntry>;
   using ParamMapType = std::unordered_map<std::string, std::string>;
 
-  static bool openFile(std::string const name = "balance.in");
+  static bool openFile(std::string const name = "");
   static void readFile();
 
   static bool hasSpec();

--- a/src/vt/vrt/collection/balance/rotatelb/rotatelb.cc
+++ b/src/vt/vrt/collection/balance/rotatelb/rotatelb.cc
@@ -54,6 +54,8 @@ void RotateLB::init(objgroup::proxy::Proxy<RotateLB> in_proxy) {
   proxy = in_proxy;
 }
 
+void RotateLB::inputParams(balance::SpecEntry* spec) { }
+
 void RotateLB::runLB() {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();

--- a/src/vt/vrt/collection/balance/rotatelb/rotatelb.h
+++ b/src/vt/vrt/collection/balance/rotatelb/rotatelb.h
@@ -70,10 +70,7 @@ struct RotateLB : BaseLB {
 
   void init(objgroup::proxy::Proxy<RotateLB> in_proxy);
   void runLB() override;
-
-  double getDefaultMinThreshold()  const override { return 0.0;  }
-  double getDefaultMaxThreshold()  const override { return 0.0;  }
-  bool   getDefaultAutoThreshold() const override { return true; }
+  void inputParams(balance::SpecEntry* spec) override;
 
 private:
   objgroup::proxy::Proxy<RotateLB> proxy = {};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
   memory
   objgroup
   scheduler
+  lb
 )
 
 option(VT_NO_BUILD_TESTS "Disable building VT tests" OFF)


### PR DESCRIPTION
The new file format allows for different parameters for each LB. Can be passed as a file or using `--vt_lb_args="c=1 k=5 f=2 i=10"`.

Example file:
```
%10 GossipLB c=1 k=5 f=2 i=10
0 HierarchicalLB min=0.9 max=1.1 auto=false
%5 GreedyLB min=1.0
120 GreedyLB c=0 k=2 f=3 i=3
```

Format:
```
[%] [iter] <LB-name> [key=value]...
```

Specific iteration lines override mods. Mods precedence is based on position in file, thus on iteration 10, `GreedyLB` will run---not `GossipLB`.

Fixes #561