### PR TITLE
595 support gtest 110

### DIFF
--- a/examples/collection_insert.cc
+++ b/examples/collection_insert.cc
@@ -105,7 +105,7 @@ int main(int argc, char** argv) {
       for (int i = range.x()/2; i < range.x(); i++) {
         proxy[i].insert(i % 2);
       }
-      proxy.finishedInserting([proxy]{
+      proxy.finishedInserting([]{
         ::fmt::print("insertions are finished2\n");
       });
     });

--- a/examples/jacobi2d_vt.cc
+++ b/examples/jacobi2d_vt.cc
@@ -94,7 +94,6 @@ private:
   size_t numObjsX_ = 1, numObjsY_ = 1;
   size_t numRowsPerObject_ = default_nrow_object;
   size_t maxIter_ = 5;
-  double normRes_ = 0.0;
 
 public:
 
@@ -106,9 +105,8 @@ public:
       msgReceived_(0), totalReceive_(0),
       numObjsX_(1), numObjsY_(1),
       numRowsPerObject_(default_nrow_object),
-      maxIter_(5), normRes_(0.0)
+      maxIter_(5)
   { }
-
 
   struct BlankMsg : vt::CollectionMessage<LinearPb2DJacobi> { };
 

--- a/examples/reduce.cc
+++ b/examples/reduce.cc
@@ -96,14 +96,12 @@ private:
 
   size_t numObjs_ = default_num_objs;
   size_t numPartsPerObject_ = default_nparts_object;
-  double quadValue = 0.0;
 
 public:
 
   explicit Integration1D()
     : vt::Collection<Integration1D, Index1D>(),
-      numObjs_(default_num_objs), numPartsPerObject_(default_nparts_object),
-      quadValue(0.0)
+      numObjs_(default_num_objs), numPartsPerObject_(default_nparts_object)
   { }
 
   //

--- a/examples/simple_collection_reduce.cc
+++ b/examples/simple_collection_reduce.cc
@@ -79,9 +79,6 @@ struct TestColl : Collection<TestColl,Index1D> {
     rmsg->getVal() = 10;
     proxy.reduce<collective::PlusOp<int>>(rmsg.get(),cb);
   }
-
-private:
-  int32_t counter_ = 0;
 };
 
 int main(int argc, char** argv) {

--- a/tests/unit/active/test_active_bcast_put.cc
+++ b/tests/unit/active/test_active_bcast_put.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
@@ -142,9 +142,9 @@ TEST_P(TestActiveBroadcastPut, test_type_safe_active_fn_bcast2) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestActiveBroadcastPut,
-  ::testing::Range(static_cast<NodeType>(0), static_cast<NodeType>(16), 1),
+  ::testing::Range(static_cast<NodeType>(0), static_cast<NodeType>(16), 1)
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/active/test_active_broadcast.cc
+++ b/tests/unit/active/test_active_broadcast.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
@@ -110,9 +110,9 @@ TEST_P(TestActiveBroadcast, test_type_safe_active_fn_bcast2) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestActiveBroadcast,
-  ::testing::Range(static_cast<NodeType>(0), static_cast<NodeType>(16), 1),
+  ::testing::Range(static_cast<NodeType>(0), static_cast<NodeType>(16), 1)
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/active/test_active_send_put.cc
+++ b/tests/unit/active/test_active_send_put.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
@@ -121,9 +121,9 @@ TEST_P(TestActiveSendPut, test_active_fn_send_put_param) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestActiveSendPut,
-  ::testing::Range(static_cast<NodeType>(2), static_cast<NodeType>(512), 4),
+  ::testing::Range(static_cast<NodeType>(2), static_cast<NodeType>(512), 4)
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/atomic/test_atomic.cc
+++ b/tests/unit/atomic/test_atomic.cc
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <memory>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/collection/test_broadcast.cc
+++ b/tests/unit/collection/test_broadcast.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"
@@ -108,7 +108,7 @@ struct BroadcastHandlers {
 template <typename CollectionT>
 struct TestBroadcast : TestParallelHarness {};
 
-TYPED_TEST_CASE_P(TestBroadcast);
+TYPED_TEST_SUITE_P(TestBroadcast);
 
 TYPED_TEST_P(TestBroadcast, test_broadcast_1) {
   using ColType = TypeParam;
@@ -134,7 +134,7 @@ TYPED_TEST_P(TestBroadcast, test_broadcast_1) {
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P(TestBroadcast, test_broadcast_1);
+REGISTER_TYPED_TEST_SUITE_P(TestBroadcast, test_broadcast_1);
 
 using CollectionTestTypes = testing::Types<
   bcast_col_            ::TestCol<int32_t>,
@@ -147,7 +147,7 @@ using CollectionTestTypes = testing::Types<
   bcast_col_            ::TestCol<int64_t,int64_t>
 >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
   test_bcast, TestBroadcast, CollectionTestTypes
 );
 

--- a/tests/unit/collection/test_collection_common.h
+++ b/tests/unit/collection/test_collection_common.h
@@ -50,7 +50,7 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <cstdint>
 #include <tuple>

--- a/tests/unit/collection/test_collection_construct_common.h
+++ b/tests/unit/collection/test_collection_construct_common.h
@@ -54,7 +54,7 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <cstdint>
 #include <tuple>
@@ -137,8 +137,8 @@ protected:
   bool constructed_ = false;
 };
 
-TYPED_TEST_CASE_P(TestConstruct);
-TYPED_TEST_CASE_P(TestConstructDist);
+TYPED_TEST_SUITE_P(TestConstruct);
+TYPED_TEST_SUITE_P(TestConstructDist);
 
 TYPED_TEST_P(TestConstruct, test_construct_1) {
   using ColType   = TypeParam;
@@ -177,8 +177,8 @@ TYPED_TEST_P(TestConstructDist, test_construct_distributed_1) {
   >(msg);
 }
 
-REGISTER_TYPED_TEST_CASE_P(TestConstruct,     test_construct_1);
-REGISTER_TYPED_TEST_CASE_P(TestConstructDist, test_construct_distributed_1);
+REGISTER_TYPED_TEST_SUITE_P(TestConstruct,     test_construct_1);
+REGISTER_TYPED_TEST_SUITE_P(TestConstructDist, test_construct_distributed_1);
 
 }}} // end namespace vt::tests::unit
 

