### PR TITLE
#708 vector balancing, part 1

### DIFF
--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -135,8 +135,8 @@ void ElementStats::updatePhase(PhaseType const& inc) {
     cur_phase_, inc
   );
 
-  phase_timings_.resize(cur_phase_ + 1);
   cur_phase_ += inc;
+  phase_timings_.resize(cur_phase_ + 1);
 }
 
 PhaseType ElementStats::getPhase() const {
@@ -144,6 +144,7 @@ PhaseType ElementStats::getPhase() const {
 }
 
 TimeType ElementStats::getLoad(PhaseType const& phase) const {
+  vtAssert(phase_timings_.size() >= phase, "Must have phase");
   auto const& total_load = phase_timings_.at(phase);
 
   debug_print(
@@ -152,7 +153,6 @@ TimeType ElementStats::getLoad(PhaseType const& phase) const {
     total_load, phase, phase_timings_.size()
   );
 
-  vtAssert(phase_timings_.size() >= phase, "Must have phase");
   return total_load;
 }
 

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -160,6 +160,22 @@ TimeType ElementStats::getLoad(PhaseType const& phase) const {
   return total_load;
 }
 
+TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
+  vtAssert(phase_timings_.size() > phase, "Must have phase");
+  auto const& subphase_loads = subphase_timings_.at(phase);
+
+  vtAssert(subphase_loads.size() > subphase, "Must have subphase");
+  auto total_load = subphase_loads.at(subphase);
+
+  debug_print(
+    lb, node,
+    "ElementStats: getLoad: load={}, phase={}, subphase={}\n",
+    total_load, phase, subphase
+  );
+
+  return total_load;
+}
+
 
 CommMapType const&
 ElementStats::getComm(PhaseType const& phase) {

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -121,6 +121,10 @@ void ElementStats::addTime(TimeType const& time) {
   phase_timings_.resize(cur_phase_ + 1);
   phase_timings_.at(cur_phase_) += time;
 
+  subphase_timings_.resize(cur_phase_ + 1);
+  subphase_timings_.at(cur_phase_).resize(cur_subphase_ + 1);
+  subphase_timings_.at(cur_phase_).at(cur_subphase_) += time;
+
   debug_print(
     lb, node,
     "ElementStats: addTime: time={}, cur_load={}\n",
@@ -169,6 +173,10 @@ ElementStats::getComm(PhaseType const& phase) {
   );
 
   return phase_comm;
+}
+
+void ElementStats::setSubPhase(int subphase) {
+  cur_subphase_ = subphase;
 }
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -175,7 +175,7 @@ ElementStats::getComm(PhaseType const& phase) {
   return phase_comm;
 }
 
-void ElementStats::setSubPhase(int subphase) {
+void ElementStats::setSubPhase(SubphaseType subphase) {
   cur_subphase_ = subphase;
 }
 

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -162,6 +162,9 @@ TimeType ElementStats::getLoad(PhaseType const& phase) const {
 }
 
 TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
+  if (subphase == no_subphase)
+    return getLoad(phase);
+
   vtAssert(phase_timings_.size() > phase, "Must have phase");
   auto const& subphase_loads = subphase_timings_.at(phase);
 

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -150,27 +150,15 @@ PhaseType ElementStats::getPhase() const {
 TimeType ElementStats::getLoad(PhaseType const& phase) const {
   vtAssert(phase_timings_.size() > phase, "Must have phase");
 
-  if (focused_subphase_ != no_subphase) {
-    auto const& total_load = subphase_timings_.at(phase).at(focused_subphase_);
+  auto const& total_load = phase_timings_.at(phase);
 
-    debug_print(
-                lb, node,
-                "ElementStats: getLoad: load={}, phase={}, focused_subphase={}, size={}\n",
-                total_load, phase, focused_subphase_, phase_timings_.size()
-                );
+  debug_print(
+              lb, node,
+              "ElementStats: getLoad: load={}, phase={}, size={}\n",
+              total_load, phase, phase_timings_.size()
+              );
 
-    return total_load;
-  } else {
-    auto const& total_load = phase_timings_.at(phase);
-
-    debug_print(
-                lb, node,
-                "ElementStats: getLoad: load={}, phase={}, size={}\n",
-                total_load, phase, phase_timings_.size()
-                );
-
-    return total_load;
-  }
+  return total_load;
 }
 
 TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
@@ -208,10 +196,20 @@ void ElementStats::setSubPhase(SubphaseType subphase) {
   cur_subphase_ = subphase;
 }
 
-void ElementStats::setFocusedSubPhase(SubphaseType subphase) {
-  focused_subphase_ = subphase;
+/*static*/
+void ElementStats::setFocusedSubPhase(VirtualProxyType collection, SubphaseType subphase) {
+  focused_subphase_[collection] = subphase;
 }
 
-/*static*/ ElementStats::SubphaseType ElementStats::focused_subphase_ = ElementStats::no_subphase;
+/*static*/
+ElementStats::SubphaseType ElementStats::getFocusedSubPhase(VirtualProxyType collection) {
+  auto i = focused_subphase_.find(collection);
+  if (i != focused_subphase_.end())
+    return i->second;
+  else
+    return no_subphase;
+}
+
+/*static*/ std::unordered_map<VirtualProxyType,ElementStats::SubphaseType> ElementStats::focused_subphase_;
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -148,7 +148,7 @@ PhaseType ElementStats::getPhase() const {
 }
 
 TimeType ElementStats::getLoad(PhaseType const& phase) const {
-  vtAssert(phase_timings_.size() >= phase, "Must have phase");
+  vtAssert(phase_timings_.size() > phase, "Must have phase");
   auto const& total_load = phase_timings_.at(phase);
 
   debug_print(

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -149,15 +149,28 @@ PhaseType ElementStats::getPhase() const {
 
 TimeType ElementStats::getLoad(PhaseType const& phase) const {
   vtAssert(phase_timings_.size() > phase, "Must have phase");
-  auto const& total_load = phase_timings_.at(phase);
 
-  debug_print(
-    lb, node,
-    "ElementStats: getLoad: load={}, phase={}, size={}\n",
-    total_load, phase, phase_timings_.size()
-  );
+  if (focused_subphase_ != no_subphase) {
+    auto const& total_load = subphase_timings_.at(phase).at(focused_subphase_);
 
-  return total_load;
+    debug_print(
+                lb, node,
+                "ElementStats: getLoad: load={}, phase={}, focused_subphase={}, size={}\n",
+                total_load, phase, focused_subphase_, phase_timings_.size()
+                );
+
+    return total_load;
+  } else {
+    auto const& total_load = phase_timings_.at(phase);
+
+    debug_print(
+                lb, node,
+                "ElementStats: getLoad: load={}, phase={}, size={}\n",
+                total_load, phase, phase_timings_.size()
+                );
+
+    return total_load;
+  }
 }
 
 TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
@@ -176,7 +189,6 @@ TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
   return total_load;
 }
 
-
 CommMapType const&
 ElementStats::getComm(PhaseType const& phase) {
   comm_.resize(phase + 1);
@@ -192,7 +204,14 @@ ElementStats::getComm(PhaseType const& phase) {
 }
 
 void ElementStats::setSubPhase(SubphaseType subphase) {
+  vtAssert(subphase < no_subphase, "subphase must be less than sentinel");
   cur_subphase_ = subphase;
 }
+
+void ElementStats::setFocusedSubPhase(SubphaseType subphase) {
+  focused_subphase_ = subphase;
+}
+
+/*static*/ ElementStats::SubphaseType ElementStats::focused_subphase_ = ElementStats::no_subphase;
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -89,6 +89,7 @@ struct ElementStats {
   PhaseType getPhase() const;
   TimeType getLoad(PhaseType const& phase) const;
   CommMapType const& getComm(PhaseType const& phase);
+  void setSubPhase(int subphase);
 
   template <typename Serializer>
   void serialize(Serializer& s);
@@ -106,6 +107,9 @@ protected:
   PhaseType cur_phase_ = fst_lb_phase;
   std::vector<TimeType> phase_timings_ = {};
   std::vector<CommMapType> comm_ = {};
+
+  int cur_subphase_ = 0;
+  std::vector<std::vector<TimeType>> subphase_timings_ = {};
 };
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -94,6 +94,9 @@ struct ElementStats {
   CommMapType const& getComm(PhaseType const& phase);
   void setSubPhase(SubphaseType subphase);
 
+  static const constexpr SubphaseType no_subphase = std::numeric_limits<SubphaseType>::max();
+  static void setFocusedSubPhase(SubphaseType subphase);
+
   template <typename Serializer>
   void serialize(Serializer& s);
 
@@ -113,6 +116,8 @@ protected:
 
   SubphaseType cur_subphase_ = 0;
   std::vector<std::vector<TimeType>> subphase_timings_ = {};
+
+  static SubphaseType focused_subphase_;
 };
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -63,6 +63,7 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 
 struct ElementStats {
   using PhaseType       = uint64_t;
+  using SubphaseType    = uint16_t;
   using ArgType         = vt::arguments::ArgConfig;
 
   ElementStats() = default;
@@ -89,7 +90,7 @@ struct ElementStats {
   PhaseType getPhase() const;
   TimeType getLoad(PhaseType const& phase) const;
   CommMapType const& getComm(PhaseType const& phase);
-  void setSubPhase(int subphase);
+  void setSubPhase(SubphaseType subphase);
 
   template <typename Serializer>
   void serialize(Serializer& s);
@@ -108,7 +109,7 @@ protected:
   std::vector<TimeType> phase_timings_ = {};
   std::vector<CommMapType> comm_ = {};
 
-  int cur_subphase_ = 0;
+  SubphaseType cur_subphase_ = 0;
   std::vector<std::vector<TimeType>> subphase_timings_ = {};
 };
 

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -58,6 +58,7 @@
 #include <cstdint>
 #include <vector>
 #include <tuple>
+#include <unordered_map>
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
@@ -95,7 +96,8 @@ struct ElementStats {
   void setSubPhase(SubphaseType subphase);
 
   static const constexpr SubphaseType no_subphase = std::numeric_limits<SubphaseType>::max();
-  static void setFocusedSubPhase(SubphaseType subphase);
+  static void setFocusedSubPhase(VirtualProxyType collection, SubphaseType subphase);
+  static SubphaseType getFocusedSubPhase(VirtualProxyType collection);
 
   template <typename Serializer>
   void serialize(Serializer& s);
@@ -117,7 +119,7 @@ protected:
   SubphaseType cur_subphase_ = 0;
   std::vector<std::vector<TimeType>> subphase_timings_ = {};
 
-  static SubphaseType focused_subphase_;
+  static std::unordered_map<VirtualProxyType, SubphaseType> focused_subphase_;
 };
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -89,6 +89,8 @@ struct ElementStats {
   void updatePhase(PhaseType const& inc = 1);
   PhaseType getPhase() const;
   TimeType getLoad(PhaseType const& phase) const;
+  TimeType getLoad(PhaseType phase, SubphaseType subphase) const;
+
   CommMapType const& getComm(PhaseType const& phase);
   void setSubPhase(SubphaseType subphase);
 

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -88,7 +88,7 @@ template <typename ColT>
   auto const& cur_phase = msg->getPhase();
   auto const& proxy = col->getCollectionProxy();
   auto const& untyped_proxy = col->getProxy();
-  auto const& total_load = stats.getLoad(cur_phase, getFocusedSubPhase(proxy.getProxy()));
+  auto const& total_load = stats.getLoad(cur_phase, getFocusedSubPhase(untyped_proxy));
   auto const& comm = stats.getComm(cur_phase);
   auto const& idx = col->getIndex();
   auto const& elm_proxy = proxy[idx];

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -67,6 +67,8 @@ void ElementStats::serialize(Serializer& s) {
   s | cur_phase_;
   s | phase_timings_;
   s | comm_;
+  s | cur_subphase_;
+  s | subphase_timings_;
 }
 
 template <typename ColT>

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -88,7 +88,7 @@ template <typename ColT>
   auto const& cur_phase = msg->getPhase();
   auto const& proxy = col->getCollectionProxy();
   auto const& untyped_proxy = col->getProxy();
-  auto const& total_load = stats.getLoad(cur_phase);
+  auto const& total_load = stats.getLoad(cur_phase, getFocusedSubPhase(proxy.getProxy()));
   auto const& comm = stats.getComm(cur_phase);
   auto const& idx = col->getIndex();
   auto const& elm_proxy = proxy[idx];


### PR DESCRIPTION
This is sufficient API to see how it fits together with EMPIRE, I think.

To validate the changes all the way through, I'm going to add code on one side or the other to force consideration of only a single subphase's load when making LB decisions.