### PR TITLE
#635 fix barename and namespace extraction

### DIFF
--- a/src/vt/registry/auto/auto_registry_general.h
+++ b/src/vt/registry/auto/auto_registry_general.h
@@ -96,6 +96,8 @@ struct FunctorAdapterArgs {
     using TE = vt::util::demangle::TemplateExtract;
     using DU = vt::util::demangle::DemanglerUtils;
     auto ns = TE::getTypeName<ObjTypeT>();
+    if (ns.empty())
+      ns = "(none)";
     return DU::removeSpaces(ns);
   }
 
@@ -127,6 +129,8 @@ struct FunctorAdapter {
     using TE = vt::util::demangle::TemplateExtract;
     using DU = vt::util::demangle::DemanglerUtils;
     auto ns = TE::getNamespace(TE::getValueNamePtr<F,f>());
+    if (ns.empty())
+      ns = "(none)";
     return DU::removeSpaces(ns);
   }
 
@@ -156,6 +160,8 @@ struct FunctorAdapterMember {
     using TE = vt::util::demangle::TemplateExtract;
     using DU = vt::util::demangle::DemanglerUtils;
     auto ns = TE::getNamespace(TE::getValueName<F,f>());
+    if (ns.empty())
+      ns = "(none)";
     return DU::removeSpaces(ns);
   }
 

--- a/src/vt/utils/demangle/demangle.cc
+++ b/src/vt/utils/demangle/demangle.cc
@@ -82,8 +82,9 @@ TemplateExtract::lastNamedPfType(std::string const& pf, std::string const& tpara
 
 // Given a::b or a::b<c::d> or a<>::b<c>, eg. determines the
 // starting position at which it can be a namespace vs class.
-// That is, the starting position of the rightmost "::" that
+// That is, the STARTING position of the rightmost "::" that
 // is not located inside angle brackets
+// If there is no namespace the result will not start with a "::".
 size_t getNameDivide(
  std::string const& str,
  size_t best, size_t start, size_t depth
@@ -133,12 +134,13 @@ TemplateExtract::getBarename(std::string const& typestr) {
   size_t s = skipTypePrefix(typestr);
   size_t d = getNameDivide(typestr, s, s, 0);
 
-  // skip "::" divider
-  d += 2;
-  if (d >= typestr.length())
-    return typestr;
-
-  return typestr.substr(d, std::string::npos);
+  if (typestr.substr(d, 2) == "::") {
+    // skip "::" divider
+    return typestr.substr(d + 2, std::string::npos);
+  } else {
+    // Namespace is not present - already bare.
+    return typestr.substr(d, std::string::npos);
+  }
 }
 
 /*static*/ std::string

--- a/src/vt/utils/demangle/demangle.h
+++ b/src/vt/utils/demangle/demangle.h
@@ -130,11 +130,13 @@ struct TemplateExtract {
   }
 
   /// Given a string like 'a::b::c', return the namespace of 'a::b'.
-  /// Removes leading '&', if present (as it appears for 'values representing types').
   /// Does not strip out extra template parameterization artifacts.
+  /// Removes any leading '&', if present (as in 'values representing types').
   static std::string getNamespace(std::string const& typestr);
 
   /// Given a string like 'a::b::c', return the barename of 'c'.
+  /// Returns the bare name in absense of any namespace (eg. 'c' -> 'c').
+  /// Removes any leading '&', if present (as in 'values representing types').
   static std::string getBarename(std::string const& typestr);
 
   /// Given a string like 'void (...)' (that is, the string representation of


### PR DESCRIPTION
- Fixes bug where barenames outside of any namespace could have
  leading characters removed.

- The "(none)" namespace placeholer is used for types that
  do not belong to any namespace.