### PR TITLE
#599 ensure events Log objects are properly managed

### DIFF
--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -156,7 +156,9 @@ void Trace::addUserNote(std::string const& note) {
   auto const type = TraceConstantsType::UserSuppliedNote;
   auto const time = getCurrentTime();
 
-  logEvent(new LogType(time, type, note, Log::UserDataType{}));
+  logEvent(
+    std::make_unique<LogType>(time, type, note, Log::UserDataType{})
+  );
 }
 
 void Trace::addUserData(int32_t data) {
@@ -169,7 +171,9 @@ void Trace::addUserData(int32_t data) {
   auto const type = TraceConstantsType::UserSupplied;
   auto const time = getCurrentTime();
 
-  logEvent(new LogType(time, type, std::string{}, data));
+  logEvent(
+    std::make_unique<LogType>(time, type, std::string{}, data)
+  );
 }
 
 void Trace::addUserBracketedNote(
@@ -184,7 +188,9 @@ void Trace::addUserBracketedNote(
 
   auto const type = TraceConstantsType::UserSuppliedBracketedNote;
 
-  logEvent(new LogType(begin, end, type, note, event));
+  logEvent(
+    std::make_unique<LogType>(begin, end, type, note, event)
+  );
 }
 
 UserEventIDType Trace::registerUserEventColl(std::string const& name) {
@@ -222,7 +228,9 @@ void Trace::addUserEvent(UserEventIDType event) {
   auto const time = getCurrentTime();
   NodeType const node = theContext()->getNode();
 
-  logEvent(new LogType(time, type, node, event, true));
+  logEvent(
+    std::make_unique<LogType>(time, type, node, event, true)
+  );
 }
 
 void Trace::addUserEventManual(UserSpecEventIDType event) {
@@ -246,8 +254,12 @@ void Trace::addUserEventBracketed(UserEventIDType event, double begin, double en
   auto const type = TraceConstantsType::UserEventPair;
   NodeType const node = theContext()->getNode();
 
-  logEvent(new LogType(begin, type, node, event, true));
-  logEvent(new LogType(end, type, node, event, false));
+  logEvent(
+    std::make_unique<LogType>(begin, type, node, event, true)
+  );
+  logEvent(
+    std::make_unique<LogType>(end, type, node, event, false)
+  );
 }
 
 void Trace::addUserEventBracketedBegin(UserEventIDType event) {
@@ -261,7 +273,9 @@ void Trace::addUserEventBracketedBegin(UserEventIDType event) {
   auto const time = getCurrentTime();
   NodeType const node = theContext()->getNode();
 
-  logEvent(new LogType(time, type, node, event, true));
+  logEvent(
+    std::make_unique<LogType>(time, type, node, event, true)
+  );
 }
 
 void Trace::addUserEventBracketedEnd(UserEventIDType event) {
@@ -275,7 +289,9 @@ void Trace::addUserEventBracketedEnd(UserEventIDType event) {
   auto const time = getCurrentTime();
   NodeType const node = theContext()->getNode();
 
-  logEvent(new LogType(time, type, node, event, false));
+  logEvent(
+    std::make_unique<LogType>(time, type, node, event, false)
+  );
 }
 
 void Trace::addUserEventBracketedManualBegin(UserSpecEventIDType event) {
@@ -315,9 +331,11 @@ void Trace::beginProcessing(
 
   auto const type = TraceConstantsType::BeginProcessing;
 
-  logEvent(new LogType(time, ep, type,
-                       event, len, from_node,
-                       idx1, idx2, idx3, idx4));
+  logEvent(
+    std::make_unique<LogType>(
+      time, ep, type, event, len, from_node, idx1, idx2, idx3, idx4
+    )
+  );
 }
 
 void Trace::endProcessing(
@@ -334,9 +352,11 @@ void Trace::endProcessing(
 
   auto const type = TraceConstantsType::EndProcessing;
 
-  logEvent(new LogType(time, ep, type,
-                       event, len, from_node,
-                       idx1, idx2, idx3, idx4));
+  logEvent(
+    std::make_unique<LogType>(
+      time, ep, type, event, len, from_node, idx1, idx2, idx3, idx4
+    )
+  );
 }
 
 void Trace::beginIdle(double const time) {
@@ -347,7 +367,9 @@ void Trace::beginIdle(double const time) {
   auto const type = TraceConstantsType::BeginIdle;
   NodeType const node = theContext()->getNode();
 
-  logEvent(new LogType(time, type, node));
+  logEvent(
+    std::make_unique<LogType>(time, type, node)
+  );
   idle_begun_ = true; // must set AFTER logEvent
 }
 
@@ -359,7 +381,9 @@ void Trace::endIdle(double const time) {
   auto const type = TraceConstantsType::EndIdle;
   NodeType const node = theContext()->getNode();
 
-  logEvent(new LogType(time, type, node));
+  logEvent(
+    std::make_unique<LogType>(time, type, node)
+  );
   idle_begun_ = false; // must set AFTER logEvent
 }
 
@@ -369,7 +393,9 @@ TraceEventIDType Trace::messageCreation(
   auto const type = TraceConstantsType::Creation;
   NodeType const node = theContext()->getNode();
 
-  return logEvent(new LogType(time, ep, type, node, len));
+  return logEvent(
+    std::make_unique<LogType>(time, ep, type, node, len)
+  );
 }
 
 TraceEventIDType Trace::messageCreationBcast(
@@ -378,7 +404,9 @@ TraceEventIDType Trace::messageCreationBcast(
   auto const type = TraceConstantsType::CreationBcast;
   NodeType const node = theContext()->getNode();
 
-  return logEvent(new LogType(time, ep, type, node, len));
+  return logEvent(
+    std::make_unique<LogType>(time, ep, type, node, len)
+  );
 }
 
 TraceEventIDType Trace::messageRecv(
@@ -388,14 +416,13 @@ TraceEventIDType Trace::messageRecv(
   auto const type = TraceConstantsType::MessageRecv;
   NodeType const node = theContext()->getNode();
 
-  return logEvent(new LogType(time, ep, type, node, len));
+  return logEvent(
+    std::make_unique<LogType>(time, ep, type, node, len)
+  );
 }
 
-TraceEventIDType Trace::logEvent(LogType* log) {
+TraceEventIDType Trace::logEvent(std::unique_ptr<LogType> log) {
   assert(log != nullptr && "log cannot be null");
-
-  // Honor promise of ownership; log remains valid in scope.
-  auto log_uptr = std::unique_ptr<LogType>{log};
 
   if (not enabled_ || not checkEnabled()) {
     return no_trace_event;
@@ -434,10 +461,10 @@ TraceEventIDType Trace::logEvent(LogType* log) {
       traces_.push_back(std::move(end_log));
     }
 
-    // push on open stack.
-    open_events_.push(log);
+    // push on open stack -- object is owned by trace collection, NOT stack.
+    open_events_.push(log.get());
 
-    traces_.push_back(std::move(log_uptr));
+    traces_.push_back(std::move(log));
 
     return log->event;
   };
@@ -459,7 +486,7 @@ TraceEventIDType Trace::logEvent(LogType* log) {
     // set up begin/end links
     open_events_.pop();
 
-    traces_.push_back(std::move(log_uptr));
+    traces_.push_back(std::move(log));
 
     if (not open_events_.empty()) {
       LogType* top_event = open_events_.top();
@@ -484,28 +511,28 @@ TraceEventIDType Trace::logEvent(LogType* log) {
   };
 
   auto basic_new_event_create = [&]() -> TraceEventIDType {
-    traces_.push_back(std::move(log_uptr));
+    traces_.push_back(std::move(log));
 
     log->event = cur_event_++;
     return log->event;
   };
 
   auto basic_no_event_create = [&]() -> TraceEventIDType {
-    traces_.push_back(std::move(log_uptr));
+    traces_.push_back(std::move(log));
 
     log->event = no_trace_event;
     return log->event;
   };
 
   auto basic_cur_event = [&]() -> TraceEventIDType {
-    traces_.push_back(std::move(log_uptr));
+    traces_.push_back(std::move(log));
 
     log->event = cur_event_;
     return log->event;
   };
 
   auto basic_create = [&]() -> TraceEventIDType {
-    traces_.push_back(std::move(log_uptr));
+    traces_.push_back(std::move(log));
 
     return log->event;
   };
@@ -603,6 +630,7 @@ void Trace::writeLogFile(gzFile file) {
 
     // force guaranteed type (used in format specifiers)
     size_t event_seq_id = TraceRegistry::getEvent(log->ep).theEventSeq();
+
 
     switch (log->type) {
     case TraceConstantsType::BeginProcessing:
@@ -739,6 +767,10 @@ void Trace::writeLogFile(gzFile file) {
     default:
       vtAssertInfo(false, "Unimplemented log type", converted_time, log->node);
     }
+
+    // LogType is released - however, the collection itself is
+    // not trimmed and will grow without bounds fsvo growth.
+    log.reset(nullptr);
   }
 
   // All open events for LogType* objects are invalidated once the

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -181,8 +181,7 @@ private:
 
   /// Log an event, returning a trace event ID if accepted
   /// or no_trace_event if not accepted (eg. no tracing on node).
-  /// TAKES OWNERSHIP of the supplied Log object.
-  TraceEventIDType logEvent(LogType* log);
+  TraceEventIDType logEvent(std::unique_ptr<LogType> log);
 
 private:
   TraceContainerType traces_;

--- a/src/vt/trace/trace_log.h
+++ b/src/vt/trace/trace_log.h
@@ -56,7 +56,6 @@
 namespace vt { namespace trace {
 
 struct Log {
-  using LogPtrType         = std::shared_ptr<Log>;
   using TraceConstantsType = eTraceConstants;
   using UserDataType       = int32_t;
 
@@ -66,8 +65,8 @@ struct Log {
   TraceEntryIDType ep = no_trace_entry_id;
   TraceConstantsType type = TraceConstantsType::InvalidTraceType;
   TraceEventIDType event = no_trace_event;
-  TraceMsgLenType msg_len = 0;
   NodeType node = uninitialized_destination;
+  TraceMsgLenType msg_len = 0;
   uint64_t idx1 = 0, idx2 = 0, idx3 = 0, idx4 = 0;
 
   std::string user_supplied_note = "";
@@ -75,14 +74,17 @@ struct Log {
   UserEventIDType user_event = 0;
   bool user_start = false;
 
+  // [obsolete] - use appropriate ctor
   void setUserNote(std::string const& note) {
     user_supplied_note = note;
   }
 
+  // [obsolete] - use appropriate ctor
   void setUserData(UserDataType data) {
     user_supplied_data = data;
   }
 
+  // User event
   Log(
     double const in_begin_time, double const in_end_time,
     TraceConstantsType const in_type, std::string const& in_note,
@@ -91,33 +93,39 @@ struct Log {
       type(in_type), event(in_event), user_supplied_note(in_note)
   { }
 
+  // User event
   Log(
-    double const in_time, TraceConstantsType const in_type,
-    std::string const& in_note
-  ) : time(in_time), type(in_type), user_supplied_note(in_note)
+      double const in_time, TraceConstantsType const in_type,
+      std::string const& in_note, UserDataType in_data
+  ) : time(in_time), type(in_type),
+      user_supplied_note(in_note), user_supplied_data(in_data)
   { }
 
-  Log(double const in_time, TraceConstantsType const in_type)
-    : time(in_time), type(in_type)
-  { }
-
+  // User event
   Log(
     double const in_time, TraceConstantsType const in_type,
+    NodeType in_node,
     UserEventIDType in_user_event, bool in_user_start
-  ) : time(in_time), type(in_type), user_event(in_user_event),
-      user_start(in_user_start)
+  ) : time(in_time), type(in_type),
+      node(in_node),
+      user_event(in_user_event), user_start(in_user_start)
   { }
 
-  Log(
-    double const in_time, TraceConstantsType const in_type,
-    UserDataType const in_data
-  ) : time(in_time), type(in_type), user_supplied_data(in_data)
+  // Used for idle
+  Log(double const in_time, TraceConstantsType const in_type,
+      NodeType in_node)
+    : time(in_time), type(in_type),
+      node(in_node)
   { }
 
+  // Used for messages
   Log(
-    double const in_time, TraceEntryIDType const in_ep,
-    TraceConstantsType const in_type, TraceMsgLenType const in_msg_len = 0
-  ) : time(in_time), ep(in_ep), type(in_type), msg_len(in_msg_len)
+    double const in_time, TraceEntryIDType const in_ep, TraceConstantsType const in_type,
+    NodeType in_node,
+    TraceMsgLenType const in_msg_len
+  ) : time(in_time), ep(in_ep), type(in_type),
+      node(in_node),
+      msg_len(in_msg_len)
   { }
 
   Log(
@@ -125,7 +133,7 @@ struct Log {
     TraceEventIDType in_event, TraceMsgLenType in_msg_len, NodeType in_node,
     uint64_t in_idx1, uint64_t in_idx2, uint64_t in_idx3, uint64_t in_idx4
   ) : time(in_time), ep(in_ep), type(in_type), event(in_event),
-      msg_len(in_msg_len), node(in_node), idx1(in_idx1), idx2(in_idx2),
+      node(in_node), msg_len(in_msg_len), idx1(in_idx1), idx2(in_idx2),
       idx3(in_idx3), idx4(in_idx4)
   { }
 };


### PR DESCRIPTION
- Avoids valgrind warnings - mostly merge-friendly with #241.

- Defines when ownership is accepted and is future-ready
  for a change to unique_ptr, if such is desired.

- Eliminates most post-construction modification of events.