### PR TITLE
710 Termination: use DS-epoch by default in dep send chain

### DIFF
--- a/src/vt/messaging/dependent_send_chain.h
+++ b/src/vt/messaging/dependent_send_chain.h
@@ -160,7 +160,10 @@ class DependentSendChain final {
     // Set up a 'closed' epoch so that we keep an invariant of always
     // having an epoch to call addAction on, rather than edge cases of
     // whether we've made one yet or not
-    last_epoch_ = theTerm()->makeEpochRooted();
+
+    // The parameter `true` here tells VT to use an efficient rooted DS-epoch
+    // by default. This can still be overridden by command-line flags
+    last_epoch_ = theTerm()->makeEpochRooted(true);
     theTerm()->finishedEpoch(last_epoch_);
   }
 


### PR DESCRIPTION
Fixes #710 

Unfortunately, the last fix to switch `nextStep` to using DS epochs by default missed a call in dependent send chain. This is a major problem for EMPIRE performance.