### PR TITLE
696 HierarchicalLB: Add strategy argument to LB file

### DIFF
--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
@@ -139,6 +139,7 @@ private:
   double max_threshold = 0.0f;
   double min_threshold = 0.0f;
   bool auto_threshold = true;
+  HeapExtractEnum extract_strategy = HeapExtractEnum::LoadOverLessThan;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/read_lb.h
+++ b/src/vt/vrt/collection/balance/read_lb.h
@@ -97,6 +97,17 @@ struct Converter<int32_t> {
   }
 };
 
+template <>
+struct Converter<std::string> {
+  static std::string convert(std::string val, std::string default_) {
+    if (val.size() > 0) {
+      return val;
+    } else {
+      return default_;
+    }
+  }
+};
+
 struct SpecEntry {
   SpecEntry(
     SpecIndex const in_idx, std::string const in_name,


### PR DESCRIPTION
Note: I based this PR off of beta.5 instead of develop.

Add a string argument called `strategy` to the LB file entries for `HierarchicalLB` to control what value of `HeapExtractEnum` is passed to `calcLoadOver`. The accepted strings are the names of `HeapExtractEnum` values that have been implemented, which are currently `LoadOverLessThan` (default), `LoadOverGreaterThan`, and `LoadOverOneEach`. This option allows deviating from the default practice of preferring to migrate the smallest objects.

I have omitted `LoadOverRandom` because it doesn't appear to be implemented (and there did not appear to be any check that this value wasn't selected).  Please correct me if I am wrong.

Please let me know if you have suggestions for better strings to use.  I can see rephrasing to use something like `Smallest` for `LoadOverLessThan` and `Largest` for `LoadOverGreaterThan`, but I'm not sure what would fit for `LoadOverOneEach` (which means take one candidate from each size bin, if I understand correctly).

Fixes #696