### PR TITLE
597 migration leak

### DIFF
--- a/src/vt/vrt/collection/migrate/migrate_msg.h
+++ b/src/vt/vrt/collection/migrate/migrate_msg.h
@@ -61,8 +61,14 @@ struct MigrateMsg final : ::vt::Message {
     NodeType const& in_to, HandlerType const& in_map_fn, IndexT const& in_range,
     ColT* in_elm
   ) : elm_proxy_(in_elm_proxy), from_(in_from), to_(in_to), map_fn_(in_map_fn),
-      range_(in_range), elm_(in_elm)
+      range_(in_range), owns_elm_(false), elm_(in_elm)
   { }
+
+  ~MigrateMsg() {
+    if (elm_ and owns_elm_) {
+      delete elm_;
+    }
+  }
 
   VrtElmProxy<ColT, IndexT> getElementProxy() const { return elm_proxy_; }
   NodeType getFromNode() const { return from_; }
@@ -75,6 +81,7 @@ struct MigrateMsg final : ::vt::Message {
     s | elm_proxy_ | from_ | to_ | map_fn_ | range_;
     if (s.isUnpacking()) {
       elm_ = new ColT{};
+      owns_elm_ = true;
     }
     s | *elm_;
   }
@@ -85,6 +92,7 @@ private:
   NodeType to_ = uninitialized_destination;
   HandlerType map_fn_ = uninitialized_handler;
   IndexT range_;
+  bool owns_elm_ = false;
 public:
   ColT* elm_ = nullptr;
 };

--- a/src/vt/vrt/collection/migrate/migrate_msg.h
+++ b/src/vt/vrt/collection/migrate/migrate_msg.h
@@ -61,7 +61,7 @@ struct MigrateMsg final : ::vt::Message {
     NodeType const& in_to, HandlerType const& in_map_fn, IndexT const& in_range,
     ColT* in_elm
   ) : elm_proxy_(in_elm_proxy), from_(in_from), to_(in_to), map_fn_(in_map_fn),
