### PR TITLE
575 event registry bugs

### DIFF
--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -265,7 +265,7 @@ EventType ActiveMessenger::sendMsgSized(
     auto const handler = envelopeGetHandler(msg->env);
     bool const is_auto = HandlerManagerType::isHandlerAuto(handler);
     if (is_auto) {
-      trace::TraceEntryIDType ep = auto_registry::theTraceID(
+      trace::TraceEntryIDType ep = auto_registry::handlerTraceID(
         handler, auto_registry::RegistryTypeEnum::RegGeneral
       );
       if (not is_bcast) {

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -298,19 +298,12 @@ EventType ActiveMessenger::sendMsgSized(
     base, uninitialized_destination, msg_size, true, &deliver
   );
 
-  EventType ret = no_event;
-
   if (deliver) {
-    EventType event = no_event;
-
     sendMsgBytesWithPut(dest, base, msg_size, send_tag);
-
-    ret = event;
-  } else {
-    ret = ret_event;
+    return no_event;
   }
 
-  return ret;
+  return ret_event;
 }
 
 ActiveMessenger::SendDataRetType ActiveMessenger::sendData(

--- a/src/vt/parameterization/parameterization.h
+++ b/src/vt/parameterization/parameterization.h
@@ -87,7 +87,7 @@ static void dataMessageHandler(DataMsg<Tuple>* msg) {
   );
 
 #if backend_check_enabled(trace_enabled)
-  trace::TraceEntryIDType ep = auto_registry::theTraceID(
+  trace::TraceEntryIDType ep = auto_registry::handlerTraceID(
     msg->sub_han, auto_registry::RegistryTypeEnum::RegGeneral
   );
   trace::TraceEventIDType event = envelopeGetTraceEvent(msg->env);

--- a/src/vt/rdma/state/rdma_state.cc
+++ b/src/vt/rdma/state/rdma_state.cc
@@ -255,7 +255,7 @@ void State::getData(
       ::vt::HandlerType const reg_han =
         tag == no_tag or get_any_tag ? this_get_handler :
         std::get<2>(get_tag_holder.find(tag)->second);
-      trace::TraceEntryIDType trace_id = auto_registry::theTraceID(
+      trace::TraceEntryIDType trace_id = auto_registry::handlerTraceID(
         reg_han, auto_registry::RegistryTypeEnum::RegRDMAGet
       );
       trace::TraceEventIDType event = theMsg()->getCurrentTraceEvent();
@@ -321,7 +321,7 @@ void State::putData(
       ::vt::HandlerType const reg_han =
         tag == no_tag or put_any_tag ? this_put_handler :
         std::get<2>(put_tag_holder.find(tag)->second);
-      trace::TraceEntryIDType trace_id = auto_registry::theTraceID(
+      trace::TraceEntryIDType trace_id = auto_registry::handlerTraceID(
         reg_han, auto_registry::RegistryTypeEnum::RegRDMAPut
       );
       trace::TraceEventIDType event = theMsg()->getCurrentTraceEvent();

--- a/src/vt/registry/auto/auto_registry.cc
+++ b/src/vt/registry/auto/auto_registry.cc
@@ -52,7 +52,7 @@
 namespace vt { namespace auto_registry {
 
 #if backend_check_enabled(trace_enabled)
-trace::TraceEntryIDType theTraceID(
+trace::TraceEntryIDType handlerTraceID(
   HandlerType const& handler, RegistryTypeEnum reg_type
 ) {
   switch (reg_type) {

--- a/src/vt/registry/auto/auto_registry.h
+++ b/src/vt/registry/auto/auto_registry.h
@@ -87,10 +87,6 @@ void setHandlerTraceName(std::string const& name, std::string const& parent = ""
 template <typename T, T value>
 void setHandlerTraceName(std::string const& name, std::string const& parent = "");
 
-void setTraceName(
-  trace::TraceEntryIDType id, std::string const& name, std::string const& parent
-);
-
 }} // end namespace vt::auto_registry
 
 #include "vt/registry/auto/auto_registry_impl.h"

--- a/src/vt/registry/auto/auto_registry_impl.h
+++ b/src/vt/registry/auto/auto_registry_impl.h
@@ -155,28 +155,7 @@ void setHandlerTraceName(std::string const& name, std::string const& parent) {
 inline void setTraceName(
   trace::TraceEntryIDType id, std::string const& name, std::string const& parent
 ) {
-#if backend_check_enabled(trace_enabled)
-  using TraceContainersType = trace::TraceRegistry::TraceContainersType;
-  auto event_iter = TraceContainersType::getEventContainer().find(id);
-  vtAssertExpr(event_iter != TraceContainersType::getEventContainer().end());
-  if (event_iter != TraceContainersType::getEventContainer().end()) {
-    if (name != "") {
-      event_iter->second.setEventName(name);
-    }
-    if (parent != "") {
-      auto type_id = event_iter->second.theEventTypeId();
-      auto iter = TraceContainersType::getEventTypeContainer().find(type_id);
-      vtAssertInfo(
-        iter != TraceContainersType::getEventTypeContainer().end(),
-        "Event type must exist",
-        name, parent, id, type_id
-      );
-      if (iter != TraceContainersType::getEventTypeContainer().end()) {
-        iter->second.setEventName(parent);
-      }
-    }
-  }
-#endif
+  trace::TraceRegistry::setTraceName(id, name, parent);
 }
 
 }} // end namespace vt::auto_registry

--- a/src/vt/registry/auto/auto_registry_impl.h
+++ b/src/vt/registry/auto/auto_registry_impl.h
@@ -130,7 +130,7 @@ void setHandlerTraceNameObjGroup(
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerObjGroup<ObjT,MsgT,f>(ctrl);
   auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegObjGroup);
-  setTraceName(trace_id, name, parent);
+  trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }
 
@@ -139,7 +139,7 @@ void setHandlerTraceName(std::string const& name, std::string const& parent) {
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandler<MsgT,f>(nullptr);
   auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegGeneral);
-  setTraceName(trace_id, name, parent);
+  trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }
 
@@ -148,14 +148,8 @@ void setHandlerTraceName(std::string const& name, std::string const& parent) {
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerParam<T,value>();
   auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegGeneral);
-  setTraceName(trace_id, name, parent);
+  trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
-}
-
-inline void setTraceName(
-  trace::TraceEntryIDType id, std::string const& name, std::string const& parent
-) {
-  trace::TraceRegistry::setTraceName(id, name, parent);
 }
 
 }} // end namespace vt::auto_registry

--- a/src/vt/registry/auto/auto_registry_impl.h
+++ b/src/vt/registry/auto/auto_registry_impl.h
@@ -129,7 +129,7 @@ void setHandlerTraceNameObjGroup(
 ) {
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerObjGroup<ObjT,MsgT,f>(ctrl);
-  auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegObjGroup);
+  auto const trace_id = handlerTraceID(handler, RegistryTypeEnum::RegObjGroup);
   trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }
@@ -138,7 +138,7 @@ template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 void setHandlerTraceName(std::string const& name, std::string const& parent) {
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandler<MsgT,f>(nullptr);
-  auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegGeneral);
+  auto const trace_id = handlerTraceID(handler, RegistryTypeEnum::RegGeneral);
   trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }
@@ -147,7 +147,7 @@ template <typename T, T value>
 void setHandlerTraceName(std::string const& name, std::string const& parent) {
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerParam<T,value>();
-  auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegGeneral);
+  auto const trace_id = handlerTraceID(handler, RegistryTypeEnum::RegGeneral);
   trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }

--- a/src/vt/registry/auto/auto_registry_interface.h
+++ b/src/vt/registry/auto/auto_registry_interface.h
@@ -65,7 +65,7 @@ AutoActiveType getAutoHandler(HandlerType const& handler);
 AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const& handler);
 
 #if backend_check_enabled(trace_enabled)
-  trace::TraceEntryIDType theTraceID(
+  trace::TraceEntryIDType handlerTraceID(
     HandlerType const& handler, RegistryTypeEnum reg_type
   );
 #endif

--- a/src/vt/registry/auto/collection/auto_registry_collection.impl.h
+++ b/src/vt/registry/auto/collection/auto_registry_collection.impl.h
@@ -89,7 +89,7 @@ void setHandlerTraceNameColl(std::string const& name, std::string const& parent)
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerCollection<ColT,MsgT,f>(nullptr);
   auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegVrtCollection);
-  setTraceName(trace_id, name, parent);
+  trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }
 
@@ -98,10 +98,9 @@ void setHandlerTraceNameCollMem(std::string const& name, std::string const& pare
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerCollectionMem<ColT,MsgT,f>(nullptr);
   auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegVrtCollectionMember);
-  setTraceName(trace_id, name, parent);
+  trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }
-
 
 }} /* end namespace vt::auto_registry */
 

