### PR TITLE
#680 fix trace guard

### DIFF
--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -436,7 +436,7 @@ TraceProcessingTag Trace::beginProcessing(
 }
 
 void Trace::endProcessing(
-  TraceProcessingTag const processing_tag,
+  TraceProcessingTag const& processing_tag,
   double const time
 ) {
   if (not checkDynamicRuntimeEnabled()) {
@@ -447,7 +447,7 @@ void Trace::endProcessing(
   TraceEventIDType event = processing_tag.event_;
 
   // Allow no-op cases (ie. beginProcessing disabled)
-  if (event == trace::no_trace_event) {
+  if (ep == trace::no_trace_entry_id) {
     return;
   }
 

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -124,7 +124,7 @@ struct Trace {
   /// Finalize a paired event.
   /// The processing_tag value comes from beginProcessing.
   void endProcessing(
-    TraceProcessingTag processing_tag,
+    TraceProcessingTag const& processing_tag,
     double const time = getCurrentTime()
   );
 


### PR DESCRIPTION
- Was incorrectly guarding 'event type' == 0, which CAN be true..
  ..even if it probably should be the case. Now guards against
  the 'entry id' itself.

Fixes #680