### PR TITLE
Split stage runtime initialization and argument resolution (Cleaned)

### DIFF
--- a/src/vt/collective/collective_ops.h
+++ b/src/vt/collective/collective_ops.h
@@ -68,7 +68,10 @@ struct CollectiveAnyOps {
   );
   ///
   /// \brief Allocate routine to allow for two-step initialization
-  /// with configuration from command line and input (YAML) file
+  /// with configuration from command line and input file
+  /// \param[in] is_interop: bool (Default value = false)
+  /// \param[in] num_workers: WorkerCountType (Default value = no_workers)
+  /// \param[in] comm: Pointer to MPI_Comm (Default value = nullptr)
   ///
   static RuntimePtrType allocate(
     bool is_interop = false,

--- a/src/vt/collective/collective_ops.h
+++ b/src/vt/collective/collective_ops.h
@@ -66,6 +66,15 @@ struct CollectiveAnyOps {
     int& argc, char**& argv, WorkerCountType const num_workers = no_workers,
     bool is_interop = false, MPI_Comm* comm = nullptr
   );
+  ///
+  /// \brief Allocate routine to allow for two-step initialization
+  /// with configuration from command line and input (YAML) file
+  ///
+  static RuntimePtrType allocate(
+    bool is_interop = false,
+    WorkerCountType const num_workers = no_workers,
+    MPI_Comm* comm = nullptr
+  );
   static void finalize(RuntimePtrType in_rt = nullptr);
   static void scheduleThenFinalize(
     RuntimePtrType in_rt = nullptr, WorkerCountType const workers = no_workers

--- a/src/vt/collective/collective_ops.h
+++ b/src/vt/collective/collective_ops.h
@@ -56,28 +56,46 @@
 
 namespace vt {
 
+/** \file */
+
 static constexpr runtime::RuntimeInstType const collective_default_inst =
   runtime::RuntimeInstType::DefaultInstance;
 
+/**
+ * \struct CollectiveAnyOps collective_ops.h vt/collective/collective_ops.h
+ *
+ * \brief ...
+ *
+ */
 template <runtime::RuntimeInstType instance = collective_default_inst>
 struct CollectiveAnyOps {
   // The general methods that interact with the managed runtime holder
+
   static RuntimePtrType initialize(
     int& argc, char**& argv, WorkerCountType const num_workers = no_workers,
     bool is_interop = false, MPI_Comm* comm = nullptr
   );
-  ///
-  /// \brief Allocate routine to allow for two-step initialization
-  /// with configuration from command line and input file
-  /// \param[in] is_interop: bool (Default value = false)
-  /// \param[in] num_workers: WorkerCountType (Default value = no_workers)
-  /// \param[in] comm: Pointer to MPI_Comm (Default value = nullptr)
-  ///
+
+  /** 
+   * \brief Static allocation routine to allow for two-step initialization
+   *
+   * The routine must be called after an initialization that did not parse
+   * the command-line parameters.
+   * This separation allows to resolve parameters specified in an input file.
+   *
+   * \param[in] is_interop (Default value = false)
+   * \param[in] num_workers (Default value = no_workers)
+   * \param[in] comm: Pointer to MPI_Comm (Default value = nullptr)
+   *
+   * \return RuntimePtrType Pointer to the initialized runtime object
+   *
+   */ 
   static RuntimePtrType allocate(
     bool is_interop = false,
     WorkerCountType const num_workers = no_workers,
     MPI_Comm* comm = nullptr
   );
+
   static void finalize(RuntimePtrType in_rt = nullptr);
   static void scheduleThenFinalize(
     RuntimePtrType in_rt = nullptr, WorkerCountType const workers = no_workers

--- a/src/vt/collective/startup.cc
+++ b/src/vt/collective/startup.cc
@@ -69,6 +69,14 @@ RuntimePtrType initialize(MPI_Comm* comm) {
   return CollectiveOps::initialize(argc,argv,no_workers,true,comm);
 }
 
+RuntimePtrType allocate(
+  bool is_interop,
+  WorkerCountType const num_workers,
+  MPI_Comm* comm
+) {
+  return CollectiveOps::allocate(is_interop, num_workers, comm);
+}
+
 void finalize(RuntimePtrType in_rt) {
   if (in_rt) {
     return CollectiveOps::finalize(std::move(in_rt));

--- a/src/vt/collective/startup.h
+++ b/src/vt/collective/startup.h
@@ -57,6 +57,13 @@ RuntimePtrType initialize(
 RuntimePtrType initialize(int& argc, char**& argv, MPI_Comm* comm = nullptr);
 RuntimePtrType initialize(MPI_Comm* comm = nullptr);
 
+///
+/// \brief Allocate routine to allow for two-step initialization
+/// with configuration from command line and input file
+/// \param[in] is_interop: bool (Default value = false)
+/// \param[in] num_workers: WorkerCountType (Default value = no_workers)
+/// \param[in] comm: Pointer to MPI_Comm (Default value = nullptr)
+///
 RuntimePtrType allocate(
   bool is_interop = false,
   WorkerCountType const num_workers = no_workers,

--- a/src/vt/collective/startup.h
+++ b/src/vt/collective/startup.h
@@ -57,6 +57,12 @@ RuntimePtrType initialize(
 RuntimePtrType initialize(int& argc, char**& argv, MPI_Comm* comm = nullptr);
 RuntimePtrType initialize(MPI_Comm* comm = nullptr);
 
+RuntimePtrType allocate(
+  bool is_interop = false,
+  WorkerCountType const num_workers = no_workers,
+  MPI_Comm* comm = nullptr
+);
+
 void finalize(RuntimePtrType in_rt);
 void finalize();
 

--- a/src/vt/collective/startup.h
+++ b/src/vt/collective/startup.h
@@ -50,27 +50,83 @@
 
 namespace vt {
 
+/** \file */
+
+/**
+ * \brief Intialization with parsing of command-line parameters
+ *
+ * \param[in,out] argc number of command-line parameters
+ * \param[in,out] argv array of command-line parameters
+ * \param[in] is_interop (Default value = false)
+ * \param[in] num_workers (Default value = no_workers)
+ * \param[in] comm Pointer to MPI_Comm (Default value = nullptr)
+ *
+ * \return RuntimePtrType Pointer to the new runtime object
+ *
+ */
 RuntimePtrType initialize(
   int& argc, char**& argv, WorkerCountType const num_workers,
   bool is_interop = false, MPI_Comm* comm = nullptr
 );
+
+/**
+ * \brief Intialization with parsing of command-line parameters
+ *
+ * \param[in,out] argc number of command-line parameters
+ * \param[in,out] argv array of command-line parameters
+ * \param[in] comm Pointer to MPI_Comm (Default value = nullptr)
+ *
+ * \return RuntimePtrType Pointer to the new runtime object
+ *
+ */
 RuntimePtrType initialize(int& argc, char**& argv, MPI_Comm* comm = nullptr);
+
+/**
+ * \brief Intialization
+ *
+ * \param[in] comm Pointer to MPI_Comm (Default value = nullptr)
+ *
+ * \return RuntimePtrType Pointer to the new runtime object
+ *
+ */
 RuntimePtrType initialize(MPI_Comm* comm = nullptr);
 
-///
-/// \brief Allocate routine to allow for two-step initialization
-/// with configuration from command line and input file
-/// \param[in] is_interop: bool (Default value = false)
-/// \param[in] num_workers: WorkerCountType (Default value = no_workers)
-/// \param[in] comm: Pointer to MPI_Comm (Default value = nullptr)
-///
+/**
+ * \brief Allocate routine to allow for two-step initialization
+ *
+ * This routine must be called after initializing the runtime object.
+ * It allows to parse and resolve parameters from command line
+ * and from an input file.
+ *
+ * \param[in] is_interop (Default value = false)
+ * \param[in] num_workers (Default value = no_workers)
+ * \param[in] comm Pointer to MPI_Comm (Default value = nullptr)
+ *
+ * \return RuntimePtrType Pointer to the new runtime object
+ *
+ */
 RuntimePtrType allocate(
   bool is_interop = false,
   WorkerCountType const num_workers = no_workers,
   MPI_Comm* comm = nullptr
 );
 
+/**
+ * \brief Finalize
+ *
+ * This routine ...
+ *
+ * \param[in] in_rt
+ *
+ */
 void finalize(RuntimePtrType in_rt);
+
+/**
+ * \brief Finalize
+ *
+ * This routine ...
+ *
+ */
 void finalize();
 
 } /* end namespace vt */

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -1031,7 +1031,6 @@ void PrintOnOff<T>::output() {
 
   auto green = debug::green();
   auto reset = debug::reset();
-  auto bd_green = debug::bd_green();
   auto magenta = debug::magenta();
   auto vt_pre = debug::vtPre();
 

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -146,6 +146,7 @@ void ArgsManager::initializeOutputControl()
   auto quiet = std::string("Quiet VT-output (only errors, warnings)");
   auto ptr_quiet = addFlag("vt_quiet",
     Args::config.vt_quiet, quiet, outputGroup);
+  ptr_quiet->setPrintOption(PrintOption::whenSet);
 }
 
 void ArgsManager::initializeSignalHandling()
@@ -1082,7 +1083,6 @@ void Warning::output() {
   if ((condition_) && (!condition_()))
     return;
 
-  auto green = debug::green();
   auto red = debug::red();
   auto reset = debug::reset();
   auto bd_green = debug::bd_green();
@@ -1248,9 +1248,7 @@ void Anchor<T>::print() {
   }
   //---
   auto green = debug::green();
-  auto red = debug::red();
   auto reset = debug::reset();
-  auto bd_green = debug::bd_green();
   auto magenta = debug::magenta();
   auto vt_pre = debug::vtPre();
   //---
@@ -1334,7 +1332,6 @@ void Anchor<T>::addGeneralInstance(ContextEnum ctxt, const T& value) {
                        std::string(" Context ") + smap_[ctxt] +
                        std::string(" Already Inserted ");
     throw std::runtime_error(code);
-    return;
   }
   Instance<T> myCase(value, static_cast<AnchorBase*>(this));
   specifications_.insert(std::make_pair(ctxt, myCase));

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -989,9 +989,7 @@ void PrintOn<T>::output() {
     return;
 
   auto green = debug::green();
-  auto red = debug::red();
   auto reset = debug::reset();
-  auto bd_green = debug::bd_green();
   auto magenta = debug::magenta();
   auto vt_pre = debug::vtPre();
 

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -146,7 +146,7 @@ void ArgsManager::initializeOutputControl()
   auto quiet = std::string("Quiet VT-output (only errors, warnings)");
   auto ptr_quiet = addFlag("vt_quiet",
     Args::config.vt_quiet, quiet, outputGroup);
-  ptr_quiet->setPrintOption(PrintOption::whenSet);
+  ptr_quiet->setPrintOption(PrintOption::whenSet, nullptr);
 }
 
 void ArgsManager::initializeSignalHandling()
@@ -1032,7 +1032,6 @@ void PrintOnOff<T>::output() {
     return;
 
   auto green = debug::green();
-  auto red = debug::red();
   auto reset = debug::reset();
   auto bd_green = debug::bd_green();
   auto magenta = debug::magenta();
@@ -1085,7 +1084,6 @@ void Warning::output() {
 
   auto red = debug::red();
   auto reset = debug::reset();
-  auto bd_green = debug::bd_green();
   auto magenta = debug::magenta();
   auto vt_pre = debug::vtPre();
 

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -52,124 +52,92 @@
 
 namespace vt { namespace arguments {
 
-/*static*/ bool        ArgConfig::vt_color              = true;
-/*static*/ bool        ArgConfig::vt_no_color           = false;
-/*static*/ bool        ArgConfig::vt_quiet              = false;
+//--- Initialization of static variables for vt::AnchorBase
+/*static*/ Configs Args::config = {};
+/*static*/ bool Args::parsed = false;
 
-/*static*/ bool        ArgConfig::colorize_output       = false;
-/*static*/ int32_t     ArgConfig::vt_sched_num_progress = 2;
-/*static*/ int32_t     ArgConfig::vt_sched_progress_han = 0;
-/*static*/ double      ArgConfig::vt_sched_progress_sec = 0.0;
-/*static*/ bool        ArgConfig::vt_no_sigint          = false;
-/*static*/ bool        ArgConfig::vt_no_sigsegv         = false;
-/*static*/ bool        ArgConfig::vt_no_terminate       = false;
+/*static*/
+int Args::parse(int& argc, char**& argv) {
 
-/*static*/ bool        ArgConfig::vt_no_warn_stack      = false;
-/*static*/ bool        ArgConfig::vt_no_assert_stack    = false;
-/*static*/ bool        ArgConfig::vt_no_abort_stack     = false;
-/*static*/ bool        ArgConfig::vt_no_stack           = false;
-/*static*/ std::string ArgConfig::vt_stack_file         = "";
-/*static*/ std::string ArgConfig::vt_stack_dir          = "";
-/*static*/ int32_t     ArgConfig::vt_stack_mod          = 0;
-
-/*static*/ bool        ArgConfig::vt_trace              = false;
-/*static*/ bool        ArgConfig::vt_trace_mpi          = false;
-/*static*/ std::string ArgConfig::vt_trace_file         = "";
-/*static*/ std::string ArgConfig::vt_trace_dir          = "";
-/*static*/ int32_t     ArgConfig::vt_trace_mod          = 0;
-/*static*/ int32_t     ArgConfig::vt_trace_flush_size   = 0;
-
-/*static*/ bool        ArgConfig::vt_lb                 = false;
-/*static*/ bool        ArgConfig::vt_lb_file            = false;
-/*static*/ bool        ArgConfig::vt_lb_quiet           = false;
-/*static*/ std::string ArgConfig::vt_lb_file_name       = "";
-/*static*/ std::string ArgConfig::vt_lb_name            = "NoLB";
-/*static*/ std::string ArgConfig::vt_lb_args            = "";
-/*static*/ int32_t     ArgConfig::vt_lb_interval        = 1;
-/*static*/ bool        ArgConfig::vt_lb_stats           = false;
-/*static*/ std::string ArgConfig::vt_lb_stats_dir       = "vt_lb_stats";
-/*static*/ std::string ArgConfig::vt_lb_stats_file      = "stats";
-
-/*static*/ bool        ArgConfig::vt_term_rooted_use_ds = false;
-/*static*/ bool        ArgConfig::vt_term_rooted_use_wave = false;
-/*static*/ bool        ArgConfig::vt_no_detect_hang     = false;
-/*static*/ int64_t     ArgConfig::vt_hang_freq          = 1024;
-/*static*/ bool        ArgConfig::vt_epoch_graph_on_hang= true;
-/*static*/ bool        ArgConfig::vt_epoch_graph_terse  = false;
-/*static*/ bool        ArgConfig::vt_print_no_progress  = true;
-
-/*static*/ bool        ArgConfig::vt_pause              = false;
-
-/*static*/ bool        ArgConfig::vt_debug_all          = false;
-/*static*/ bool        ArgConfig::vt_debug_verbose      = false;
-/*static*/ bool        ArgConfig::vt_debug_none         = false;
-/*static*/ bool        ArgConfig::vt_debug_gen          = false;
-/*static*/ bool        ArgConfig::vt_debug_runtime      = false;
-/*static*/ bool        ArgConfig::vt_debug_active       = false;
-/*static*/ bool        ArgConfig::vt_debug_term         = false;
-/*static*/ bool        ArgConfig::vt_debug_termds       = false;
-/*static*/ bool        ArgConfig::vt_debug_barrier      = false;
-/*static*/ bool        ArgConfig::vt_debug_event        = false;
-/*static*/ bool        ArgConfig::vt_debug_pipe         = false;
-/*static*/ bool        ArgConfig::vt_debug_pool         = false;
-/*static*/ bool        ArgConfig::vt_debug_reduce       = false;
-/*static*/ bool        ArgConfig::vt_debug_rdma         = false;
-/*static*/ bool        ArgConfig::vt_debug_rdma_channel = false;
-/*static*/ bool        ArgConfig::vt_debug_rdma_state   = false;
-/*static*/ bool        ArgConfig::vt_debug_param        = false;
-/*static*/ bool        ArgConfig::vt_debug_handler      = false;
-/*static*/ bool        ArgConfig::vt_debug_hierlb       = false;
-/*static*/ bool        ArgConfig::vt_debug_gossiplb     = false;
-/*static*/ bool        ArgConfig::vt_debug_scatter      = false;
-/*static*/ bool        ArgConfig::vt_debug_sequence     = false;
-/*static*/ bool        ArgConfig::vt_debug_sequence_vrt = false;
-/*static*/ bool        ArgConfig::vt_debug_serial_msg   = false;
-/*static*/ bool        ArgConfig::vt_debug_trace        = false;
-/*static*/ bool        ArgConfig::vt_debug_location     = false;
-/*static*/ bool        ArgConfig::vt_debug_lb           = false;
-/*static*/ bool        ArgConfig::vt_debug_vrt          = false;
-/*static*/ bool        ArgConfig::vt_debug_vrt_coll     = false;
-/*static*/ bool        ArgConfig::vt_debug_worker       = false;
-/*static*/ bool        ArgConfig::vt_debug_group        = false;
-/*static*/ bool        ArgConfig::vt_debug_broadcast    = false;
-/*static*/ bool        ArgConfig::vt_debug_objgroup     = false;
-
-/*static*/ bool        ArgConfig::vt_user_1             = false;
-/*static*/ bool        ArgConfig::vt_user_2             = false;
-/*static*/ bool        ArgConfig::vt_user_3             = false;
-/*static*/ int32_t     ArgConfig::vt_user_int_1         = 0;
-/*static*/ int32_t     ArgConfig::vt_user_int_2         = 0;
-/*static*/ int32_t     ArgConfig::vt_user_int_3         = 0;
-/*static*/ std::string ArgConfig::vt_user_str_1         = "";
-/*static*/ std::string ArgConfig::vt_user_str_2         = "";
-/*static*/ std::string ArgConfig::vt_user_str_3         = "";
-
-/*static*/ bool        ArgConfig::parsed                = false;
-
-/*static*/ int ArgConfig::parse(int& argc, char**& argv) {
-  static CLI::App app{"vt"};
-
-  if (parsed || argc == 0 || argv == nullptr) {
+  if (parsed || argc == 0 || argv == nullptr)
     return 0;
-  }
 
   // CLI11 app parser expects to get the arguments in *reverse* order!
   std::vector<std::string> args;
-  for (auto i = argc-1; i > 0; i--) {
-    args.push_back(std::string(argv[i]));
+  for (int i = argc - 1; i > 0; i--) {
+    args.emplace_back(argv[i]);
   }
 
   // fmt::print("argc={}, argv={}\n", argc, print_ptr(argv));
 
+  /* Setup the parser */
+  std::unique_ptr<CLI::App> app_ = std::make_unique<CLI::App>("vt");
+  setup(app_.get());
+
+  /* Run the parser */
+  app_->allow_extras(true);
+  try {
+    app_->parse(args);
+  } catch (CLI::Error &ex) {
+    return app_->exit(ex);
+  }
+
+  // Determine the final colorization setting.
+  if (config.vt_no_color) {
+    config.colorize_output = false;
+  } else {
+    // Otherwise, colorize.
+    // (Within MPI there is no good method to auto-detect.)
+    config.colorize_output = true;
+  }
+
+  /*
+   * Put the arguments back into argc, argv, but properly order them based on
+   * the input order by comparing between the current args
+   */
+  std::vector<std::string> ret_args;
+  std::vector<std::size_t> ret_idx;
+  int item = 0;
+
+  // Iterate forward (CLI11 reverses the order when it modifies the args)
+  for (auto&& skipped : args) {
+    for (int ii = item; ii < argc; ii++) {
+      if (std::string(argv[ii]) == skipped) {
+        ret_idx.push_back(ii);
+        item++;
+        break;
+      }
+    }
+    ret_args.push_back(skipped);
+  }
+
+  // Use the saved index to setup the new_argv and new_argc
+  int new_argc = static_cast<int>(ret_args.size()) + 1;
+  char** new_argv = new char*[new_argc + 1];
+  new_argv[0] = argv[0];
+  for (int ii = 1; ii < new_argc; ii++) {
+    new_argv[ii] = argv[ret_idx[ii - 1]];
+  }
+
+  // Set them back with all vt arguments elided
+  argc = new_argc;
+  argv = new_argv;
+
+  parsed = true;
+  return 0;
+}
+
+/*static*/
+void Args::setup(CLI::App *app_) {
   /*
    * Flags for controlling the colorization of output from vt
    */
   auto quiet  = "Quiet the output from vt (only errors, warnings)";
   auto always = "Colorize output (default)";
   auto never  = "Do not colorize output (overrides --vt_color)";
-  auto a  = app.add_flag("-c,--vt_color",      vt_color,      always);
-  auto b  = app.add_flag("-n,--vt_no_color",   vt_no_color,   never);
-  auto a1 = app.add_flag("-q,--vt_quiet",      vt_quiet,      quiet);
+  auto a  = app_->add_flag("-c,--vt_color",      config.vt_color,      always);
+  auto b  = app_->add_flag("-n,--vt_no_color",   config.vt_no_color,   never);
+  auto a1 = app_->add_flag("-q,--vt_quiet",      config.vt_quiet,      quiet);
   auto outputGroup = "Output Control";
   a->group(outputGroup);
   b->group(outputGroup);
@@ -182,9 +150,9 @@ namespace vt { namespace arguments {
   auto no_sigint      = "Do not register signal handler for SIGINT";
   auto no_sigsegv     = "Do not register signal handler for SIGSEGV";
   auto no_terminate   = "Do not register handler for std::terminate";
-  auto d = app.add_flag("--vt_no_SIGINT",    vt_no_sigint,    no_sigint);
-  auto e = app.add_flag("--vt_no_SIGSEGV",   vt_no_sigsegv,   no_sigsegv);
-  auto f = app.add_flag("--vt_no_terminate", vt_no_terminate, no_terminate);
+  auto d = app_->add_flag("--vt_no_SIGINT",    config.vt_no_sigint,    no_sigint);
+  auto e = app_->add_flag("--vt_no_SIGSEGV",   config.vt_no_sigsegv,   no_sigsegv);
+  auto f = app_->add_flag("--vt_no_terminate", config.vt_no_terminate, no_terminate);
   auto signalGroup = "Signa Handling";
   d->group(signalGroup);
   e->group(signalGroup);
@@ -201,13 +169,13 @@ namespace vt { namespace arguments {
   auto file   = "Dump stack traces to file instead of stdout";
   auto dir    = "Name of directory to write stack files";
   auto mod    = "Write stack dump if (node % vt_stack_mod) == 0";
-  auto g = app.add_flag("--vt_no_warn_stack",   vt_no_warn_stack,   warn);
-  auto h = app.add_flag("--vt_no_assert_stack", vt_no_assert_stack, assert);
-  auto i = app.add_flag("--vt_no_abort_stack",  vt_no_abort_stack,  abort);
-  auto j = app.add_flag("--vt_no_stack",        vt_no_stack,        stack);
-  auto k = app.add_option("--vt_stack_file",    vt_stack_file,      file, "");
-  auto l = app.add_option("--vt_stack_dir",     vt_stack_dir,       dir,  "");
-  auto m = app.add_option("--vt_stack_mod",     vt_stack_mod,       mod,  1);
+  auto g = app_->add_flag("--vt_no_warn_stack",   config.vt_no_warn_stack,   warn);
+  auto h = app_->add_flag("--vt_no_assert_stack", config.vt_no_assert_stack, assert);
+  auto i = app_->add_flag("--vt_no_abort_stack",  config.vt_no_abort_stack,  abort);
+  auto j = app_->add_flag("--vt_no_stack",        config.vt_no_stack,        stack);
+  auto k = app_->add_option("--vt_stack_file",    config.vt_stack_file,      file, "");
+  auto l = app_->add_option("--vt_stack_dir",     config.vt_stack_dir,       dir,  "");
+  auto m = app_->add_option("--vt_stack_mod",     config.vt_stack_mod,       mod,  1);
   auto stackGroup = "Dump Stack Backtrace";
   g->group(stackGroup);
   h->group(stackGroup);
@@ -228,13 +196,13 @@ namespace vt { namespace arguments {
   auto tdir      = "Name of directory for trace files";
   auto tmod      = "Output trace file if (node % vt_stack_mod) == 0";
   auto tflushmod = "Flush output trace every (vt_trace_flush_size) trace records";
-  auto n  = app.add_flag("--vt_trace",              vt_trace,           trace);
-  auto nm = app.add_flag("--vt_trace_mpi",          vt_trace_mpi,       trace_mpi);
-  auto o  = app.add_option("--vt_trace_file",       vt_trace_file,      tfile, "");
-  auto p  = app.add_option("--vt_trace_dir",        vt_trace_dir,       tdir,  "");
-  auto q  = app.add_option("--vt_trace_mod",        vt_trace_mod,       tmod,  1);
-  auto qf = app.add_option("--vt_trace_flush_size", vt_trace_flush_size,tflushmod,
-    0);
+  auto n  = app_->add_flag("--vt_trace",              config.vt_trace,           trace);
+  auto nm = app_->add_flag("--vt_trace_mpi",          config.vt_trace_mpi,       trace_mpi);
+  auto o  = app_->add_option("--vt_trace_file",       config.vt_trace_file,      tfile, "");
+  auto p  = app_->add_option("--vt_trace_dir",        config.vt_trace_dir,       tdir,  "");
+  auto q  = app_->add_option("--vt_trace_mod",        config.vt_trace_mod,       tmod,  1);
+  auto qf = app_->add_option("--vt_trace_flush_size", config.vt_trace_flush_size,tflushmod,
+                           0);
   auto traceGroup = "Tracing Configuration";
   n->group(traceGroup);
   nm->group(traceGroup);
@@ -284,39 +252,39 @@ namespace vt { namespace arguments {
   auto cbp = "Enable debug_broadcast    = \"" debug_pp(broadcast)    "\"";
   auto dbp = "Enable debug_objgroup     = \"" debug_pp(objgroup)     "\"";
 
-  auto r  = app.add_flag("--vt_debug_all",          vt_debug_all,          rp);
-  auto r1 = app.add_flag("--vt_debug_verbose",      vt_debug_verbose,      rq);
-  auto aa = app.add_flag("--vt_debug_none",         vt_debug_none,         aap);
-  auto ba = app.add_flag("--vt_debug_gen",          vt_debug_gen,          bap);
-  auto ca = app.add_flag("--vt_debug_runtime",      vt_debug_runtime,      cap);
-  auto da = app.add_flag("--vt_debug_active",       vt_debug_active,       dap);
-  auto ea = app.add_flag("--vt_debug_term",         vt_debug_term,         eap);
-  auto fa = app.add_flag("--vt_debug_termds",       vt_debug_termds,       fap);
-  auto ga = app.add_flag("--vt_debug_barrier",      vt_debug_barrier,      gap);
-  auto ha = app.add_flag("--vt_debug_event",        vt_debug_event,        hap);
-  auto ia = app.add_flag("--vt_debug_pipe",         vt_debug_pipe,         iap);
-  auto ja = app.add_flag("--vt_debug_pool",         vt_debug_pool,         jap);
-  auto ka = app.add_flag("--vt_debug_reduce",       vt_debug_reduce,       kap);
-  auto la = app.add_flag("--vt_debug_rdma",         vt_debug_rdma,         lap);
-  auto ma = app.add_flag("--vt_debug_rdma_channel", vt_debug_rdma_channel, map);
-  auto na = app.add_flag("--vt_debug_rdma_state",   vt_debug_rdma_state,   nap);
-  auto oa = app.add_flag("--vt_debug_param",        vt_debug_param,        oap);
-  auto pa = app.add_flag("--vt_debug_handler",      vt_debug_handler,      pap);
-  auto qa = app.add_flag("--vt_debug_hierlb",       vt_debug_hierlb,       qap);
-  auto qb = app.add_flag("--vt_debug_gossiplb",     vt_debug_gossiplb,     qbp);
-  auto ra = app.add_flag("--vt_debug_scatter",      vt_debug_scatter,      rap);
-  auto sa = app.add_flag("--vt_debug_sequence",     vt_debug_sequence,     sap);
-  auto ta = app.add_flag("--vt_debug_sequence_vrt", vt_debug_sequence_vrt, tap);
-  auto ua = app.add_flag("--vt_debug_serial_msg",   vt_debug_serial_msg,   uap);
-  auto va = app.add_flag("--vt_debug_trace",        vt_debug_trace,        vap);
-  auto wa = app.add_flag("--vt_debug_location",     vt_debug_location,     wap);
-  auto xa = app.add_flag("--vt_debug_lb",           vt_debug_lb,           xap);
-  auto ya = app.add_flag("--vt_debug_vrt",          vt_debug_vrt,          yap);
-  auto za = app.add_flag("--vt_debug_vrt_coll",     vt_debug_vrt_coll,     zap);
-  auto ab = app.add_flag("--vt_debug_worker",       vt_debug_worker,       abp);
-  auto bb = app.add_flag("--vt_debug_group",        vt_debug_group,        bbp);
-  auto cb = app.add_flag("--vt_debug_broadcast",    vt_debug_broadcast,    cbp);
-  auto db = app.add_flag("--vt_debug_objgroup",     vt_debug_objgroup,     dbp);
+  auto r  = app_->add_flag("--vt_debug_all",          config.vt_debug_all,          rp);
+  auto r1 = app_->add_flag("--vt_debug_verbose",      config.vt_debug_verbose,      rq);
+  auto aa = app_->add_flag("--vt_debug_none",         config.vt_debug_none,         aap);
+  auto ba = app_->add_flag("--vt_debug_gen",          config.vt_debug_gen,          bap);
+  auto ca = app_->add_flag("--vt_debug_runtime",      config.vt_debug_runtime,      cap);
+  auto da = app_->add_flag("--vt_debug_active",       config.vt_debug_active,       dap);
+  auto ea = app_->add_flag("--vt_debug_term",         config.vt_debug_term,         eap);
+  auto fa = app_->add_flag("--vt_debug_termds",       config.vt_debug_termds,       fap);
+  auto ga = app_->add_flag("--vt_debug_barrier",      config.vt_debug_barrier,      gap);
+  auto ha = app_->add_flag("--vt_debug_event",        config.vt_debug_event,        hap);
+  auto ia = app_->add_flag("--vt_debug_pipe",         config.vt_debug_pipe,         iap);
+  auto ja = app_->add_flag("--vt_debug_pool",         config.vt_debug_pool,         jap);
+  auto ka = app_->add_flag("--vt_debug_reduce",       config.vt_debug_reduce,       kap);
+  auto la = app_->add_flag("--vt_debug_rdma",         config.vt_debug_rdma,         lap);
+  auto ma = app_->add_flag("--vt_debug_rdma_channel", config.vt_debug_rdma_channel, map);
+  auto na = app_->add_flag("--vt_debug_rdma_state",   config.vt_debug_rdma_state,   nap);
+  auto oa = app_->add_flag("--vt_debug_param",        config.vt_debug_param,        oap);
+  auto pa = app_->add_flag("--vt_debug_handler",      config.vt_debug_handler,      pap);
+  auto qa = app_->add_flag("--vt_debug_hierlb",       config.vt_debug_hierlb,       qap);
+  auto qb = app_->add_flag("--vt_debug_gossiplb",     config.vt_debug_gossiplb,     qbp);
+  auto ra = app_->add_flag("--vt_debug_scatter",      config.vt_debug_scatter,      rap);
+  auto sa = app_->add_flag("--vt_debug_sequence",     config.vt_debug_sequence,     sap);
+  auto ta = app_->add_flag("--vt_debug_sequence_vrt", config.vt_debug_sequence_vrt, tap);
+  auto ua = app_->add_flag("--vt_debug_serial_msg",   config.vt_debug_serial_msg,   uap);
+  auto va = app_->add_flag("--vt_debug_trace",        config.vt_debug_trace,        vap);
+  auto wa = app_->add_flag("--vt_debug_location",     config.vt_debug_location,     wap);
+  auto xa = app_->add_flag("--vt_debug_lb",           config.vt_debug_lb,           xap);
+  auto ya = app_->add_flag("--vt_debug_vrt",          config.vt_debug_vrt,          yap);
+  auto za = app_->add_flag("--vt_debug_vrt_coll",     config.vt_debug_vrt_coll,     zap);
+  auto ab = app_->add_flag("--vt_debug_worker",       config.vt_debug_worker,       abp);
+  auto bb = app_->add_flag("--vt_debug_group",        config.vt_debug_group,        bbp);
+  auto cb = app_->add_flag("--vt_debug_broadcast",    config.vt_debug_broadcast,    cbp);
+  auto db = app_->add_flag("--vt_debug_objgroup",     config.vt_debug_objgroup,     dbp);
   auto debugGroup = "Debug Print Configuration (must be compile-time enabled)";
   r->group(debugGroup);
   r1->group(debugGroup);
@@ -372,16 +340,16 @@ namespace vt { namespace arguments {
   auto lbd = "vt_lb_stats";
   auto lbs = "stats";
   auto lba = "";
-  auto s  = app.add_flag("--vt_lb",              vt_lb,             lb);
-  auto t  = app.add_flag("--vt_lb_file",         vt_lb_file,        lb_file);
-  auto t1 = app.add_flag("--vt_lb_quiet",        vt_lb_quiet,       lb_quiet);
-  auto u  = app.add_option("--vt_lb_file_name",  vt_lb_file_name,   lb_file_name, lbf);
-  auto v  = app.add_option("--vt_lb_name",       vt_lb_name,        lb_name,      lbn);
-  auto v1 = app.add_option("--vt_lb_args",       vt_lb_args,        lb_args,      lba);
-  auto w  = app.add_option("--vt_lb_interval",   vt_lb_interval,    lb_interval,  lbi);
-  auto ww = app.add_flag("--vt_lb_stats",        vt_lb_stats,       lb_stats);
-  auto wx = app.add_option("--vt_lb_stats_dir",  vt_lb_stats_dir,   lb_stats_dir, lbd);
-  auto wy = app.add_option("--vt_lb_stats_file", vt_lb_stats_file,  lb_stats_file,lbs);
+  auto s  = app_->add_flag("--vt_lb",              config.vt_lb,             lb);
+  auto t  = app_->add_flag("--vt_lb_file",         config.vt_lb_file,        lb_file);
+  auto t1 = app_->add_flag("--vt_lb_quiet",        config.vt_lb_quiet,       lb_quiet);
+  auto u  = app_->add_option("--vt_lb_file_name",  config.vt_lb_file_name,   lb_file_name, lbf);
+  auto v  = app_->add_option("--vt_lb_name",       config.vt_lb_name,        lb_name,      lbn);
+  auto v1 = app_->add_option("--vt_lb_args",       config.vt_lb_args,        lb_args,      lba);
+  auto w  = app_->add_option("--vt_lb_interval",   config.vt_lb_interval,    lb_interval,  lbi);
+  auto ww = app_->add_flag("--vt_lb_stats",        config.vt_lb_stats,       lb_stats);
+  auto wx = app_->add_option("--vt_lb_stats_dir",  config.vt_lb_stats_dir,   lb_stats_dir, lbd);
+  auto wy = app_->add_option("--vt_lb_stats_file", config.vt_lb_stats_file,  lb_stats_file,lbs);
   auto debugLB = "Load Balancing";
   s->group(debugLB);
   t->group(debugLB);
@@ -406,13 +374,13 @@ namespace vt { namespace arguments {
   auto terse        = "Output epoch graph to file in terse mode";
   auto progress     = "Print termination counts when progress is stalled";
   auto hfd          = 1024;
-  auto x  = app.add_flag("--vt_no_detect_hang",        vt_no_detect_hang,       hang);
-  auto x1 = app.add_flag("--vt_term_rooted_use_ds",    vt_term_rooted_use_ds,   ds);
-  auto x2 = app.add_flag("--vt_term_rooted_use_wave",  vt_term_rooted_use_wave, wave);
-  auto x3 = app.add_option("--vt_epoch_graph_on_hang", vt_epoch_graph_on_hang,  graph_on, true);
-  auto x4 = app.add_flag("--vt_epoch_graph_terse",     vt_epoch_graph_terse,    terse);
-  auto x5 = app.add_option("--vt_print_no_progress",   vt_print_no_progress,    progress, true);
-  auto y = app.add_option("--vt_hang_freq",            vt_hang_freq,      hang_freq, hfd);
+  auto x  = app_->add_flag("--vt_no_detect_hang",        config.vt_no_detect_hang,       hang);
+  auto x1 = app_->add_flag("--vt_term_rooted_use_ds",    config.vt_term_rooted_use_ds,   ds);
+  auto x2 = app_->add_flag("--vt_term_rooted_use_wave",  config.vt_term_rooted_use_wave, wave);
+  auto x3 = app_->add_option("--vt_epoch_graph_on_hang", config.vt_epoch_graph_on_hang,  graph_on, true);
+  auto x4 = app_->add_flag("--vt_epoch_graph_terse",     config.vt_epoch_graph_terse,    terse);
+  auto x5 = app_->add_option("--vt_print_no_progress",   config.vt_print_no_progress,    progress, true);
+  auto y = app_->add_option("--vt_hang_freq",            config.vt_hang_freq,      hang_freq, hfd);
   auto debugTerm = "Termination";
   x->group(debugTerm);
   x1->group(debugTerm);
@@ -427,7 +395,7 @@ namespace vt { namespace arguments {
    */
 
   auto pause        = "Pause at startup so GDB/LLDB can be attached";
-  auto z = app.add_flag("--vt_pause", vt_pause, pause);
+  auto z = app_->add_flag("--vt_pause", config.vt_pause, pause);
   auto launchTerm = "Debugging/Launch";
   z->group(launchTerm);
 
@@ -445,15 +413,15 @@ namespace vt { namespace arguments {
   auto userstr1 = "User Option 1c (std::string)";
   auto userstr2 = "User Option 2c (std::string)";
   auto userstr3 = "User Option 3c (std::string)";
-  auto u1  = app.add_flag("--vt_user_1", vt_user_1, user1);
-  auto u2  = app.add_flag("--vt_user_2", vt_user_2, user2);
-  auto u3  = app.add_flag("--vt_user_3", vt_user_3, user3);
-  auto ui1 = app.add_option("--vt_user_int_1", vt_user_int_1, userint1, 0);
-  auto ui2 = app.add_option("--vt_user_int_2", vt_user_int_2, userint2, 0);
-  auto ui3 = app.add_option("--vt_user_int_3", vt_user_int_3, userint3, 0);
-  auto us1 = app.add_option("--vt_user_str_1", vt_user_str_1, userstr1, "");
-  auto us2 = app.add_option("--vt_user_str_2", vt_user_str_2, userstr2, "");
-  auto us3 = app.add_option("--vt_user_str_3", vt_user_str_3, userstr3, "");
+  auto u1  = app_->add_flag("--vt_user_1", config.vt_user_1, user1);
+  auto u2  = app_->add_flag("--vt_user_2", config.vt_user_2, user2);
+  auto u3  = app_->add_flag("--vt_user_3", config.vt_user_3, user3);
+  auto ui1 = app_->add_option("--vt_user_int_1", config.vt_user_int_1, userint1, 0);
+  auto ui2 = app_->add_option("--vt_user_int_2", config.vt_user_int_2, userint2, 0);
+  auto ui3 = app_->add_option("--vt_user_int_3", config.vt_user_int_3, userint3, 0);
+  auto us1 = app_->add_option("--vt_user_str_1", config.vt_user_str_1, userstr1, "");
+  auto us2 = app_->add_option("--vt_user_str_2", config.vt_user_str_2, userstr2, "");
+  auto us3 = app_->add_option("--vt_user_str_3", config.vt_user_str_3, userstr3, "");
   auto userOpts = "User Options";
   u1->group(userOpts);
   u2->group(userOpts);
@@ -472,67 +440,13 @@ namespace vt { namespace arguments {
   auto nsched = "Number of times to run the progress function in scheduler";
   auto ksched = "Run the MPI progress function at least every k handlers that run";
   auto ssched = "Run the MPI progress function at least every s seconds";
-  auto sca = app.add_option("--vt_sched_num_progress", vt_sched_num_progress, nsched, 2);
-  auto hca = app.add_option("--vt_sched_progress_han", vt_sched_progress_han, ksched, 0);
-  auto kca = app.add_option("--vt_sched_progress_sec", vt_sched_progress_sec, ssched, 0.0);
+  auto sca = app_->add_option("--vt_sched_num_progress", config.vt_sched_num_progress, nsched, 2);
+  auto hca = app_->add_option("--vt_sched_progress_han", config.vt_sched_progress_han, ksched, 0);
+  auto kca = app_->add_option("--vt_sched_progress_sec", config.vt_sched_progress_sec, ssched, 0.0);
   auto schedulerGroup = "Scheduler Configuration";
   sca->group(schedulerGroup);
   hca->group(schedulerGroup);
   kca->group(schedulerGroup);
-
-  /*
-   * Run the parser!
-   */
-  app.allow_extras(true);
-  try {
-    app.parse(args);
-  } catch (CLI::Error &ex) {
-    return app.exit(ex);
-  }
-
-  // Determine the final colorization setting.
-  if (vt_no_color) {
-    colorize_output = false;
-  } else {
-    // Otherwise, colorize.
-    // (Within MPI there is no good method to auto-detect.)
-    colorize_output = true;
-  }
-
-  /*
-   * Put the arguments back into argc, argv, but properly order them based on
-   * the input order by comparing between the current args
-   */
-  std::vector<std::string> ret_args;
-  std::vector<std::size_t> ret_idx;
-  int item = 0;
-
-  // Iterate forward (CLI11 reverses the order when it modifies the args)
-  for (auto&& skipped : args) {
-    for (auto ii = item; ii < argc; ii++) {
-      if (std::string(argv[ii]) == skipped) {
-        ret_idx.push_back(ii);
-        item++;
-        break;
-      }
-    }
-    ret_args.push_back(skipped);
-  }
-
-  // Use the saved index to setup the new_argv and new_argc
-  int new_argc = ret_args.size() + 1;
-  char** new_argv = new char*[new_argc + 1];
-  new_argv[0] = argv[0];
-  for (auto ii = 1; ii < new_argc; ii++) {
-    new_argv[ii] = argv[ret_idx[ii - 1]];
-  }
-
-  // Set them back with all vt arguments elided
-  argc = new_argc;
-  argv = new_argv;
-
-  parsed = true;
-  return 1;
 }
 
 }} /* end namespace vt::arguments */

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -60,6 +60,17 @@ class App;
 
 namespace vt { namespace arguments {
 
+/** \file */
+
+/**
+ * \struct Configs args.h vt/configs/arguments/args.h
+ *
+ * \brief The structure with the sets of simulation parameters
+ *
+ * This structure lists all the parameters that could be set
+ * at the start of a simulation.
+ *
+ */
 struct Configs {
 public:
   bool vt_color = true;
@@ -158,61 +169,92 @@ public:
 };
 
 
-/// \brief Enum for the Context where the Parameters is set
+/// Enum for the context where the parameters is set
 enum struct ContextEnum : std::uint8_t { dFault, commandLine, thirdParty };
 
 
-/// \brief Enum for the Print Status
+/// Enum for the print status
 enum struct PrintOption : std::uint8_t { never = 0, whenSet = 2, always = 255 };
 
 
-/// \brief Forward declaration
+//--- Forward declaration
 struct Printer;
 
 
-/// \brief Virtual struct for storing an option/flag
+/**
+ * \struct AnchorBase args.h vt/configs/arguments/args.h
+ *
+ * \brief Virtual structure for storing a parameter (option or flag).
+ *
+ * ...
+ *
+ */
 struct AnchorBase: std::enable_shared_from_this<AnchorBase> {
 
-  /// \brief Count how many instances of the parameter 'name'
-  /// have been specified.
-  /// \param[in] name Parameter to specify
+  /**
+   * \brief Count how many instances of the parameter 'name' have been specified.
+   *
+   * ...
+   *
+   * \param[in] name Parameter to specify
+   *
+   * \return Count
+   */
   virtual int count() const = 0;
 
-  /// \brief Virtual function to print information
+  /**
+   * \brief Virtual function to print information
+   */
   virtual void print() = 0;
 
-  /// \brief Resets to the default value
+  /**
+   * \brief Virtual function to reset to the default value
+   */
   virtual void resetToDefault() = 0;
 
-  /// \brief Virtual function to resolve precedence rules
+  /**
+   * \brief Virtual function to resolve precedence rules
+   */
   virtual void resolve() = 0;
 
-  /// \brief Set the printing option for the anchor
-  ///
-  /// \param[in] po Enum PrintOption for the anchor
-  /// \param[in] fun Function returning a boolean to constraint the printing
-  ///
+  /**
+   * \brief Set the printing option for the anchor
+   * 
+   * \param[in] po Enum PrintOption for the anchor
+   * \param[in] fun Function returning a boolean to constraint the printing
+   */ 
   virtual void setPrintOption(PrintOption po, std::function<bool()> fun) = 0;
 
-  /// \brief Virtual function returning resolved value
-  /// \returns Resolved value
+  /**
+   * \brief Virtual function returning resolved value
+   *
+   * \returns Resolved value
+   */
   virtual std::string stringifyValue() const = 0;
 
-  /// \brief Virtual function returning context for resolved value
-  /// \returns Context
+  /**
+   * \brief Virtual function returning context for resolved value
+   *
+   * \returns Context
+   */
   virtual std::string stringifyContext() const = 0;
 
-  /// \brief Virtual function returning context for resolved value
-  /// \returns Default value
+  /**
+   * \brief Virtual function returning context for resolved value
+   *
+   * \returns Default value
+   */
   virtual std::string stringifyDefault() const = 0;
 
   //--------------------------------------------//
   // Non-virtual member functions
   //--------------------------------------------//
 
-  /// \brief Sets excluded option
-  ///
-  /// \param[in] opt  Pointer to the option to exclude
+  /**
+   * \brief Sets excluded option
+   * 
+   * \param[in] opt  Pointer to the option to exclude
+   */
   void excludes(const std::shared_ptr<AnchorBase>& opt) {
     excludes_.insert(opt);
     // Help text should be symmetric - excluding a should exclude b
@@ -222,64 +264,88 @@ struct AnchorBase: std::enable_shared_from_this<AnchorBase> {
     //
   }
 
-  /// \brief Returns the description of the anchor
-  /// \return Description
+  /** 
+   * \brief Returns the description of the anchor
+   * 
+   * ...
+   *
+   * \return String for the description
+   */
   std::string getDescription() const { return description_; }
 
-  /// \brief Returns the group name of the anchor
-  /// \return Group
+  /**
+   * \brief Returns the group name of the anchor
+   *
+   * \return String for the group
+   */
   std::string getGroup() const { return group_; }
 
-  /// \brief Returns the name of the anchor
-  /// \return Name of the option
+  /**
+   * \brief Returns the name of the anchor
+   *
+   * \return Name of the anchor
+   *
   std::string getName() const { return name_; }
 
-  /// \brief Function to determine whether the precedence rules
-  /// have been applied or not.
-  /// \returns Boolean
+  /**
+   * \brief Function to determine whether the precedence rules have been applied.
+   *
+   * \returns Boolean
+   */
   bool isResolved() const { return isResolved_; }
 
-  /// \brief Sets dependence on a specific flag being turned off
-  ///
-  /// \param[in] opt  Pointer to the flag to depend on
+  /**
+   * \brief Sets dependence on a specific flag being turned off
+   * 
+   * \param[in] opt Pointer to the flag to depend on
+   */
   void needsOptionOff(std::shared_ptr<AnchorBase> const& opt) {
     needsOptOff_.insert(opt);
   }
 
-  /// \brief Sets dependence on a specific flag being turned on
-  ///
-  /// \param[in] opt  Pointer to the flag to depend on
+  /**
+   * \brief Sets dependence on a specific flag being turned on
+   * 
+   * \param[in] opt Pointer to the flag to depend on
+   */
   void needsOptionOn(std::shared_ptr<AnchorBase> const& opt) {
     needsOptOn_.insert(opt);
   }
 
-  /// \brief Set the group name for the anchor
-  ///
-  /// \param[in] grp_ String for the name of the group
+  /**
+   * \brief Set the group name for the anchor
+   *
+   * \param[in] grp_ String for the name of the group
+   */
   void setGroup(const std::string& grp_) { group_ = grp_; }
 
-  /// \brief Set the printing option for the anchor
-  ///
-  /// \param[in] po Enum PrintOption for the anchor
-  /// \param[in] fun Function returning a boolean to constraint the printing
-  ///
+  /**
+   * \brief Set the printing option for the anchor
+   * 
+   * \param[in] po Enum PrintOption for the anchor
+   * \param[in] fun Function returning a boolean to constraint the printing
+   */ 
   virtual void setPrintOptionImpl(PrintOption po, std::function<bool()> fun)=0;
 
 protected:
-  /// \brief Constructor
-  ///
-  /// \param[in] name Label for the anchor
-  /// \param[in] desc Description of the anchor
-  ///
-  /// \note The anchor will be assigned to a default group, named 'Default'.
-  ///
+
+  /**
+   * \brief Constructor
+   * 
+   * \param[in] name Label for the anchor
+   * \param[in] desc Description of the anchor
+   * 
+   * \note The anchor will be assigned to a default group, named 'Default'.
+   */
   AnchorBase(std::string name, std::string desc, std::string grp);
 
 protected:
 
-  //--- Build enum for ordering the context
-  //--- Order of the contexts can be specified
-  //--- independently of an instance for that context.
+  /// Enum for ordering the context
+  ///
+  /// Order of the contexts can be specified independently of 
+  /// an instance for that context.
+  ///
   enum struct OrderContextEnum : std::uint8_t {
     MIN = 0,
     dFault = 1,
@@ -288,201 +354,280 @@ protected:
     MAX = 255
   };
 
-  //--- Map from 'ContextEnum' flag to an ordered flag.
+  /// Map from 'ContextEnum' flag to an ordered flag.
   static std::map<ContextEnum, OrderContextEnum> emap_;
 
-  //--- Map from 'ContextEnum' flag to a descriptive string.
+  /// Map from 'ContextEnum' flag to a descriptive string.
   static std::map<ContextEnum, std::string> smap_;
 
+  /// Boolean to indicate whether precedence rules have been applied.
   bool isResolved_;
 
+  /// String name for the anchor
   std::string name_;
+
+  /// String name for the group containing the anchor
   std::string group_;
+
+  /// String name for the description of the anchor 
   std::string description_;
 
-  /// \brief Map ordering the different instances of an 'anchor'
+  /// Map ordering the different instances of an 'anchor'
   std::map<ContextEnum, OrderContextEnum> ordering_;
 
-  /// \brief List of options that are needed to be OFF for this option
+  /// Set of anchors that are needed to be OFF for this anchors
   std::set<std::shared_ptr<AnchorBase>> needsOptOff_;
 
-  /// \brief List of options that are needed to be ON for this option
+  /// Set of anchors that are needed to be ON for this anchors
   std::set<std::shared_ptr<AnchorBase>> needsOptOn_;
 
-  /// \brief List of options that are excluded with this option
+  /// Set of anchors that are excluded with this anchors
   std::set<std::shared_ptr<AnchorBase>> excludes_;
 
-  /// \brief Printing options for the anchor
+  /// Printing options for the anchor
   PrintOption statusPrint_ = PrintOption::never;
 
-  /// \brief Pointer to 'Printer' object for displaying message
-  /// on the startup banner.
+  /// Pointer to 'Printer' object for displaying message on the startup banner.
   std::unique_ptr<Printer> screenPrint_;
 
 };
 
 
-/// \brief Template struct for storing an option/flag
+/**
+ * /struct Anchor args.h vt/configs/arguments/args.h
+ *
+ * \brief Template struct for storing an option/flag
+ *
+ * ...
+ *
+ */
 template <typename T>
 struct Anchor : public AnchorBase {
 
 public:
-  /// \brief Constructor
-  ///
-  /// \param[in] var Variable to specify and whose initial value
-  ///                defines the default value
-  /// \param[in] name Label for the parameter of interest
-  /// \param[in] desc String describing the anchor
-  /// \param[in] grp  String for the group owning the anchor
-  ///
+  /**
+   * \brief Constructor
+   * 
+   * \param[in] var Variable to specify and whose initial value
+   *                defines the default value
+   * \param[in] name Label for the parameter of interest
+   * \param[in] desc String describing the anchor
+   * \param[in] grp  String for the group owning the anchor
+   *
+   */ 
   explicit Anchor(
     T& var, const std::string& name, const std::string& desc,
     const std::string& grp = "Default"
   );
 
-  /// \brief Add instance from a third party with a specific value
-  ///
-  /// \param[in] value Value to specify for the third party context
-  /// \param[in] highestPrecedence Boolean determining whether the instance
-  /// should have the highest priority (default = false)
+  /**
+   *  \brief Add instance with a specific value
+   *
+   * The routine adds a specific value for an instance of the anchor.
+   *
+   * \param[in] value Value to specify for the third party context
+   * \param[in] highestPrecedence Boolean determining whether the instance
+   * should have the highest priority (default = false)
+   */
   void addInstance(const T& value, bool highestPrecedence = false);
 
-  /// \brief Counts the current number of instances for the option
-  ///
-  /// \returns Number of instances for the option
+  /**
+   * \brief Counts the current number of instances for the anchor 
+   * 
+   * \returns Number of instances for the anchor
+   */
   int count() const override {
     return static_cast<int>(specifications_.size());
   }
 
-  /// \brief Sets highest priority (precedence) for a context
-  ///
-  /// \param[in] origin Context for the highest priority
-  ///
-  /// \note If a different context had already the highest priority,
-  /// this context priority will be reset to its original value.
-  ///
+  /**
+   * \brief Sets highest priority (precedence) for a context
+   * 
+   * \param[in] origin Context for the highest priority
+   * 
+   * \note If a different context had already the highest priority,
+   * this context priority will be reset to its original value.
+   */ 
   void setHighestPrecedence(const ContextEnum& origin);
 
-  /// \brief Sets a new default value.
-  ///
-  /// \param ref Value to assign as default
+  /**
+   * \brief Sets a new default value.
+   * 
+   * \param[in] ref Value to assign as default
+   */
   void setNewDefaultValue(const T& ref);
 
-  /// \brief Set the printing option for the anchor
-  ///
-  /// \param[in] po Enum PrintOption for the anchor
-  /// \param[in] fun Function returning a boolean to constraint the printing
-  ///
+  /**
+   * \brief Set the printing option for the anchor
+   *
+   * ...
+   * 
+   * \param[in] po Enum PrintOption for the anchor
+   * \param[in] fun Function returning a boolean to constraint the printing
+   */ 
   void setPrintOption(PrintOption po, std::function<bool()> fun) override;
 
-  /// \brief Returns the default value for the anchor
-  ///
-  /// \returns Default value of the anchor
+  /**
+   * \brief Returns the default value for the anchor
+   * 
+   * \returns Default value of the anchor
+   */
   const T getDefaultValue() const;
 
-  /// \brief Returns the value for the current instance
-  ///
-  /// \returns Value of the current instance
+  /**
+   * \brief Returns the value for the current instance
+   * 
+   * \returns Value of the current instance
+   */
   const T& getValue() const { return value_; }
 
-  /// \brief Virtual function returning resolved value
-  /// \returns Resolved value
+  /**
+   * \brief Virtual function returning resolved value
+   * \returns Resolved value
+   */
   std::string stringifyValue() const override;
 
-  /// \brief Virtual function returning context for resolved value
-  /// \returns String for resolved context
+  /**
+   * \brief Virtual function returning context for resolved value
+   *
+   * \returns String for resolved context
+   */
   std::string stringifyContext() const override;
 
-  /// \brief Virtual function returning default value
-  /// \returns String for default value
+  /**
+   * \brief Virtual function returning default value
+   *
+   * \returns String for default value
+   */
   std::string stringifyDefault() const override;
 
-  /// \brief Resets to the default value
+  /**
+   * \brief Resets to the default value
+   */
   void resetToDefault() override;
 
   //
   //--- Printing routines
   //
 
-  /// \brief Printing routine about the anchor
+  /**
+   * \brief Printing routine about the anchor
+   */
   void print() override;
 
-  /// \brief Set the printing message for the banner as a warning
-  ///
-  /// \param[in] String to display for the anchor
-  ///
-  /// \note The message will be of the form
-  /// "Warning: 'NAME' has no effect: compile-time feature 'MSG' is disabled"
-  ///
+  /**
+   * \brief Set the printing message for the banner as a warning
+   * 
+   * \param[in] String to display for the anchor
+   * 
+   * \note The message will be of the form
+   * "Warning: 'NAME' has no effect: compile-time feature 'MSG' is disabled"
+   */ 
   void setBannerMsgWarning(std::string msg, std::function<bool()> fun=nullptr);
 
-  /// \brief Add instance from a particular context
-  ///
-  /// \param[in] ctxt Context for the instance
-  /// \param[in] value Value specified by the instance
-  ///
+  /**
+   * \brief Add instance from a particular context
+   * 
+   * \param[in] ctxt Context for the instance
+   * \param[in] value Value specified by the instance
+   */ 
   void addGeneralInstance(ContextEnum ctxt, const T& value);
 
-  /// \brief Checks whether two 'excluded' options have specifications
-  ///         in addition to their default ones.
+  /**
+   * \brief Checks whether two 'excluded' options have specifications
+   *         in addition to their default ones.
+   */
   void checkExcludes() const;
 
-  /// \brief Resolves the precedence rules among the instances
+  /**
+   * \brief Resolves the precedence rules among the instances
+   */
   void resolve() override;
 
-  /// \brief Set the printing option for the anchor
-  ///
-  /// \param[in] po Enum PrintOption for the anchor
-  /// \param[in] fun Function returning a boolean to constraint the printing
-  ///
+  /**
+   * \brief Set the printing option for the anchor
+   * 
+   * \param[in] po Enum PrintOption for the anchor
+   * \param[in] fun Function returning a boolean to constraint the printing
+   */ 
   void setPrintOptionImpl(PrintOption po, std::function<bool()> fun) override;
 
 protected:
 
-  //--- Structure for storing each instance of one anchor
+  /**
+   *
+   * \brief Structure for storing each instance of an anchor
+   *
+   */
   template <typename U = T>
   struct Instance {
 
   public:
-    /// \brief Constructor
-    ///
-    /// \param[in] ref Value of the anchor for this instance
-    /// \param[in] parent Pointer for the parent anchor
+
+    /**
+     * \brief Constructor
+     * 
+     * \param[in] ref Value of the anchor for this instance
+     * \param[in] parent Pointer for the parent anchor
+     *
+     */
     explicit Instance(const U& rval, AnchorBase* parent)
       : value_(rval), parent_(parent)
     {}
 
-    /// \brief Dummy Constructor
+    /** 
+     * \brief Dummy Constructor
+     *
+     */
     Instance() : value_(), parent_(nullptr)
     {}
 
-    /// \brief Copy Constructor
+    /**
+     *  \brief Copy Constructor
+     *
+     * \param[in] ref Reference to existing instance
+     *
+     */
     Instance(const Instance<U>& ref)
       : value_(ref.value_), parent_(ref.parent_)
     {}
 
-    /// \brief Destructor
+    /**
+     * \brief Destructor
+     */
     ~Instance() = default;
 
-    /// \brief Assignment operator
+    /**
+     *  \brief Assignment operator
+     *
+     * \param[in] ref Reference to existing instance
+     *
+     */
     Instance<U>& operator=(const Instance<U>& ref) {
       value_ = ref.value_;
       parent_ = ref.parent_;
       return *this;
     }
 
-    /// \brief Sets new value for the instance
-    ///
-    /// \param ref New value to insert for the instance
+    /**
+     *  \brief Sets new value for the instance
+     * 
+     * \param[in] ref New value to insert for the instance
+     *
+     */
     void setNewValue(const U& ref) { value_ = ref; }
 
-    /// \brief Returns the value for the current instance
-    ///
-    /// \returns Value of the current instance
+    /**
+     *  \brief Returns the value for the current instance
+     *
+     * \returns Value of the current instance
+     */
     const U& getValue() const { return value_; }
 
   protected:
+    /// Parameter-value for this instance
     U value_;
+    /// Pointer to the anchor corresponding to that instance
     AnchorBase* parent_ = nullptr;
   };
   //---
@@ -496,51 +641,65 @@ protected:
 
 };
 
+//---Forward declaration
 struct ArgsManager;
 
+/**
+ * \struct Args args.h vt/configs/arguments/args.h
+ *
+ * \brief The main class for configuring the set of simulation parameters.
+ *
+ */
 struct Args {
 
 public:
+
+  /// Static set of configuration parameters
   static Configs config;
 
 public:
 
-  /// \brief Parse the command line inputs and resolve the precedence rules
-  ///
-  /// \param[in,out] argc Number of arguments
-  /// \param[in,out] argv Array of arguments
-  ///
-  /// \note When exiting, argc and argv will be modified in presence of
-  /// redundancy.
-  ///
-  /// \note At exit, the configuration parameters will be set.
-  ///
+  /**
+   * \brief Parse the command line inputs and resolve the precedence rules
+   * 
+   * \param[in,out] argc Number of arguments
+   * \param[in,out] argv Array of arguments
+   * 
+   * \note When exiting, argc and argv will be modified in presence of
+   * redundancy.
+   * \note At exit, the configuration parameters will be set.
+   *
+   */ 
   static void parseAndResolve(int& argc, char**& argv);
 
-  /// \brief Returns pointer to the option object for specific name.
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name Label for the parameter of interest
-  /// \return Pointer to the anchor with the specified label
+  /**
+   * \brief Returns pointer to the option object for specific name.
+   *
+   * ...
+   * 
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name Label for the parameter of interest
+   *
+   * \return Pointer to the anchor with the specified label
+   */
   template <typename T>
   static std::shared_ptr<Anchor<T>> getOption(const std::string& name);
 
-  /// \brief Add flag for boolean or integral flag
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name Label for the parameter of interest
-  /// \param[in] anchor_value Variable to specify and whose initial value
-  ///                         defines the default value
-  /// \param[in] desc String describing the option
-  ///
-  /// \return Pointer to the anchor with the specified label
-  ///
-  /// \note Creates two instances one for the default value
-  /// (with the current value in 'anchor_value') and
-  /// one for the command line.
-  ///
-  /// \note Matches the argument interface as CLI::App
-  ///
+  /**
+   * \brief Add flag for boolean or integral flag
+   * 
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name Label for the parameter of interest
+   * \param[in] anchor_value Variable to specify and whose initial value
+   *                         defines the default value
+   * \param[in] desc String describing the option
+   * \param[in] grp  String for the group owning the anchor
+   * 
+   * \return Pointer to the anchor with the specified label
+   * 
+   * \note Matches the argument interface as CLI::App
+   *
+   */ 
   template <
     typename T,
     typename = typename std::enable_if<
@@ -550,38 +709,35 @@ public:
     T& anchor_value, const std::string& desc = {},
     const std::string& grp = "Default");
 
-  /// \brief Add option for a specified name
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name String labelling the option
-  /// \param[in] anchor_value Variable to specify and whose initial value
-  ///                         defines the default value
-  /// \param[in] desc String describing the option
-  /// \param[in] grp  String for the group owning the anchor
-  ///
-  /// \return Pointer to the anchor with the specified label
-  ///
-  /// \note Creates two instances one for the default value
-  /// (with the current value in 'anchor_value') and
-  /// one for the command line.
-  ///
-  /// \note Matches the argument interface as CLI::App
-  ///
+  /**
+   * \brief Add option for a specified name
+   *
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name String labelling the option
+   * \param[in] anchor_value Variable to specify and whose initial value
+   *                         defines the default value
+   * \param[in] desc String describing the option
+   * \param[in] grp  String for the group owning the anchor
+   * 
+   * \return Pointer to the anchor with the specified label
+   * 
+   * \note Matches the argument interface as CLI::App
+   */
   template <typename T>
   static std::shared_ptr<Anchor<T>> addOption(const std::string& name,
     T& anchor_value, const std::string& desc = "",
     const std::string& grp = "Default");
 
-  /// \brief Set new default value for a specified name
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name String labelling the option
-  /// \param[in] anchor_value Variable to specify and whose initial value
-  ///                         defines the default value
-  /// \param[in] desc String describing the option
-  ///
-  /// \return Pointer to the anchor with the specified label
-  ///
+  /**
+   * \brief Set new default value for a specified name
+   * 
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name String labelling the option
+   * \param[in] anchor_value Variable to specify and whose initial value
+   *                         defines the default value
+   *
+   * \return Pointer to the anchor with the specified label
+   */ 
   template <typename T>
   static std::shared_ptr<Anchor<T>> setNewDefaultValue(const std::string& name,
     const T& anchor_value);
@@ -590,25 +746,28 @@ public:
   // --- Printing routines
   //
 
-  /// \brief Print the list of options and instances
-  ///
+  /**
+   * \brief Print the list of options and instances
+   */
   static void printBanner();
 
-  /// \brief Create string to output the configuration, i.e.
-  /// the values of all the options.
-  ///
-  /// \param[in] default_also Boolean to identify whether or not to print
-  /// default value
-  /// \param[in] write_description Boolean to turn on/off the printing
-  /// of the parameter description
-  /// \param[in] prefix String containing a prefix to add before each
-  /// option name
-  ///
-  /// \return String describing all the options
-  ///
-  /// \note Creates a string in the ".INI" formatted
-  /// (INI format: https://cliutils.gitlab.io/CLI11Tutorial/chapters/config.html
-  /// )
+  /**
+   * \brief Create string to output the configuration
+   *
+   * This routine generates a string of values for the current configuration.
+   * The string stores a ".INI"-formatted output.
+   * (INI format: https://cliutils.gitlab.io/CLI11Tutorial/chapters/config.html )
+   *
+   * \param[in] default_also Boolean to identify whether or not to print
+   * default value
+   * \param[in] write_description Boolean to turn on/off the printing
+   * of the parameter description
+   * \param[in] prefix String containing a prefix to add before each
+   * option name
+   * 
+   * \return String describing all the options
+   * 
+   */
   static std::string outputConfig(bool default_also, bool write_description,
     std::string prefix);
 
@@ -617,13 +776,23 @@ private:
   static bool parsed_;
   static std::unique_ptr<ArgsManager> manager_;
 
-  // \brief Routine to verify that the manager has been allocated.
   static void checkInitialization();
 
 };
 
+/**
+ * \brief Returns value of user-specified flag
+ */
 inline bool user1() { return Args::config.vt_user_1; }
+
+/**
+ * \brief Returns value of user-specified flag
+ */
 inline bool user2() { return Args::config.vt_user_2; }
+
+/**
+ * \brief Returns value of user-specified flag
+ */
 inline bool user3() { return Args::config.vt_user_3; }
 
 }} /* end namespace vt::arguments */

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -48,6 +48,7 @@
 // Do not pull in any VT dependencies here
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -170,7 +171,7 @@ struct Printer;
 
 
 /// \brief Virtual struct for storing an option/flag
-struct AnchorBase : public std::enable_shared_from_this<AnchorBase> {
+struct AnchorBase: std::enable_shared_from_this<AnchorBase> {
 
   /// \brief Count how many instances of the parameter 'name'
   /// have been specified.

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -49,114 +49,128 @@
 
 #include <string>
 
+namespace CLI {
+class App;
+}
+
 namespace vt { namespace arguments {
 
-struct ArgConfig {
+struct Configs {
+public:
+  bool vt_color = true;
+  bool vt_no_color = false;
+  bool vt_auto_color = false;
+  bool vt_quiet = false;
+
+  // Derived from vt_*_color arguments after parsing.
+  bool colorize_output = false;
+  int32_t vt_sched_num_progress = 2;
+  int32_t vt_sched_progress_han = 0;
+  double vt_sched_progress_sec = 0.0;
+  bool vt_no_sigint = false;
+  bool vt_no_sigsegv = false;
+  bool vt_no_terminate = false;
+
+  bool vt_no_warn_stack = false;
+  bool vt_no_assert_stack = false;
+  bool vt_no_abort_stack = false;
+  bool vt_no_stack = false;
+  std::string vt_stack_file = {};
+  std::string vt_stack_dir = {};
+  int32_t vt_stack_mod = 1;
+
+  bool vt_trace = false;
+  bool vt_trace_mpi = false;
+  std::string vt_trace_file = {};
+  std::string vt_trace_dir = {};
+  int32_t vt_trace_mod = 1;
+  int32_t vt_trace_flush_size = 1;
+
+  bool vt_lb = false;
+  bool vt_lb_file = false;
+  bool vt_lb_quiet = false;
+  std::string vt_lb_file_name = "balance.in";
+  std::string vt_lb_name = "NoLB";
+  std::string vt_lb_args = {};
+  int32_t vt_lb_interval = 1;
+  bool vt_lb_stats = false;
+  std::string vt_lb_stats_dir = "vt_lb_stats";
+  std::string vt_lb_stats_file = "stats";
+
+  bool vt_no_detect_hang = false;
+  bool vt_print_no_progress = true;
+  bool vt_epoch_graph_on_hang = true;
+  bool vt_epoch_graph_terse = false;
+  bool vt_term_rooted_use_ds = false;
+  bool vt_term_rooted_use_wave = false;
+  int64_t vt_hang_freq = 1024;
+
+  bool vt_pause = false;
+
+  bool vt_debug_all = false;
+  bool vt_debug_verbose = false;
+  bool vt_debug_none = false;
+  bool vt_debug_gen = false;
+  bool vt_debug_runtime = false;
+  bool vt_debug_active = false;
+  bool vt_debug_term = false;
+  bool vt_debug_termds = false;
+  bool vt_debug_barrier = false;
+  bool vt_debug_event = false;
+  bool vt_debug_pipe = false;
+  bool vt_debug_pool = false;
+  bool vt_debug_reduce = false;
+  bool vt_debug_rdma = false;
+  bool vt_debug_rdma_channel = false;
+  bool vt_debug_rdma_state = false;
+  bool vt_debug_param = false;
+  bool vt_debug_handler = false;
+  bool vt_debug_hierlb = false;
+  bool vt_debug_gossiplb = false;
+  bool vt_debug_scatter = false;
+  bool vt_debug_sequence = false;
+  bool vt_debug_sequence_vrt = false;
+  bool vt_debug_serial_msg = false;
+  bool vt_debug_trace = false;
+  bool vt_debug_location = false;
+  bool vt_debug_lb = false;
+  bool vt_debug_vrt = false;
+  bool vt_debug_vrt_coll = false;
+  bool vt_debug_worker = false;
+  bool vt_debug_group = false;
+  bool vt_debug_broadcast = false;
+  bool vt_debug_objgroup = false;
+
+  bool vt_user_1 = false;
+  bool vt_user_2 = false;
+  bool vt_user_3 = false;
+  int32_t vt_user_int_1 = 0;
+  int32_t vt_user_int_2 = 0;
+  int32_t vt_user_int_3 = 0;
+  std::string vt_user_str_1 = {};
+  std::string vt_user_str_2 = {};
+  std::string vt_user_str_3 = {};
+};
+
+struct Args {
+
+public:
+  static Configs config;
+
+public:
 
   static int parse(int& argc, char**& argv);
 
-public:
-  static bool vt_color;
-  static bool vt_no_color;
-  static bool vt_auto_color;
-  static bool vt_quiet;
-
-  // Derived from vt_*_color arguments after parsing.
-  static bool colorize_output;
-  static int32_t vt_sched_num_progress;
-  static int32_t vt_sched_progress_han;
-  static double vt_sched_progress_sec;
-  static bool vt_no_sigint;
-  static bool vt_no_sigsegv;
-  static bool vt_no_terminate;
-
-  static bool vt_no_warn_stack;
-  static bool vt_no_assert_stack;
-  static bool vt_no_abort_stack;
-  static bool vt_no_stack;
-  static std::string vt_stack_file;
-  static std::string vt_stack_dir;
-  static int32_t vt_stack_mod;
-
-  static bool vt_trace;
-  static bool vt_trace_mpi;
-  static std::string vt_trace_file;
-  static std::string vt_trace_dir;
-  static int32_t vt_trace_mod;
-  static int32_t vt_trace_flush_size;
-
-  static bool vt_lb;
-  static bool vt_lb_file;
-  static bool vt_lb_quiet;
-  static std::string vt_lb_file_name;
-  static std::string vt_lb_name;
-  static std::string vt_lb_args;
-  static int32_t vt_lb_interval;
-  static bool vt_lb_stats;
-  static std::string vt_lb_stats_dir;
-  static std::string vt_lb_stats_file;
-
-  static bool vt_no_detect_hang;
-  static bool vt_print_no_progress;
-  static bool vt_epoch_graph_on_hang;
-  static bool vt_epoch_graph_terse;
-  static bool vt_term_rooted_use_ds;
-  static bool vt_term_rooted_use_wave;
-  static int64_t vt_hang_freq;
-
-  static bool vt_pause;
-
-  static bool vt_debug_all;
-  static bool vt_debug_verbose;
-  static bool vt_debug_none;
-  static bool vt_debug_gen;
-  static bool vt_debug_runtime;
-  static bool vt_debug_active;
-  static bool vt_debug_term;
-  static bool vt_debug_termds;
-  static bool vt_debug_barrier;
-  static bool vt_debug_event;
-  static bool vt_debug_pipe;
-  static bool vt_debug_pool;
-  static bool vt_debug_reduce;
-  static bool vt_debug_rdma;
-  static bool vt_debug_rdma_channel;
-  static bool vt_debug_rdma_state;
-  static bool vt_debug_param;
-  static bool vt_debug_handler;
-  static bool vt_debug_hierlb;
-  static bool vt_debug_gossiplb;
-  static bool vt_debug_scatter;
-  static bool vt_debug_sequence;
-  static bool vt_debug_sequence_vrt;
-  static bool vt_debug_serial_msg;
-  static bool vt_debug_trace;
-  static bool vt_debug_location;
-  static bool vt_debug_lb;
-  static bool vt_debug_vrt;
-  static bool vt_debug_vrt_coll;
-  static bool vt_debug_worker;
-  static bool vt_debug_group;
-  static bool vt_debug_broadcast;
-  static bool vt_debug_objgroup;
-
-  static bool vt_user_1;
-  static bool vt_user_2;
-  static bool vt_user_3;
-  static int32_t vt_user_int_1;
-  static int32_t vt_user_int_2;
-  static int32_t vt_user_int_3;
-  static std::string vt_user_str_1;
-  static std::string vt_user_str_2;
-  static std::string vt_user_str_3;
-
 private:
   static bool parsed;
+
+  static void setup(CLI::App *app_);
+
 };
 
-inline bool user1() { return ArgConfig::vt_user_1; }
-inline bool user2() { return ArgConfig::vt_user_2; }
-inline bool user3() { return ArgConfig::vt_user_3; }
+inline bool user1() { return Args::config.vt_user_1; }
+inline bool user2() { return Args::config.vt_user_2; }
+inline bool user3() { return Args::config.vt_user_3; }
 
 }} /* end namespace vt::arguments */
 

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -47,7 +47,11 @@
 
 // Do not pull in any VT dependencies here
 
+#include <map>
+#include <set>
 #include <string>
+#include <unordered_map>
+
 
 namespace CLI {
 class App;
@@ -152,6 +156,352 @@ public:
   std::string vt_user_str_3 = {};
 };
 
+
+/// \brief Enum for the Context where the Parameters is set
+enum struct ContextEnum : std::uint8_t { dFault, commandLine, thirdParty };
+
+
+/// \brief Enum for the Print Status
+enum struct PrintOption : std::uint8_t { never = 0, whenSet = 2, always = 255 };
+
+
+/// \brief Forward declaration
+struct Printer;
+
+
+/// \brief Virtual struct for storing an option/flag
+struct AnchorBase : public std::enable_shared_from_this<AnchorBase> {
+
+  /// \brief Count how many instances of the parameter 'name'
+  /// have been specified.
+  /// \param[in] name Parameter to specify
+  virtual int count() const = 0;
+
+  /// \brief Virtual function to print information
+  virtual void print() = 0;
+
+  /// \brief Resets to the default value
+  virtual void resetToDefault() = 0;
+
+  /// \brief Virtual function to resolve precedence rules
+  virtual void resolve() = 0;
+
+  /// \brief Set the printing option for the anchor
+  ///
+  /// \param[in] po Enum PrintOption for the anchor
+  /// \param[in] fun Function returning a boolean to constraint the printing
+  ///
+  virtual void
+  setPrintOption(PrintOption po, std::function<bool()> fun) = 0;
+
+  /// \brief Virtual function returning resolved value
+  /// \returns Resolved value
+  virtual std::string stringifyValue() const = 0;
+
+  /// \brief Virtual function returning context for resolved value
+  /// \returns Context
+  virtual std::string stringifyContext() const = 0;
+
+  /// \brief Virtual function returning context for resolved value
+  /// \returns Default value
+  virtual std::string stringifyDefault() const = 0;
+
+  //--------------------------------------------//
+  // Non-virtual member functions
+  //--------------------------------------------//
+
+  /// \brief Sets excluded option
+  ///
+  /// \param[in] opt  Pointer to the option to exclude
+  void excludes(const std::shared_ptr<AnchorBase>& opt) {
+    excludes_.insert(opt);
+    // Help text should be symmetric - excluding a should exclude b
+    opt->excludes_.insert(shared_from_this());
+    //
+    // Ignoring the insert return value, excluding twice (or more) is allowed.
+    //
+  }
+
+  /// \brief Returns the description of the anchor
+  /// \return Description
+  std::string getDescription() const { return description_; }
+
+  /// \brief Returns the group name of the anchor
+  /// \return Group
+  std::string getGroup() const { return group_; }
+
+  /// \brief Returns the name of the anchor
+  /// \return Name of the option
+  std::string getName() const { return name_; }
+
+  /// \brief Function to determine whether the precedence rules
+  /// have been applied or not.
+  /// \returns Boolean
+  bool isResolved() const { return isResolved_; }
+
+  /// \brief Sets dependence on a specific flag being turned off
+  ///
+  /// \param[in] opt  Pointer to the flag to depend on
+  void needsOptionOff(std::shared_ptr<AnchorBase> const& opt) {
+    needsOptOff_.insert(opt);
+  }
+
+  /// \brief Sets dependence on a specific flag being turned on
+  ///
+  /// \param[in] opt  Pointer to the flag to depend on
+  void needsOptionOn(std::shared_ptr<AnchorBase> const& opt) {
+    needsOptOn_.insert(opt);
+  }
+
+  /// \brief Set the group name for the anchor
+  ///
+  /// \param[in] grp_ String for the name of the group
+  void setGroup(const std::string& grp_) { group_ = grp_; }
+
+protected:
+  /// \brief Constructor
+  ///
+  /// \param[in] name Label for the anchor
+  /// \param[in] desc Description of the anchor
+  ///
+  /// \note The anchor will be assigned to a default group, named 'Default'.
+  ///
+  AnchorBase(std::string name, std::string desc, std::string grp);
+
+  /// \brief Set the printing option for the anchor
+  ///
+  /// \param[in] po Enum PrintOption for the anchor
+  /// \param[in] fun Function returning a boolean to constraint the printing
+  ///
+  virtual void
+  setPrintOptionImpl(PrintOption po, std::function<bool()> fun) = 0;
+
+protected:
+
+  //--- Build enum for ordering the context
+  //--- Order of the contexts can be specified
+  //--- independently of an instance for that context.
+  enum struct OrderContextEnum : std::uint8_t {
+    MIN = 0,
+    dFault = 1,
+    commandLine = 2,
+    thirdParty = 3,
+    MAX = 255
+  };
+
+  //--- Map from 'ContextEnum' flag to an ordered flag.
+  static std::map<ContextEnum, OrderContextEnum> emap_;
+
+  //--- Map from 'ContextEnum' flag to a descriptive string.
+  static std::map<ContextEnum, std::string> smap_;
+
+  bool isResolved_;
+
+  std::string name_;
+  std::string group_;
+  std::string description_;
+
+  /// \brief Map ordering the different instances of an 'anchor'
+  std::map<ContextEnum, OrderContextEnum> ordering_;
+
+  /// \brief List of options that are needed to be OFF for this option
+  std::set<std::shared_ptr<AnchorBase>> needsOptOff_;
+
+  /// \brief List of options that are needed to be ON for this option
+  std::set<std::shared_ptr<AnchorBase>> needsOptOn_;
+
+  /// \brief List of options that are excluded with this option
+  std::set<std::shared_ptr<AnchorBase>> excludes_;
+
+  /// \brief Printing options for the anchor
+  PrintOption statusPrint_ = PrintOption::never;
+
+  /// \brief Pointer to 'Printer' object for displaying message
+  /// on the startup banner.
+  std::unique_ptr<Printer> screenPrint_;
+
+};
+
+
+/// \brief Template struct for storing an option/flag
+template <typename T>
+struct Anchor : public AnchorBase {
+
+public:
+  /// \brief Constructor
+  ///
+  /// \param[in] var Variable to specify and whose initial value
+  ///                defines the default value
+  /// \param[in] name Label for the parameter of interest
+  /// \param[in] desc String describing the anchor
+  /// \param[in] grp  String for the group owning the anchor
+  ///
+  explicit Anchor(
+    T& var, const std::string& name, const std::string& desc,
+    const std::string& grp = "Default"
+  );
+
+  /// \brief Add instance from a third party with a specific value
+  ///
+  /// \param[in] value Value to specify for the third party context
+  /// \param[in] highestPrecedence Boolean determining whether the instance
+  /// should have the highest priority (default = false)
+  void addInstance(const T& value, bool highestPrecedence = false);
+
+  /// \brief Counts the current number of instances for the option
+  ///
+  /// \returns Number of instances for the option
+  int count() const override {
+    return static_cast<int>(specifications_.size());
+  }
+
+  /// \brief Sets highest priority (precedence) for a context
+  ///
+  /// \param[in] origin Context for the highest priority
+  ///
+  /// \note If a different context had already the highest priority,
+  /// this context priority will be reset to its original value.
+  ///
+  void setHighestPrecedence(const ContextEnum& origin);
+
+  /// \brief Sets a new default value.
+  ///
+  /// \param ref Value to assign as default
+  void setNewDefaultValue(const T& ref);
+
+  /// \brief Set the printing option for the anchor
+  ///
+  /// \param[in] po Enum PrintOption for the anchor
+  /// \param[in] fun Function returning a boolean to constraint the printing
+  ///
+  void setPrintOption(PrintOption po, std::function<bool()> fun) override;
+
+  /// \brief Returns the default value for the anchor
+  ///
+  /// \returns Default value of the anchor
+  const T getDefaultValue() const;
+
+  /// \brief Returns the value for the current instance
+  ///
+  /// \returns Value of the current instance
+  const T& getValue() const { return value_; }
+
+  /// \brief Virtual function returning resolved value
+  /// \returns Resolved value
+  std::string stringifyValue() const override;
+
+  /// \brief Virtual function returning context for resolved value
+  /// \returns String for resolved context
+  std::string stringifyContext() const override;
+
+  /// \brief Virtual function returning default value
+  /// \returns String for default value
+  std::string stringifyDefault() const override;
+
+  /// \brief Resets to the default value
+  void resetToDefault() override;
+
+  //
+  //--- Printing routines
+  //
+
+  /// \brief Printing routine about the anchor
+  void print() override;
+
+  /// \brief Set the printing message for the banner as a warning
+  ///
+  /// \param[in] String to display for the anchor
+  ///
+  /// \note The message will be of the form
+  /// "Warning: 'NAME' has no effect: compile-time feature 'MSG' is disabled"
+  ///
+  void setBannerMsgWarning(std::string msg,
+    std::function<bool()> fun = nullptr);
+
+protected:
+  /// \brief Add instance from a particular context
+  ///
+  /// \param[in] ctxt Context for the instance
+  /// \param[in] value Value specified by the instance
+  ///
+  void addGeneralInstance(ContextEnum ctxt, const T& value);
+
+  /// \brief Checks whether two 'excluded' options have specifications
+  ///         in addition to their default ones.
+  void checkExcludes() const;
+
+  /// \brief Resolves the precedence rules among the instances
+  void resolve() override;
+
+  /// \brief Set the printing option for the anchor
+  ///
+  /// \param[in] po Enum PrintOption for the anchor
+  /// \param[in] fun Function returning a boolean to constraint the printing
+  ///
+  void setPrintOptionImpl(PrintOption po, std::function<bool()> fun) override;
+
+//  friend struct ArgSetup;
+
+protected:
+
+  //--- Structure for storing each instance of one anchor
+  template <typename U = T>
+  struct Instance {
+
+  public:
+    /// \brief Constructor
+    ///
+    /// \param[in] ref Value of the anchor for this instance
+    /// \param[in] parent Pointer for the parent anchor
+    explicit Instance(const U& rval, AnchorBase* parent)
+      : value_(rval), parent_(parent)
+    {}
+
+    /// \brief Dummy Constructor
+    Instance() : value_(), parent_(nullptr)
+    {}
+
+    /// \brief Copy Constructor
+    Instance(const Instance<U>& ref)
+      : value_(ref.value_), parent_(ref.parent_)
+    {}
+
+    /// \brief Destructor
+    ~Instance() = default;
+
+    /// \brief Assignment operator
+    Instance<U>& operator=(const Instance<U>& ref) {
+      value_ = ref.value_;
+      parent_ = ref.parent_;
+      return *this;
+    }
+
+    /// \brief Sets new value for the instance
+    ///
+    /// \param ref New value to insert for the instance
+    void setNewValue(const U& ref) { value_ = ref; }
+
+    /// \brief Returns the value for the current instance
+    ///
+    /// \returns Value of the current instance
+    const U& getValue() const { return value_; }
+
+  protected:
+    U value_;
+    AnchorBase* parent_ = nullptr;
+  };
+  //---
+
+  T& value_ = {};
+  std::unordered_map<ContextEnum, Instance<T>> specifications_;
+  bool hasNewDefault_ = false;
+  ContextEnum resolvedContext_ = ContextEnum::dFault;
+  Instance<T> resolvedInstance_;
+  bool resolvedToDefault_ = false;
+
+};
+
+
 struct Args {
 
 public:
@@ -161,7 +511,56 @@ public:
 
   static int parse(int& argc, char**& argv);
 
+  /// \brief Returns pointer to the option object for specific name.
+  ///
+  /// \tparam T  Template type for the value of the parameter
+  /// \param[in] name Label for the parameter of interest
+  /// \return Pointer to the anchor with the specified label
+//  template <typename T>
+//  std::shared_ptr<Anchor<T>> getOption(const std::string& name) const;
+
+  /// \brief Set new default value for a specified name
+  ///
+  /// \tparam T  Template type for the value of the parameter
+  /// \param[in] name String labelling the option
+  /// \param[in] anchor_value Variable to specify and whose initial value
+  ///                         defines the default value
+  /// \param[in] desc String describing the option
+  ///
+  /// \return Pointer to the anchor with the specified label
+  ///
+//  template <typename T>
+//  std::shared_ptr<Anchor<T>>
+//  setNewDefaultValue(const std::string& name, const T& anchor_value);
+
+  //
+  // --- Printing routines
+  //
+
+  /// \brief Print the list of options and instances
+  ///
+//  void printBanner();
+
+  /// \brief Create string to output the configuration, i.e.
+  /// the values of all the options.
+  ///
+  /// \param[in] default_also Boolean to identify whether or not to print
+  /// default value
+  /// \param[in] write_description Boolean to turn on/off the printing
+  /// of the parameter description
+  /// \param[in] prefix String containing a prefix to add before each
+  /// option name
+  ///
+  /// \return String describing all the options
+  ///
+  /// \note Creates a string in the ".INI" formatted
+  /// (INI format: https://cliutils.gitlab.io/CLI11Tutorial/chapters/config.html
+  /// )
+//  std::string outputConfig(
+//    bool default_also, bool write_description, std::string prefix) const;
+
 private:
+
   static bool parsed;
 
   static void setup(CLI::App *app_);

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -284,7 +284,7 @@ struct AnchorBase: std::enable_shared_from_this<AnchorBase> {
    * \brief Returns the name of the anchor
    *
    * \return Name of the anchor
-   *
+   */
   std::string getName() const { return name_; }
 
   /**

--- a/src/vt/configs/arguments/args_utils.h
+++ b/src/vt/configs/arguments/args_utils.h
@@ -1,0 +1,139 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               args_utils.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+#if !defined INCLUDED_VT_CONFIGS_ARGUMENTS_ARGS_UTILS_H
+#define INCLUDED_VT_CONFIGS_ARGUMENTS_ARGS_UTILS_H
+
+#include <string>
+
+namespace vt { namespace arguments {
+
+template <typename T>
+std::string getDisplayValue(const T& val) {
+  std::string res;
+  return res;
+}
+
+template <>
+std::string getDisplayValue<bool>(const bool& val) {
+  return val ? std::string("ON") : std::string("OFF");
+}
+
+template <>
+std::string getDisplayValue<int>(const int& val) {
+  return std::to_string(val);
+}
+
+template <>
+std::string getDisplayValue<std::string>(const std::string& val) {
+  std::string res = std::string("\"") + val + std::string("\"");
+  return res;
+}
+
+
+struct Printer {
+  public:
+  virtual void output() = 0;
+  virtual ~Printer() = default;
+};
+
+
+template <typename T>
+struct Anchor;
+
+
+template <typename T>
+struct PrintOn : public Printer {
+  public:
+  PrintOn(Anchor<T>* opt, std::string msg_str);
+
+  PrintOn(
+    Anchor<T>* opt, std::string msg_str, std::function<bool()> fun);
+
+  void output() override;
+  ~PrintOn() override = default;
+
+  protected:
+  Anchor<T>* option_ = nullptr;
+  std::string msg_str_;
+  std::function<bool()> condition_ = nullptr;
+};
+
+
+template <typename T>
+struct PrintOnOff : public Printer {
+  public:
+  PrintOnOff(
+    Anchor<T>* opt, std::string msg_on, std::string msg_off);
+  PrintOnOff(
+    Anchor<T>* opt, std::string msg_on, std::string msg_off,
+    std::function<bool()> fun);
+  void output() override;
+  ~PrintOnOff() override = default;
+
+  protected:
+  Anchor<T>* option_;
+  std::string msg_on_;
+  std::string msg_off_;
+  std::function<bool()> condition_ = nullptr;
+};
+
+
+struct Warning : public Printer {
+  public:
+  Warning(Anchor<bool>* opt, std::string compile);
+  Warning(
+    Anchor<bool>* opt, std::string compile, std::function<bool()> fun);
+  void output() override;
+  ~Warning() override = default;;
+
+  protected:
+  Anchor<bool>* option_;
+  std::string compile_;
+  std::function<bool()> condition_ = nullptr;
+};
+
+
+}} // namespace vt::arguments
+
+#endif

--- a/src/vt/configs/arguments/args_utils.h
+++ b/src/vt/configs/arguments/args_utils.h
@@ -265,7 +265,7 @@ struct Warning : public Printer {
   /**
    * \brief Destructor
    */
-  ~Warning() override = default;;
+  ~Warning() override = default;
 
   protected:
   /// Pointer to the anchor

--- a/src/vt/configs/arguments/args_utils.h
+++ b/src/vt/configs/arguments/args_utils.h
@@ -48,120 +48,263 @@
 
 namespace vt { namespace arguments {
 
+/**
+ * \file
+ */
+
+/**
+ * \brief Function to convert variable into string
+ * 
+ * \param[in] val Value to convert into string
+ *
+ * \return String representation of variable
+ *
+ */
 template <typename T>
 std::string getDisplayValue(const T& val) {
   std::string res;
   return res;
 }
 
+/**
+ * \brief Function to convert variable into string
+ *
+ * \param[in] val Boolean value to convert into string
+ *
+ * \return String representation of variable
+ */
 template <>
 std::string getDisplayValue<bool>(const bool& val) {
   return val ? std::string("ON") : std::string("OFF");
 }
 
+/**
+ * \brief Function to convert variable into string
+ *
+ * \param[in] val Integral value to convert into string
+ *
+ * \return String representation of variable
+ */
 template <>
 std::string getDisplayValue<int>(const int& val) {
   return std::to_string(val);
 }
 
+/**
+ * \brief Function to convert variable into string
+ *
+ * \param[in] val String filename to convert.
+ *
+ * \return String representation of variable
+ */
 template <>
 std::string getDisplayValue<std::string>(const std::string& val) {
   std::string res = std::string("\"") + val + std::string("\"");
   return res;
 }
 
-
-// \brief Function to verify that a string is acceptable
-//
-// \param[in] name String to verifyName
-//
-// \return 'Cleaned-up' string
-//
-// \note This function removes any '-' characters at the start
-// and verify that the remaining characters are acceptable.
-//
+/**
+ * \brief Function to verify that a string is acceptable
+ *
+ * \param[in] name String to verifyName
+ *
+ * \return 'Cleaned-up' string
+ *
+ * \note This function removes any '-' characters at the start
+ * and verify that the remaining characters are acceptable.
+ */
 std::string verifyName(const std::string &name);
 
-
+/**
+ * \struct Printer args_utils.h vt/configs/arguments/args_utils.h
+ *
+ * Virtual class to manage the display of an anchor.
+ */
 struct Printer {
   public:
+  /**
+   * \brief Function to trigger the printing of message
+   */
   virtual void output() = 0;
+
+  /**
+   * \brief Virtual destructor 
+   */
   virtual ~Printer() = default;
 };
 
 
+// Forward declaration
 template <typename T>
 struct Anchor;
 
 
+/**
+ * \struct PrinterOn args_utils.h vt/configs/arguments/args_utils.h
+ *
+ * Class to manage the display of an active anchor.
+ */
 template <typename T>
 struct PrintOn : public Printer {
-  public:
+public:
+  /**
+   * \brief Constructor to specify a print message when the anchor is on (or active).
+   *
+   * \param[in] opt: Pointer to the anchor
+   * \param[in] msg_str: Message when the anchor is on (active).
+   */
   PrintOn(Anchor<T>* opt, std::string msg_str);
 
+  /**
+   * \brief Constructor to specify a print message when the anchor is on (or active).
+   *
+   * \param[in] opt: Pointer to the anchor
+   * \param[in] msg_str: Message when the anchor is on (active).
+   * \param[in] fun Boolean function to control the printing 
+   */
   PrintOn(Anchor<T>* opt, std::string msg_str, std::function<bool()> fun);
 
+  /**
+   * \brief Function to trigger the printing of message
+   */
   void output() override;
+
+  /**
+   * \brief Destructor
+   */
   ~PrintOn() override = default;
 
   protected:
+  /// Pointer to the anchor
   Anchor<T>* option_ = nullptr;
+  /// Message to display
   std::string msg_str_;
+  /// Conditional function 
   std::function<bool()> condition_ = nullptr;
 };
 
 
+/**
+ * \struct PrinterOnOff args_utils.h vt/configs/arguments/args_utils.h
+ *
+ * Class to manage the display of an active (or inactive) anchor.
+ */
 template <typename T>
 struct PrintOnOff : public Printer {
   public:
+  /**
+   * \brief Constructor to specify a print message when the anchor is on (or active).
+   *
+   * \param[in] opt: Pointer to the anchor
+   * \param[in] msg_on: Message when the anchor is on (active).
+   * \param[in] msg_off: Message when the anchor is off (inactive).
+   */
   PrintOnOff(Anchor<T>* opt, std::string msg_on, std::string msg_off);
+
+  /**
+   * \brief Constructor to specify a print message when the anchor is on (or active).
+   *
+   * \param[in] opt: Pointer to the anchor
+   * \param[in] msg_on: Message when the anchor is on (active).
+   * \param[in] msg_off: Message when the anchor is off (inactive).
+   * \param[in] fun Boolean function to control the printing 
+   */
   PrintOnOff(Anchor<T>* opt, std::string msg_on, std::string msg_off,
     std::function<bool()> fun);
+
+  /**
+   * \brief Function to trigger the printing of message
+   */
   void output() override;
+
+  /**
+   * \brief Destructor
+   */
   ~PrintOnOff() override = default;
 
   protected:
-  Anchor<T>* option_;
+  /// Pointer to the anchor
+  Anchor<T>* option_ = nullptr;
+  /// Message to display if active
   std::string msg_on_;
+  /// Message to display if inactive
   std::string msg_off_;
+  /// Conditional function 
   std::function<bool()> condition_ = nullptr;
 };
 
-
+/**
+ * \struct Warning args_utils.h vt/configs/arguments/args_utils.h
+ *
+ * Class to manage the display of a warning for an anchor.
+ */
 struct Warning : public Printer {
   public:
-  Warning(Anchor<bool>* opt, std::string compile);
-  Warning(Anchor<bool>* opt, std::string compile, std::function<bool()> fun);
+  /**
+   * \brief Constructor to specify a warning for an anchor.
+   *
+   * \param[in] opt: Pointer to the anchor
+   * \param[in] warning: Warning message
+   */
+  Warning(Anchor<bool>* opt, std::string warning);
+
+  /**
+   * \brief Constructor to specify a warning for an anchor.
+   *
+   * \param[in] opt Pointer to the anchor
+   * \param[in] warning Warning message
+   * \param[in] fun Boolean function to control warning
+   */
+  Warning(Anchor<bool>* opt, std::string warning, std::function<bool()> fun);
+
+  /**
+   * \brief Function to trigger the printing of message
+   */
   void output() override;
+
+  /**
+   * \brief Destructor
+   */
   ~Warning() override = default;;
 
   protected:
+  /// Pointer to the anchor
   Anchor<bool>* option_;
+  /// Warning message related to compilation flag
   std::string compile_;
+  /// Conditional function 
   std::function<bool()> condition_ = nullptr;
 };
 
 
+/**
+ * \struct ArgsManager args_utils.h vt/configs/arguments/args_utils.h
+ *
+ * This structure is part of the implementation for managing
+ * the parsing and the resolution of precedence rules for 
+ * command-line parameters, default values, and parameters from input file.
+ */
 struct ArgsManager {
 
+  /**
+   * \brief Copy constructor
+   */
   explicit ArgsManager(const std::string& name);
 
-  /// \brief Add flag for boolean or integral flag
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name Label for the parameter of interest
-  /// \param[in] anchor_value Variable to specify and whose initial value
-  ///                         defines the default value
-  /// \param[in] desc String describing the option
-  ///
-  /// \return Pointer to the anchor with the specified label
-  ///
-  /// \note Creates two instances one for the default value
-  /// (with the current value in 'anchor_value') and
-  /// one for the command line.
-  ///
-  /// \note Matches the argument interface as CLI::App
-  ///
+  /**
+   * \brief Add flag for boolean or integral flag
+   * 
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name Label for the parameter of interest
+   * \param[in] anchor_value Variable to specify and whose initial value
+   *                         defines the default value
+   * \param[in] desc String describing the anchor 
+   * \param[in] grp String describing the group containing the anchor 
+   * 
+   * \return Pointer to the anchor with the specified label
+   * 
+   * \note Matches the argument interface as CLI::App
+   */ 
   template <
     typename T,
     typename = typename std::enable_if<
@@ -171,128 +314,178 @@ struct ArgsManager {
     const std::string& desc = {},
     const std::string& grp = "Default");
 
-  /// \brief Add a flag to CLI setup
-  ///
-  /// \param[in] Pointer to the specific anchor
-  /// \param[in] sname String labelling the option
-  /// \param[in] anchor_value Variable to specify and whose initial value
-  ///                         defines the default value
-  /// \param[in] desc String describing the option
-  ///
+  /**
+   * \brief Add a flag to CLI setup
+   * 
+   * \param[in] Pointer to the specific anchor
+   * \param[in] sname String labelling the anchor 
+   * \param[in] anchor_value Variable to specify and whose initial value
+   *                        defines the default value
+   * \param[in] desc String describing the anchor 
+   */ 
   template <typename T>
   void addFlagToCLI(Anchor<T>* aptr, const std::string& sname, T& anchor_value,
     const std::string& desc) {}
 
-  /// \brief Add option for a specified name
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name String labelling the option
-  /// \param[in] anchor_value Variable to specify and whose initial value
-  ///                         defines the default value
-  /// \param[in] desc String describing the option
-  /// \param[in] grp  String for the group owning the anchor
-  ///
-  /// \return Pointer to the anchor with the specified label
-  ///
-  /// \note Creates two instances one for the default value
-  /// (with the current value in 'anchor_value') and
-  /// one for the command line.
-  ///
-  /// \note Matches the argument interface as CLI::App
-  ///
+  /**
+   * \brief Add option for a specified name
+   * 
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name String labelling the option
+   * \param[in] anchor_value Variable to specify and whose initial value
+   *                         defines the default value
+   * \param[in] desc String describing the option
+   * \param[in] grp  String for the group owning the anchor
+   * 
+   * \return Pointer to the anchor with the specified label
+   * 
+   * \note Matches the argument interface as CLI::App
+   */ 
   template <typename T>
   std::shared_ptr<Anchor<T>> addOption(const std::string& name,T& anchor_value,
     const std::string& desc = "",
     const std::string& grp = "Default");
 
-  /// \brief Gather the list of all group names
-  ///
-  /// \returns List of group names
+  /**
+   * \brief Gather the list of all group names
+   * 
+   * \return Vector of group names
+   */
   std::vector<std::string> getGroupList() const;
 
-  /// \brief Get the list of options for a given group name
-  ///
-  /// \param[in] gname Name of group to study
-  /// \returns List of options in the group
+  /**
+   * \brief Get the list of options for a given group name
+   * 
+   * \param[in] gname Name of group to study
+   *
+   * \return Map from string anchors to their pointers in the group
+   */
   std::map<std::string, std::shared_ptr<AnchorBase>> getGroupOptions(
     const std::string& gname) const;
 
-  /// \brief Returns pointer to the option object for specific name.
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name Label for the parameter of interest
-  /// \return Pointer to the anchor with the specified label
+  /**
+   * \brief Returns pointer to the option object for specific name.
+   * 
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name Label for the parameter of interest
+   *
+   * \return Pointer to the anchor with the specified label
+   */
   template<typename T>
   std::shared_ptr<Anchor<T>> getOption(const std::string &name);
 
-  /// \brief Create string to output the configuration, i.e.
-  /// the values of all the options.
-  ///
-  /// \param[in] default_also Boolean to identify whether or not to print
-  /// default value
-  /// \param[in] write_description Boolean to turn on/off the printing
-  /// of the parameter description
-  /// \param[in] prefix String containing a prefix to add before each
-  /// option name
-  ///
-  /// \return String describing all the options
-  ///
-  /// \note Creates a string in the ".INI" formatted
-  /// (INI format: https://cliutils.gitlab.io/CLI11Tutorial/chapters/config.html
-  /// )
+  /**
+   * \brief Create string to output the configuration, i.e.
+   *
+   * The values of all the parameters are stored in a string
+   * with the ".INI" format
+   * (INI format: https://cliutils.gitlab.io/CLI11Tutorial/chapters/config.html )
+   * 
+   * \param[in] default_also Boolean to identify whether or not to print
+   * default value
+   * \param[in] write_description Boolean to turn on/off the printing
+   * of the parameter description
+   * \param[in] prefix String containing a prefix to add before each
+   * option name
+   * 
+   * \return String describing all the options
+  */ 
   std::string outputConfig(bool default_also, bool write_description,
     std::string prefix) const;
 
-  /// \brief Parse the command line arguments
-  ///
-  /// \param[in,out] argc Number of arguments
-  /// \param[in,out] argv Array of arguments
-  ///
-  /// \note On exit, argc and argv will be modified in presence of redundancy.
-  ///
+  /**
+   * \brief Parse the command line arguments
+   * 
+   * \param[in,out] argc Number of arguments
+   * \param[in,out] argv Array of arguments
+   * 
+   * \note On exit, argc and argv will be modified in presence of redundancy.
+   */ 
   void parse(int &argc, char**& argv);
 
-  /// \brief Routine to review some default parameters
-  /// after parsing and before printing
-  ///
+  /**
+   * \brief Routine to review some default parameters
+   * after parsing and before printing
+   */ 
   void postParsingReview();
 
-  /// \brief Resolve the different options by applying all precedence rules
-  ///
+  /**
+   * \brief Resolve the different options by applying all precedence rules
+   */ 
   void resolveOptions() {
     for (const auto& opt : options_) {
       opt.second->resolve();
     }
   }
-  /// \brief Set new default value for a specified name
-  ///
-  /// \tparam T  Template type for the value of the parameter
-  /// \param[in] name String labelling the option
-  /// \param[in] anchor_value Variable to specify and whose initial value
-  ///                         defines the default value
-  /// \param[in] desc String describing the option
-  ///
-  /// \return Pointer to the anchor with the specified label
-  ///
+
+  /**
+   * \brief Set new default value for a specified name
+   * 
+   * \tparam T  Template type for the value of the parameter
+   * \param[in] name String labelling the anchor
+   * \param[in] anchor_value Variable to specify and whose initial value
+   *                         defines the default value
+   * 
+   * \return Pointer to the anchor with the specified label
+   */ 
   template <typename T>
   std::shared_ptr<Anchor<T>> setNewDefaultValue(const std::string& name,
     const T& anchor_value);
 
 protected:
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the output
+   */
   void initializeOutputControl();
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the signal handling 
+   */
   void initializeSignalHandling();
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the termination 
+   */
   void initializeTermination();
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the stack group
+   */
   void initializeStackGroup();
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the tracing group
+   */
   void initializeTracing();
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the load balancing group
+   */
   void initializeLoadBalancing();
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the user-options group
+   */
   void initializeUserOptions();
+
+  /**
+   * \brief Function to define default and command-line instances
+   * for parameters controlling the debugging group
+   */
   void initializeDebug();
 
 public:
-  //
-  //--- Member variables
-  //
+  /// Pointer to the CLI interface
   std::unique_ptr<CLI::App> app_;
+  /// Map from a string to its anchor pointer
   std::map<std::string, std::shared_ptr<AnchorBase>> options_;
 };
 

--- a/src/vt/configs/debug/debug_colorize.h
+++ b/src/vt/configs/debug/debug_colorize.h
@@ -52,7 +52,7 @@
 namespace vt { namespace debug {
 
 inline bool colorizeOutput() {
-  return arguments::ArgConfig::colorize_output;
+  return arguments::Args::config.colorize_output;
 }
 
 inline std::string green()    { return colorizeOutput() ? "\033[32m"   : ""; }

--- a/src/vt/configs/debug/debug_print.h
+++ b/src/vt/configs/debug/debug_print.h
@@ -82,9 +82,9 @@
   vt_print_colorize_impl(::vt::debug::blue(), "[" + std::to_string(proc) + "]", "")
 
 #define debug_argument_option(opt)                                      \
-  ::vt::arguments::ArgConfig::vt_debug_ ## opt
+  ::vt::arguments::Args::config.vt_debug_ ## opt
 
-#define debug_all_option ::vt::arguments::ArgConfig::vt_debug_all
+#define debug_all_option ::vt::arguments::Args::config.vt_debug_all
 
 #define debug_print_impl(force, inconfig, inmode, cat, ctx, ...)        \
   vt::config::ApplyOp<                                                  \
@@ -139,7 +139,7 @@
 
 #define vt_print(feature, ...)                                          \
   do {                                                                  \
-    if (!::vt::arguments::ArgConfig::vt_quiet) {                        \
+    if (!::vt::arguments::Args::config.vt_quiet) {                      \
       vt_print_force_impl(feature, node, __VA_ARGS__);                  \
     }                                                                   \
   } while(0);
@@ -168,7 +168,7 @@ struct DebugPrintOp;
 template <CatEnum cat, ModeEnum mod, typename Arg, typename... Args>
 static inline void debugPrintImpl(NodeType node, Arg&& arg, Args&&... args) {
   bool const verb = vt_option_check_enabled(mod, ModeEnum::verbose);
-  if ((verb and ::vt::arguments::ArgConfig::vt_debug_verbose) or not verb) {
+  if ((verb and ::vt::arguments::Args::config.vt_debug_verbose) or not verb) {
     auto user = fmt::format(std::forward<Arg>(arg),std::forward<Args>(args)...);
     fmt::print(
       "{} {} {} {}",
@@ -187,7 +187,7 @@ template <CatEnum cat, ModeEnum mod>
 struct DebugPrintOp<cat, CtxEnum::node, mod> {
   template <typename Arg, typename... Args>
   void operator()(bool const rt_option, Arg&& arg, Args&&... args) {
-    if (rt_option or vt::arguments::ArgConfig::vt_debug_all) {
+    if (rt_option or vt::arguments::Args::config.vt_debug_all) {
       auto no_node = static_cast<NodeType>(-1);
       auto node = vt::curRT != nullptr ? vt::debug::preNode() : no_node;
       debugPrintImpl<cat,mod>(node,std::forward<Arg>(arg),std::forward<Args>(args)...);
@@ -199,7 +199,7 @@ template <CatEnum cat, ModeEnum mod>
 struct DebugPrintOp<cat, CtxEnum::unknown, mod> {
   template <typename Arg, typename... Args>
   void operator()(bool const rt_option, Arg&& arg, Args&&... args) {
-    if (rt_option or vt::arguments::ArgConfig::vt_debug_all) {
+    if (rt_option or vt::arguments::Args::config.vt_debug_all) {
       debugPrintImpl<cat,mod>(-1,std::forward<Arg>(arg),std::forward<Args>(args)...);
     }
   }

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -55,11 +55,13 @@
 
 namespace vt { namespace messaging {
 
+using ArgVT = arguments::Args;
+
 ActiveMessenger::ActiveMessenger()
   : this_node_(theContext()->getNode())
 {
   #if backend_check_enabled(trace_enabled)
-    if (ArgType::vt_trace_mpi) {
+    if (ArgVT::config.vt_trace_mpi) {
       trace_irecv     = trace::registerEventCollective("MPI_Irecv");
       trace_isend     = trace::registerEventCollective("MPI_Isend");
     }
@@ -212,7 +214,7 @@ EventType ActiveMessenger::sendMsgBytes(
   {
     #if backend_check_enabled(trace_enabled)
       double tr_begin = 0;
-      if (ArgType::vt_trace_mpi) {
+      if (ArgVT::config.vt_trace_mpi) {
         tr_begin = vt::timing::Timing::getCurrentTime();
       }
     #endif
@@ -223,7 +225,7 @@ EventType ActiveMessenger::sendMsgBytes(
     );
 
     #if backend_check_enabled(trace_enabled)
-      if (ArgType::vt_trace_mpi) {
+      if (ArgVT::config.vt_trace_mpi) {
         auto tr_end = vt::timing::Timing::getCurrentTime();
         auto tr_note = fmt::format("Isend(AM): dest={}, bytes={}", dest, msg_size);
         trace::addUserBracketedNote(tr_begin, tr_end, tr_note, trace_isend);
@@ -336,7 +338,7 @@ ActiveMessenger::SendDataRetType ActiveMessenger::sendData(
   {
     #if backend_check_enabled(trace_enabled)
       double tr_begin = 0;
-      if (ArgType::vt_trace_mpi) {
+      if (ArgVT::config.vt_trace_mpi) {
         tr_begin = vt::timing::Timing::getCurrentTime();
       }
     #endif
@@ -347,7 +349,7 @@ ActiveMessenger::SendDataRetType ActiveMessenger::sendData(
     );
 
     #if backend_check_enabled(trace_enabled)
-      if (ArgType::vt_trace_mpi) {
+      if (ArgVT::config.vt_trace_mpi) {
         auto tr_end = vt::timing::Timing::getCurrentTime();
         auto tr_note = fmt::format("Isend(Data): dest={}, bytes={}", dest, num_bytes);
         trace::addUserBracketedNote(tr_begin, tr_end, tr_note, trace_isend);
@@ -448,7 +450,7 @@ bool ActiveMessenger::recvDataMsgBuffer(
       {
         #if backend_check_enabled(trace_enabled)
           double tr_begin = 0;
-          if (ArgType::vt_trace_mpi) {
+          if (ArgVT::config.vt_trace_mpi) {
             tr_begin = vt::timing::Timing::getCurrentTime();
           }
         #endif
@@ -459,7 +461,7 @@ bool ActiveMessenger::recvDataMsgBuffer(
         );
 
         #if backend_check_enabled(trace_enabled)
-          if (ArgType::vt_trace_mpi) {
+          if (ArgVT::config.vt_trace_mpi) {
             auto tr_end = vt::timing::Timing::getCurrentTime();
             auto tr_note = fmt::format(
               "Irecv(Data): from={}, bytes={}",
@@ -743,7 +745,7 @@ bool ActiveMessenger::tryProcessIncomingActiveMsg() {
     {
       #if backend_check_enabled(trace_enabled)
         double tr_begin = 0;
-        if (ArgType::vt_trace_mpi) {
+        if (ArgVT::config.vt_trace_mpi) {
           tr_begin = vt::timing::Timing::getCurrentTime();
         }
       #endif
@@ -754,7 +756,7 @@ bool ActiveMessenger::tryProcessIncomingActiveMsg() {
       );
 
       #if backend_check_enabled(trace_enabled)
-        if (ArgType::vt_trace_mpi) {
+        if (ArgVT::config.vt_trace_mpi) {
           auto tr_end = vt::timing::Timing::getCurrentTime();
           auto tr_note = fmt::format(
             "Irecv(AM): from={}, bytes={}",

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -173,7 +173,6 @@ struct ActiveMessenger {
   using EpochStackType       = std::stack<EpochType>;
   using PendingSendType      = PendingSend;
   using ListenerType         = std::unique_ptr<Listener>;
-  using ArgType              = vt::arguments::ArgConfig;
 
   ActiveMessenger();
 

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -205,7 +205,7 @@ ActiveMessenger::sendMsgSz(
   }
   setupEpochMsg(msg);
 
-  auto base = promoteMsg(msg).template to<BaseMsgType>();;
+  auto base = promoteMsg(msg).template to<BaseMsgType>();
   return PendingSendType(base, msg_size);
 }
 

--- a/src/vt/messaging/irecv_holder.h
+++ b/src/vt/messaging/irecv_holder.h
@@ -58,7 +58,7 @@ namespace vt { namespace messaging {
 
 template <typename T>
 struct IRecvHolder {
-  using ArgType = vt::arguments::ArgConfig;
+  using ArgVT = vt::arguments::Args;
 
   IRecvHolder() = default;
 
@@ -96,7 +96,7 @@ struct IRecvHolder {
         MPI_Test(&e.req, &flag, &stat);
         if (flag == 1) {
           #if backend_check_enabled(trace_enabled)
-            if (ArgType::vt_trace_mpi) {
+            if (ArgVT::config.vt_trace_mpi) {
               auto tr_note = fmt::format(
                 "Irecv completed: from={}", stat.MPI_SOURCE
               );

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -107,7 +107,7 @@ Runtime::Runtime(bool const interop_mode, RuntimeInstType const in_instance)
 }
 
 void Runtime::parseAndSetup(int& argc, char**& argv) {
-  ArgVT::parse(argc, argv);
+  ArgVT::parseAndResolve(argc, argv);
   parsed_arg_ = true;
   if (argc > 0) {
     prog_name_ = std::string(argv[0]);

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -60,35 +60,51 @@
 
 namespace vt { namespace runtime {
 
+/** \file */
+
+/**
+ * \struct Runtime runtime.h vt/runtime/runtime.h
+ *
+ * \brief
+ */
 struct Runtime {
   template <typename ComponentT>
   using ComponentPtrType = std::unique_ptr<ComponentT>;
 
-  /// \brief Constructor for Runtime object
-  ///
-  /// \param argc
-  /// \param argv
-  /// \param in_num_workers
-  /// \param interop_mode
-  /// \param in_comm
-  /// \param in_instance
-  ///
-  /// \note The command line arguments (argc, argv) will get parsed.
-  ///
+  /**
+   * \brief Constructor for Runtime object
+   * 
+   * Constructor to use when combining the parsing and initialization
+   * at the same time.
+   * In particular, this routine does not allow to specify parameters
+   * with an input file.
+   * 
+   * \param[in,out] argc
+   * \param[in,out] argv
+   * \param[in] in_num_workers
+   * \param[in] interop_mode
+   * \param[in] in_comm
+   * \param[in] in_instance
+   * 
+   */
   Runtime(
     int& argc, char**& argv,
     WorkerCountType in_num_workers = no_workers, bool const interop_mode = false,
     MPI_Comm* in_comm = nullptr,
     RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance
   );
-  /// \brief Constructor for Runtime object.
-  ///
-  /// \param interop_mode
-  /// \param in_instance
-  ///
-  /// \note No action is done during the creation of the object.
-  /// In particular, this routine will not parse the command line arguments.
-  ///
+
+  /**
+   * \brief Constructor for Runtime object.
+   *
+   * Simple constructor to use when doing the two-step initialization.
+   * No action is done during the creation of the object.
+   * In particular, this routine will not parse the command line arguments.
+   * 
+   * \param[in] interop_mode
+   * \param[in] in_instance
+   * 
+   */ 
   explicit Runtime(
     bool const interop_mode = false,
     RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance);
@@ -97,14 +113,23 @@ struct Runtime {
   Runtime(Runtime&&) = delete;
   Runtime& operator=(Runtime const&) = delete;
 
+  /**
+   * \brief Virtual destructor
+   */
   virtual ~Runtime();
 
-  /// \brief Sets the pointer for the MPI communicator
-  /// \param[in] in_comm: Pointer to the MPI_Comm
+  /**
+   * \brief Sets the pointer for the MPI communicator
+   *
+   * \param[in] in_comm: Pointer to the MPI_Comm
+   */
   void setMPIComm(MPI_Comm* in_comm) { communicator_ = in_comm; }
 
-  /// \brief Sets the number of workers
-  /// \param[in] in_num_workers: Number of workers
+  /** 
+   * \brief Sets the number of workers
+   *
+   * \param[in] in_num_workers: Number of workers
+   */
   void setNumWorkers(WorkerCountType in_num_workers) {
     num_workers_ = in_num_workers;
   }
@@ -155,10 +180,12 @@ protected:
   void finalizeComponents();
   void finalizeOptionalComponents();
 
-  // \brief Routine to parse the command-line parameters and
-  // to setup the simulation parameters.
-  // \param[in] argc: Reference to the number of command-line arguments
-  // \param[in] argv: Reference to the array of command-line arguments
+  /**
+   * \brief Routine to parse the command-line parameters and
+   * to setup the simulation parameters.
+   * \param[in] argc: Reference to the number of command-line arguments
+   * \param[in] argv: Reference to the array of command-line arguments
+   */
   void parseAndSetup(int& argc, char**& argv);
 
   void sync();

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -65,13 +65,31 @@ struct Runtime {
   using ComponentPtrType = std::unique_ptr<ComponentT>;
   using ArgType = vt::arguments::ArgConfig;
 
+  /// \brief Constructor for Runtime object
+  ///
+  /// \param argc
+  /// \param argv
+  /// \param in_num_workers
+  /// \param interop_mode
+  /// \param in_comm
+  /// \param in_instance
+  ///
+  /// \note The command line arguments (argc, argv) will get parsed.
+  ///
   Runtime(
     int& argc, char**& argv,
     WorkerCountType in_num_workers = no_workers, bool const interop_mode = false,
     MPI_Comm* in_comm = nullptr,
     RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance
   );
-
+  /// \brief Constructor for Runtime object.
+  ///
+  /// \param interop_mode
+  /// \param in_instance
+  ///
+  /// \note No action is done during the creation of the object.
+  /// In particular, this routine will not parse the command line arguments.
+  ///
   explicit Runtime(
     bool const interop_mode = false,
     RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance);

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -99,7 +99,12 @@ struct Runtime {
 
   virtual ~Runtime();
 
+  /// \brief Sets the pointer for the MPI communicator
+  /// \param[in] in_comm: Pointer to the MPI_Comm
   void setMPIComm(MPI_Comm* in_comm) { communicator_ = in_comm; }
+
+  /// \brief Sets the number of workers
+  /// \param[in] in_num_workers: Number of workers
   void setNumWorkers(WorkerCountType in_num_workers) {
     num_workers_ = in_num_workers;
   }
@@ -150,6 +155,10 @@ protected:
   void finalizeComponents();
   void finalizeOptionalComponents();
 
+  // \brief Routine to parse the command-line parameters and
+  // to setup the simulation parameters.
+  // \param[in] argc: Reference to the number of command-line arguments
+  // \param[in] argv: Reference to the array of command-line arguments
   void parseAndSetup(int& argc, char**& argv);
 
   void sync();

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -72,11 +72,20 @@ struct Runtime {
     RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance
   );
 
+  explicit Runtime(
+    bool const interop_mode = false,
+    RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance);
+
   Runtime(Runtime const&) = delete;
   Runtime(Runtime&&) = delete;
   Runtime& operator=(Runtime const&) = delete;
 
   virtual ~Runtime();
+
+  void setMPIComm(MPI_Comm* in_comm) { communicator_ = in_comm; }
+  void setNumWorkers(WorkerCountType in_num_workers) {
+    num_workers_ = in_num_workers;
+  }
 
   bool isTerminated() const { return not runtime_active_; }
   bool isFinializeble() const { return initialized_ and not finalized_; }
@@ -123,6 +132,8 @@ protected:
   void finalizeTrace();
   void finalizeComponents();
   void finalizeOptionalComponents();
+
+  void parseAndSetup(int& argc, char**& argv);
 
   void sync();
   void setup();
@@ -180,6 +191,10 @@ protected:
   MPI_Comm* communicator_ = nullptr;
   int user_argc_ = 0;
   char** user_argv_ = nullptr;
+
+private:
+  // True if argument parsing (from CLI or input file) has been performed
+  bool parsed_arg_ = false;
 };
 
 }} /* end namespace vt::runtime */

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -63,7 +63,6 @@ namespace vt { namespace runtime {
 struct Runtime {
   template <typename ComponentT>
   using ComponentPtrType = std::unique_ptr<ComponentT>;
-  using ArgType = vt::arguments::ArgConfig;
 
   /// \brief Constructor for Runtime object
   ///

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -66,7 +66,7 @@ namespace vt { namespace sched {
 Scheduler::Scheduler() {
   event_triggers.resize(SchedulerEventType::SchedulerEventSize + 1);
   event_triggers_once.resize(SchedulerEventType::SchedulerEventSize + 1);
-  progress_time_enabled_ = arguments::ArgConfig::vt_sched_progress_sec != 0.0;
+  progress_time_enabled_ = arguments::Args::config.vt_sched_progress_sec != 0.0;
 }
 
 void Scheduler::enqueue(ActionType action) {
@@ -130,17 +130,17 @@ bool Scheduler::progressMsgOnlyImpl() {
 bool Scheduler::shouldCallProgress(
   int32_t processed_since_last_progress, TimeType time_since_last_progress
 ) const {
-  using ArgType   = arguments::ArgConfig;
+  using ArgVT = arguments::Args;
 
   // By default, `vt_sched_progress_han` is 0 and will happen every time we go
   // through the scheduler
-  bool k_handler_enabled = ArgType::vt_sched_progress_han != 0;
+  bool k_handler_enabled = ArgVT::config.vt_sched_progress_han != 0;
   bool k_handlers_executed =
     k_handler_enabled and
-    processed_since_last_progress >= ArgType::vt_sched_progress_han;
+    processed_since_last_progress >= ArgVT::config.vt_sched_progress_han;
   bool enough_time_passed =
     progress_time_enabled_ and
-    time_since_last_progress > ArgType::vt_sched_progress_sec;
+    time_since_last_progress > ArgVT::config.vt_sched_progress_sec;
 
   return
     (not progress_time_enabled_ and not k_handler_enabled) or
@@ -152,7 +152,7 @@ void Scheduler::runProgress(bool msg_only) {
    * Run through the progress functions `num_iter` times, making forward
    * progress on MPI
    */
-  auto const num_iter = std::max(1, arguments::ArgConfig::vt_sched_num_progress);
+  auto const num_iter = std::max(1, arguments::Args::config.vt_sched_num_progress);
   for (int i = 0; i < num_iter; i++) {
     if (msg_only) {
       // This is a special case used only during startup when other components

--- a/src/vt/termination/graph/epoch_graph.cc
+++ b/src/vt/termination/graph/epoch_graph.cc
@@ -167,7 +167,7 @@ std::string EpochGraph::outputDOT(bool verbose) {
     NodeType node = std::get<1>(elm.second);
     bool collective = std::get<2>(elm.second);
     std::string str = std::get<3>(elm.second);
-    if (not arguments::ArgConfig::vt_epoch_graph_terse or verbose) {
+    if (not arguments::Args::config.vt_epoch_graph_terse or verbose) {
       if (collective) {
         builder += fmt::format(
           "\t{:x} [shape=record height=1 label=\"{}|{} collective | {:x} {}\"]\n",

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -62,6 +62,8 @@
 
 namespace vt { namespace term {
 
+using ArgType = vt::arguments::ArgConfig;
+
 static EpochType const arch_epoch_coll = 0ull;
 
 TerminationDetector::TerminationDetector()

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -58,7 +58,6 @@
 #include "vt/epoch/epoch.h"
 #include "vt/activefn/activefn.h"
 #include "vt/collective/tree/tree.h"
-#include "vt/configs/arguments/args.h"
 #include "vt/termination/graph/epoch_graph_reduce.h"
 
 #include <cstdint>
@@ -80,7 +79,6 @@ struct TerminationDetector :
   using TermStateType      = TermState;
   using TermStateDSType    = term::ds::StateDS::TerminatorType;
   using WindowType         = std::unique_ptr<EpochWindow>;
-  using ArgType            = vt::arguments::ArgConfig;
   using SuccessorBagType   = EpochDependency::SuccessorBagType;
   using EpochGraph         = termination::graph::EpochGraph;
   using EpochGraphMsg      = termination::graph::EpochGraphMsg<EpochGraph>;

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -72,8 +72,7 @@ struct vt_gzFile {
   vt_gzFile(gzFile pS) : file_type(pS) { }
 };
 
-using ArgType = vt::arguments::ArgConfig;
-
+using ArgVT = vt::arguments::Args;
 using LogType = Trace::LogType;
 
 template <typename EventT>
@@ -151,11 +150,11 @@ void Trace::setupNames(
     vtAssert(false, "Must have current directory");
   }
 
-  if (ArgType::vt_trace_dir.empty()) {
+  if (ArgVT::config.vt_trace_dir.empty()) {
     full_dir_name_ = std::string(cur_dir) + "/" + dir_name;
   }
   else {
-    full_dir_name_ = ArgType::vt_trace_dir;
+    full_dir_name_ = ArgVT::config.vt_trace_dir;
   }
 
   if (full_dir_name_[full_dir_name_.size() - 1] != '/')
@@ -174,12 +173,12 @@ void Trace::setupNames(
   auto const prog_name = pc[pc.size()-1];
 
   auto const node_str = "." + std::to_string(node) + ".log.gz";
-  if (ArgType::vt_trace_file.empty()) {
+  if (ArgVT::config.vt_trace_file.empty()) {
     full_trace_name_ = full_dir_name_ + trace_name;
     full_sts_name_   = full_dir_name_ + prog_name + ".sts";
   } else {
-    full_trace_name_ = full_dir_name_ + ArgType::vt_trace_file + node_str;
-    full_sts_name_   = full_dir_name_ + ArgType::vt_trace_file + ".sts";
+    full_trace_name_ = full_dir_name_ + ArgVT::config.vt_trace_file + node_str;
+    full_sts_name_   = full_dir_name_ + ArgVT::config.vt_trace_file + ".sts";
   }
 }
 
@@ -663,8 +662,8 @@ TraceEventIDType Trace::logEvent(std::unique_ptr<LogType> log) {
 
   // If auto-flush, can flush immediately.
   // TODO: log time of flushing; unify with group-end.
-  if (ArgType::vt_trace_flush_size not_eq 0
-      and traces_.size() >= ArgType::vt_trace_flush_size) {
+  if (ArgVT::config.vt_trace_flush_size not_eq 0
+      and traces_.size() >= ArgVT::config.vt_trace_flush_size) {
     writeTracesFile(incremental_flush_mode);
   }
 
@@ -672,13 +671,13 @@ TraceEventIDType Trace::logEvent(std::unique_ptr<LogType> log) {
 }
 
 /*static*/ bool Trace::traceWritingEnabled(NodeType node) {
-  return (ArgType::vt_trace
-          and (ArgType::vt_trace_mod == 0
-               or (node % ArgType::vt_trace_mod == 0)));
+  return (ArgVT::config.vt_trace
+          and (ArgVT::config.vt_trace_mod == 0
+               or (node % ArgVT::config.vt_trace_mod == 0)));
 }
 
 /*static*/ bool Trace::isStsOutputNode(NodeType node) {
-  return (ArgType::vt_trace
+  return (ArgVT::config.vt_trace
           and node == designated_root_node);
 }
 
@@ -710,7 +709,7 @@ void Trace::cleanupTracesFile() {
 }
 
 void Trace::flushTracesFile(bool useGlobalSync) {
-  if (ArgType::vt_trace_flush_size == 0) {
+  if (ArgVT::config.vt_trace_flush_size == 0) {
     // Flush the traces at the end only
     return;
   }
@@ -719,7 +718,7 @@ void Trace::flushTracesFile(bool useGlobalSync) {
     // (Consider pushing out: barrier usages are probably domain-specific.)
     theCollective()->barrier();
   }
-  if (traces_.size() >= ArgType::vt_trace_flush_size) {
+  if (traces_.size() >= ArgVT::config.vt_trace_flush_size) {
     writeTracesFile(incremental_flush_mode);
   }
 }

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -118,7 +118,7 @@ void BaseLB::importProcessorData(
 }
 
 void BaseLB::getArgs(PhaseType phase) {
-  using ArgType = vt::arguments::ArgConfig;
+  using ArgVT = vt::arguments::Args;
   using namespace balance;
 
   bool has_spec = ReadLBSpec::hasSpec();
@@ -130,7 +130,7 @@ void BaseLB::getArgs(PhaseType phase) {
       vtAssert(false, "Error no spec found, which must exist");
     }
   } else {
-    auto const args = ArgType::vt_lb_args;
+    auto const args = ArgVT::config.vt_lb_args;
     spec_entry_ = std::make_unique<SpecEntry>(
       ReadLBSpec::makeSpecFromParams(args)
     );

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -53,7 +53,6 @@
 #include "vt/vrt/collection/balance/stats_msg.h"
 #include "vt/timing/timing.h"
 #include "vt/vrt/collection/types/migratable.fwd.h"
-#include "vt/configs/arguments/args.h"
 
 #include <cstdint>
 #include <vector>
@@ -63,7 +62,6 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 
 struct ElementStats {
   using PhaseType       = uint64_t;
-  using ArgType         = vt::arguments::ArgConfig;
 
   ElementStats() = default;
   ElementStats(ElementStats const&) = default;

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -57,7 +57,7 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-using ArgType = vt::arguments::ArgConfig;
+using ArgVT = vt::arguments::Args;
 
 /*static*/ objgroup::proxy::Proxy<LBManager> LBManager::proxy_;
 
@@ -77,20 +77,20 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
   LBType the_lb = LBType::NoLB;
 
   // --vt_lb is not enabled, thus do not run the load balancer
-  if (not ArgType::vt_lb) {
+  if (not ArgVT::config.vt_lb) {
     return the_lb;
   }
 
-  if (ArgType::vt_lb_file and try_file) {
+  if (ArgVT::config.vt_lb_file and try_file) {
     bool const has_spec = ReadLBSpec::hasSpec();
     if (has_spec) {
       the_lb = ReadLBSpec::getLB(phase);
     }
   } else {
-    vtAssert(ArgType::vt_lb_interval != 0, "LB Interval must not be 0");
-    if (phase % ArgType::vt_lb_interval == 0) {
+    vtAssert(ArgVT::config.vt_lb_interval != 0, "LB Interval must not be 0");
+    if (phase % ArgVT::config.vt_lb_interval == 0) {
       for (auto&& elm : lb_names_) {
-        if (elm.second == ArgType::vt_lb_name) {
+        if (elm.second == ArgVT::config.vt_lb_name) {
           the_lb = elm.first;
           break;
         }
@@ -134,7 +134,7 @@ void LBManager::collectiveImpl(
   if (num_invocations_ == num_calls) {
     auto const& this_node = theContext()->getNode();
 
-    if (this_node == 0 and not ArgType::vt_lb_quiet) {
+    if (this_node == 0 and not ArgVT::config.vt_lb_quiet) {
       debug_print(
         lb, node,
         "LBManager::collectiveImpl: phase={}, balancer={}, name={}\n",
@@ -216,7 +216,7 @@ void LBManager::releaseNow(PhaseType phase) {
   if (this_node == 0) {
     vt_print(
       lb,
-      "LBManaager::releaseNow: finished LB, phase={}, invocations={}\n",
+      "LBManager::releaseNow: finished LB, phase={}, invocations={}\n",
       phase, num_invocations_
     );
   }

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -57,6 +57,8 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
+using ArgType = vt::arguments::ArgConfig;
+
 /*static*/ objgroup::proxy::Proxy<LBManager> LBManager::proxy_;
 
 LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.h
@@ -49,7 +49,6 @@
 #include "vt/vrt/collection/balance/lb_type.h"
 #include "vt/vrt/collection/balance/lb_invoke/invoke_msg.h"
 #include "vt/vrt/collection/balance/lb_invoke/start_lb_msg.h"
-#include "vt/configs/arguments/args.h"
 #include "vt/objgroup/headers.h"
 
 #include <functional>
@@ -57,7 +56,6 @@
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
 struct LBManager {
-  using ArgType = vt::arguments::ArgConfig;
 
   LBManager() = default;
   LBManager(LBManager const&) = delete;

--- a/src/vt/vrt/collection/balance/proc_stats.cc
+++ b/src/vt/vrt/collection/balance/proc_stats.cc
@@ -125,10 +125,10 @@ std::unordered_map<ElementIDType,ProcStats::MigrateFnType>
 }
 
 /*static*/ void ProcStats::createStatsFile() {
-  using ArgType = vt::arguments::ArgConfig;
+  using ArgVT = vt::arguments::Args;
   auto const node = theContext()->getNode();
-  auto const base_file = std::string(ArgType::vt_lb_stats_file);
-  auto const dir = std::string(ArgType::vt_lb_stats_dir);
+  auto const base_file = std::string(ArgVT::config.vt_lb_stats_file);
+  auto const dir = std::string(ArgVT::config.vt_lb_stats_dir);
   auto const file = fmt::format("{}.{}.out", base_file, node);
   auto const file_name = fmt::format("{}/{}", dir, file);
 

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -56,6 +56,8 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
+using ArgVT = arguments::Args;
+
 /*static*/ std::string ReadLBSpec::filename = {};
 /*static*/ SpecIndex ReadLBSpec::num_entries_ = 0;
 /*static*/ typename ReadLBSpec::SpecMapType ReadLBSpec::spec_mod_ = {};
@@ -64,13 +66,13 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 /*static*/ bool ReadLBSpec::read_complete_ = false;
 
 /*static*/ bool ReadLBSpec::hasSpec() {
-  if (not ArgType::vt_lb_file) {
+  if (not ArgVT::config.vt_lb_file) {
     return false;
   }
   if (read_complete_) {
     return true;
   } else {
-    auto const file_name = ArgType::vt_lb_file_name;
+    auto const file_name = ArgVT::config.vt_lb_file_name;
     if (file_name == "") {
       vtAbort(
         "--vt_lb_file enabled but no file name is specified: --vt_lb_file_name"

--- a/src/vt/vrt/collection/balance/read_lb.h
+++ b/src/vt/vrt/collection/balance/read_lb.h
@@ -143,7 +143,6 @@ private:
  */
 
 struct ReadLBSpec {
-  using ArgType      = vt::arguments::ArgConfig;
   using SpecMapType  = std::unordered_map<SpecIndex,SpecEntry>;
   using ParamMapType = std::unordered_map<std::string, std::string>;
 

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -51,6 +51,8 @@
 
 namespace vt { namespace vrt { namespace collection {
 
+using ArgType = vt::arguments::ArgConfig;
+
 CollectionManager::CollectionManager() {
   balance::LBManager::init();
 }

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -51,7 +51,7 @@
 
 namespace vt { namespace vrt { namespace collection {
 
-using ArgType = vt::arguments::ArgConfig;
+using ArgVT = vt::arguments::Args;
 
 CollectionManager::CollectionManager() {
   balance::LBManager::init();
@@ -62,7 +62,7 @@ CollectionManager::CollectionManager() {
 
   // Statistics output when LB is enabled and appropriate flag is enabled
 #if backend_check_enabled(lblite)
-  if (ArgType::vt_lb_stats) {
+  if (ArgVT::config.vt_lb_stats) {
     balance::ProcStats::outputStatsFile();
     balance::ProcStats::clearStats();
   }

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -72,7 +72,6 @@
 #include "vt/collective/collective_alg.h"
 #include "vt/collective/reduce/reduce_msg.h"
 #include "vt/collective/reduce/reduce_hash.h"
-#include "vt/configs/arguments/args.h"
 #include "vt/vrt/collection/balance/proc_stats.h"
 #include "vt/vrt/collection/balance/lb_common.h"
 
@@ -116,7 +115,6 @@ struct CollectionManager {
   using CleanupListFnType = std::unordered_map<VirtualProxyType,std::list<CleanupFnType>>;
   using DispatchHandlerType = auto_registry::AutoHandlerType;
   using ActionVecType = std::vector<ActionType>;
-  using ArgType = vt::arguments::ArgConfig;
 
   template <typename ColT, typename IndexT = typename ColT::IndexType>
   using DistribConstructFn = std::function<VirtualPtrType<ColT>(IndexT idx)>;

--- a/tests/unit/scheduler/test_scheduler_progress.cc
+++ b/tests/unit/scheduler/test_scheduler_progress.cc
@@ -53,6 +53,8 @@
 
 namespace vt { namespace tests { namespace unit {
 
+using ArgVT = vt::arguments::Args;
+
 struct TestSchedProgress : TestParallelHarness { };
 
 TEST_F(TestSchedProgress, test_scheduler_progress_1) {
@@ -61,8 +63,8 @@ TEST_F(TestSchedProgress, test_scheduler_progress_1) {
   using namespace std::chrono_literals;
 
   // Run the progress function every second at least
-  vt::arguments::ArgConfig::vt_sched_progress_han = 0;
-  vt::arguments::ArgConfig::vt_sched_progress_sec = 1.0;
+  ArgVT::config.vt_sched_progress_han = 0;
+  ArgVT::config.vt_sched_progress_sec = 1.0;
 
   bool done = false;
 
@@ -77,7 +79,7 @@ TEST_F(TestSchedProgress, test_scheduler_progress_1) {
 
   // Fill the queue with a second amount of work, in smaller increments to see
   // if progress triggers too early
-  for (int i = 0; i < vt::arguments::ArgConfig::vt_sched_progress_sec / 0.05; i++) {
+  for (int i = 0; i < ArgVT::config.vt_sched_progress_sec / 0.05; i++) {
     testSched->enqueue([]{ sleep_for(50ms); });
   }
 
@@ -88,12 +90,12 @@ TEST_F(TestSchedProgress, test_scheduler_progress_1) {
   // This ought to take close to a second
   EXPECT_GT(
     vt::timing::Timing::getCurrentTime() - cur_time,
-    vt::arguments::ArgConfig::vt_sched_progress_sec * fudge
+    ArgVT::config.vt_sched_progress_sec * fudge
   );
 
   // Switch back to default scheduler settings (to not slow down other tests)
-  vt::arguments::ArgConfig::vt_sched_progress_han = 0;
-  vt::arguments::ArgConfig::vt_sched_progress_sec = 0.0;
+  ArgVT::config.vt_sched_progress_han = 0;
+  ArgVT::config.vt_sched_progress_sec = 0.0;
 }
 
 TEST_F(TestSchedProgress, test_scheduler_progress_2) {
@@ -102,8 +104,8 @@ TEST_F(TestSchedProgress, test_scheduler_progress_2) {
   using namespace std::chrono_literals;
 
   // Run scheduler every 10 handlers at least
-  vt::arguments::ArgConfig::vt_sched_progress_han = 10;
-  vt::arguments::ArgConfig::vt_sched_progress_sec = 0.0;
+  ArgVT::config.vt_sched_progress_han = 10;
+  ArgVT::config.vt_sched_progress_sec = 0.0;
 
   bool done = false;
 
@@ -127,12 +129,12 @@ TEST_F(TestSchedProgress, test_scheduler_progress_2) {
   // This ought to take close to a second
   EXPECT_GT(
     vt::timing::Timing::getCurrentTime() - cur_time,
-    vt::arguments::ArgConfig::vt_sched_progress_sec * fudge
+    ArgVT::config.vt_sched_progress_sec * fudge
   );
 
   // Switch back to default scheduler settings (to not slow down other tests)
-  vt::arguments::ArgConfig::vt_sched_progress_han = 0;
-  vt::arguments::ArgConfig::vt_sched_progress_sec = 0.0;
+  ArgVT::config.vt_sched_progress_han = 0;
+  ArgVT::config.vt_sched_progress_sec = 0.0;
 }
 
 

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -459,8 +459,8 @@ TEST_P(TestTermDepSendChain, test_term_dep_send_chain) {
   auto const k = std::get<1>(tup);
   auto const migrate = std::get<2>(tup);
 
-  vt::arguments::ArgConfig::vt_term_rooted_use_wave = !use_ds;
-  vt::arguments::ArgConfig::vt_term_rooted_use_ds = use_ds;
+  vt::arguments::Args::config.vt_term_rooted_use_wave = !use_ds;
+  vt::arguments::Args::config.vt_term_rooted_use_ds = use_ds;
 
   auto local = std::make_unique<MyObjGroup>();
   local->startup();


### PR DESCRIPTION
** Replaces closed pull-request #475  (with a cleaner history for a simpler rebase)

Split the runtime initialization.
Allow for a third-party specification of arguments.
Set precedence rule for each argument.
Generate the startup banner.
Give the option to create a ".INI" file with the simulation parameters.