--- a/src/vt/registry/auto/collection/auto_registry_collection.impl.h
+++ b/src/vt/registry/auto/collection/auto_registry_collection.impl.h
@@ -88,7 +88,7 @@ template <typename ColT, typename MsgT, ActiveColTypedFnType<MsgT, ColT>* f>
 void setHandlerTraceNameColl(std::string const& name, std::string const& parent) {
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerCollection<ColT,MsgT,f>(nullptr);
-  auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegVrtCollection);
+  auto const trace_id = handlerTraceID(handler, RegistryTypeEnum::RegVrtCollection);
   trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }
@@ -97,7 +97,7 @@ template <typename ColT, typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f
 void setHandlerTraceNameCollMem(std::string const& name, std::string const& parent) {
 #if backend_check_enabled(trace_enabled)
   auto const handler = makeAutoHandlerCollectionMem<ColT,MsgT,f>(nullptr);
-  auto const trace_id = theTraceID(handler, RegistryTypeEnum::RegVrtCollectionMember);
+  auto const trace_id = handlerTraceID(handler, RegistryTypeEnum::RegVrtCollectionMember);
   trace::TraceRegistry::setTraceName(trace_id, name, parent);
 #endif
 }

--- a/src/vt/runnable/collection.impl.h
+++ b/src/vt/runnable/collection.impl.h
@@ -66,7 +66,7 @@ template <typename MsgT, typename ElementT>
     auto reg_enum = member ?
       auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
       auto_registry::RegistryTypeEnum::RegVrtCollection;
-    trace::TraceEntryIDType trace_id = auto_registry::theTraceID(
+    trace::TraceEntryIDType trace_id = auto_registry::handlerTraceID(
       handler, reg_enum
     );
     trace::TraceEventIDType trace_event = theMsg()->getCurrentTraceEvent();

--- a/src/vt/runnable/general.impl.h
+++ b/src/vt/runnable/general.impl.h
@@ -75,7 +75,7 @@ template <typename MsgT>
   }
 
   #if backend_check_enabled(trace_enabled)
