### PR TITLE
#587 Fix warning with GNU compilers

### DIFF
--- a/src/vt/group/collective/group_info_collective.cc
+++ b/src/vt/group/collective/group_info_collective.cc
@@ -375,7 +375,7 @@ void InfoColl::upTree() {
     );
 
     auto msg = makeSharedMessage<GroupCollectiveMsg>(
-      group,op,is_in_group,subtree_,child,0,extra
+      group,op,is_in_group,static_cast<NodeType>(subtree_),child,0,extra
     );
     theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg);
     /*


### PR DESCRIPTION
Fixes #587 

Quick change for beta.4 to fix a new warning that popped up based on the last group refactor in beta.4