### PR TITLE
#668: signed vs unsigned warnings with gcc 9.2.0 in test_term_cleanup

### DIFF
--- a/tests/unit/termination/test_term_cleanup.cc
+++ b/tests/unit/termination/test_term_cleanup.cc
@@ -89,20 +89,20 @@ TEST_F(TestTermCleanup, test_termination_cleanup_1) {
     theTerm()->addAction(epoch, [&]{ done = true; });
     do vt::runScheduler(); while (not done);
 
-    EXPECT_LT(theTerm()->getEpochState().size(), 2);
-    EXPECT_EQ(theTerm()->getEpochWaitSet().size(), 0);
-    EXPECT_EQ(theTerm()->getDSTermMap().size(), 0);
-    EXPECT_LT(theTerm()->getEpochReadySet().size(), 2);
+    EXPECT_LT(theTerm()->getEpochState().size(), std::size_t{2});
+    EXPECT_EQ(theTerm()->getEpochWaitSet().size(), std::size_t{0});
+    EXPECT_EQ(theTerm()->getDSTermMap().size(), std::size_t{0});
+    EXPECT_LT(theTerm()->getEpochReadySet().size(), std::size_t{2});
   }
 
   while (not vt::rt->isTerminated() or not vt::theSched()->isIdle()) {
     vt::runScheduler();
   }
 
-  EXPECT_LT(theTerm()->getEpochState().size(), 2);
-  EXPECT_EQ(theTerm()->getEpochWaitSet().size(), 0);
-  EXPECT_EQ(theTerm()->getDSTermMap().size(), 0);
-  EXPECT_LT(theTerm()->getEpochReadySet().size(), 2);
+  EXPECT_LT(theTerm()->getEpochState().size(), std::size_t{2});
+  EXPECT_EQ(theTerm()->getEpochWaitSet().size(), std::size_t{0});
+  EXPECT_EQ(theTerm()->getDSTermMap().size(), std::size_t{0});
+  EXPECT_LT(theTerm()->getEpochReadySet().size(), std::size_t{2});
 }
 
 TEST_F(TestTermCleanup, test_termination_cleanup_2) {
@@ -155,10 +155,10 @@ TEST_F(TestTermCleanup, test_termination_cleanup_2) {
     vt::runScheduler();
   }
 
-  EXPECT_LT(theTerm()->getEpochState().size(), 2);
-  EXPECT_EQ(theTerm()->getEpochWaitSet().size(), 0);
-  EXPECT_EQ(theTerm()->getDSTermMap().size(), 0);
-  EXPECT_LT(theTerm()->getEpochReadySet().size(), 2);
+  EXPECT_LT(theTerm()->getEpochState().size(), std::size_t{2});
+  EXPECT_EQ(theTerm()->getEpochWaitSet().size(), std::size_t{0});
+  EXPECT_EQ(theTerm()->getDSTermMap().size(), std::size_t{0});
+  EXPECT_LT(theTerm()->getEpochReadySet().size(), std::size_t{2});
 }
 
 


### PR DESCRIPTION
This can also be applied to 1.0.0-beta-5