-      range_(in_range), owns_elm_(false), elm_(in_elm)
+      range_(in_range), elm_(in_elm)
   { }
 
   ~MigrateMsg() {

--- a/src/vt/vrt/collection/migrate/migrate_msg.h
+++ b/src/vt/vrt/collection/migrate/migrate_msg.h
@@ -50,21 +50,7 @@
 #include "vt/vrt/proxy/collection_elm_proxy.h"
 #include "vt/vrt/collection/collection_info.h"
 
-#include <memory>
-
 namespace vt { namespace vrt { namespace collection {
-
-/*
- * For, now declare our own serializer for unique_ptr that doesn't cover the
- * specialized destructor case. Eventually this code should move to checkpoint
- */
-template <typename SerializerT, typename T>
-void serializeUniquePtr(SerializerT& s, std::unique_ptr<T>& ptr) {
-  if (s.isUnpacking()) {
-    ptr = std::make_unique<T>();
-  }
-  s | *ptr;
-}
 
 template <typename ColT, typename IndexT>
 struct MigrateMsg final : ::vt::Message {
@@ -73,10 +59,16 @@ struct MigrateMsg final : ::vt::Message {
   MigrateMsg(
     VrtElmProxy<ColT, IndexT> const& in_elm_proxy, NodeType const& in_from,
     NodeType const& in_to, HandlerType const& in_map_fn, IndexT const& in_range,
-    std::unique_ptr<ColT> in_elm
+    ColT* in_elm
   ) : elm_proxy_(in_elm_proxy), from_(in_from), to_(in_to), map_fn_(in_map_fn),
-      range_(in_range), elm_(std::move(in_elm))
+      range_(in_range), elm_(in_elm)
   { }
+
+  ~MigrateMsg() {
+    if (elm_ and owns_elm_) {
+      delete elm_;
+    }
+  }
 
   VrtElmProxy<ColT, IndexT> getElementProxy() const { return elm_proxy_; }
   NodeType getFromNode() const { return from_; }
@@ -87,7 +79,11 @@ struct MigrateMsg final : ::vt::Message {
   template <typename Serializer>
   void serialize(Serializer& s) {
     s | elm_proxy_ | from_ | to_ | map_fn_ | range_;
-    serializeUniquePtr(s, elm_);
+    if (s.isUnpacking()) {
+      elm_ = new ColT{};
+      owns_elm_ = true;
+    }
+    s | *elm_;
   }
 
 private:
@@ -96,8 +92,9 @@ private:
   NodeType to_ = uninitialized_destination;
   HandlerType map_fn_ = uninitialized_handler;
   IndexT range_;
+  bool owns_elm_ = false;
 public:
-  std::unique_ptr<ColT> elm_ = nullptr;
+  ColT* elm_ = nullptr;
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -129,6 +129,7 @@ struct MyCol : vt::Collection<MyCol,vt::Index2D> {
   }
 
   void op1(OpMsg* msg) {
+    migrating = false;
     checkIncExpectedStep(0);
     EXPECT_EQ(msg->a, calcVal(1,idx));
     EXPECT_EQ(msg->b, calcVal(2,idx));
@@ -273,9 +274,6 @@ struct MyCol : vt::Collection<MyCol,vt::Index2D> {
     vt::Collection<MyCol,vt::Index2D>::serialize(s);
     s | iter | step | idx | final_check | max_x | max_y | started_op6_;
     s | migrating;
-    if (s.isUnpacking()) {
-      migrating = false;
-    }
     s | op6_counter_;
 
     // Skip the stack op6_msgs_ because migration only occurs after all op-steps

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -158,7 +158,7 @@ struct MyCol : vt::Collection<MyCol,vt::Index2D> {
   void op4(ProxyMsg* msg) {
     checkExpectedStep(3);
     // fmt::print("op4: idx={}, iter={}\n", idx, iter);
-    msg->cb.send(new OpIdxMsg(idx));
+    msg->cb.send(vt::makeMessage<OpIdxMsg>(idx).get());
   }
   void op4Impl(OpMsg* msg) {
     checkIncExpectedStep(3);
@@ -190,10 +190,10 @@ struct MyCol : vt::Collection<MyCol,vt::Index2D> {
     auto xm1 = idx.x() - 1 >= 0 ? idx.x() - 1 : max_x - 1;
     auto ym1 = idx.y() - 1 >= 0 ? idx.y() - 1 : max_y - 1;
     std::vector<double> v = { 1.0, 2.0, 3.0 };
-    proxy(xp1,idx.y()).template send<OpVMsg, &MyCol::op6Impl>(new OpVMsg(v));
-    proxy(xm1,idx.y()).template send<OpVMsg, &MyCol::op6Impl>(new OpVMsg(v));
-    proxy(idx.x(),yp1).template send<OpVMsg, &MyCol::op6Impl>(new OpVMsg(v));
-    proxy(idx.x(),ym1).template send<OpVMsg, &MyCol::op6Impl>(new OpVMsg(v));
+    proxy(xp1,idx.y()).template send<OpVMsg, &MyCol::op6Impl>(v);
+    proxy(xm1,idx.y()).template send<OpVMsg, &MyCol::op6Impl>(v);
+    proxy(idx.x(),yp1).template send<OpVMsg, &MyCol::op6Impl>(v);
+    proxy(idx.x(),ym1).template send<OpVMsg, &MyCol::op6Impl>(v);
     // fmt::print(
     //   "op6: idx={}, iter={}, a={}, b={}\n", idx, iter, msg->a, msg->b
     // );
@@ -334,7 +334,7 @@ struct MyObjGroup {
     chains_->nextStep([=](vt::Index2D idx) {
       auto a = calcVal(1,idx);
       auto b = calcVal(2,idx);
-      return backend_proxy(idx).template send<OpMsg, &MyCol::op1>(new OpMsg(a,b));
+      return backend_proxy(idx).template send<OpMsg, &MyCol::op1>(a,b);
     });
   }
 
@@ -342,7 +342,7 @@ struct MyObjGroup {
     chains_->nextStep([=](vt::Index2D idx) {
       auto a = calcVal(3,idx);
       auto b = calcVal(4,idx);
-      return backend_proxy(idx).template send<OpMsg, &MyCol::op2>(new OpMsg(a,b));
+      return backend_proxy(idx).template send<OpMsg, &MyCol::op2>(a,b);
     });
   }
 
@@ -352,7 +352,7 @@ struct MyObjGroup {
       for (auto i = 0; i < 10; i++) {
         v.push_back(idx.x()*i + idx.y());
       }
-      return backend_proxy(idx).template send<OpVMsg, &MyCol::op3>(new OpVMsg(v));
+      return backend_proxy(idx).template send<OpVMsg, &MyCol::op3>(v);
     });
   }
 
@@ -363,7 +363,7 @@ struct MyObjGroup {
       auto next = node + 1 < num ? node + 1 : 0;
       auto proxy = frontend_proxy(next);
       auto c = vt::theCB()->makeSend<MyObjGroup,OpIdxMsg,&MyObjGroup::op4Impl>(proxy);
-      return backend_proxy(idx).template send<ProxyMsg, &MyCol::op4>(new ProxyMsg(c));
+      return backend_proxy(idx).template send<ProxyMsg, &MyCol::op4>(c);
     });
   }
   void op4Impl(OpIdxMsg* msg) {
@@ -371,14 +371,14 @@ struct MyObjGroup {
     auto idx = msg->idx;
     auto a = calcVal(5,idx);
     auto b = calcVal(6,idx);
-    backend_proxy(idx).template send<OpMsg, &MyCol::op4Impl>(new OpMsg(a,b));
+    backend_proxy(idx).template send<OpMsg, &MyCol::op4Impl>(a,b);
   }
 
   void op5() {
     chains_->nextStep([=](vt::Index2D idx) {
       auto a = calcVal(7,idx);
       auto b = calcVal(8,idx);
-      return backend_proxy(idx).template send<OpMsg, &MyCol::op5>(new OpMsg(a,b));
+      return backend_proxy(idx).template send<OpMsg, &MyCol::op5>(a,b);
     });
   }
 
@@ -386,7 +386,7 @@ struct MyObjGroup {
     chains_->nextStepCollective([=](vt::Index2D idx) {
       auto a = calcVal(9,idx);
       auto b = calcVal(10,idx);
-      return backend_proxy(idx).template send<OpMsg, &MyCol::op6>(new OpMsg(a,b));
+      return backend_proxy(idx).template send<OpMsg, &MyCol::op6>(a,b);
     });
   }
 
@@ -394,7 +394,7 @@ struct MyObjGroup {
     chains_->nextStep([=](vt::Index2D idx) {
       auto a = calcVal(11,idx);
       auto b = calcVal(12,idx);
-      return backend_proxy(idx).template send<OpMsg, &MyCol::op7>(new OpMsg(a,b));
+      return backend_proxy(idx).template send<OpMsg, &MyCol::op7>(a,b);
     });
   }
 
@@ -402,7 +402,7 @@ struct MyObjGroup {
     chains_->nextStep([=](vt::Index2D idx) {
       auto a = calcVal(13,idx);
       auto b = calcVal(14,idx);
-      return backend_proxy(idx).template send<OpMsg, &MyCol::doMigrate>(new OpMsg(a,b));
+      return backend_proxy(idx).template send<OpMsg, &MyCol::doMigrate>(a,b);
     });
   }
 
@@ -422,7 +422,7 @@ struct MyObjGroup {
 
   void finalCheck(int i) {
     chains_->nextStep([=](vt::Index2D idx) {
-      return backend_proxy(idx).template send<FinalMsg, &MyCol::finalCheck>(new FinalMsg(i));
+      return backend_proxy(idx).template send<FinalMsg, &MyCol::finalCheck>(i);
     });
   }
 

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -158,7 +158,8 @@ struct MyCol : vt::Collection<MyCol,vt::Index2D> {
   void op4(ProxyMsg* msg) {
     checkExpectedStep(3);
     // fmt::print("op4: idx={}, iter={}\n", idx, iter);
-    msg->cb.send(vt::makeMessage<OpIdxMsg>(idx).get());
+    auto m = vt::makeMessage<OpIdxMsg>(idx);
+    msg->cb.send(m.get());
   }
   void op4Impl(OpMsg* msg) {
     checkIncExpectedStep(3);


### PR DESCRIPTION
Fixes #597 

Migration leak showing up in EMPIRE. During de-serialization, a copy of `ColT` was not being deallocated properly, leaking during every migration.