### PR TITLE
689 New tracing enable specification file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,8 @@ set(
     objgroup
       objgroup/proxy objgroup/holder objgroup/active_func objgroup/dispatch
       objgroup/type_registry
-
+    trace
+      trace/file_spec
 )
 list(APPEND PROJECT_SUBDIRS_LIST ${TOP_LEVEL_SUBDIRS})
 

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -83,7 +83,7 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_trace_sys_location   = false;
 /*static*/ bool        ArgConfig::vt_trace_sys_collection = false;
 /*static*/ bool        ArgConfig::vt_trace_sys_serial_msg = false;
-/*static*/ bool        ArgConfig::vt_trace_spec_enabled   = false;
+/*static*/ bool        ArgConfig::vt_trace_spec           = false;
 /*static*/ std::string ArgConfig::vt_trace_spec_file_name = "";
 
 
@@ -244,7 +244,7 @@ namespace vt { namespace arguments {
   auto tsyscoll  = "Trace system virtual context collection events";
   auto tsyssmsg  = "Trace system serialization manager events";
   auto tspec     = "Enable trace spec file (defines which phases tracing is on)";
-  auto tspecfile = "File containing trace spec; --vt_trace_spec_enabled to enable";
+  auto tspecfile = "File containing trace spec; --vt_trace_spec to enable";
   auto n  = app.add_flag("--vt_trace",              vt_trace,           trace);
   auto nm = app.add_flag("--vt_trace_mpi",          vt_trace_mpi,       trace_mpi);
   auto o  = app.add_option("--vt_trace_file",       vt_trace_file,      tfile, "");
@@ -257,7 +257,7 @@ namespace vt { namespace arguments {
   auto qx = app.add_flag("--vt_trace_sys_location",   vt_trace_sys_location,   tsysloc);
   auto qy = app.add_flag("--vt_trace_sys_collection", vt_trace_sys_collection, tsyscoll);
   auto qz = app.add_flag("--vt_trace_sys_serial_msg", vt_trace_sys_serial_msg, tsyssmsg);
-  auto qza = app.add_flag("--vt_trace_spec_enabled",   vt_trace_spec_enabled,   tspec);
+  auto qza = app.add_flag("--vt_trace_spec",          vt_trace_spec,           tspec);
   auto qzb = app.add_option("--vt_trace_spec_file_name", vt_trace_spec_file_name, tspecfile, "");
   auto traceGroup = "Tracing Configuration";
   n->group(traceGroup);

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -84,7 +84,7 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_trace_sys_collection = false;
 /*static*/ bool        ArgConfig::vt_trace_sys_serial_msg = false;
 /*static*/ bool        ArgConfig::vt_trace_spec           = false;
-/*static*/ std::string ArgConfig::vt_trace_spec_file_name = "";
+/*static*/ std::string ArgConfig::vt_trace_spec_file      = "";
 
 
 /*static*/ bool        ArgConfig::vt_lb                 = false;
@@ -258,7 +258,7 @@ namespace vt { namespace arguments {
   auto qy = app.add_flag("--vt_trace_sys_collection", vt_trace_sys_collection, tsyscoll);
   auto qz = app.add_flag("--vt_trace_sys_serial_msg", vt_trace_sys_serial_msg, tsyssmsg);
   auto qza = app.add_flag("--vt_trace_spec",          vt_trace_spec,           tspec);
-  auto qzb = app.add_option("--vt_trace_spec_file_name", vt_trace_spec_file_name, tspecfile, "");
+  auto qzb = app.add_option("--vt_trace_spec_file",   vt_trace_spec_file,      tspecfile, "");
   auto traceGroup = "Tracing Configuration";
   n->group(traceGroup);
   nm->group(traceGroup);

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -83,6 +83,9 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_trace_sys_location   = false;
 /*static*/ bool        ArgConfig::vt_trace_sys_collection = false;
 /*static*/ bool        ArgConfig::vt_trace_sys_serial_msg = false;
+/*static*/ bool        ArgConfig::vt_trace_spec_enabled   = false;
+/*static*/ std::string ArgConfig::vt_trace_spec_file_name = "";
+
 
 /*static*/ bool        ArgConfig::vt_lb                 = false;
 /*static*/ bool        ArgConfig::vt_lb_file            = false;
@@ -240,6 +243,8 @@ namespace vt { namespace arguments {
   auto tsysloc   = "Trace system location manager events";
   auto tsyscoll  = "Trace system virtual context collection events";
   auto tsyssmsg  = "Trace system serialization manager events";
+  auto tspec     = "Enable trace spec file (defines which phases tracing is on)";
+  auto tspecfile = "File containing trace spec; --vt_trace_spec_enabled to enable";
   auto n  = app.add_flag("--vt_trace",              vt_trace,           trace);
   auto nm = app.add_flag("--vt_trace_mpi",          vt_trace_mpi,       trace_mpi);
   auto o  = app.add_option("--vt_trace_file",       vt_trace_file,      tfile, "");
@@ -252,6 +257,8 @@ namespace vt { namespace arguments {
   auto qx = app.add_flag("--vt_trace_sys_location",   vt_trace_sys_location,   tsysloc);
   auto qy = app.add_flag("--vt_trace_sys_collection", vt_trace_sys_collection, tsyscoll);
   auto qz = app.add_flag("--vt_trace_sys_serial_msg", vt_trace_sys_serial_msg, tsyssmsg);
+  auto qza = app.add_flag("--vt_trace_spec_enabled",   vt_trace_spec_enabled,   tspec);
+  auto qzb = app.add_option("--vt_trace_spec_file_name", vt_trace_spec_file_name, tspecfile, "");
   auto traceGroup = "Tracing Configuration";
   n->group(traceGroup);
   nm->group(traceGroup);
@@ -264,6 +271,8 @@ namespace vt { namespace arguments {
   qx->group(traceGroup);
   qy->group(traceGroup);
   qz->group(traceGroup);
+  qza->group(traceGroup);
+  qzb->group(traceGroup);
 
 
   /*

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -90,7 +90,7 @@ public:
   static int32_t vt_trace_mod;
   static int32_t vt_trace_flush_size;
   static bool vt_trace_spec;
-  static std::string vt_trace_spec_file_name;
+  static std::string vt_trace_spec_file;
 
   static bool vt_lb;
   static bool vt_lb_file;

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -89,7 +89,7 @@ public:
   static std::string vt_trace_dir;
   static int32_t vt_trace_mod;
   static int32_t vt_trace_flush_size;
-  static bool vt_trace_spec_enabled;
+  static bool vt_trace_spec;
   static std::string vt_trace_spec_file_name;
 
   static bool vt_lb;

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -89,6 +89,8 @@ public:
   static std::string vt_trace_dir;
   static int32_t vt_trace_mod;
   static int32_t vt_trace_flush_size;
+  static bool vt_trace_spec_enabled;
+  static std::string vt_trace_spec_file_name;
 
   static bool vt_lb;
   static bool vt_lb_file;

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1057,6 +1057,10 @@ void Runtime::setup() {
     MPI_Barrier(theContext->getComm());
   });
 
+# if backend_check_enabled(trace_enabled)
+  theTrace->parseSpec();
+# endif
+
   if (ArgType::vt_pause) {
     pauseForDebugger();
   }

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -599,6 +599,29 @@ void Runtime::printStartupBanner() {
       auto f12 = opt_on("--vt_trace_sys_all", f11);
       fmt::print("{}\t{}{}", vt_pre, f12, reset);
     }
+    if (ArgType::vt_trace_spec_enabled) {
+      {
+        auto f11 = fmt::format("Using trace enable specification for phases");
+        auto f12 = opt_on("--vt_trace_spec_enabled", f11);
+        fmt::print("{}\t{}{}", vt_pre, f12, reset);
+      }
+      if (ArgType::vt_trace_spec_file_name == "") {
+        auto warn_trace_file = fmt::format(
+          "{}Warning:{} {}{}{} has no effect: not specification file given"
+          " option {}{}{} is empty{}\n", red, reset, magenta,
+          "--vt_trace_spec_enabled",
+          reset, magenta, "--vt_trace_spec_file_name", reset, reset
+        );
+        fmt::print("{}\t{}{}", vt_pre, warn_trace_file, reset);
+      } else {
+        auto f11 = fmt::format(
+          "Using trace specification file \"{}\"",
+          ArgType::vt_trace_spec_file_name
+        );
+        auto f12 = opt_inverse("--vt_trace_spec_enabled", f11);
+        fmt::print("{}\t{}{}", vt_pre, f12, reset);
+      }
+    }
   }
   #endif
 

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -607,7 +607,7 @@ void Runtime::printStartupBanner() {
       }
       if (ArgType::vt_trace_spec_file_name == "") {
         auto warn_trace_file = fmt::format(
-          "{}Warning:{} {}{}{} has no effect: not specification file given"
+          "{}Warning:{} {}{}{} has no effect: no specification file given"
           " option {}{}{} is empty{}\n", red, reset, magenta,
           "--vt_trace_spec_enabled",
           reset, magenta, "--vt_trace_spec_file_name", reset, reset

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1058,7 +1058,7 @@ void Runtime::setup() {
   });
 
 # if backend_check_enabled(trace_enabled)
-  theTrace->parseSpec();
+  theTrace->loadAndBroadcastSpec();
 # endif
 
   if (ArgType::vt_pause) {

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -599,17 +599,17 @@ void Runtime::printStartupBanner() {
       auto f12 = opt_on("--vt_trace_sys_all", f11);
       fmt::print("{}\t{}{}", vt_pre, f12, reset);
     }
-    if (ArgType::vt_trace_spec_enabled) {
+    if (ArgType::vt_trace_spec) {
       {
         auto f11 = fmt::format("Using trace enable specification for phases");
-        auto f12 = opt_on("--vt_trace_spec_enabled", f11);
+        auto f12 = opt_on("--vt_trace_spec", f11);
         fmt::print("{}\t{}{}", vt_pre, f12, reset);
       }
       if (ArgType::vt_trace_spec_file_name == "") {
         auto warn_trace_file = fmt::format(
           "{}Warning:{} {}{}{} has no effect: no specification file given"
           " option {}{}{} is empty{}\n", red, reset, magenta,
-          "--vt_trace_spec_enabled",
+          "--vt_trace_spec",
           reset, magenta, "--vt_trace_spec_file_name", reset, reset
         );
         fmt::print("{}\t{}{}", vt_pre, warn_trace_file, reset);
@@ -618,7 +618,7 @@ void Runtime::printStartupBanner() {
           "Using trace specification file \"{}\"",
           ArgType::vt_trace_spec_file_name
         );
-        auto f12 = opt_inverse("--vt_trace_spec_enabled", f11);
+        auto f12 = opt_inverse("--vt_trace_spec", f11);
         fmt::print("{}\t{}{}", vt_pre, f12, reset);
       }
     }

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -605,18 +605,18 @@ void Runtime::printStartupBanner() {
         auto f12 = opt_on("--vt_trace_spec", f11);
         fmt::print("{}\t{}{}", vt_pre, f12, reset);
       }
-      if (ArgType::vt_trace_spec_file_name == "") {
+      if (ArgType::vt_trace_spec_file == "") {
         auto warn_trace_file = fmt::format(
           "{}Warning:{} {}{}{} has no effect: no specification file given"
           " option {}{}{} is empty{}\n", red, reset, magenta,
           "--vt_trace_spec",
-          reset, magenta, "--vt_trace_spec_file_name", reset, reset
+          reset, magenta, "--vt_trace_spec_file", reset, reset
         );
         fmt::print("{}\t{}{}", vt_pre, warn_trace_file, reset);
       } else {
         auto f11 = fmt::format(
           "Using trace specification file \"{}\"",
-          ArgType::vt_trace_spec_file_name
+          ArgType::vt_trace_spec_file
         );
         auto f12 = opt_inverse("--vt_trace_spec", f11);
         fmt::print("{}\t{}{}", vt_pre, f12, reset);

--- a/src/vt/runtime/runtime_holder.h
+++ b/src/vt/runtime/runtime_holder.h
@@ -105,7 +105,7 @@ private:
   }
 
   void release() {
-    if (owner_ && rt_ && rt_->isFinializeble() && rt_->hasSchedRun()) {
+    if (owner_ && rt_ && rt_->isFinializeble() && rt_->hasSchedRun() && rt_->isTerminated()) {
       rt_->finalize();
     }
     rt_ = nullptr;

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -216,14 +216,13 @@ void Spec::transferSpec(SpecMsg* msg) {
 void Spec::insertSpec(
   SpecIndex phase, SpecIndex neg, SpecIndex pos, bool is_mod, SpecMapType& map
 ) {
-  auto& filename = ArgType::vt_trace_spec_file_name;
   auto iter = map.find(phase);
   if (iter != map.end()) {
     auto str = fmt::format(
       "Parsing file \"{}\" error: multiple lines start with the same {}:"
       " value \"{}{}\"",
       is_mod ? "mod phase" : "phase",
-      filename,
+      ArgType::vt_trace_spec_file_name,
       is_mod ? "%" : "",
       phase
     );

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -72,18 +72,18 @@ bool Spec::checkTraceEnabled(SpecIndex in_phase) {
 
 bool Spec::hasSpec() {
   if (ArgType::vt_trace_spec) {
-    if (ArgType::vt_trace_spec_file_name == "") {
+    if (ArgType::vt_trace_spec_file == "") {
       vtAbort(
         "--vt_trace_spec enabled but no file name is specified:"
-        " --vt_trace_spec_file_name"
+        " --vt_trace_spec_file"
       );
       return false;
     } else {
-      auto& filename = ArgType::vt_trace_spec_file_name;
+      auto& filename = ArgType::vt_trace_spec_file;
       std::ifstream file(filename);
       if (not file.good()) {
         auto str = fmt::format(
-          "--vt_trace_spec_file_name={} is not a valid file", filename
+          "--vt_trace_spec_file={} is not a valid file", filename
         );
         vtAbort(str);
         return false;
@@ -101,7 +101,7 @@ void Spec::parse() {
     return;
   }
 
-  auto& filename = ArgType::vt_trace_spec_file_name;
+  auto& filename = ArgType::vt_trace_spec_file;
   std::ifstream file(filename);
   vtAssertExpr(file.good());
 
@@ -222,7 +222,7 @@ void Spec::insertSpec(
       "Parsing file \"{}\" error: multiple lines start with the same {}:"
       " value \"{}{}\"",
       is_mod ? "mod phase" : "phase",
-      ArgType::vt_trace_spec_file_name,
+      ArgType::vt_trace_spec_file,
       is_mod ? "%" : "",
       phase
     );

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -71,10 +71,10 @@ bool Spec::checkTraceEnabled(SpecIndex in_phase) {
 }
 
 bool Spec::hasSpec() {
-  if (ArgType::vt_trace_spec_enabled) {
+  if (ArgType::vt_trace_spec) {
     if (ArgType::vt_trace_spec_file_name == "") {
       vtAbort(
-        "--vt_trace_spec_enabled enabled but no file name is specified:"
+        "--vt_trace_spec enabled but no file name is specified:"
         " --vt_trace_spec_file_name"
       );
       return false;

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -1,0 +1,262 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                   spec.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include "vt/config.h"
+#include "vt/trace/file_spec/spec.h"
+#include "vt/objgroup/manager.h"
+
+#include <fstream>
+
+namespace vt { namespace trace { namespace file_spec {
+
+void Spec::init(ProxyType in_proxy) {
+  proxy_ = in_proxy;
+}
+
+bool Spec::checkTraceEnabled(SpecIndex in_phase) {
+  vtAssertExpr(has_spec_);
+
+  for (auto&& elm : spec_mod_) {
+    if (elm.second.testTraceEnabledFor(in_phase)) {
+      return true;
+    }
+  }
+  for (auto&& elm : spec_exact_) {
+    if (elm.second.testTraceEnabledFor(in_phase)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool Spec::hasSpec() {
+  if (ArgType::vt_trace_spec_enabled) {
+    if (ArgType::vt_trace_spec_file_name == "") {
+      vtAbort(
+        "--vt_trace_spec_enabled enabled but no file name is specified:"
+        " --vt_trace_spec_file_name"
+      );
+      return false;
+    } else {
+      auto& filename = ArgType::vt_trace_spec_file_name;
+      std::ifstream file(filename);
+      if (not file.good()) {
+        auto str = fmt::format(
+          "--vt_trace_spec_file_name={} is not a valid file", filename
+        );
+        vtAbort(str);
+        return false;
+      } else {
+        return true;
+      }
+    }
+  } else {
+    return false;
+  }
+}
+
+void Spec::parse() {
+  if (not hasSpec()) {
+    return;
+  }
+
+  auto& filename = ArgType::vt_trace_spec_file_name;
+  std::ifstream file(filename);
+  vtAssertExpr(file.good());
+
+  while (!file.eof()) {
+    bool is_mod  = false;
+    SpecIndex phase = -1;
+    SpecIndex phase_negative_offset = 0;
+    SpecIndex phase_positive_offset = 0;
+
+    int c = eatWhitespace(file);
+
+    /*
+     * Optionally parse an entry that starts with an mod phase: "% ..."
+     *                                                           ^
+     */
+    if (static_cast<char>(c) == '%') {
+      is_mod = true;
+      // Eat up the '%', move to next
+      file.get();
+      c = eatWhitespace(file);
+    }
+
+    /*
+     * Parse phase/mod phase: "[%]10..."
+     *                            ^^
+     */
+    if (std::isdigit(c)) {
+      file >> phase;
+    }
+
+    c = eatWhitespace(file);
+
+    /*
+     * Parse negative offset for phase/mod: "[%]10 -5..."
+     *                                             ^^
+     * This offset must be negative or zero!
+     */
+    if (std::isdigit(c) or static_cast<char>(c) == '-') {
+      file >> phase_negative_offset;
+      if (phase_negative_offset > 0) {
+        auto str = fmt::format(
+          "Parsing file \"{}\" error: found offset in negative offset position"
+          " that is > 0: value \"{}\"",
+          filename,
+          phase_negative_offset
+        );
+        vtAbort(str);
+      }
+    }
+
+    c = eatWhitespace(file);
+
+    /*
+     * Parse positive offset for phase/mod: "[%]10 -5 5..."
+     *                                                ^
+     * This offset must be positive or zero!
+     */
+    if (std::isdigit(c)) {
+      file >> phase_positive_offset;
+      if (phase_positive_offset < 0) {
+        auto str = fmt::format(
+          "Parsing file \"{}\" error: found offset in positive offset position"
+          " that is < 0: value \"{}\"",
+          filename,
+          phase_positive_offset
+        );
+        vtAbort(str);
+      }
+    }
+
+    eatWhitespace(file);
+
+    /*
+     * Entry is complete; eat all the following newlines
+     */
+    while (file.peek() == '\n') {
+      file.get();
+    }
+
+    debug_print(
+      trace, node,
+      "Spec::parser: is_mod={}, phase={}, neg={}, pos={}\n",
+      is_mod, phase, phase_negative_offset, phase_positive_offset
+    );
+
+    // We have a whole entry, put in the spec; it should not already exist
+    insertSpec(
+      phase, phase_negative_offset, phase_positive_offset, is_mod,
+      is_mod ? spec_mod_ : spec_exact_
+    );
+  }
+
+  has_spec_ = true;
+}
+
+void Spec::broadcastSpecWaitReceive() {
+  broadcastSpec();
+  do vt::runScheduler(); while (not finished_bcast_);
+}
+
+void Spec::doneBcast(DoneMsg*) {
+  finished_bcast_ = true;
+}
+
+void Spec::broadcastSpec() {
+  auto root = theContext()->getNode();
+  auto msg = makeMessage<SpecMsg>(spec_mod_, spec_exact_, root);
+  proxy_.template broadcast<SpecMsg, &Spec::transferSpec>(msg.get());
+}
+
+void Spec::transferSpec(SpecMsg* msg) {
+  // The broadcast will hit all nodes, so the node that it exists on will
+  // ignore it
+  if (not has_spec_) {
+    spec_mod_ = msg->spec_mod_;
+    spec_exact_ = msg->spec_exact_;
+    has_spec_ = true;
+  }
+}
+
+void Spec::insertSpec(
+  SpecIndex phase, SpecIndex neg, SpecIndex pos, bool is_mod, SpecMapType& map
+) {
+  auto& filename = ArgType::vt_trace_spec_file_name;
+  auto iter = map.find(phase);
+  if (iter != map.end()) {
+    auto str = fmt::format(
+      "Parsing file \"{}\" error: multiple lines start with the same {}:"
+      " value \"{}{}\"",
+      is_mod ? "mod phase" : "phase",
+      filename,
+      is_mod ? "%" : "",
+      phase
+    );
+    vtAbort(str);
+  } else {
+    map.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(phase),
+      std::forward_as_tuple(SpecEntry{phase, neg, pos, is_mod})
+    );
+  }
+}
+
+int Spec::eatWhitespace(std::ifstream& file) {
+  while (not file.eof() and std::isspace(file.peek()) and file.peek() != '\n') {
+    file.get();
+  }
+  return file.eof() ? 0 : file.peek();
+}
+
+/*static*/ typename Spec::ProxyType Spec::construct() {
+  auto proxy = theObjGroup()->makeCollective<Spec>();
+  proxy.get()->init(proxy);
+  return proxy;
+}
+
+}}} /* end namespace vt::trace::file_spec */

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -50,11 +50,11 @@
 
 namespace vt { namespace trace { namespace file_spec {
 
-void Spec::init(ProxyType in_proxy) {
+void TraceSpec::init(ProxyType in_proxy) {
   proxy_ = in_proxy;
 }
 
-bool Spec::checkTraceEnabled(SpecIndex in_phase) {
+bool TraceSpec::checkTraceEnabled(SpecIndex in_phase) {
   vtAssertExpr(has_spec_);
 
   for (auto&& elm : spec_mod_) {
@@ -70,7 +70,7 @@ bool Spec::checkTraceEnabled(SpecIndex in_phase) {
   return false;
 }
 
-bool Spec::hasSpec() {
+bool TraceSpec::hasSpec() {
   if (ArgType::vt_trace_spec) {
     if (ArgType::vt_trace_spec_file == "") {
       vtAbort(
@@ -96,7 +96,7 @@ bool Spec::hasSpec() {
   }
 }
 
-void Spec::parse() {
+void TraceSpec::parse() {
   if (not hasSpec()) {
     return;
   }
@@ -183,7 +183,7 @@ void Spec::parse() {
 
     debug_print(
       trace, node,
-      "Spec::parser: is_mod={}, phase={}, neg={}, pos={}\n",
+      "TraceSpec::parser: is_mod={}, phase={}, neg={}, pos={}\n",
       is_mod, phase, phase_negative_offset, phase_positive_offset
     );
 
@@ -197,13 +197,13 @@ void Spec::parse() {
   has_spec_ = true;
 }
 
-void Spec::broadcastSpec() {
+void TraceSpec::broadcastSpec() {
   auto root = theContext()->getNode();
   auto msg = makeMessage<SpecMsg>(spec_mod_, spec_exact_, root);
-  proxy_.template broadcast<SpecMsg, &Spec::transferSpec>(msg.get());
+  proxy_.template broadcast<SpecMsg, &TraceSpec::transferSpec>(msg.get());
 }
 
-void Spec::transferSpec(SpecMsg* msg) {
+void TraceSpec::transferSpec(SpecMsg* msg) {
   // The broadcast will hit all nodes, so the node that it exists on will
   // ignore it
   if (not has_spec_) {
@@ -213,7 +213,7 @@ void Spec::transferSpec(SpecMsg* msg) {
   }
 }
 
-void Spec::insertSpec(
+void TraceSpec::insertSpec(
   SpecIndex phase, SpecIndex neg, SpecIndex pos, bool is_mod, SpecMapType& map
 ) {
   auto iter = map.find(phase);
@@ -236,15 +236,15 @@ void Spec::insertSpec(
   }
 }
 
-int Spec::eatWhitespace(std::ifstream& file) {
+int TraceSpec::eatWhitespace(std::ifstream& file) {
   while (not file.eof() and std::isspace(file.peek()) and file.peek() != '\n') {
     file.get();
   }
   return file.eof() ? 0 : file.peek();
 }
 
-/*static*/ typename Spec::ProxyType Spec::construct() {
-  auto proxy = theObjGroup()->makeCollective<Spec>();
+/*static*/ typename TraceSpec::ProxyType TraceSpec::construct() {
+  auto proxy = theObjGroup()->makeCollective<TraceSpec>();
   proxy.get()->init(proxy);
   return proxy;
 }

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -141,15 +141,15 @@ void TraceSpec::parse() {
      */
     if (std::isdigit(c) or static_cast<char>(c) == '-') {
       file >> phase_negative_offset;
-      if (phase_negative_offset > 0) {
-        auto str = fmt::format(
+      vtAbortIf(
+        phase_negative_offset > 0,
+        fmt::format(
           "Parsing file \"{}\" error: found offset in negative offset position"
           " that is > 0: value \"{}\"",
           filename,
           phase_negative_offset
-        );
-        vtAbort(str);
-      }
+        )
+      );
     }
 
     c = eatWhitespace(file);
@@ -161,15 +161,15 @@ void TraceSpec::parse() {
      */
     if (std::isdigit(c)) {
       file >> phase_positive_offset;
-      if (phase_positive_offset < 0) {
-        auto str = fmt::format(
+      vtAbortIf(
+        phase_positive_offset < 0,
+        fmt::format(
           "Parsing file \"{}\" error: found offset in positive offset position"
           " that is < 0: value \"{}\"",
           filename,
           phase_positive_offset
-        );
-        vtAbort(str);
-      }
+        )
+      );
     }
 
     eatWhitespace(file);
@@ -216,24 +216,22 @@ void TraceSpec::transferSpec(SpecMsg* msg) {
 void TraceSpec::insertSpec(
   SpecIndex phase, SpecIndex neg, SpecIndex pos, bool is_mod, SpecMapType& map
 ) {
-  auto iter = map.find(phase);
-  if (iter != map.end()) {
-    auto str = fmt::format(
+  vtAbortIf(
+    map.find(phase) != map.end(),
+    fmt::format(
       "Parsing file \"{}\" error: multiple lines start with the same {}:"
       " value \"{}{}\"",
       is_mod ? "mod phase" : "phase",
       ArgType::vt_trace_spec_file,
       is_mod ? "%" : "",
       phase
-    );
-    vtAbort(str);
-  } else {
-    map.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(phase),
-      std::forward_as_tuple(SpecEntry{phase, neg, pos, is_mod})
-    );
-  }
+    )
+  );
+  map.emplace(
+    std::piecewise_construct,
+    std::forward_as_tuple(phase),
+    std::forward_as_tuple(SpecEntry{phase, neg, pos, is_mod})
+  );
 }
 
 int TraceSpec::eatWhitespace(std::ifstream& file) {

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -197,15 +197,6 @@ void Spec::parse() {
   has_spec_ = true;
 }
 
-void Spec::broadcastSpecWaitReceive() {
-  broadcastSpec();
-  do vt::runScheduler(); while (not finished_bcast_);
-}
-
-void Spec::doneBcast(DoneMsg*) {
-  finished_bcast_ = true;
-}
-
 void Spec::broadcastSpec() {
   auto root = theContext()->getNode();
   auto msg = makeMessage<SpecMsg>(spec_mod_, spec_exact_, root);

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -195,6 +195,20 @@ public:
    */
   bool specReceived() const { return has_spec_; };
 
+  /**
+   * \brief Clear the current specification (used for testing)
+   */
+  void clear() {
+    spec_mod_.clear();
+    spec_exact_.clear();
+    has_spec_ = false;
+  }
+
+  /**
+   * \brief Get the proxy for the objgroup (used for testing)
+   */
+  ProxyType getProxy() const { return proxy_; }
+
 private:
   /**
    * \struct SpecMsg

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -54,7 +54,7 @@
 namespace vt { namespace trace { namespace file_spec {
 
 /**
- * \struct Spec spec.h vt/trace/file_spec/spec.h
+ * \struct TraceSpec spec.h vt/trace/file_spec/spec.h
  *
  * \brief Parses trace spec file when available and tests when its enabled. A
  * single node parses the specification; all others receive the spec from a
@@ -82,8 +82,8 @@ namespace vt { namespace trace { namespace file_spec {
  * { [0,3], [97,103], * [195,205], [297,303], ... }
  *
  */
-struct Spec {
-  using ProxyType    = vt::objgroup::proxy::Proxy<Spec>;
+struct TraceSpec {
+  using ProxyType    = vt::objgroup::proxy::Proxy<TraceSpec>;
   using ArgType      = vt::arguments::ArgConfig;
   using SpecIndex    = int64_t;
   using DoneMsg      = collective::ReduceNoneMsg;
@@ -150,7 +150,7 @@ private:
 
 private:
   /**
-   * \brief Initialize the Spec objgroup
+   * \brief Initialize the \c TraceSpec objgroup
    *
    * \param[in] in_proxy the objgroup proxy
    */
@@ -158,7 +158,7 @@ private:
 
 public:
   /**
-   * \brief Construct a new Spec objgroup
+   * \brief Construct a new \c TraceSpec objgroup
    *
    * \return the proxy
    */

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -83,9 +83,9 @@ namespace vt { namespace trace { namespace file_spec {
  *
  * Whether tracing is enabled is calculated as an OR across all specification
  * entries. Thus, if a given phase is contained in any spec line, it is
- * enabled. Please note that 0 % 100 = 0. Therefore, if the above example did
- * not contain the first line, tracing would be enabled as:
- * { [0,3], [97,103], * [195,205], [297,303], ... }
+ * enabled. Note that 0 % 100 = 0. Therefore, if the above example did not
+ * contain the first line, tracing would be enabled as: { [0,3], [97,103], *
+ * [195,205], [297,303], ... }
  *
  */
 struct TraceSpec {

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -68,7 +68,13 @@ namespace vt { namespace trace { namespace file_spec {
  * """
  *
  * This specifies that tracing will be enabled on the following phases:
- * { [0,10], [97,103], [195,205], [297,303], ... }
+ * {
+ *   [0,10], # phase 0 with offsets 0,+10 (subsumes [0,3] from %100 -3 3)
+ *   [97,103] # any phase % 100 with offset -3,+3
+ *   [195,205] # phase 200 with offsets -5,+5 (subsumes [197,203] from %100 -3 3)
+ *   [297,303] # any phase % 100 with offset -3,+3
+ *   [n%100-3,n%100+3] ... # any phase % 100 with offset -3,+3
+ * }
  *
  * The sets of mod-phase and phase-specific entries must be unique. There may be
  * overlap across the two sets, but not within them. Having two entries that

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -56,8 +56,9 @@ namespace vt { namespace trace { namespace file_spec {
 /**
  * \struct Spec spec.h vt/trace/file_spec/spec.h
  *
- * \brief Parses trace spec file when available and tests when its enabled. One
- * node can do the parsing, the other receive the spec from a broadcast.
+ * \brief Parses trace spec file when available and tests when its enabled. A
+ * single node parses the specification; all others receive the spec from a
+ * broadcast.
  *
  * Parses the following format:
  * """
@@ -120,10 +121,10 @@ private:
     bool testTraceEnabledFor(SpecIndex in_idx) const {
       if (is_mod_) {
         // Check if mod idx_ is within range, by dividing out idx_ we get the
-        // pos/neg offset from that nod value
+        // pos/neg offset from that mod value
         return in_idx % idx_ >= idx_ + neg_ or in_idx % idx_ <= pos_;
       } else {
-        // Check intersection with range: [idx_-neg_, idx_-pos_]
+        // Check intersection with range: [idx_+neg_, idx_+pos_]
         return in_idx >= idx_ + neg_ and in_idx <= idx_ + pos_;
       }
     }

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -84,8 +84,14 @@ namespace vt { namespace trace { namespace file_spec {
  * Whether tracing is enabled is calculated as an OR across all specification
  * entries. Thus, if a given phase is contained in any spec line, it is
  * enabled. Note that 0 % 100 = 0. Therefore, if the above example did not
- * contain the first line, tracing would be enabled as: { [0,3], [97,103], *
- * [195,205], [297,303], ... }
+ * contain the first line, tracing would be enabled as:
+ *
+ * {
+ *   [0,3], # any phase mod 100 from -3,+3
+ *   [97,103],
+ *   [195,205],
+ *   [297,303], ...
+ *  }
  *
  */
 struct TraceSpec {

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -124,7 +124,7 @@ private:
         return in_idx % idx_ >= idx_ + neg_ or in_idx % idx_ <= pos_;
       } else {
         // Check intersection with range: [idx_-neg_, idx_-pos_]
-        return in_idx >= idx_ - neg_ and in_idx <= idx_ + pos_;
+        return in_idx >= idx_ + neg_ and in_idx <= idx_ + pos_;
       }
     }
 

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -208,20 +208,6 @@ public:
    */
   bool specReceived() const { return has_spec_; };
 
-  /**
-   * \brief Clear the current specification (used for testing)
-   */
-  void clear() {
-    spec_mod_.clear();
-    spec_exact_.clear();
-    has_spec_ = false;
-  }
-
-  /**
-   * \brief Get the proxy for the objgroup (used for testing)
-   */
-  ProxyType getProxy() const { return proxy_; }
-
 private:
   /**
    * \struct SpecMsg

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -185,12 +185,6 @@ public:
    */
   void parse();
 
-  // /**
-  //  * \brief Call broadcast on parsed specification and then wait for them to
-  //  * receive it
-  //  */
-  // void broadcastSpecWaitReceive();
-
   /**
    * \brief Broadcast parsed specification to all nodes
    */
@@ -226,12 +220,6 @@ private:
     SpecMapType spec_exact_;
     NodeType root_ = uninitialized_destination;
   };
-
-  // /**
-  //  * \brief Invoked by reduce when broadcast is finished and all nodes have the
-  //  * specification
-  //  */
-  // void doneBcast(DoneMsg*);
 
   /**
    * \brief Handler to receive parsed specification

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -60,7 +60,7 @@ namespace vt { namespace trace { namespace file_spec {
  * single node parses the specification; all others receive the spec from a
  * broadcast.
  *
- * Parses the following format:
+ * Parses the following format: [%]<phase> <range negative> <range positive>
  * """
  * 0 0 10
  * %100 -3 3

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -1,0 +1,274 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                    spec.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_TRACE_FILE_SPEC_SPEC_H
+#define INCLUDED_VT_TRACE_FILE_SPEC_SPEC_H
+
+#include "vt/config.h"
+#include "vt/objgroup/proxy/proxy_objgroup.h"
+#include "vt/collective/reduce/operators/default_msg.h"
+
+#include <unordered_map>
+
+namespace vt { namespace trace { namespace file_spec {
+
+/**
+ * \struct Spec spec.h vt/trace/file_spec/spec.h
+ *
+ * \brief Parses trace spec file when available and tests when its enabled. One
+ * node can do the parsing, the other receive the spec from a broadcast.
+ *
+ * Parses the following format:
+ * """
+ * 0 0 10
+ * %100 -3 3
+ * 200 -5 5
+ * """
+ *
+ * This specifies that tracing will be enabled on the following phases:
+ * { [0,10], [97,103], [195,205], [297,303], ... }
+ *
+ * The sets of mod-phase and phase-specific entries must be unique. There may be
+ * overlap across the two sets, but not within them. Having two entries that
+ * start with "%100" or two entries that start with "100" would be invalid and
+ * trigger a parsing error. But having a "%100" and "100" entry is valid.
+ *
+ * Whether tracing is enabled is calculated as an OR across all specification
+ * entries. Thus, if a given phase is contained in any spec line, it is
+ * enabled. Please note that 0 % 100 = 0. Therefore, if the above example did
+ * not contain the first line, tracing would be enabled as:
+ * { [0,3], [97,103], * [195,205], [297,303], ... }
+ *
+ */
+struct Spec {
+  using ProxyType    = vt::objgroup::proxy::Proxy<Spec>;
+  using ArgType      = vt::arguments::ArgConfig;
+  using SpecIndex    = int64_t;
+  using DoneMsg      = collective::ReduceNoneMsg;
+
+private:
+  /**
+   * \struct SpecEntry
+   *
+   * \brief Holds a single entry in a trace spec file; checks if a given phase
+   * is enabled within that spec
+   */
+  struct SpecEntry {
+    SpecEntry() = default;
+    SpecEntry(SpecIndex in_idx, SpecIndex in_neg, SpecIndex in_pos, bool in_mod)
+      : idx_(in_idx),
+        neg_(in_neg),
+        pos_(in_pos),
+        is_mod_(in_mod)
+    { }
+
+    /**
+     * \brief Get the spec index for this entry
+     *
+     * \return the spec index
+     */
+    SpecIndex getIdx() const { return idx_; }
+
+    /**
+     * \brief Check if a given phase is enabled within this spec entry
+     *
+     * \param[in] in_idx the index to check
+     *
+     * \return whether tracing is enabled based on this entry
+     */
+    bool testTraceEnabledFor(SpecIndex in_idx) const {
+      if (is_mod_) {
+        // Check if mod idx_ is within range, by dividing out idx_ we get the
+        // pos/neg offset from that nod value
+        return in_idx % idx_ >= neg_ or in_idx % idx_ <= pos_;
+      } else {
+        // Check intersection with range: [idx_-neg_, idx_-pos_]
+        return in_idx >= idx_ - neg_ or in_idx <= idx_ + pos_;
+      }
+    }
+
+    /**
+     * \brief Serializer for \c SpecEntry
+     *
+     * \param[in] s serializer
+     */
+    template <typename SerializerT>
+    void serialize(SerializerT& s) {
+      s | idx_ | neg_ | pos_ | is_mod_;
+    }
+
+  private:
+    SpecIndex idx_ = 0;         /**< Index for spec entry (mod or phase) */
+    SpecIndex neg_ = 0;         /**< Negative offset for spec entry */
+    SpecIndex pos_ = 0;         /**< Positive offset for spec entry */
+    bool is_mod_ =  false;      /**< Whether this entry is a mod-entry */
+  };
+
+  using SpecMapType  = std::unordered_map<SpecIndex,SpecEntry>;
+
+private:
+  /**
+   * \brief Initialize the Spec objgroup
+   *
+   * \param[in] in_proxy the objgroup proxy
+   */
+  void init(ProxyType in_proxy);
+
+public:
+  /**
+   * \brief Construct a new Spec objgroup
+   *
+   * \return the proxy
+   */
+  static ProxyType construct();
+
+  /**
+   * \brief Check entire spec to see if tracing is enabled on any of the entries
+   *
+   * \param[in] in_phase the phase to check
+   *
+   * \return whether tracing is enabled
+   */
+  bool checkTraceEnabled(SpecIndex in_phase);
+
+  /**
+   * \brief Check if a specification is enabled, file specified, and file
+   * exists. Aborts if file specified but the file is not accessible
+   *
+   * \return whether a spec exists
+   */
+  bool hasSpec();
+
+  /**
+   * \brief Parse the specification file
+   */
+  void parse();
+
+  // /**
+  //  * \brief Call broadcast on parsed specification and then wait for them to
+  //  * receive it
+  //  */
+  // void broadcastSpecWaitReceive();
+
+  /**
+   * \brief Broadcast parsed specification to all nodes
+   */
+  void broadcastSpec();
+
+  /**
+   * \brief Check if spec has been received
+   */
+  bool specReceived() const { return has_spec_; };
+
+private:
+  /**
+   * \struct SpecMsg
+   *
+   * \brief Holds the spec for broadcasting to all nodes
+   */
+  struct SpecMsg : vt::Message {
+    SpecMsg() = default;
+    SpecMsg(SpecMapType in_mod, SpecMapType in_exact, NodeType in_root)
+      : spec_mod_(in_mod),
+        spec_exact_(in_exact),
+        root_(in_root)
+    { }
+
+    template <typename SerializerT>
+    void serialize(SerializerT& s) {
+      s | spec_mod_;
+      s | spec_exact_;
+      s | root_;
+    }
+
+    SpecMapType spec_mod_;
+    SpecMapType spec_exact_;
+    NodeType root_ = uninitialized_destination;
+  };
+
+  // /**
+  //  * \brief Invoked by reduce when broadcast is finished and all nodes have the
+  //  * specification
+  //  */
+  // void doneBcast(DoneMsg*);
+
+  /**
+   * \brief Handler to receive parsed specification
+   *
+   * \param[in] msg the incoming spec msg
+   */
+  void transferSpec(SpecMsg* msg);
+
+  /**
+   * \brief Insert an entry into the specification holders
+   *
+   * \param[in] phase the phase mod or specific
+   * \param[in] neg negative offset
+   * \param[in] pos positive offset
+   * \param[in] is_mod whether it's a mod-phase
+   * \param[in] map the map to add it to
+   */
+  void insertSpec(
+    SpecIndex phase, SpecIndex neg, SpecIndex pos, bool is_mod, SpecMapType& map
+  );
+
+  /**
+   * \brief Eat whitespace during parsing except for newlines
+   *
+   * \param[in] file the file to read
+   *
+   * \return the current character after whitespace is eaten
+   */
+  int eatWhitespace(std::ifstream& file);
+
+private:
+  ProxyType proxy_;
+  SpecMapType spec_mod_;
+  SpecMapType spec_exact_;
+  bool has_spec_ = false;
+};
+
+}}} /* end namespace vt::trace::file_spec */
+
+#endif /*INCLUDED_VT_TRACE_FILE_SPEC_SPEC_H*/

--- a/src/vt/trace/file_spec/spec.h
+++ b/src/vt/trace/file_spec/spec.h
@@ -121,10 +121,10 @@ private:
       if (is_mod_) {
         // Check if mod idx_ is within range, by dividing out idx_ we get the
         // pos/neg offset from that nod value
-        return in_idx % idx_ >= neg_ or in_idx % idx_ <= pos_;
+        return in_idx % idx_ >= idx_ + neg_ or in_idx % idx_ <= pos_;
       } else {
         // Check intersection with range: [idx_-neg_, idx_-pos_]
-        return in_idx >= idx_ - neg_ or in_idx <= idx_ + pos_;
+        return in_idx >= idx_ - neg_ and in_idx <= idx_ + pos_;
       }
     }
 

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -145,7 +145,7 @@ void Trace::initialize() {
 
 void Trace::loadAndBroadcastSpec() {
   if (ArgType::vt_trace_spec) {
-    auto spec_proxy = file_spec::Spec::construct();
+    auto spec_proxy = file_spec::TraceSpec::construct();
     theTerm()->produce();
     if (theContext()->getNode() == 0) {
       auto spec_ptr = spec_proxy.get();
@@ -637,8 +637,8 @@ bool Trace::checkDynamicRuntimeEnabled() {
 void Trace::setTraceEnabledCurrentPhase(PhaseType cur_phase) {
   if (spec_proxy_ != vt::no_obj_group) {
     // SpecIndex is signed due to negative/positive, phase is not signed
-    auto spec_index = static_cast<file_spec::Spec::SpecIndex>(cur_phase);
-    vt::objgroup::proxy::Proxy<file_spec::Spec> proxy(spec_proxy_);
+    auto spec_index = static_cast<file_spec::TraceSpec::SpecIndex>(cur_phase);
+    vt::objgroup::proxy::Proxy<file_spec::TraceSpec> proxy(spec_proxy_);
     bool ret = proxy.get()->checkTraceEnabled(spec_index);
 
     if (trace_enabled_cur_phase_ != ret) {

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -144,7 +144,7 @@ void Trace::initialize() {
 }
 
 void Trace::parseSpec() {
-  if (ArgType::vt_trace_spec_enabled) {
+  if (ArgType::vt_trace_spec) {
     auto spec_proxy = file_spec::Spec::construct();
     theTerm()->produce();
     if (theContext()->getNode() == 0) {

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -158,7 +158,7 @@ void Trace::parseSpec() {
     spec_proxy_ = spec_proxy.getProxy();
 
     // Set enabled for the initial phase
-    theTrace()->setTraceEnabledCurrentPhase(0);
+    setTraceEnabledCurrentPhase(0);
   }
 }
 

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -650,6 +650,12 @@ void Trace::setTraceEnabledCurrentPhase(PhaseType cur_phase) {
         );
         open_events_.pop();
       }
+
+      // Go ahead and perform a trace flush when tracing is disabled (and was
+      // previously enabled) to reduce memory footprint.
+      if (not ret) {
+        flushTracesFile(false);
+      }
     }
 
     trace_enabled_cur_phase_ = ret;

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -143,7 +143,7 @@ void Trace::initialize() {
   );
 }
 
-void Trace::parseSpec() {
+void Trace::loadAndBroadcastSpec() {
   if (ArgType::vt_trace_spec) {
     auto spec_proxy = file_spec::Spec::construct();
     theTerm()->produce();

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -49,6 +49,7 @@
 #include "vt/trace/trace.h"
 #include "vt/utils/demangle/demangle.h"
 #include "vt/trace/file_spec/spec.h"
+#include "vt/objgroup/headers.h"
 
 #include <cinttypes>
 #include <fstream>

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -183,7 +183,7 @@ struct Trace {
 
   bool checkDynamicRuntimeEnabled();
 
-  void parseSpec();
+  void loadAndBroadcastSpec();
   void setTraceEnabledCurrentPhase(PhaseType cur_phase);
 
   void flushTracesFile(bool useGlobalSync);

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -183,6 +183,9 @@ struct Trace {
 
   bool checkDynamicRuntimeEnabled();
 
+  void parseSpec();
+  void setTraceEnabledCurrentPhase(PhaseType cur_phase);
+
   void flushTracesFile(bool useGlobalSync);
   void cleanupTracesFile();
 
@@ -251,6 +254,8 @@ private:
   std::unique_ptr<vt_gzFile> log_file_;
   bool wrote_sts_file_          = false;
   size_t trace_write_count_     = 0;
+  ObjGroupProxyType spec_proxy_ = vt::no_obj_group;
+  bool trace_enabled_cur_phase_ = true;
 };
 
 }} //end namespace vt::trace

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -240,7 +240,7 @@ void LBManager::releaseNow(PhaseType phase) {
 }
 
 void LBManager::setTraceEnabledNextPhase(PhaseType phase) {
-  // Check if tracing is enabled for this next phase. Do this immediately before
+  // Set if tracing is enabled for this next phase. Do this immediately before
   // LB runs so LB is always instrumented as the beginning of the next phase
 # if backend_check_enabled(trace_enabled)
   theTrace()->setTraceEnabledCurrentPhase(phase + 1);

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -239,4 +239,12 @@ void LBManager::releaseNow(PhaseType phase) {
   num_invocations_ = num_release_ = 0;
 }
 
+void LBManager::setTraceEnabledNextPhase(PhaseType phase) {
+  // Check if tracing is enabled for this next phase. Do this immediately before
+  // LB runs so LB is always instrumented as the beginning of the next phase
+# if backend_check_enabled(trace_enabled)
+  theTrace()->setTraceEnabledCurrentPhase(phase + 1);
+# endif
+}
+
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.h
@@ -104,14 +104,24 @@ protected:
   void releaseNow(PhaseType phase);
 
 public:
+  void checkTraceEnabledNextPhase(PhaseType phase) {
+    // Check if tracing is enabled for this next phase. Do this immediately before
+    // LB runs so LB is always instrumented as the beginning of the next phase
+# if backend_check_enabled(trace_enabled)
+    theTrace()->setTraceEnabledCurrentPhase(phase + 1);
+# endif
+  }
+
   template <typename MsgT>
   void sysLB(MsgT* msg) {
     debug_print(lb, node, "sysLB\n");
+    checkTraceEnabledNextPhase(msg->phase_);
     return collectiveImpl(msg->phase_, msg->lb_, msg->manual_, msg->num_collections_);
   }
   template <typename MsgT>
   void sysReleaseLB(MsgT* msg) {
     debug_print(lb, node, "sysReleaseLB\n");
+    checkTraceEnabledNextPhase(msg->phase_);
     return releaseImpl(msg->phase_, msg->num_collections_);
   }
 

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.h
@@ -104,7 +104,7 @@ protected:
   void releaseNow(PhaseType phase);
 
 public:
-  void checkTraceEnabledNextPhase(PhaseType phase) {
+  void setTraceEnabledNextPhase(PhaseType phase) {
     // Check if tracing is enabled for this next phase. Do this immediately before
     // LB runs so LB is always instrumented as the beginning of the next phase
 # if backend_check_enabled(trace_enabled)
@@ -115,13 +115,13 @@ public:
   template <typename MsgT>
   void sysLB(MsgT* msg) {
     debug_print(lb, node, "sysLB\n");
-    checkTraceEnabledNextPhase(msg->phase_);
+    setTraceEnabledNextPhase(msg->phase_);
     return collectiveImpl(msg->phase_, msg->lb_, msg->manual_, msg->num_collections_);
   }
   template <typename MsgT>
   void sysReleaseLB(MsgT* msg) {
     debug_print(lb, node, "sysReleaseLB\n");
-    checkTraceEnabledNextPhase(msg->phase_);
+    setTraceEnabledNextPhase(msg->phase_);
     return releaseImpl(msg->phase_, msg->num_collections_);
   }
 

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.h
@@ -104,13 +104,7 @@ protected:
   void releaseNow(PhaseType phase);
 
 public:
-  void setTraceEnabledNextPhase(PhaseType phase) {
-    // Check if tracing is enabled for this next phase. Do this immediately before
-    // LB runs so LB is always instrumented as the beginning of the next phase
-# if backend_check_enabled(trace_enabled)
-    theTrace()->setTraceEnabledCurrentPhase(phase + 1);
-# endif
-  }
+  void setTraceEnabledNextPhase(PhaseType phase);
 
   template <typename MsgT>
   void sysLB(MsgT* msg) {

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3110,6 +3110,12 @@ void CollectionManager::nextPhase(
   CollectionProxyWrapType<ColT, typename ColT::IndexType> const& proxy,
   PhaseType const& cur_phase, ActionFinishedLBType continuation
 ) {
+  // Check if tracing is enabled for this next phase. Do this immediately before
+  // LB runs so LB is always instrumented as the beginning of the next phase
+# if backend_check_enabled(trace_enabled)
+  theTrace()->setTraceEnabledCurrentPhase(cur_phase + 1);
+# endif
+
   using namespace balance;
   using MsgType = PhaseMsg<ColT>;
   auto msg = makeSharedMessage<MsgType>(cur_phase, proxy, true, false);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3110,12 +3110,6 @@ void CollectionManager::nextPhase(
   CollectionProxyWrapType<ColT, typename ColT::IndexType> const& proxy,
   PhaseType const& cur_phase, ActionFinishedLBType continuation
 ) {
-  // Check if tracing is enabled for this next phase. Do this immediately before
-  // LB runs so LB is always instrumented as the beginning of the next phase
-# if backend_check_enabled(trace_enabled)
-  theTrace()->setTraceEnabledCurrentPhase(cur_phase + 1);
-# endif
-
   using namespace balance;
   using MsgType = PhaseMsg<ColT>;
   auto msg = makeSharedMessage<MsgType>(cur_phase, proxy, true, false);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(
   objgroup
   scheduler
   lb
+  trace
 )
 
 option(VT_NO_BUILD_TESTS "Disable building VT tests" OFF)

--- a/tests/unit/trace/test_trace_spec_reader.cc
+++ b/tests/unit/trace/test_trace_spec_reader.cc
@@ -1,0 +1,207 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                          test_trace_spec_reader.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <vt/trace/file_spec/spec.h>
+
+#include "test_parallel_harness.h"
+
+#include <fstream>
+
+namespace vt { namespace tests { namespace unit {
+
+using TestTraceSpec = TestParallelHarness;
+
+TEST_F(TestTraceSpec, test_trace_spec_1) {
+  using Spec = vt::trace::file_spec::Spec;
+  using Arg = vt::arguments::ArgConfig;
+
+  std::string file_name = "test_trace_spec_1.txt";
+  if (theContext()->getNode() == 0) {
+    std::ofstream out(file_name);
+    out << ""
+      "0 0 3\n"
+      "%5 -1 1\n";
+    out.close();
+  }
+  theCollective()->barrier();
+
+  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec_file_name = file_name;
+
+  auto proxy = Spec::construct();
+  theTerm()->produce();
+  if (theContext()->getNode() == 0) {
+    proxy.get()->parse();
+    proxy.get()->broadcastSpec();
+  }
+  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  theTerm()->consume();
+
+  for (typename Spec::SpecIndex i = 0; i < 1000; i++) {
+    bool is_enabled = proxy.get()->checkTraceEnabled(i);
+    EXPECT_EQ(is_enabled, i < 4 or i % 5 == 0 or i % 5 == 1 or i % 5 == 4);
+  }
+}
+
+TEST_F(TestTraceSpec, test_trace_spec_2) {
+  using Spec = vt::trace::file_spec::Spec;
+  using Arg = vt::arguments::ArgConfig;
+
+  std::string file_name = "test_trace_spec_2.txt";
+  if (theContext()->getNode() == 0) {
+    std::ofstream out(file_name);
+    out << ""
+      "%   10 0     1   \n"
+      "0   -100    0\n"
+      "\n"
+      "\n"
+      ;
+    out.close();
+  }
+  theCollective()->barrier();
+
+  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec_file_name = file_name;
+
+  auto proxy = Spec::construct();
+  theTerm()->produce();
+  if (theContext()->getNode() == 0) {
+    proxy.get()->parse();
+    proxy.get()->broadcastSpec();
+  }
+  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  theTerm()->consume();
+
+  for (typename Spec::SpecIndex i = 0; i < 1000; i++) {
+    bool is_enabled = proxy.get()->checkTraceEnabled(i);
+    EXPECT_EQ(is_enabled, i % 10 == 0 or i % 10 == 1);
+  }
+}
+
+TEST_F(TestTraceSpec, test_trace_spec_3) {
+  using Spec = vt::trace::file_spec::Spec;
+  using Arg = vt::arguments::ArgConfig;
+
+  std::string file_name = "test_trace_spec_3.txt";
+  if (theContext()->getNode() == 0) {
+    std::ofstream out(file_name);
+    out << ""
+      "%   10 -5 0   \n"
+      "0   0    1\n"
+      "%   20 -3 3   \n"
+      "   100 -10 10   \n"
+      "\n"
+      "\n"
+      ;
+    out.close();
+  }
+  theCollective()->barrier();
+
+  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec_file_name = file_name;
+
+  auto proxy = Spec::construct();
+  theTerm()->produce();
+  if (theContext()->getNode() == 0) {
+    proxy.get()->parse();
+    proxy.get()->broadcastSpec();
+  }
+  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  theTerm()->consume();
+
+  for (typename Spec::SpecIndex i = 0; i < 1000; i++) {
+    bool is_enabled = proxy.get()->checkTraceEnabled(i);
+    EXPECT_EQ(
+      is_enabled,
+      i == 0 or i == 1 or
+      i % 20 <= 3 or
+      i % 10 >= 5 or i % 10 == 0 or
+      (i >= 90 and i <= 110)
+    );
+  }
+}
+
+TEST_F(TestTraceSpec, test_trace_spec_4) {
+  using Spec = vt::trace::file_spec::Spec;
+  using Arg = vt::arguments::ArgConfig;
+
+  std::string file_name = "test_trace_spec_4.txt";
+  if (theContext()->getNode() == 0) {
+    std::ofstream out(file_name);
+    out << ""
+      "% 98   -5 0  \n"
+      "  %   99 -3 3   \n"
+      "   1 0 2   \n"
+      "\n"
+      "\n"
+      ;
+    out.close();
+  }
+  theCollective()->barrier();
+
+  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec_file_name = file_name;
+
+  auto proxy = Spec::construct();
+  theTerm()->produce();
+  if (theContext()->getNode() == 0) {
+    proxy.get()->parse();
+    proxy.get()->broadcastSpec();
+  }
+  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  theTerm()->consume();
+
+  for (typename Spec::SpecIndex i = 0; i < 1000; i++) {
+    bool is_enabled = proxy.get()->checkTraceEnabled(i);
+    EXPECT_EQ(
+      is_enabled,
+      i == 1 or i == 2 or i == 3 or
+      i % 99 >= 96 or i % 99 <= 3 or
+      i % 98 >= 93 or i % 98 == 0
+    );
+  }
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/trace/test_trace_spec_reader.cc
+++ b/tests/unit/trace/test_trace_spec_reader.cc
@@ -67,7 +67,7 @@ TEST_F(TestTraceSpec, test_trace_spec_1) {
   }
   theCollective()->barrier();
 
-  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec = true;
   Arg::vt_trace_spec_file_name = file_name;
 
   auto proxy = Spec::construct();
@@ -102,7 +102,7 @@ TEST_F(TestTraceSpec, test_trace_spec_2) {
   }
   theCollective()->barrier();
 
-  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec = true;
   Arg::vt_trace_spec_file_name = file_name;
 
   auto proxy = Spec::construct();
@@ -139,7 +139,7 @@ TEST_F(TestTraceSpec, test_trace_spec_3) {
   }
   theCollective()->barrier();
 
-  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec = true;
   Arg::vt_trace_spec_file_name = file_name;
 
   auto proxy = Spec::construct();
@@ -181,7 +181,7 @@ TEST_F(TestTraceSpec, test_trace_spec_4) {
   }
   theCollective()->barrier();
 
-  Arg::vt_trace_spec_enabled = true;
+  Arg::vt_trace_spec = true;
   Arg::vt_trace_spec_file_name = file_name;
 
   auto proxy = Spec::construct();

--- a/tests/unit/trace/test_trace_spec_reader.cc
+++ b/tests/unit/trace/test_trace_spec_reader.cc
@@ -68,7 +68,7 @@ TEST_F(TestTraceSpec, test_trace_spec_1) {
   theCollective()->barrier();
 
   Arg::vt_trace_spec = true;
-  Arg::vt_trace_spec_file_name = file_name;
+  Arg::vt_trace_spec_file = file_name;
 
   auto proxy = Spec::construct();
   theTerm()->produce();
@@ -103,7 +103,7 @@ TEST_F(TestTraceSpec, test_trace_spec_2) {
   theCollective()->barrier();
 
   Arg::vt_trace_spec = true;
-  Arg::vt_trace_spec_file_name = file_name;
+  Arg::vt_trace_spec_file = file_name;
 
   auto proxy = Spec::construct();
   theTerm()->produce();
@@ -140,7 +140,7 @@ TEST_F(TestTraceSpec, test_trace_spec_3) {
   theCollective()->barrier();
 
   Arg::vt_trace_spec = true;
-  Arg::vt_trace_spec_file_name = file_name;
+  Arg::vt_trace_spec_file = file_name;
 
   auto proxy = Spec::construct();
   theTerm()->produce();
@@ -182,7 +182,7 @@ TEST_F(TestTraceSpec, test_trace_spec_4) {
   theCollective()->barrier();
 
   Arg::vt_trace_spec = true;
-  Arg::vt_trace_spec_file_name = file_name;
+  Arg::vt_trace_spec_file = file_name;
 
   auto proxy = Spec::construct();
   theTerm()->produce();

--- a/tests/unit/trace/test_trace_spec_reader.cc
+++ b/tests/unit/trace/test_trace_spec_reader.cc
@@ -54,7 +54,7 @@ namespace vt { namespace tests { namespace unit {
 using TestTraceSpec = TestParallelHarness;
 
 TEST_F(TestTraceSpec, test_trace_spec_1) {
-  using Spec = vt::trace::file_spec::Spec;
+  using Spec = vt::trace::file_spec::TraceSpec;
   using Arg = vt::arguments::ArgConfig;
 
   std::string file_name = "test_trace_spec_1.txt";
@@ -86,7 +86,7 @@ TEST_F(TestTraceSpec, test_trace_spec_1) {
 }
 
 TEST_F(TestTraceSpec, test_trace_spec_2) {
-  using Spec = vt::trace::file_spec::Spec;
+  using Spec = vt::trace::file_spec::TraceSpec;
   using Arg = vt::arguments::ArgConfig;
 
   std::string file_name = "test_trace_spec_2.txt";
@@ -121,7 +121,7 @@ TEST_F(TestTraceSpec, test_trace_spec_2) {
 }
 
 TEST_F(TestTraceSpec, test_trace_spec_3) {
-  using Spec = vt::trace::file_spec::Spec;
+  using Spec = vt::trace::file_spec::TraceSpec;
   using Arg = vt::arguments::ArgConfig;
 
   std::string file_name = "test_trace_spec_3.txt";
@@ -164,7 +164,7 @@ TEST_F(TestTraceSpec, test_trace_spec_3) {
 }
 
 TEST_F(TestTraceSpec, test_trace_spec_4) {
-  using Spec = vt::trace::file_spec::Spec;
+  using Spec = vt::trace::file_spec::TraceSpec;
   using Arg = vt::arguments::ArgConfig;
 
   std::string file_name = "test_trace_spec_4.txt";


### PR DESCRIPTION
Fixes #689 

Adds a new tracing specification file to enabled traces based on patterns on the LB phase. Needed for large scale EMPIRE runs on Trinity