-    trace::TraceEntryIDType trace_id = auto_registry::theTraceID(
+    trace::TraceEntryIDType trace_id = auto_registry::handlerTraceID(
       handler, auto_registry::RegistryTypeEnum::RegGeneral
     );
     trace::TraceEventIDType trace_event = trace::no_trace_event;
@@ -132,7 +132,7 @@ template <typename MsgT>
   using HandlerManagerType = HandlerManager;
 
   #if backend_check_enabled(trace_enabled)
-    trace::TraceEntryIDType trace_id = auto_registry::theTraceID(
+    trace::TraceEntryIDType trace_id = auto_registry::handlerTraceID(
       handler, auto_registry::RegistryTypeEnum::RegObjGroup
     );
     trace::TraceEventIDType trace_event = trace::no_trace_event;

--- a/src/vt/runnable/vrt.impl.h
+++ b/src/vt/runnable/vrt.impl.h
@@ -61,7 +61,7 @@ template <typename MsgT, typename ElementT>
   HandlerType handler, MsgT* msg, ElementT* elm, NodeType from_node
 ) {
   #if backend_check_enabled(trace_enabled)
-    trace::TraceEntryIDType trace_id = auto_registry::theTraceID(
+    trace::TraceEntryIDType trace_id = auto_registry::handlerTraceID(
       handler, auto_registry::RegistryTypeEnum::RegVrt
     );
     trace::TraceEventIDType trace_event = envelopeGetTraceEvent(msg->env);

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -643,11 +643,8 @@ void Trace::writeLogFile(gzFile file, TraceContainerType const& traces) {
       std::underlying_type<decltype(log->type)>::type
     >(log->type);
 
-    auto* events = TraceContainersType::getEventContainer();
-    auto event_iter = events->find(log->ep);
-
-    auto const event_seq_id = log->ep == no_trace_entry_id ?
-      no_trace_entry_id : event_iter->second.theEventSeq();
+    TraceEntryIDType event_seq_id;
+    TraceRegistry::getEventSequence(log->ep, /*out*/ event_seq_id);
 
     auto const num_nodes = theContext()->getNumNodes();
 

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -445,18 +445,14 @@ void Trace::editLastEntry(std::function<void(LogPtrType)> fn) {
   }
 }
 
-bool hasTraceEntry(TraceEntryIDType ep) {
-  TraceEntryIDType seq;
-  return TraceRegistry::getEventSequence(ep, seq);
-}
-
 TraceEventIDType Trace::logEvent(LogPtrType log) {
   if (not enabled_ || not checkEnabled()) {
     return 0;
   }
 
   vtAssert(
-    log->ep == no_trace_entry_id or hasTraceEntry(log->ep),
+   log->ep == no_trace_entry_id
+   or TraceRegistry::getEvent(log->ep).theEventId() not_eq no_trace_entry_id,
     "Event must exist that was logged"
   );
 
@@ -640,7 +636,8 @@ void Trace::writeLogFile(gzFile file, TraceContainerType const& traces) {
   for (auto&& log : traces) {
 
     vtAssert(
-      log->ep == no_trace_entry_id or hasTraceEntry(log->ep),
+      log->ep == no_trace_entry_id
+      or TraceRegistry::getEvent(log->ep).theEventId() not_eq no_trace_entry_id,
       "Event must exist that was logged"
     );
 
@@ -650,8 +647,8 @@ void Trace::writeLogFile(gzFile file, TraceContainerType const& traces) {
       std::underlying_type<decltype(log->type)>::type
     >(log->type);
 
-    TraceEntryIDType event_seq_id;
-    TraceRegistry::getEventSequence(log->ep, /*out*/ event_seq_id);
+    // force guaranteed type (used in format specifiers)
+    size_t event_seq_id = TraceRegistry::getEvent(log->ep).theEventSeq();
 
     auto const num_nodes = theContext()->getNumNodes();
 

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -439,8 +439,8 @@ void Trace::editLastEntry(std::function<void(LogPtrType)> fn) {
 }
 
 bool hasTraceEntry(TraceEntryIDType ep) {
-  auto& events = TraceRegistry::TraceContainersType::getEventContainer();
-  return events.find(ep) != events.end();
+  TraceEntryIDType seq;
+  return TraceRegistry::getEventSequence(ep, seq);
 }
 
 TraceEventIDType Trace::logEvent(LogPtrType log) {
@@ -606,8 +606,8 @@ void Trace::writeTracesFile() {
     "write_traces_file: traces.size={}, "
     "event_type_container.size={}, event_container.size={}\n",
     traces_.size(),
-    TraceContainersType::event_type_container.size(),
-    TraceContainersType::event_container.size()
+    TraceContainersType::getEventTypeContainer()->size(),
+    TraceContainersType::getEventContainer()->size()
   );
 
   if (checkEnabled()) {
@@ -643,7 +643,8 @@ void Trace::writeLogFile(gzFile file, TraceContainerType const& traces) {
       std::underlying_type<decltype(log->type)>::type
     >(log->type);
 
-    auto event_iter = TraceContainersType::getEventContainer().find(log->ep);
+    auto* events = TraceContainersType::getEventContainer();
+    auto event_iter = events->find(log->ep);
 
     auto const event_seq_id = log->ep == no_trace_entry_id ?
       no_trace_entry_id : event_iter->second.theEventSeq();
@@ -799,9 +800,11 @@ void Trace::writeLogFile(gzFile file, TraceContainerType const& traces) {
 void Trace::outputControlFile(std::ofstream& file) {
   auto const num_nodes = theContext()->getNumNodes();
 
-  auto const num_event_types =
-    TraceContainersType::getEventTypeContainer().size();
-  auto const num_events = TraceContainersType::getEventContainer().size();
+  auto* event_types = TraceContainersType::getEventTypeContainer();
+  auto* events = TraceContainersType::getEventContainer();
+
+  auto const num_event_types = event_types->size();
+  auto const num_events = events->size();
   auto const num_user_events = user_event.getEvents().size();
 
   file << "PROJECTIONS_ID\n"
@@ -819,7 +822,7 @@ void Trace::outputControlFile(std::ofstream& file) {
   ContainerEventSortedType sorted_event;
   ContainerEventTypeSortedType sorted_event_type;
 
-  for (auto&& elem : TraceContainersType::getEventContainer()) {
+  for (auto&& elem : *TraceContainersType::getEventContainer()) {
     sorted_event.emplace(
       std::piecewise_construct,
       std::forward_as_tuple(&elem.second),
@@ -827,7 +830,7 @@ void Trace::outputControlFile(std::ofstream& file) {
     );
   }
 
-  for (auto&& elem : TraceContainersType::getEventTypeContainer()) {
+  for (auto&& elem : *TraceContainersType::getEventTypeContainer()) {
     sorted_event_type.emplace(
       std::piecewise_construct,
       std::forward_as_tuple(&elem.second),

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -462,18 +462,19 @@ TraceEventIDType Trace::logEvent(LogPtrType log) {
 
   auto grouped_begin = [&]() -> TraceEventIDType {
     if (not open_events_.empty()) {
+      LogType* top_event = open_events_.top();
       traces_.push_back(
         new LogType(
           log->time,
-          open_events_.top()->ep,
+          top_event->ep,
           TraceConstantsType::EndProcessing,
-          open_events_.top()->event,
-          open_events_.top()->msg_len,
-          open_events_.top()->node,
-          open_events_.top()->idx1,
-          open_events_.top()->idx2,
-          open_events_.top()->idx3,
-          open_events_.top()->idx4
+          top_event->event,
+          top_event->msg_len,
+          top_event->node,
+          top_event->idx1,
+          top_event->idx2,
+          top_event->idx3,
+          top_event->idx4
         )
       );
     }
@@ -505,18 +506,19 @@ TraceEventIDType Trace::logEvent(LogPtrType log) {
     traces_.push_back(log);
 
     if (not open_events_.empty()) {
+      LogType* top_event = open_events_.top();
       traces_.push_back(
         new LogType(
           log->time,
-          open_events_.top()->ep,
+          top_event->ep,
           TraceConstantsType::BeginProcessing,
-          open_events_.top()->event,
-          open_events_.top()->msg_len,
-          open_events_.top()->node,
-          open_events_.top()->idx1,
-          open_events_.top()->idx2,
-          open_events_.top()->idx3,
-          open_events_.top()->idx4
+          top_event->event,
+          top_event->msg_len,
+          top_event->node,
+          top_event->idx1,
+          top_event->idx2,
+          top_event->idx3,
+          top_event->idx4
         )
       );
     }
@@ -583,20 +585,10 @@ TraceEventIDType Trace::logEvent(LogPtrType log) {
 }
 
 bool Trace::checkEnabled() {
-  if (ArgType::vt_trace) {
-    auto const node = theContext()->getNode();
-    if (ArgType::vt_trace_mod == 0) {
-      return true;
-    } else if (node % ArgType::vt_trace_mod == 1) {
-      return true;
-    } else {
-      return false;
-    }
-  } else {
-    return false;
-  }
+  return ArgType::vt_trace
+    and (ArgType::vt_trace_mod == 0
+         or theContext()->getNode() % ArgType::vt_trace_mod == 1);
 }
-
 
 void Trace::enableTracing() {
   enabled_ = true;

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -54,8 +54,16 @@
 #include <inttypes.h>
 #include <iostream>
 #include <fstream>
+#include <map>
 
 namespace vt { namespace trace {
+
+template <typename EventT>
+struct TraceEventSeqCompare {
+  bool operator()(EventT* const a, EventT* const b) const {
+    return a->theEventSeq() < b->theEventSeq();
+  }
+};
 
 Trace::Trace(std::string const& in_prog_name, std::string const& in_trace_name)
   : prog_name_(in_prog_name), trace_name_(in_trace_name),
@@ -103,8 +111,7 @@ void Trace::setupNames(
 
   if (ArgType::vt_trace_dir != "") {
     full_dir_name = ArgType::vt_trace_dir;
-  }
-  else {
+  } else {
     full_dir_name = std::string(cur_dir) + "/" + dir_name;
   }
 
@@ -113,9 +120,9 @@ void Trace::setupNames(
 
   if (theContext()->getNode() == 0) {
     int flag = mkdir(full_dir_name.c_str(), S_IRWXU);
-	if ((flag < 0) && (errno != EEXIST)) {
+    if ((flag < 0) && (errno != EEXIST)) {
       vtAssert(flag >= 0, "Must be able to make directory");
-	}
+    }
   }
 
   auto const tc = util::demangle::DemanglerUtils::splitString(trace_name_, '/');
@@ -795,6 +802,15 @@ void Trace::writeLogFile(gzFile file, TraceContainerType const& traces) {
 }
 
 void Trace::outputControlFile(std::ofstream& file) {
+
+  using ContainerEventSortedType = std::map<
+    TraceContainerEventType::mapped_type*, bool, TraceEventSeqCompare<TraceEventType>
+  >;
+
+  using ContainerEventTypeSortedType = std::map<
+    TraceContainerEventClassType::mapped_type*, bool, TraceEventSeqCompare<EventClassType>
+  >;
+
   auto const num_nodes = theContext()->getNumNodes();
 
   auto* event_types = TraceContainersType::getEventTypeContainer();

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -49,10 +49,10 @@
 #include "vt/context/context.h"
 #include "vt/configs/arguments/args.h"
 #include "vt/trace/trace_common.h"
+#include "vt/trace/trace_containers.h"
 #include "vt/trace/trace_registry.h"
 #include "vt/trace/trace_constants.h"
 #include "vt/trace/trace_event.h"
-#include "vt/trace/trace_containers.h"
 #include "vt/trace/trace_log.h"
 #include "vt/trace/trace_user_event.h"
 
@@ -74,7 +74,7 @@ namespace vt { namespace trace {
 struct Trace {
   using LogType             = Log;
   using TraceConstantsType  = eTraceConstants;
-  using TraceContainersType = TraceContainers<void>;
+  using TraceContainersType = TraceContainers;
   using TimeIntegerType     = int64_t;
   using LogPtrType          = LogType*;
   using TraceContainerType  = std::vector<LogPtrType>;

--- a/src/vt/trace/trace_common.h
+++ b/src/vt/trace/trace_common.h
@@ -45,28 +45,31 @@
 #if !defined INCLUDED_TRACE_TRACE_COMMON_H
 #define INCLUDED_TRACE_TRACE_COMMON_H
 
-#include "vt/config.h"
+#include "vt/configs/types/types_type.h"
 
 #include <cstdint>
-#include <functional>
-#include <string>
 
 namespace vt { namespace trace {
 
-static constexpr uint32_t const trace_flush_size = 100000;
+// trace events
+using TraceEntryIDType    = size_t; // uint32_t, maybe..
+using TraceEntrySeqType   = uint32_t;
 
-using TraceEntryIDType = std::hash<std::string>::result_type;
-using TraceEventIDType = uint32_t;
-using TraceMsgLenType = size_t;
+static constexpr TraceEntryIDType const no_trace_entry_id = 0;
+static constexpr TraceEntrySeqType const no_trace_entry_seq = -1;
+
+// user traces
+using TraceEventIDType    = uint32_t;
+using TraceMsgLenType     = size_t;
 using UserSpecEventIDType = int32_t;
 using UserEventIDType     = int64_t;
 
-static constexpr TraceEntryIDType const no_trace_entry_id = u64empty;
 static constexpr TraceEventIDType const no_trace_event = 0;
+static constexpr BitCountType const trace_event_num_bits = 32;
+
 static constexpr NodeType const designated_root_node = 0;
 static constexpr int64_t const trace_reserve_count = 1048576;
-
-static constexpr BitCountType const trace_event_num_bits = 32;
+static constexpr uint32_t const trace_flush_size = 100000;
 
 }} //end namespace vt::trace
 

--- a/src/vt/trace/trace_containers.cc
+++ b/src/vt/trace/trace_containers.cc
@@ -1,54 +1,12 @@
-/*
-//@HEADER
-// *****************************************************************************
-//
-//                              trace_containers.h
-//                           DARMA Toolkit v. 1.0.0
-//                       DARMA/vt => Virtual Transport
-//
-// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
-// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-// Government retains certain rights in this software.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// * Redistributions of source code must retain the above copyright notice,
-//   this list of conditions and the following disclaimer.
-//
-// * Redistributions in binary form must reproduce the above copyright notice,
-//   this list of conditions and the following disclaimer in the documentation
-//   and/or other materials provided with the distribution.
-//
-// * Neither the name of the copyright holder nor the names of its
-//   contributors may be used to endorse or promote products derived from this
-//   software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact darma@sandia.gov
-//
-// *****************************************************************************
-//@HEADER
-*/
-
-#include "vt/config.h"
 #include "vt/trace/trace_common.h"
 #include "vt/trace/trace_containers.h"
 
 namespace vt { namespace trace {
 
-/*static*/ TraceContainerEventClassType* TraceContainers::event_type_container_ = nullptr;
-/*static*/ TraceContainerEventType* TraceContainers::event_container_ = nullptr;
+/*static*/ TraceContainerEventClassType*
+TraceContainers::event_type_container_{nullptr};
+
+/*static*/ TraceContainerEventType*
+TraceContainers::event_container_{nullptr};
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_containers.cc
+++ b/src/vt/trace/trace_containers.cc
@@ -4,9 +4,9 @@
 namespace vt { namespace trace {
 
 /*static*/ TraceContainerEventClassType*
-TraceContainers::event_type_container_{nullptr};
+TraceContainers::event_type_container_;
 
 /*static*/ TraceContainerEventType*
-TraceContainers::event_container_{nullptr};
+TraceContainers::event_container_;
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_containers.cc
+++ b/src/vt/trace/trace_containers.cc
@@ -1,12 +1,32 @@
 #include "vt/trace/trace_common.h"
 #include "vt/trace/trace_containers.h"
 
+#include <memory>
+
 namespace vt { namespace trace {
 
+// These MUST have static-lifetime and be initialized during constant
+// initialization as they are modified during dynamic initialization as
+// that is when auto-handler events are registered.
+// Using a constexpr constructor / initializer list is also relevant.
+// - https://en.cppreference.com/w/cpp/language/constant_initialization
+static std::unique_ptr<TraceContainerEventClassType> event_type_container_{};
+static std::unique_ptr<TraceContainerEventType> event_container_{};
+
 /*static*/ TraceContainerEventClassType*
-TraceContainers::event_type_container_;
+TraceContainers::getEventTypeContainer(){
+  if (event_type_container_ == nullptr) {
+    event_type_container_ = std::make_unique<TraceContainerEventClassType>();
+  }
+  return event_type_container_.get();
+}
 
 /*static*/ TraceContainerEventType*
-TraceContainers::event_container_;
+TraceContainers::getEventContainer(){
+  if (event_container_ == nullptr) {
+    event_container_ = std::make_unique<TraceContainerEventType>();
+  }
+  return event_container_.get();
+}
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_containers.cc
+++ b/src/vt/trace/trace_containers.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                               trace_registry.h
+//                              trace_containers.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,30 +42,13 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_TRACE_TRACE_REGISTRY_H
-#define INCLUDED_TRACE_TRACE_REGISTRY_H
-
+#include "vt/config.h"
 #include "vt/trace/trace_common.h"
 #include "vt/trace/trace_containers.h"
 
 namespace vt { namespace trace {
 
-struct TraceRegistry {
-  using TraceContainersType = TraceContainers;
-
-  static TraceEntryIDType registerEventHashed(
-    std::string const& event_type_name, std::string const& event_name
-  );
-
-  static void setTraceName(
-    TraceEntryIDType id, std::string const& name, std::string const& parent
-  );
-
-  /// Returns true assigns seq if the for the corresponding ID.
-  /// Returns false if the event does not exist.
-  static bool getEventSequence(TraceEntryIDType id, TraceEntryIDType& seq);
-};
+/*static*/ TraceContainerEventClassType* TraceContainers::event_type_container_ = nullptr;
+/*static*/ TraceContainerEventType* TraceContainers::event_container_ = nullptr;
 
 }} //end namespace vt::trace
-
-#endif /*INCLUDED_TRACE_TRACE_REGISTRY_H*/

--- a/src/vt/trace/trace_containers.h
+++ b/src/vt/trace/trace_containers.h
@@ -50,25 +50,14 @@
 #include "vt/trace/trace_event.h"
 
 #include <cstdint>
-#include <string>
-#include <functional>
 #include <unordered_map>
-#include <map>
 
 namespace vt { namespace trace {
 
-template <typename T, typename U>
-using EventLookupType = std::unordered_map<T, U>;
-
-template <typename T, typename U, typename Comp>
-using EventSortedType = std::map<T, U, Comp>;
-
 using TraceEventType = Event;
 using EventClassType = EventClass;
-using TraceContainerEventType = EventLookupType<TraceEntryIDType, TraceEventType>;
-using TraceContainerEventClassType = EventLookupType<TraceEntryIDType, EventClassType>;
-
-struct Trace;
+using TraceContainerEventType = std::unordered_map<TraceEntryIDType, TraceEventType>;
+using TraceContainerEventClassType = std::unordered_map<TraceEntryIDType, EventClassType>;
 
 // Container types are created-as-needed, which occurs during
 // intialization to avoid intiailization ordering issues.
@@ -86,30 +75,10 @@ class TraceContainers {
     return event_container_;
   }
 
-  friend struct Trace;
-
  private:
   static TraceContainerEventClassType* event_type_container_;
   static TraceContainerEventType* event_container_;
 };
-
-template <typename EventT>
-struct TraceEventSeqCompare {
-  bool operator()(EventT* const a, EventT* const b) const {
-    return a->theEventSeq() < b->theEventSeq();
-  }
-};
-
-template <typename T>
-using EventCompareType = TraceEventSeqCompare<T>;
-
-using ContainerEventSortedType = EventSortedType<
-  TraceContainerEventType::mapped_type*, bool, EventCompareType<TraceEventType>
->;
-
-using ContainerEventTypeSortedType = EventSortedType<
-  TraceContainerEventClassType::mapped_type*, bool, EventCompareType<EventClassType>
->;
 
 }} //end namespace vt::trace
 

--- a/src/vt/trace/trace_containers.h
+++ b/src/vt/trace/trace_containers.h
@@ -70,31 +70,28 @@ using TraceContainerEventClassType = EventLookupType<TraceEntryIDType, EventClas
 
 struct Trace;
 
-// Use static template initialization pattern to deal with ordering issues with
-// auto-registry
-template <typename = void>
+// Container types are created-as-needed, which occurs during
+// intialization to avoid intiailization ordering issues.
 class TraceContainers {
  public:
-  static TraceContainerEventClassType& getEventTypeContainer(){
-    return event_type_container;
+  static TraceContainerEventClassType* getEventTypeContainer(){
+    if (not event_type_container_)
+      event_type_container_ = new TraceContainerEventClassType();
+    return event_type_container_;
   }
 
-  static TraceContainerEventType& getEventContainer(){
-    return event_container;
+  static TraceContainerEventType* getEventContainer(){
+    if (not event_container_)
+      event_container_ = new TraceContainerEventType();
+    return event_container_;
   }
 
   friend struct Trace;
 
  private:
-  static TraceContainerEventClassType event_type_container;
-  static TraceContainerEventType event_container;
+  static TraceContainerEventClassType* event_type_container_;
+  static TraceContainerEventType* event_container_;
 };
-
-template <typename T>
-TraceContainerEventClassType TraceContainers<T>::event_type_container = {};
-
-template <typename T>
-TraceContainerEventType TraceContainers<T>::event_container = {};
 
 template <typename EventT>
 struct TraceEventSeqCompare {

--- a/src/vt/trace/trace_containers.h
+++ b/src/vt/trace/trace_containers.h
@@ -49,7 +49,6 @@
 #include "vt/trace/trace_common.h"
 #include "vt/trace/trace_event.h"
 
-#include <cstdint>
 #include <unordered_map>
 
 namespace vt { namespace trace {
@@ -59,25 +58,14 @@ using EventClassType = EventClass;
 using TraceContainerEventType = std::unordered_map<TraceEntryIDType, TraceEventType>;
 using TraceContainerEventClassType = std::unordered_map<TraceEntryIDType, EventClassType>;
 
-// Container types are created-as-needed, which occurs during
-// intialization to avoid intiailization ordering issues.
 class TraceContainers {
  public:
-  static TraceContainerEventClassType* getEventTypeContainer(){
-    if (not event_type_container_)
-      event_type_container_ = new TraceContainerEventClassType();
-    return event_type_container_;
-  }
-
-  static TraceContainerEventType* getEventContainer(){
-    if (not event_container_)
-      event_container_ = new TraceContainerEventType();
-    return event_container_;
-  }
-
- private:
-  static TraceContainerEventClassType* event_type_container_;
-  static TraceContainerEventType* event_container_;
+  /// Returns container of all registered event types (aka parents).
+  /// The returned pointer is only valid for the current scope.
+  static TraceContainerEventClassType* getEventTypeContainer();
+  /// Returns container of all registered event.
+  /// The returned pointer is only valid for the current scope.
+  static TraceContainerEventType* getEventContainer();
 };
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_event.cc
+++ b/src/vt/trace/trace_event.cc
@@ -55,7 +55,7 @@ EventClass::EventClass(
 ) : event(in_event), hash_event(in_hash_event)
 {
   auto const& event_hash =  std::hash<std::string>{}(in_hash_event);
-  this_event_ = event_hash;
+  this_event_ = event_hash == 0 ? 1 : event_hash;
 }
 
 TraceEntryIDType EventClass::theEventId() const {

--- a/src/vt/trace/trace_event.cc
+++ b/src/vt/trace/trace_event.cc
@@ -42,61 +42,51 @@
 //@HEADER
 */
 
-
 #include "vt/trace/trace_event.h"
-#include "vt/utils/bits/bits_common.h"
 
 #include <string>
 
 namespace vt { namespace trace {
 
 EventClass::EventClass(
-  std::string const& in_event, std::string const& in_hash_event
-) : event(in_event), hash_event(in_hash_event)
-{
-  auto const& event_hash =  std::hash<std::string>{}(in_hash_event);
-  this_event_ = event_hash == 0 ? 1 : event_hash;
-}
+  TraceEntryIDType id,
+  TraceEntrySeqType seq,
+  std::string const& in_event
+) : this_event_(id), this_event_seq_(seq), event_(in_event)
+{}
 
 TraceEntryIDType EventClass::theEventId() const {
   return this_event_;
 }
 
-TraceEntryIDType EventClass::theEventSeqId() const {
+TraceEntrySeqType EventClass::theEventSeq() const {
   return this_event_seq_;
 }
 
 std::string EventClass::theEventName() const {
-  return event;
+  return event_;
 }
 
 void EventClass::setEventName(std::string const& in_str) {
-  event = in_str;
-}
-
-void EventClass::setEventSeq(TraceEntryIDType const& seq) {
-  this_event_seq_ = seq;
-}
-
-TraceEntryIDType EventClass::theEventSeq() const {
-  return this_event_seq_;
+  event_ = in_str;
 }
 
 Event::Event(
-  std::string const& in_event, std::string const& in_hash_event,
-  TraceEntryIDType const& in_event_type
-) : EventClass(in_event, in_hash_event), this_event_type_(in_event_type)
+  TraceEntryIDType id,
+  TraceEntrySeqType seq,
+  std::string const& in_event,
+  TraceEntryIDType in_event_type,
+  TraceEntrySeqType in_event_type_seq
+) : EventClass(id, seq, in_event),
+    this_event_type_(in_event_type),
+    this_event_type_seq_(in_event_type_seq)
 { }
 
 TraceEntryIDType Event::theEventTypeId() const {
   return this_event_type_;
 }
 
-void Event::setEventTypeSeq(TraceEntryIDType const& seq) {
-  this_event_type_seq_ = seq;
-}
-
-TraceEntryIDType Event::theEventTypeSeq() const {
+TraceEntrySeqType Event::theEventTypeSeq() const {
   return this_event_type_seq_;
 }
 

--- a/src/vt/trace/trace_event.h
+++ b/src/vt/trace/trace_event.h
@@ -45,50 +45,51 @@
 #if !defined INCLUDED_TRACE_TRACE_EVENT_H
 #define INCLUDED_TRACE_TRACE_EVENT_H
 
-#include "vt/config.h"
 #include "vt/trace/trace_common.h"
 
-#include <cstdint>
-#include <unordered_map>
 #include <string>
-#include <functional>
 
 namespace vt { namespace trace {
 
 struct EventClass {
-  EventClass(std::string const& in_event, std::string const& in_hash_event);
+  EventClass(
+    TraceEntryIDType id,
+    TraceEntrySeqType seq,
+    std::string const& in_event
+  );
   EventClass(EventClass const&) = default;
+  EventClass(EventClass&&) = default;
 
   TraceEntryIDType theEventId() const;
-  TraceEntryIDType theEventSeqId() const;
+  TraceEntrySeqType theEventSeq() const;
 
   std::string theEventName() const;
   void setEventName(std::string const& in_str);
-  void setEventSeq(TraceEntryIDType const& seq);
-  TraceEntryIDType theEventSeq() const;
 
 private:
   TraceEntryIDType this_event_ = no_trace_entry_id;
-  TraceEntryIDType this_event_seq_ = no_trace_entry_id;
+  TraceEntrySeqType this_event_seq_ = no_trace_entry_seq;
 
-  std::string event;
-  std::string hash_event;
+  std::string event_;
 };
 
 struct Event : EventClass {
   Event(
-    std::string const& in_event, std::string const& in_hash_event,
-    TraceEntryIDType const& in_event_type
+    TraceEntryIDType id,
+    TraceEntrySeqType seq,
+    std::string const& in_event,
+    TraceEntryIDType in_event_type,
+    TraceEntrySeqType in_event_seq
   );
   Event(Event const&) = default;
+  Event(Event&&) = default;
 
   TraceEntryIDType theEventTypeId() const;
-  void setEventTypeSeq(TraceEntryIDType const& seq);
-  TraceEntryIDType theEventTypeSeq() const;
+  TraceEntrySeqType theEventTypeSeq() const;
 
 private:
   TraceEntryIDType this_event_type_ = no_trace_entry_id;
-  TraceEntryIDType this_event_type_seq_ = no_trace_entry_id;
+  TraceEntrySeqType this_event_type_seq_ = no_trace_entry_seq;
 };
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_log.h
+++ b/src/vt/trace/trace_log.h
@@ -61,15 +61,17 @@ struct Log {
   using UserDataType       = int32_t;
 
   double time = 0.0;
+  double end_time = 0.0;
+
   TraceEntryIDType ep = no_trace_entry_id;
   TraceConstantsType type = TraceConstantsType::InvalidTraceType;
   TraceEventIDType event = no_trace_event;
   TraceMsgLenType msg_len = 0;
   NodeType node = uninitialized_destination;
   uint64_t idx1 = 0, idx2 = 0, idx3 = 0, idx4 = 0;
+
   std::string user_supplied_note = "";
   UserDataType user_supplied_data = 0;
-  double end_time = 0.0;
   UserEventIDType user_event = 0;
   bool user_start = false;
 
@@ -85,8 +87,8 @@ struct Log {
     double const in_begin_time, double const in_end_time,
     TraceConstantsType const in_type, std::string const& in_note,
     TraceEventIDType const in_event
-  ) : time(in_begin_time), type(in_type), event(in_event),
-      user_supplied_note(in_note), end_time(in_end_time)
+  ) : time(in_begin_time), end_time(in_end_time),
+      type(in_type), event(in_event), user_supplied_note(in_note)
   { }
 
   Log(

--- a/src/vt/trace/trace_registry.cc
+++ b/src/vt/trace/trace_registry.cc
@@ -1,0 +1,75 @@
+#include "vt/config.h"
+#include "vt/context/context.h"
+
+#include "vt/trace/trace_common.h"
+#include "vt/trace/trace_event.h"
+#include "vt/trace/trace_containers.h"
+#include "vt/trace/trace_registry.h"
+
+namespace vt { namespace trace {
+
+/*static*/ TraceEntryIDType
+TraceRegistry::registerEventHashed(
+    std::string const& event_type_name, std::string const& event_name
+  ) {
+  #if backend_check_enabled(trace_enabled) && backend_check_enabled(trace)
+  debug_print(
+    trace, node,
+    "register_event_hashed: event_type_name={}, event_name={}, "
+    "event_type_container.size={}\n",
+    event_type_name.c_str(), event_name.c_str(),
+    TraceContainersType::getEventTypeContainer().size()
+  );
+  #endif
+
+  TraceEntryIDType event_type_seq = no_trace_entry_id;
+  EventClassType new_event_type(event_type_name, event_type_name);
+
+  auto type_iter = TraceContainersType::getEventTypeContainer().find(
+    new_event_type.theEventId()
+  );
+
+  if (type_iter == TraceContainersType::getEventTypeContainer().end()) {
+    event_type_seq = TraceContainersType::getEventTypeContainer().size();
+    new_event_type.setEventSeq(event_type_seq);
+
+    TraceContainersType::getEventTypeContainer().emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(new_event_type.theEventId()),
+      std::forward_as_tuple(new_event_type)
+    );
+  } else {
+    event_type_seq = type_iter->second.theEventSeq();
+  }
+
+  TraceEntryIDType event_seq = no_trace_entry_id;
+  TraceEventType new_event(
+    event_name,
+    event_type_name + std::string("::") + event_name,
+    new_event_type.theEventId()
+  );
+
+  new_event.setEventTypeSeq(event_type_seq);
+
+  auto event_iter = TraceContainersType::getEventTypeContainer().find(
+    new_event.theEventId()
+  );
+
+  if (event_iter == TraceContainersType::getEventTypeContainer().end()) {
+    event_seq = TraceContainersType::getEventContainer().size();
+    new_event.setEventSeq(event_seq);
+
+    TraceContainersType::getEventContainer().emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(new_event.theEventId()),
+      std::forward_as_tuple(new_event)
+    );
+  } else {
+    event_seq = event_iter->second.theEventSeq();
+  }
+
+  return new_event.theEventId();
+}
+
+}} //end namespace vt::trace
+

--- a/src/vt/trace/trace_registry.cc
+++ b/src/vt/trace/trace_registry.cc
@@ -11,10 +11,9 @@ namespace vt { namespace trace {
 /*static*/ TraceEntryIDType
 TraceRegistry::registerEventHashed(
     std::string const& event_type_name, std::string const& event_name
-  ) {
-
-  auto* event_types = TraceContainersType::getEventTypeContainer();
-  auto* events = TraceContainersType::getEventContainer();
+) {
+  auto* event_types = TraceContainers::getEventTypeContainer();
+  auto* events = TraceContainers::getEventContainer();
 
   // Trace registration (mostly) happens during initialization
   // of templates from the auto-registy.
@@ -80,34 +79,43 @@ TraceRegistry::registerEventHashed(
 
 /*static*/ void
 TraceRegistry::setTraceName(
-  TraceEntryIDType id, std::string const& name, std::string const& parent) {
+  TraceEntryIDType id, std::string const& name, std::string const& type_name
+) {
 #if backend_check_enabled(trace_enabled)
   auto* events = TraceContainers::getEventContainer();
   auto event_iter = events->find(id);
-  vtAssertExpr(event_iter != events->end());
+  // TODO, increase guard here perhaps:
+  // vtAssertInfo(
+  //   iter != event_types->end(),
+  //   "Event must exist",
+  //   name, parent, id, type_id
+  // );
+
   if (event_iter != events->end()) {
+    auto type_id = event_iter->second.theEventTypeId();
     if (name != "") {
       event_iter->second.setEventName(name);
     }
-    if (parent != "") {
-      auto type_id = event_iter->second.theEventTypeId();
+
+    if (type_name != "") {
       auto* event_types = TraceContainers::getEventTypeContainer();
       auto iter = event_types->find(type_id);
       vtAssertInfo(
         iter != event_types->end(),
         "Event type must exist",
-        name, parent, id, type_id
+        name, type_name, id, type_id
       );
       if (iter != event_types->end()) {
-        iter->second.setEventName(parent);
+        iter->second.setEventName(type_name);
       }
     }
   }
 #endif
 }
 
-/*static*/ bool TraceRegistry::getEventSequence(TraceEntryIDType id, TraceEntryIDType &seq) {
-  auto* events = TraceContainersType::getEventContainer();
+/*static*/ bool
+TraceRegistry::getEventSequence(TraceEntryIDType id, TraceEntryIDType &seq) {
+  auto* events = TraceContainers::getEventContainer();
   auto iter = events->find(id);
   if (iter != events->end()) {
     seq = iter->second.theEventSeqId();

--- a/src/vt/trace/trace_registry.h
+++ b/src/vt/trace/trace_registry.h
@@ -66,9 +66,9 @@ struct TraceRegistry {
     TraceEntryIDType id, std::string const& name, std::string const& type_name
   );
 
-  /// Returns true assigns seq if the for the corresponding ID.
-  /// Returns false if the event does not exist.
-  static bool getEventSequence(TraceEntryIDType id, TraceEntryIDType& seq);
+  /// Returns the event that corresponds with tie ID.
+  /// If not found the returned event has no_trace_entry_id for an ID.
+  static EventClassType getEvent(TraceEntryIDType id);
 };
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_registry.h
+++ b/src/vt/trace/trace_registry.h
@@ -45,11 +45,7 @@
 #if !defined INCLUDED_TRACE_TRACE_REGISTRY_H
 #define INCLUDED_TRACE_TRACE_REGISTRY_H
 
-#include "vt/config.h"
-#include "vt/context/context.h"
-
 #include "vt/trace/trace_common.h"
-#include "vt/trace/trace_event.h"
 #include "vt/trace/trace_containers.h"
 
 namespace vt { namespace trace {
@@ -59,66 +55,7 @@ struct TraceRegistry {
 
   static TraceEntryIDType registerEventHashed(
     std::string const& event_type_name, std::string const& event_name
-  ) {
-    #if backend_check_enabled(trace_enabled) && backend_check_enabled(trace)
-    debug_print(
-      trace, node,
-      "register_event_hashed: event_type_name={}, event_name={}, "
-      "event_type_container.size={}\n",
-      event_type_name.c_str(), event_name.c_str(),
-      TraceContainersType::getEventTypeContainer().size()
-    );
-    #endif
-
-    TraceEntryIDType event_type_seq = no_trace_entry_id;
-    EventClassType new_event_type(event_type_name, event_type_name);
-
-    auto type_iter = TraceContainersType::getEventTypeContainer().find(
-      new_event_type.theEventId()
-    );
-
-    if (type_iter == TraceContainersType::getEventTypeContainer().end()) {
-      event_type_seq = TraceContainersType::getEventTypeContainer().size();
-      new_event_type.setEventSeq(event_type_seq);
-
-      TraceContainersType::getEventTypeContainer().emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(new_event_type.theEventId()),
-        std::forward_as_tuple(new_event_type)
-      );
-    } else {
-      event_type_seq = type_iter->second.theEventSeq();
-    }
-
-    TraceEntryIDType event_seq = no_trace_entry_id;
-    TraceEventType new_event(
-      event_name,
-      event_type_name + std::string("::") + event_name,
-      new_event_type.theEventId()
-    );
-
-    new_event.setEventTypeSeq(event_type_seq);
-
-    auto event_iter = TraceContainersType::getEventTypeContainer().find(
-      new_event.theEventId()
-    );
-
-    if (event_iter == TraceContainersType::getEventTypeContainer().end()) {
-      event_seq = TraceContainersType::getEventContainer().size();
-      new_event.setEventSeq(event_seq);
-
-      TraceContainersType::getEventContainer().emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(new_event.theEventId()),
-        std::forward_as_tuple(new_event)
-      );
-    } else {
-      event_seq = event_iter->second.theEventSeq();
-    }
-
-    return new_event.theEventId();
-  }
-
+  );
 };
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_registry.h
+++ b/src/vt/trace/trace_registry.h
@@ -51,14 +51,19 @@
 namespace vt { namespace trace {
 
 struct TraceRegistry {
-  using TraceContainersType = TraceContainers;
-
+  /// Registers an event, if it does not already exist.
+  /// Creates the event type (aka parent) as needed.
+  /// Returns a non-0 value.
   static TraceEntryIDType registerEventHashed(
     std::string const& event_type_name, std::string const& event_name
   );
 
+  /// Changes the name of an event and/or event type name.
+  /// Empty string values are ignored, which can be used for partial updates.
+  /// Changing the type name will affect ALL events that share the type.
+  /// Event trace IDs are not affected.
   static void setTraceName(
-    TraceEntryIDType id, std::string const& name, std::string const& parent
+    TraceEntryIDType id, std::string const& name, std::string const& type_name
   );
 
   /// Returns true assigns seq if the for the corresponding ID.


### PR DESCRIPTION
"Works better". Pre-work to make #554 easier, as in 'not going to run into these issues'.

This will be part of #554 and as it contains trace-related bugs still.

- fixed (apparent?) initialization ordering issue where events add during initialization could not be found later in certain cases (differed by example project).
- fixed cross-access of iterators
- a bunch of updates for consistency, responsibility hiding, etc.

Fixes #575