--- a/tests/unit/collection/test_construct.cc
+++ b/tests/unit/collection/test_construct.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_collection_common.h"
 #include "test_collection_construct_common.h"
@@ -128,11 +128,11 @@ using CollectionTestDistTypes = testing::Types<
   default_                       ::TestCol
 >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
   test_construct_simple, TestConstruct, CollectionTestTypes
 );
 
-INSTANTIATE_TYPED_TEST_CASE_P(
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
   test_construct_distributed_simple, TestConstructDist, CollectionTestDistTypes
 );
 

--- a/tests/unit/collection/test_construct_idx_fst.cc
+++ b/tests/unit/collection/test_construct_idx_fst.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_collection_common.h"
 #include "test_collection_construct_common.h"
@@ -89,7 +89,7 @@ using CollectionTestTypes = testing::Types<
 // detecting constructor index
 #if backend_check_enabled(detector) && backend_check_enabled(cons_multi_idx)
 
-  INSTANTIATE_TYPED_TEST_CASE_P(
+  INSTANTIATE_TYPED_TEST_SUITE_P_VT(
     test_construct_idx_fst, TestConstruct, CollectionTestTypes
   );
 

--- a/tests/unit/collection/test_construct_idx_snd.cc
+++ b/tests/unit/collection/test_construct_idx_snd.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_collection_common.h"
 #include "test_collection_construct_common.h"
@@ -89,7 +89,7 @@ using CollectionTestTypes = testing::Types<
 // detecting constructor index
 #if backend_check_enabled(detector) && backend_check_enabled(cons_multi_idx)
 
-  INSTANTIATE_TYPED_TEST_CASE_P(
+  INSTANTIATE_TYPED_TEST_SUITE_P_VT(
     test_construct_idx_snd, TestConstruct, CollectionTestTypes
   );
 

--- a/tests/unit/collection/test_construct_no_idx.cc
+++ b/tests/unit/collection/test_construct_no_idx.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_collection_common.h"
 #include "test_collection_construct_common.h"
@@ -85,11 +85,11 @@ using CollectionTestTypes = testing::Types<
   multi_param_no_idx_            ::TestCol<int64_t,int64_t>
 >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
   test_construct_no_idx, TestConstruct, CollectionTestTypes
 );
 
-INSTANTIATE_TYPED_TEST_CASE_P(
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
   test_construct_no_idx_dist, TestConstructDist, CollectionTestTypes
 );
 

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"

--- a/tests/unit/collection/test_index_types.cc
+++ b/tests/unit/collection/test_index_types.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
@@ -84,11 +84,11 @@ void TestCol<IndexT>::handler(ColMsg<IndexT>* msg) {}
 
 
 template <typename CollectionT>
-struct TestCsollectionIndexTypes : TestParallelHarness {};
+struct TestCollectionIndexTypes : TestParallelHarness {};
 
-TYPED_TEST_CASE_P(TestCsollectionIndexTypes);
+TYPED_TEST_SUITE_P(TestCollectionIndexTypes);
 
-TYPED_TEST_P(TestCsollectionIndexTypes, test_collection_index_1) {
+TYPED_TEST_P(TestCollectionIndexTypes, test_collection_index_1) {
   using IndexType     = TypeParam;
   using ColType       = test_index_types_::TestCol<IndexType>;
   using MsgType       = test_index_types_::ColMsg<IndexType>;
@@ -113,7 +113,7 @@ TYPED_TEST_P(TestCsollectionIndexTypes, test_collection_index_1) {
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P(TestCsollectionIndexTypes, test_collection_index_1);
+REGISTER_TYPED_TEST_SUITE_P(TestCollectionIndexTypes, test_collection_index_1);
 
 using CollectionTestTypes = testing::Types<
   ::vt::Index1D,
@@ -124,8 +124,8 @@ using CollectionTestTypes = testing::Types<
   ::vt::IdxType1D<std::size_t>
 >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(
-  test_collection_index, TestCsollectionIndexTypes, CollectionTestTypes
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
+  test_index_types, TestCollectionIndexTypes, CollectionTestTypes
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_insert.cc
+++ b/tests/unit/collection/test_insert.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"

--- a/tests/unit/collection/test_lb_lite.cc
+++ b/tests/unit/collection/test_lb_lite.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"

--- a/tests/unit/collection/test_query_context.cc
+++ b/tests/unit/collection/test_query_context.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"

--- a/tests/unit/collection/test_reduce_collection.cc
+++ b/tests/unit/collection/test_reduce_collection.cc
@@ -79,12 +79,12 @@ TEST_P(TestReduceCollection, test_reduce_op) {
 }
 
 #if ENABLE_REDUCE_EXPR_CALLBACK
-  INSTANTIATE_TEST_CASE_P(
-    InstantiationName, TestReduceCollection, ::testing::Range(0, 8),
+  INSTANTIATE_TEST_SUITE_P(
+    InstantiationName, TestReduceCollection, ::testing::Range(0, 8)
   );
 #else
-  INSTANTIATE_TEST_CASE_P(
-    InstantiationName, TestReduceCollection, ::testing::Range(0, 5),
+  INSTANTIATE_TEST_SUITE_P_VT(
+    InstantiationName, TestReduceCollection, ::testing::Range(0, 5)
   );
 #endif
 

--- a/tests/unit/collection/test_reduce_collection_common.h
+++ b/tests/unit/collection/test_reduce_collection_common.h
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/collection/test_send.cc
+++ b/tests/unit/collection/test_send.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"
@@ -128,8 +128,8 @@ struct TestCollectionSend : TestParallelHarness {};
 template <typename CollectionT>
 struct TestCollectionSendMem : TestParallelHarness {};
 
-TYPED_TEST_CASE_P(TestCollectionSend);
-TYPED_TEST_CASE_P(TestCollectionSendMem);
+TYPED_TEST_SUITE_P(TestCollectionSend);
+TYPED_TEST_SUITE_P(TestCollectionSendMem);
 
 TYPED_TEST_P(TestCollectionSend, test_collection_send_1) {
   using ColType = TypeParam;
@@ -181,8 +181,8 @@ TYPED_TEST_P(TestCollectionSendMem, test_collection_send_ptm_1) {
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P(TestCollectionSend, test_collection_send_1);
-REGISTER_TYPED_TEST_CASE_P(TestCollectionSendMem, test_collection_send_ptm_1);
+REGISTER_TYPED_TEST_SUITE_P(TestCollectionSend, test_collection_send_1);
+REGISTER_TYPED_TEST_SUITE_P(TestCollectionSendMem, test_collection_send_ptm_1);
 
 using CollectionTestTypes = testing::Types<
   send_col_            ::TestCol<int32_t>,
@@ -195,10 +195,10 @@ using CollectionTestTypes = testing::Types<
   send_col_            ::TestCol<int64_t,int64_t>
 >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
   test_collection_send, TestCollectionSend, CollectionTestTypes
 );
-INSTANTIATE_TYPED_TEST_CASE_P(
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
   test_collection_send_mem, TestCollectionSendMem, CollectionTestTypes
 );
 

--- a/tests/unit/collectives/test_collectives_reduce.cc
+++ b/tests/unit/collectives/test_collectives_reduce.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/collectives/test_collectives_scatter.cc
+++ b/tests/unit/collectives/test_collectives_scatter.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/context/context_vrt_test.cc
+++ b/tests/unit/context/context_vrt_test.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 

--- a/tests/unit/context/context_vrtmanager_test.cc
+++ b/tests/unit/context/context_vrtmanager_test.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 

--- a/tests/unit/context/context_vrtmessage_test.cc
+++ b/tests/unit/context/context_vrtmessage_test.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 

--- a/tests/unit/context/context_vrtproxy_test.cc
+++ b/tests/unit/context/context_vrtproxy_test.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 

--- a/tests/unit/epoch/test_epoch.cc
+++ b/tests/unit/epoch/test_epoch.cc
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <memory>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"
@@ -184,9 +184,9 @@ TEST_P(TestEpochParam, basic_test_epoch_all_1) {
   EXPECT_EQ(cat, epoch::eEpochCategory::InsertEpoch);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestEpochParam,
-  ::testing::Range(static_cast<EpochType>(1), static_cast<EpochType>(100), 10),
+  ::testing::Range(static_cast<EpochType>(1), static_cast<EpochType>(100), 10)
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/group/test_group.cc
+++ b/tests/unit/group/test_group.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/index/test_index.cc
+++ b/tests/unit/index/test_index.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 

--- a/tests/unit/index/test_index_linearization.cc
+++ b/tests/unit/index/test_index_linearization.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 

--- a/tests/unit/location/test_location.cc
+++ b/tests/unit/location/test_location.cc
@@ -262,8 +262,9 @@ TEST_F(TestLocation, test_migrate_multiple_entities) /* NOLINT */ {
   }
 }
 
-TYPED_TEST_CASE_P(TestLocationRoute);  /* NOLINT */
-TYPED_TEST_P(TestLocationRoute, test_route_entity)  /* NOLINT */ {
+TYPED_TEST_SUITE_P(TestLocationRoute);
+
+TYPED_TEST_P(TestLocationRoute, test_route_entity) {
 
   auto const nb_nodes = vt::theContext()->getNumNodes();
   auto const my_node  = vt::theContext()->getNode();
@@ -382,12 +383,15 @@ TYPED_TEST_P(TestLocationRoute, test_entity_cache_migrated_entity) /* NOLINT */{
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P /* NOLINT */ (
+REGISTER_TYPED_TEST_SUITE_P(
   TestLocationRoute,
   test_route_entity, test_entity_cache_hits, test_entity_cache_migrated_entity
 );
-INSTANTIATE_TYPED_TEST_CASE_P /* NOLINT */ (
-  Message, TestLocationRoute, location::MsgType
+
+using LocationMsgType = location::MsgType;
+
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(
+  test_location_message, TestLocationRoute, LocationMsgType
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/main.cc
+++ b/tests/unit/main.cc
@@ -45,7 +45,7 @@
 #include <vector>
 #include <memory>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/mapping/test_mapping.cc
+++ b/tests/unit/mapping/test_mapping.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 

--- a/tests/unit/mapping/test_mapping_registry.cc
+++ b/tests/unit/mapping/test_mapping_registry.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 

--- a/tests/unit/memory/test_memory_active.cc
+++ b/tests/unit/memory/test_memory_active.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
@@ -70,7 +70,7 @@ struct TestMemoryActive : TestParallelHarness {
 
 static constexpr int32_t const num_msg_sent = 5;
 
-TYPED_TEST_CASE_P(TestMemoryActive);
+TYPED_TEST_SUITE_P(TestMemoryActive);
 
 TYPED_TEST_P(TestMemoryActive, test_memory_remote_send) {
   using MsgType = TypeParam;
@@ -138,7 +138,7 @@ TYPED_TEST_P(TestMemoryActive, test_memory_remote_broadcast) {
   });
 }
 
-REGISTER_TYPED_TEST_CASE_P(
+REGISTER_TYPED_TEST_SUITE_P(
   TestMemoryActive, test_memory_remote_send, test_memory_remote_broadcast
 );
 
@@ -160,8 +160,8 @@ using MsgSerial = testing::Types<
   TestMemoryActiveMsg<TestStaticBytesSerialMsg>::TestMsgC
 >;
 
-INSTANTIATE_TYPED_TEST_CASE_P(test_mem_short,  TestMemoryActive, MsgShort );
-INSTANTIATE_TYPED_TEST_CASE_P(test_mem_normal, TestMemoryActive, MsgNormal );
-INSTANTIATE_TYPED_TEST_CASE_P(test_mem_serial, TestMemoryActive, MsgSerial );
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(test_mem_short,  TestMemoryActive, MsgShort);
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(test_mem_normal, TestMemoryActive, MsgNormal);
+INSTANTIATE_TYPED_TEST_SUITE_P_VT(test_mem_serial, TestMemoryActive, MsgSerial);
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/memory/test_memory_lifetime.cc
+++ b/tests/unit/memory/test_memory_lifetime.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/pipe/test_callback_bcast.cc
+++ b/tests/unit/pipe/test_callback_bcast.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/pipe/test_callback_bcast_collection.cc
+++ b/tests/unit/pipe/test_callback_bcast_collection.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/pipe/test_callback_func.cc
+++ b/tests/unit/pipe/test_callback_func.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/pipe/test_callback_func_ctx.cc
+++ b/tests/unit/pipe/test_callback_func_ctx.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/pipe/test_callback_send.cc
+++ b/tests/unit/pipe/test_callback_send.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/pipe/test_callback_send_collection.cc
+++ b/tests/unit/pipe/test_callback_send_collection.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/pool/test_pool.cc
+++ b/tests/unit/pool/test_pool.cc
@@ -44,7 +44,7 @@
 
 #include <cstring>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/pool/test_pool_message_sizes.cc
+++ b/tests/unit/pool/test_pool_message_sizes.cc
@@ -44,7 +44,7 @@
 
 #include <cstring>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/scheduler/test_priority_bits.cc
+++ b/tests/unit/scheduler/test_priority_bits.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "vt/transport.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/scheduler/test_priority_queue.cc
+++ b/tests/unit/scheduler/test_priority_queue.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "vt/transport.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/scheduler/test_scheduler_priorities.cc
+++ b/tests/unit/scheduler/test_scheduler_priorities.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "vt/transport.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/sequencer/test_sequencer.cc
+++ b/tests/unit/sequencer/test_sequencer.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <cstdint>
 

--- a/tests/unit/sequencer/test_sequencer_extensive.cc
+++ b/tests/unit/sequencer/test_sequencer_extensive.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <cstdint>
 
@@ -265,9 +265,9 @@ TEST_P(TestSequencerExtensive, test_wait_1) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P_VT(
   test_sequencer_extensive, TestSequencerExtensive,
-  testing::ValuesIn(make_values()),
+  testing::ValuesIn(make_values())
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/sequencer/test_sequencer_for.cc
+++ b/tests/unit/sequencer/test_sequencer_for.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <cstdint>
 

--- a/tests/unit/sequencer/test_sequencer_nested.cc
+++ b/tests/unit/sequencer/test_sequencer_nested.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <cstdint>
 

--- a/tests/unit/sequencer/test_sequencer_parallel.cc
+++ b/tests/unit/sequencer/test_sequencer_parallel.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <atomic>
 #include <cstdint>
@@ -168,9 +168,9 @@ TEST_P(TestSequencerParallelParam, test_seq_parallel_param) {
 
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P_VT(
   test_seq_parallel_param, TestSequencerParallelParam,
-  ::testing::Range(static_cast<CountType>(0), static_cast<CountType>(16), 1),
+  ::testing::Range(static_cast<CountType>(0), static_cast<CountType>(16), 1)
 );
 
 struct TestSequencerParallel : TestParallelHarness {

--- a/tests/unit/sequencer/test_sequencer_vrt.cc
+++ b/tests/unit/sequencer/test_sequencer_vrt.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <cstdint>
 

--- a/tests/unit/serialization/test_parserdes.cc
+++ b/tests/unit/serialization/test_parserdes.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>

--- a/tests/unit/serialization/test_parserdes_collection.cc
+++ b/tests/unit/serialization/test_parserdes_collection.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>

--- a/tests/unit/serialization/test_serialize_messenger.cc
+++ b/tests/unit/serialization/test_serialize_messenger.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <tuple>
 #include <type_traits>

--- a/tests/unit/serialization/test_serialize_messenger_virtual.cc
+++ b/tests/unit/serialization/test_serialize_messenger_virtual.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/termination/test_integral_set.cc
+++ b/tests/unit/termination/test_integral_set.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/termination/test_term_chaining.cc
+++ b/tests/unit/termination/test_term_chaining.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
@@ -508,7 +508,7 @@ struct PrintParam {
 };
 
 // Test Wave-epoch with a narrower set of parameters since large k is very slow
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   DepSendChainInputExplodeWave, TestTermDepSendChain,
   ::testing::Combine(
     ::testing::Values(false),
@@ -519,7 +519,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // Test DS-epoch with a broader set of parameters since it is quick
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   DepSendChainInputExplodeDS, TestTermDepSendChain,
   ::testing::Combine(
     ::testing::Values(true),

--- a/tests/unit/termination/test_termination_action_common.h
+++ b/tests/unit/termination/test_termination_action_common.h
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 #include <random>
 #include <vector>
 

--- a/tests/unit/termination/test_termination_action_epochs.cc
+++ b/tests/unit/termination/test_termination_action_epochs.cc
@@ -83,22 +83,22 @@ TEST_P(TestTermRooted, test_term_detect_rooted_epoch) /* NOLINT */{
   }
 }
 
-INSTANTIATE_TEST_CASE_P /* NOLINT */(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestTermCollect,
   ::testing::Combine(
     ::testing::Range(0, 4),
     ::testing::Values(false),
     ::testing::Values(1)
-  ),
+  )
 );
 
-INSTANTIATE_TEST_CASE_P /* NOLINT */(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestTermRooted,
   ::testing::Combine(
     ::testing::Range(0, 3),
     ::testing::Bool(),
     ::testing::Values(1)
-  ),
+  )
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_termination_action_global.cc
+++ b/tests/unit/termination/test_termination_action_global.cc
@@ -58,7 +58,7 @@ TEST_P(TestTermGlobal, test_term_detect_broadcast) /* NOLINT*/{
 }
 
 // routed messages
-TEST_P(TestTermGlobal, test_term_detect_routed) /* NOLINT*/{
+TEST_P(TestTermGlobal, test_term_detect_routed) {
   // there should be at least 3 nodes for this case
   if (channel::all > 2 and channel::node == channel::root) {
     //start computation
@@ -68,13 +68,13 @@ TEST_P(TestTermGlobal, test_term_detect_routed) /* NOLINT*/{
   }
 }
 
-INSTANTIATE_TEST_CASE_P /* NOLINT*/(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestTermGlobal,
   ::testing::Combine(
     ::testing::Range(0, 3),
     ::testing::Values(false),
     ::testing::Values(1)
-  ),
+  )
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_termination_action_nested_collect.cc
+++ b/tests/unit/termination/test_termination_action_nested_collect.cc
@@ -65,17 +65,17 @@ struct TestTermNestedCollect : action::BaseFixture {
   }
 };
 
-TEST_P(TestTermNestedCollect, test_term_detect_nested_collect_epoch)/*NOLINT*/{
+TEST_P(TestTermNestedCollect, test_term_detect_nested_collect_epoch) {
   kernel(depth_, no_epoch);
 }
 
-INSTANTIATE_TEST_CASE_P /* NOLINT */(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestTermNestedCollect,
   ::testing::Combine(
     ::testing::Range(0, 3),
     ::testing::Values(false),
     ::testing::Range(2, 10, 2)
-  ),
+  )
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_termination_action_nested_rooted.cc
+++ b/tests/unit/termination/test_termination_action_nested_rooted.cc
@@ -72,17 +72,17 @@ struct TestTermNestedRooted : action::BaseFixture {
   }
 };
 
-TEST_P(TestTermNestedRooted, test_term_detect_nested_rooted_epoch) /* NOLINT */{
+TEST_P(TestTermNestedRooted, test_term_detect_nested_rooted_epoch) {
   kernel(depth_, no_epoch);
 }
 
-INSTANTIATE_TEST_CASE_P /*NOLINT*/(
+INSTANTIATE_TEST_SUITE_P_VT(
   InstantiationName, TestTermNestedRooted,
   ::testing::Combine(
     ::testing::Range(0, 3),
     ::testing::Bool(),
     ::testing::Range(2, 10, 2)
-  ),
+  )
 );
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_termination_reset.cc
+++ b/tests/unit/termination/test_termination_reset.cc
@@ -42,7 +42,7 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_parallel_harness.h"
 #include "data_message.h"

--- a/tests/unit/test_harness.h
+++ b/tests/unit/test_harness.h
@@ -44,7 +44,7 @@
 #if ! defined __VIRTUAL_TRANSPORT_TEST_HARNESS__
 #define __VIRTUAL_TRANSPORT_TEST_HARNESS__
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include <vector>
 #include <string>

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -45,8 +45,6 @@
 #if ! defined __VIRTUAL_TRANSPORT_TEST_PARALLEL_HARNESS__
 #define __VIRTUAL_TRANSPORT_TEST_PARALLEL_HARNESS__
 
-#include <gtest/gtest.h>
-
 #include <vector>
 #include <string>
 #include <memory>

--- a/tests/unit/tls/test_tls.cc
+++ b/tests/unit/tls/test_tls.cc
@@ -45,7 +45,7 @@
 #include <cstring>
 #include <memory>
 
-#include <gtest/gtest.h>
+#include "vt_gtest.h"
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"

--- a/tests/unit/vt_gtest.h
+++ b/tests/unit/vt_gtest.h
@@ -1,0 +1,101 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                vt_gtest.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+///
+/// A dress-up/wrapper for GoogleTest and 1.8 + 1.10 compatibility.
+/// Provides a shim during transition and to hide some slight awkwardness
+/// with macros and changes between versions.
+///
+/// Use
+///     #include "vt_gtest.h"
+/// instead of
+///     #include <gtest/gtest.h>
+///
+/// This is secondary from election to use a standard VT harness.
+///
+
+#ifndef __VIRTUAL_TRANSPORT_VT_GTEST__
+#define __VIRTUAL_TRANSPORT_VT_GTEST__
+
+// This define detects some future-breaking API without updating gtest target.
+// (The resulting tests are ill-defined against an incompatile gtest lib.)
+//#define GTEST_REMOVE_LEGACY_TEST_CASEAPI_ 1
+
+#include <gtest/gtest.h>
+
+// 1.8 -> 1.10 changes "Test Case" to "Test Suite" and deprecates
+// the former; these are forward-compatible shims for gtest 1.8 builds.
+// Larger changes to method names and such can't be done pre-1.10.
+
+#ifndef TYPED_TEST_SUITE_P // gtest < 1.10 (should be 1.8)
+
+#define TYPED_TEST_SUITE_P TYPED_TEST_CASE_P
+#define REGISTER_TYPED_TEST_SUITE_P REGISTER_TYPED_TEST_CASE_P
+#define INSTANTIATE_TYPED_TEST_SUITE_P INSTANTIATE_TYPED_TEST_CASE_P
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+
+// Unified macros to avoid having to specify a trailing comma to avoid
+// pedantic warning about variadic arguments relating to name generation.
+// Use the originals if wishing for name generators.
+#define INSTANTIATE_TYPED_TEST_SUITE_P_VT(Prefix, Suite, Types) \
+  INSTANTIATE_TYPED_TEST_CASE_P(Prefix, Suite, Types, /*...*/)
+// 'test case' allowed name generatiom
+#define INSTANTIATE_TEST_SUITE_P_VT(Prefix, Suite, Generator) \
+  INSTANTIATE_TEST_CASE_P(Prefix, Suite, Generator, /*...*/)
+
+#else
+
+// Unified macros to avoid having to specify a trailing comma to avoid
+// pedantic warning about variadic arguments relating to name generation.
+// Use the originals if wishing for name generators.
+#define INSTANTIATE_TYPED_TEST_SUITE_P_VT(Prefix, Suite, Types) \
+  INSTANTIATE_TYPED_TEST_SUITE_P(Prefix, Suite, Types, /*...*/)
+// 'test suite' does not allow name generation
+#define INSTANTIATE_TEST_SUITE_P_VT(Prefix, Suite, Generator) \
+  INSTANTIATE_TEST_SUITE_P(Prefix, Suite, Generator)
+
+#endif
+
+
+#endif /* __VIRTUAL_TRANSPORT_VT_GTEST__ */


### PR DESCRIPTION
"Compatibility shim" to enable VT to work sans-warnings (and sans-errors!) targeting either test 1.8 or gtest 1.10.

I usually merge this branch in locally as some compiler / gtest versions do not compile otherwise.