### PR TITLE
723 Add debugging epoch labels

### DIFF
--- a/examples/term_ds.cc
+++ b/examples/term_ds.cc
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
   }
 
   if (my_node == 0) {
-    cur_epoch = theTerm()->makeEpochRooted(true);
+    cur_epoch = theTerm()->makeEpochRooted(term::UseDS{true});
 
     theTerm()->addAction(cur_epoch, []{
       fmt::print("{}: running attached action: cur_epoch={}\n", my_node, cur_epoch);

--- a/src/vt/messaging/collection_chain_set.h
+++ b/src/vt/messaging/collection_chain_set.h
@@ -121,7 +121,7 @@ class CollectionChainSet final {
 
       // The parameter `true` here tells VT to use an efficient rooted DS-epoch
       // by default. This can still be overridden by command-line flags
-      EpochType new_epoch = theTerm()->makeEpochRooted(true);
+      EpochType new_epoch = theTerm()->makeEpochRooted(term::UseDS{true});
       vt::theMsg()->pushEpoch(new_epoch);
 
       chain.add(new_epoch, step_action(idx));

--- a/src/vt/messaging/collection_chain_set.h
+++ b/src/vt/messaging/collection_chain_set.h
@@ -115,7 +115,9 @@ class CollectionChainSet final {
    * \param[in] step_action The action to perform as a function that returns a
    * \c PendingSend
    */
-  void nextStep(std::string label, std::function<PendingSend(Index)> step_action) {
+  void nextStep(
+    std::string const& label, std::function<PendingSend(Index)> step_action
+  ) {
     for (auto &entry : chains_) {
       auto& idx = entry.first;
       auto& chain = entry.second;
@@ -176,7 +178,7 @@ class CollectionChainSet final {
    * \param[in] step_action the next step to execute, returning a \c PendingSend
    */
   void nextStepCollective(
-    std::string label, std::function<PendingSend(Index)> step_action
+    std::string const& label, std::function<PendingSend(Index)> step_action
   ) {
     auto epoch = theTerm()->makeEpochCollective(label);
     vt::theMsg()->pushEpoch(epoch);

--- a/src/vt/messaging/dependent_send_chain.h
+++ b/src/vt/messaging/dependent_send_chain.h
@@ -163,7 +163,7 @@ class DependentSendChain final {
 
     // The parameter `true` here tells VT to use an efficient rooted DS-epoch
     // by default. This can still be overridden by command-line flags
-    last_epoch_ = theTerm()->makeEpochRooted(true);
+    last_epoch_ = theTerm()->makeEpochRooted(term::UseDS{true});
     theTerm()->finishedEpoch(last_epoch_);
   }
 

--- a/src/vt/termination/dijkstra-scholten/ds.h
+++ b/src/vt/termination/dijkstra-scholten/ds.h
@@ -49,6 +49,7 @@
 #include "vt/termination/dijkstra-scholten/ack_request.h"
 #include "vt/termination/dijkstra-scholten/comm.fwd.h"
 #include "vt/termination/epoch_dependency.h"
+#include "vt/termination/epoch_label.h"
 
 #include <cstdlib>
 #include <map>
@@ -76,7 +77,7 @@ namespace vt { namespace term { namespace ds {
  */
 
 template <typename CommType>
-struct TermDS : EpochDependency {
+struct TermDS : EpochDependency, EpochLabel {
   using CountType = int64_t;
   using AckReqListType = std::list<AckRequest>;
 

--- a/src/vt/termination/epoch_label.cc
+++ b/src/vt/termination/epoch_label.cc
@@ -47,10 +47,6 @@
 
 namespace vt { namespace term {
 
-bool EpochLabel::hasLabel() const {
-  return label_ != "";
-}
-
 std::string EpochLabel::getLabel() const {
   return label_;
 }

--- a/src/vt/termination/epoch_label.cc
+++ b/src/vt/termination/epoch_label.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                term_scope.cc
+//                                epoch_label.cc
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -43,77 +43,20 @@
 */
 
 #include "vt/config.h"
-#include "vt/termination/termination.h"
-#include "vt/termination/term_common.h"
-#include "vt/scheduler/scheduler.h"
-#include "vt/messaging/active.h"
-#include "vt/utils/bits/bits_common.h"
+#include "vt/termination/epoch_label.h"
 
 namespace vt { namespace term {
 
-/*static*/ EpochType TerminationDetector::Scoped::rooted(
-  bool small, ActionType closure
-) {
-  // For now we just use Dijkstra-Scholten if the region is "small"
-  bool const use_dijkstra_scholten = small == true;
-  auto const epoch = theTerm()->makeEpochRooted(UseDS{use_dijkstra_scholten});
-  bool term_finished = false;
-  auto action = [&]{ term_finished = true; };
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  while (!term_finished) {
-    runScheduler();
-  }
-  return epoch;
+bool EpochLabel::hasLabel() const {
+  return label_ != "";
 }
 
-/*static*/ EpochType TerminationDetector::Scoped::rooted(
-  bool small, ActionType closure, ActionType action
-) {
-  bool const use_dijkstra_scholten = small == true;
-  auto const epoch = theTerm()->makeEpochRooted(UseDS{use_dijkstra_scholten});
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  return epoch;
+std::string EpochLabel::getLabel() const {
+  return label_;
 }
 
-/*static*/ EpochType TerminationDetector::Scoped::collective(
-  ActionType closure
-) {
-  auto const epoch = theTerm()->makeEpochCollective();
-  bool term_finished = false;
-  auto action = [&]{ term_finished = true; };
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  while (!term_finished) {
-    runScheduler();
-  }
-  return epoch;
-}
-
-/*static*/ EpochType TerminationDetector::Scoped::collective(
-  ActionType closure, ActionType action
-) {
-  auto const epoch = theTerm()->makeEpochCollective();
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  return epoch;
+void EpochLabel::setLabel(std::string const& label) {
+  label_ = label;
 }
 
 }} /* end namespace vt::term */

--- a/src/vt/termination/epoch_label.h
+++ b/src/vt/termination/epoch_label.h
@@ -50,7 +50,6 @@
 namespace vt { namespace term {
 
 struct EpochLabel {
-  bool hasLabel() const;
   std::string getLabel() const;
   void setLabel(std::string const& label);
 

--- a/src/vt/termination/epoch_label.h
+++ b/src/vt/termination/epoch_label.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                term_scope.cc
+//                                epoch_label.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,78 +42,22 @@
 //@HEADER
 */
 
+#if !defined INCLUDED_VT_TERMINATION_EPOCH_LABEL_H
+#define INCLUDED_VT_TERMINATION_EPOCH_LABEL_H
+
 #include "vt/config.h"
-#include "vt/termination/termination.h"
-#include "vt/termination/term_common.h"
-#include "vt/scheduler/scheduler.h"
-#include "vt/messaging/active.h"
-#include "vt/utils/bits/bits_common.h"
 
 namespace vt { namespace term {
 
-/*static*/ EpochType TerminationDetector::Scoped::rooted(
-  bool small, ActionType closure
-) {
-  // For now we just use Dijkstra-Scholten if the region is "small"
-  bool const use_dijkstra_scholten = small == true;
-  auto const epoch = theTerm()->makeEpochRooted(UseDS{use_dijkstra_scholten});
-  bool term_finished = false;
-  auto action = [&]{ term_finished = true; };
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  while (!term_finished) {
-    runScheduler();
-  }
-  return epoch;
-}
+struct EpochLabel {
+  bool hasLabel() const;
+  std::string getLabel() const;
+  void setLabel(std::string const& label);
 
-/*static*/ EpochType TerminationDetector::Scoped::rooted(
-  bool small, ActionType closure, ActionType action
-) {
-  bool const use_dijkstra_scholten = small == true;
-  auto const epoch = theTerm()->makeEpochRooted(UseDS{use_dijkstra_scholten});
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  return epoch;
-}
-
-/*static*/ EpochType TerminationDetector::Scoped::collective(
-  ActionType closure
-) {
-  auto const epoch = theTerm()->makeEpochCollective();
-  bool term_finished = false;
-  auto action = [&]{ term_finished = true; };
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  while (!term_finished) {
-    runScheduler();
-  }
-  return epoch;
-}
-
-/*static*/ EpochType TerminationDetector::Scoped::collective(
-  ActionType closure, ActionType action
-) {
-  auto const epoch = theTerm()->makeEpochCollective();
-  theTerm()->addActionEpoch(epoch,action);
-  vtAssertExpr(closure != nullptr);
-  theMsg()->pushEpoch(epoch);
-  closure();
-  theMsg()->popEpoch();
-  theTerm()->finishedEpoch(epoch);
-  return epoch;
-}
+private:
+  std::string label_ = "";
+};
 
 }} /* end namespace vt::term */
+
+#endif /*INCLUDED_VT_TERMINATION_EPOCH_LABEL_H*/

--- a/src/vt/termination/epoch_tags.cc
+++ b/src/vt/termination/epoch_tags.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                 epoch_tags.h
+//                                epoch_tags.cc
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,31 +42,19 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_TERMINATION_EPOCH_TAGS_H
-#define INCLUDED_VT_TERMINATION_EPOCH_TAGS_H
-
 #include "vt/config.h"
+#include "vt/termination/epoch_tags.h"
+#include "vt/messaging/active.h"
 
 namespace vt { namespace term {
 
-struct SuccessorEpochCapture {
-  explicit SuccessorEpochCapture(EpochType epoch)
-    : epoch_(epoch)
-  { }
-  SuccessorEpochCapture();
-  operator EpochType() const { return epoch_; }
-  bool valid() const { return epoch_ != no_epoch; }
-  EpochType epoch_ = no_epoch;
-};
-
-struct UseDS {
-  explicit UseDS(bool use_it)
-    : use_it_(use_it)
-  { }
-  operator bool() const { return use_it_; }
-  bool use_it_ = true;
-};
+SuccessorEpochCapture::SuccessorEpochCapture()
+  : epoch_(
+      (theMsg()->getEpoch() != no_epoch and
+       theMsg()->getEpoch() != term::any_epoch_sentinel) ?
+      theMsg()->getEpoch() :
+      no_epoch
+    )
+{ }
 
 }} /* end namespace vt::term */
-
-#endif /*INCLUDED_VT_TERMINATION_EPOCH_TAGS_H*/

--- a/src/vt/termination/epoch_tags.h
+++ b/src/vt/termination/epoch_tags.h
@@ -54,8 +54,11 @@ struct SuccessorEpochCapture {
     : epoch_(epoch)
   { }
   SuccessorEpochCapture();
+
   operator EpochType() const { return epoch_; }
+
   bool valid() const { return epoch_ != no_epoch; }
+
 private:
   EpochType epoch_ = no_epoch;
 };

--- a/src/vt/termination/epoch_tags.h
+++ b/src/vt/termination/epoch_tags.h
@@ -56,6 +56,7 @@ struct SuccessorEpochCapture {
   SuccessorEpochCapture();
   operator EpochType() const { return epoch_; }
   bool valid() const { return epoch_ != no_epoch; }
+private:
   EpochType epoch_ = no_epoch;
 };
 

--- a/src/vt/termination/graph/epoch_graph.cc
+++ b/src/vt/termination/graph/epoch_graph.cc
@@ -92,17 +92,32 @@ void EpochGraph::detectCycles() {
   detectCyclesImpl(stack);
 }
 
-void EpochGraph::outputImpl(std::set<std::tuple<EpochType, EpochType>> &links)  {
+void EpochGraph::outputImpl(
+  std::set<std::tuple<EpochType, std::string, EpochType, std::string>> &links
+)  {
   for (auto const& s : successors_) {
-    links.insert(std::make_pair(epoch_, s->epoch_));
+    links.insert(
+      std::make_tuple(epoch_, user_label_, s->epoch_, s->user_label_)
+    );
     s->outputImpl(links);
   }
 }
 
-EpochGraph::EpFormat EpochGraph::formatDOTEpoch(EpochType epoch) {
+EpochGraph::EpFormat EpochGraph::formatDOTEpoch(
+  EpochType epoch, std::string label
+) {
   if (epoch == term::any_epoch_sentinel) {
     return std::make_tuple(epoch, static_cast<NodeType>(-1), true, "Global");
   } else {
+    std::string label_format = "";
+    if (label != "") {
+      label_format = fmt::format(
+        "{}{}{}",
+        label != "" ? "\\\""  : "",
+        label != "" ? label : "",
+        label != "" ? "\\\"\\n"  : ""
+      );
+    }
     if (epoch::EpochManip::isRooted(epoch)) {
       auto const ds_epoch = epoch::eEpochCategory::DijkstraScholtenEpoch;
       auto const epoch_category = epoch::EpochManip::category(epoch);
@@ -110,14 +125,14 @@ EpochGraph::EpFormat EpochGraph::formatDOTEpoch(EpochType epoch) {
       auto const ep_node = epoch::EpochManip::node(epoch);
       auto const ep_seq = epoch::EpochManip::seq(epoch);
       if (is_ds) {
-        auto str = fmt::format("{:x}-DS-{}", ep_seq, ep_node);
+        auto str = fmt::format("{}{:x}-DS-{}", label_format, ep_seq, ep_node);
         return std::make_tuple(epoch, ep_node, false, str);
       } else {
-        auto str = fmt::format("{:x}-R-{}", ep_seq, ep_node);
+        auto str = fmt::format("{}{:x}-Wave-{}", label_format, ep_seq, ep_node);
         return std::make_tuple(epoch, ep_node, false, str);
       }
     } else {
-      auto str = fmt::format("{:x}-C", epoch);
+      auto str = fmt::format("{}{:x}-C", label_format, epoch);
       return std::make_tuple(epoch, static_cast<NodeType>(-1), true, str);
     }
   }
@@ -125,16 +140,16 @@ EpochGraph::EpFormat EpochGraph::formatDOTEpoch(EpochType epoch) {
 
 std::string EpochGraph::outputDOT(bool verbose) {
   std::unordered_map<EpochType, EpFormat> eps;
-  std::set<std::tuple<EpochType, EpochType>> links;
+  std::set<std::tuple<EpochType, std::string, EpochType, std::string>> links;
   std::string builder = "";
   outputImpl(links);
 
   for (auto&& elm : links) {
     if (eps.find(std::get<0>(elm)) == eps.end()) {
-      eps[std::get<0>(elm)] = formatDOTEpoch(std::get<0>(elm));
+      eps[std::get<0>(elm)] = formatDOTEpoch(std::get<0>(elm), std::get<1>(elm));
     }
-    if (eps.find(std::get<1>(elm)) == eps.end()) {
-      eps[std::get<1>(elm)] = formatDOTEpoch(std::get<1>(elm));
+    if (eps.find(std::get<2>(elm)) == eps.end()) {
+      eps[std::get<2>(elm)] = formatDOTEpoch(std::get<2>(elm), std::get<3>(elm));
     }
   }
 
@@ -170,12 +185,14 @@ std::string EpochGraph::outputDOT(bool verbose) {
     if (not arguments::ArgConfig::vt_epoch_graph_terse or verbose) {
       if (collective) {
         builder += fmt::format(
-          "\t{} [shape=record height=1 label=\"{}|{} collective | {:x} {}\"]\n",
+          "\t{} [shape=record height=1"
+          " label=\"{}|{} collective | Hex: {:x} {}\"]\n",
           elm.first, str, "{", ep, "}"
         );
       } else {
         builder += fmt::format(
-          "\t{} [shape=record height=1 label=\"{}|{} rooted | {:x} | node={} {}\"]\n",
+          "\t{} [shape=record height=1"
+          " label=\"{}|{} rooted | Hex: {:x} | node={} {}\"]\n",
           elm.first, str, "{", ep, node, "}"
         );
       }
@@ -184,7 +201,7 @@ std::string EpochGraph::outputDOT(bool verbose) {
     }
   }
   for (auto&& elm : links) {
-    builder += fmt::format("\t{}->{};\n", std::get<0>(elm), std::get<1>(elm));
+    builder += fmt::format("\t{}->{};\n", std::get<0>(elm), std::get<2>(elm));
   }
   builder += "}\n";
   return builder;

--- a/src/vt/termination/graph/epoch_graph.cc
+++ b/src/vt/termination/graph/epoch_graph.cc
@@ -170,21 +170,21 @@ std::string EpochGraph::outputDOT(bool verbose) {
     if (not arguments::ArgConfig::vt_epoch_graph_terse or verbose) {
       if (collective) {
         builder += fmt::format(
-          "\t{:x} [shape=record height=1 label=\"{}|{} collective | {:x} {}\"]\n",
+          "\t{} [shape=record height=1 label=\"{}|{} collective | {:x} {}\"]\n",
           elm.first, str, "{", ep, "}"
         );
       } else {
         builder += fmt::format(
-          "\t{:x} [shape=record height=1 label=\"{}|{} rooted | {:x} | node={} {}\"]\n",
+          "\t{} [shape=record height=1 label=\"{}|{} rooted | {:x} | node={} {}\"]\n",
           elm.first, str, "{", ep, node, "}"
         );
       }
     } else {
-      builder += fmt::format("\t{:x} [label=\"{}\"]\n", elm.first, str);
+      builder += fmt::format("\t{} [label=\"{}\"]\n", elm.first, str);
     }
   }
   for (auto&& elm : links) {
-    builder += fmt::format("\t{:x}->{:x};\n", std::get<0>(elm), std::get<1>(elm));
+    builder += fmt::format("\t{}->{};\n", std::get<0>(elm), std::get<1>(elm));
   }
   builder += "}\n";
   return builder;

--- a/src/vt/termination/graph/epoch_graph.cc
+++ b/src/vt/termination/graph/epoch_graph.cc
@@ -111,12 +111,7 @@ EpochGraph::EpFormat EpochGraph::formatDOTEpoch(
   } else {
     std::string label_format = "";
     if (label != "") {
-      label_format = fmt::format(
-        "{}{}{}",
-        label != "" ? "\\\""  : "",
-        label != "" ? label : "",
-        label != "" ? "\\\"\\n"  : ""
-      );
+      label_format = fmt::format("{}{}{}", "\\\"", label, "\\\"\\n");
     }
     if (epoch::EpochManip::isRooted(epoch)) {
       auto const ds_epoch = epoch::eEpochCategory::DijkstraScholtenEpoch;

--- a/src/vt/termination/graph/epoch_graph.cc
+++ b/src/vt/termination/graph/epoch_graph.cc
@@ -140,11 +140,15 @@ std::string EpochGraph::outputDOT(bool verbose) {
   outputImpl(links);
 
   for (auto&& elm : links) {
-    if (eps.find(std::get<0>(elm)) == eps.end()) {
-      eps[std::get<0>(elm)] = formatDOTEpoch(std::get<0>(elm), std::get<1>(elm));
+    auto epoch = std::get<0>(elm);
+    auto& epoch_label = std::get<1>(elm);
+    auto succ_epoch = std::get<2>(elm);
+    auto& succ_epoch_label = std::get<3>(elm);
+    if (eps.find(epoch) == eps.end()) {
+      eps[epoch] = formatDOTEpoch(epoch, epoch_label);
     }
-    if (eps.find(std::get<2>(elm)) == eps.end()) {
-      eps[std::get<2>(elm)] = formatDOTEpoch(std::get<2>(elm), std::get<3>(elm));
+    if (eps.find(succ_epoch) == eps.end()) {
+      eps[succ_epoch] = formatDOTEpoch(succ_epoch, succ_epoch_label);
     }
   }
 

--- a/src/vt/termination/graph/epoch_graph.h
+++ b/src/vt/termination/graph/epoch_graph.h
@@ -65,8 +65,9 @@ struct EpochGraph {
   EpochGraph(EpochGraph const&) = default;
   EpochGraph& operator=(EpochGraph const&) = default;
 
-  explicit EpochGraph(EpochType in_epoch)
-    : epoch_(in_epoch)
+  EpochGraph(EpochType in_epoch, std::string user_label)
+    : epoch_(in_epoch),
+      user_label_(user_label)
   { }
 
 public:
@@ -85,8 +86,10 @@ public:
   void detectCycles();
 
 private:
-  void outputImpl(std::set<std::tuple<EpochType, EpochType>> &links);
-  EpFormat formatDOTEpoch(EpochType epoch);
+  void outputImpl(
+    std::set<std::tuple<EpochType, std::string, EpochType, std::string>> &links
+  );
+  EpFormat formatDOTEpoch(EpochType epoch, std::string label);
 
 public:
   std::string outputDOT(bool verbose = false);
@@ -100,6 +103,7 @@ public:
   template <typename SerializerT>
   void serialize(SerializerT& s) {
     s | epoch_;
+    s | user_label_;
     std::size_t nc = successors_.size();
     s | nc;
     for (std::size_t i = 0; i < nc; i++) {
@@ -119,6 +123,7 @@ public:
 
 private:
   EpochType epoch_ = no_epoch;
+  std::string user_label_ = "";
   std::vector<std::shared_ptr<EpochGraph>> successors_ = {};
 };
 

--- a/src/vt/termination/term_state.h
+++ b/src/vt/termination/term_state.h
@@ -49,6 +49,7 @@
 #include "vt/context/context.h"
 #include "vt/termination/term_common.h"
 #include "vt/termination/epoch_dependency.h"
+#include "vt/termination/epoch_label.h"
 
 #include <vector>
 #include <cstdlib>
@@ -56,7 +57,7 @@
 
 namespace vt { namespace term {
 
-struct TermState : EpochDependency {
+struct TermState : EpochDependency, EpochLabel {
   using EventCountType = int32_t;
 
   void notifyChildReceive();

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -353,7 +353,8 @@ std::shared_ptr<TerminationDetector::EpochGraph> TerminationDetector::makeGraph(
     // Collect live epochs, both collective and rooted (excluding rooted ones
     // that did not originate on this node)
     std::unordered_map<EpochType, std::shared_ptr<EpochGraph>> live_epochs;
-    auto root = std::make_shared<EpochGraph>(any_epoch_state_.getEpoch());
+    std::string const glabel = "Global";
+    auto root = std::make_shared<EpochGraph>(any_epoch_state_.getEpoch(), glabel);
     // Collect non-rooted epochs, just collective, excluding DS or other rooted
     // epochs (info about them is localized on the creation node)
     auto const this_node = theContext()->getNode();
@@ -362,7 +363,8 @@ std::shared_ptr<TerminationDetector::EpochGraph> TerminationDetector::makeGraph(
       bool const rooted = epoch::EpochManip::isRooted(ep);
       if (not rooted or (rooted and epoch::EpochManip::node(ep) == this_node)) {
         if (not isEpochTerminated(elm.first)) {
-          live_epochs[ep] = std::make_shared<EpochGraph>(ep);
+          auto label = elm.second.getLabel();
+          live_epochs[ep] = std::make_shared<EpochGraph>(ep, label);
         }
       }
     }
@@ -371,7 +373,10 @@ std::shared_ptr<TerminationDetector::EpochGraph> TerminationDetector::makeGraph(
       // proper successor info about the rooted, DS epochs
       if (epoch::EpochManip::node(elm.first) == this_node) {
         if (not isEpochTerminated(elm.first)) {
-          live_epochs[elm.first] = std::make_shared<EpochGraph>(elm.first);
+          auto label = elm.second.getLabel();
+          live_epochs[elm.first] = std::make_shared<EpochGraph>(
+            elm.first, label
+          );
         }
       }
     }
@@ -968,14 +973,15 @@ void TerminationDetector::finishedEpoch(EpochType const& epoch) {
 }
 
 EpochType TerminationDetector::makeEpochRootedWave(
-  bool has_dep, EpochType successor
+  bool has_dep, EpochType successor, std::string label
 ) {
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch();
 
   debug_print(
     term, node,
-    "makeEpochRootedWave: root={}, has_dep={}, epoch={:x}, successor={:x}\n",
-    theContext()->getNode(), has_dep, epoch, successor
+    "makeEpochRootedWave: root={}, has_dep={}, epoch={:x}, successor={:x},"
+    "label={}\n",
+    theContext()->getNode(), has_dep, epoch, successor, label
   );
 
   /*
@@ -989,7 +995,7 @@ EpochType TerminationDetector::makeEpochRootedWave(
   /*
    *  Setup the new rooted epoch locally on the root node (this node)
    */
-  makeRootedHan(epoch,true);
+  makeRootedHan(epoch, true, label);
 
   if (has_dep) {
     addDependency(epoch, successor);
@@ -1000,7 +1006,7 @@ EpochType TerminationDetector::makeEpochRootedWave(
 }
 
 EpochType TerminationDetector::makeEpochRootedDS(
-  bool has_dep, EpochType successor
+  bool has_dep, EpochType successor, std::string label
 ) {
   auto const ds_cat = epoch::eEpochCategory::DijkstraScholtenEpoch;
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch(false, ds_cat);
@@ -1008,7 +1014,8 @@ EpochType TerminationDetector::makeEpochRootedDS(
   vtAssert(term_.find(epoch) == term_.end(), "New epoch must not exist");
 
   // Create DS term where this node is the root
-  getDSTerm(epoch, true);
+  auto ds = getDSTerm(epoch, true);
+  ds->setLabel(label);
   getWindow(epoch)->addEpoch(epoch);
   produce(epoch,1);
 
@@ -1018,15 +1025,22 @@ EpochType TerminationDetector::makeEpochRootedDS(
 
   debug_print(
     term, node,
-    "makeEpochRootedDS: has_dep={}, successor={:x}, epoch={:x}\n",
-    has_dep, successor, epoch
+    "makeEpochRootedDS: has_dep={}, successor={:x}, epoch={:x}, label={}\n",
+    has_dep, successor, epoch, label
   );
 
   return epoch;
 }
 
 EpochType TerminationDetector::makeEpochRooted(
-  bool useDS, bool has_dep, EpochType successor
+  UseDS use_ds, UseCurrentEpochAsSuccessor has_dep, EpochType successor
+) {
+  return makeEpochRooted("", use_ds, has_dep, successor);
+}
+
+EpochType TerminationDetector::makeEpochRooted(
+  std::string label, UseDS use_ds, UseCurrentEpochAsSuccessor has_dep,
+  EpochType successor
 ) {
   /*
    *  This method should only be called by the root node for the rooted epoch
@@ -1036,8 +1050,8 @@ EpochType TerminationDetector::makeEpochRooted(
 
   debug_print(
     term, node,
-    "makeEpochRooted: root={}, is_ds={}, has_dep={}, successor={:x}\n",
-    theContext()->getNode(), useDS, has_dep, successor
+    "makeEpochRooted: root={}, use_ds={}, has_dep={}, successor={:x}, label={}\n",
+    theContext()->getNode(), use_ds, has_dep, successor, label
   );
 
   bool const force_use_ds = vt::arguments::ArgConfig::vt_term_rooted_use_ds;
@@ -1046,27 +1060,38 @@ EpochType TerminationDetector::makeEpochRooted(
   // Both force options should never be turned on
   vtAssertExpr(not (force_use_ds and force_use_wave));
 
-  if ((useDS or force_use_ds) and not force_use_wave) {
-    return makeEpochRootedDS(has_dep,successor);
+  if ((use_ds or force_use_ds) and not force_use_wave) {
+    return makeEpochRootedDS(has_dep, successor, label);
   } else {
-    return makeEpochRootedWave(has_dep,successor);
+    return makeEpochRootedWave(has_dep, successor, label);
   }
 }
 
 EpochType TerminationDetector::makeEpochCollective(
-  bool has_dep, EpochType successor
+  UseCurrentEpochAsSuccessor has_dep, EpochType successor
+) {
+  debug_print(
+    term, node,
+    "makeEpochCollective: no label\n"
+  );
+
+  return makeEpochCollective("", has_dep, successor);
+}
+
+EpochType TerminationDetector::makeEpochCollective(
+  std::string label, UseCurrentEpochAsSuccessor has_dep, EpochType successor
 ) {
   auto const epoch = epoch::EpochManip::makeNewEpoch();
 
   debug_print(
     term, node,
-    "makeEpochCollective: epoch={:x}, has_dep={}, successor={:x}\n",
-    epoch, has_dep, successor
+    "makeEpochCollective: epoch={:x}, has_dep={}, successor={:x}, label={}\n",
+    epoch, has_dep, successor, label
   );
 
   getWindow(epoch)->addEpoch(epoch);
   produce(epoch,1);
-  setupNewEpoch(epoch);
+  setupNewEpoch(epoch, label);
 
   if (has_dep) {
     addDependency(epoch, successor);
@@ -1076,11 +1101,13 @@ EpochType TerminationDetector::makeEpochCollective(
 }
 
 EpochType TerminationDetector::makeEpoch(
-  bool is_coll, bool useDS, bool has_dep, EpochType successor
+  std::string label, bool is_coll, UseDS use_ds,
+  UseCurrentEpochAsSuccessor has_dep,
+  EpochType successor
 ) {
   return is_coll ?
-    makeEpochCollective(has_dep, successor) :
-    makeEpochRooted(useDS,has_dep, successor);
+    makeEpochCollective(label, has_dep, successor) :
+    makeEpochRooted(label, use_ds, has_dep, successor);
 }
 
 void TerminationDetector::activateEpoch(EpochType const& epoch) {
@@ -1099,10 +1126,13 @@ void TerminationDetector::activateEpoch(EpochType const& epoch) {
   }
 }
 
-void TerminationDetector::makeRootedHan(EpochType const& epoch, bool is_root) {
+void TerminationDetector::makeRootedHan(
+  EpochType const& epoch, bool is_root, std::string label
+) {
   bool const is_ready = !is_root;
 
-  findOrCreateState(epoch, is_ready);
+  auto& state = findOrCreateState(epoch, is_ready);
+  state.setLabel(label);
   getWindow(epoch)->addEpoch(epoch);
 
   debug_print(
@@ -1118,7 +1148,9 @@ void TerminationDetector::makeRootedHan(EpochType const& epoch, bool is_root) {
   }
 }
 
-void TerminationDetector::setupNewEpoch(EpochType const& epoch) {
+void TerminationDetector::setupNewEpoch(
+  EpochType const& epoch, std::string label
+) {
   auto epoch_iter = epoch_state_.find(epoch);
 
   bool const found = epoch_iter != epoch_state_.end();
@@ -1132,6 +1164,7 @@ void TerminationDetector::setupNewEpoch(EpochType const& epoch) {
 
   auto& state = findOrCreateState(epoch, false);
   state.notifyLocalTerminated();
+  state.setLabel(label);
 }
 
 std::size_t TerminationDetector::getNumTerminatedCollectiveEpochs() const {

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -967,7 +967,7 @@ void TerminationDetector::finishedEpoch(EpochType const& epoch) {
 }
 
 EpochType TerminationDetector::makeEpochRootedWave(
-  SuccessorEpochCapture successor, std::string label
+  SuccessorEpochCapture successor, std::string const& label
 ) {
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch();
 
@@ -1000,7 +1000,7 @@ EpochType TerminationDetector::makeEpochRootedWave(
 }
 
 EpochType TerminationDetector::makeEpochRootedDS(
-  SuccessorEpochCapture successor, std::string label
+  SuccessorEpochCapture successor, std::string const& label
 ) {
   auto const ds_cat = epoch::eEpochCategory::DijkstraScholtenEpoch;
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch(false, ds_cat);
@@ -1033,7 +1033,7 @@ EpochType TerminationDetector::makeEpochRooted(
 }
 
 EpochType TerminationDetector::makeEpochRooted(
-  std::string label, UseDS use_ds, SuccessorEpochCapture successor
+  std::string const& label, UseDS use_ds, SuccessorEpochCapture successor
 ) {
   /*
    *  This method should only be called by the root node for the rooted epoch
@@ -1072,7 +1072,7 @@ EpochType TerminationDetector::makeEpochCollective(
 }
 
 EpochType TerminationDetector::makeEpochCollective(
-  std::string label, SuccessorEpochCapture successor
+  std::string const& label, SuccessorEpochCapture successor
 ) {
   auto const epoch = epoch::EpochManip::makeNewEpoch();
 
@@ -1094,7 +1094,7 @@ EpochType TerminationDetector::makeEpochCollective(
 }
 
 EpochType TerminationDetector::makeEpoch(
-  std::string label, bool is_coll, UseDS use_ds,
+  std::string const& label, bool is_coll, UseDS use_ds,
   SuccessorEpochCapture successor
 ) {
   return is_coll ?
@@ -1119,7 +1119,7 @@ void TerminationDetector::activateEpoch(EpochType const& epoch) {
 }
 
 void TerminationDetector::makeRootedHan(
-  EpochType const& epoch, bool is_root, std::string label
+  EpochType const& epoch, bool is_root, std::string const& label
 ) {
   bool const is_ready = !is_root;
 
@@ -1141,7 +1141,7 @@ void TerminationDetector::makeRootedHan(
 }
 
 void TerminationDetector::setupNewEpoch(
-  EpochType const& epoch, std::string label
+  EpochType const& epoch, std::string const& label
 ) {
   auto epoch_iter = epoch_state_.find(epoch);
 

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -173,7 +173,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochRooted(
-    std::string label,
+    std::string const& label,
     UseDS use_ds = UseDS{false},
     SuccessorEpochCapture successor = SuccessorEpochCapture{}
   );
@@ -187,7 +187,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochCollective(
-    std::string label,
+    std::string const& label,
     SuccessorEpochCapture successor = SuccessorEpochCapture{}
   );
 
@@ -202,7 +202,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpoch(
-    std::string label,
+    std::string const& label,
     bool is_coll,
     UseDS use_ds = UseDS{false},
     SuccessorEpochCapture successor = SuccessorEpochCapture{}
@@ -217,10 +217,10 @@ public:
    * Directly call into a specific type of rooted epoch, can not be overridden
    */
   EpochType makeEpochRootedWave(
-    SuccessorEpochCapture successor, std::string label = ""
+    SuccessorEpochCapture successor, std::string const& label = ""
   );
   EpochType makeEpochRootedDS(
-    SuccessorEpochCapture successor, std::string label = ""
+    SuccessorEpochCapture successor, std::string const& label = ""
   );
 
 private:
@@ -280,10 +280,10 @@ private:
   bool propagateEpoch(TermStateType& state);
   void epochTerminated(EpochType const& epoch, CallFromEnum from);
   void epochContinue(EpochType const& epoch, TermWaveType const& wave);
-  void setupNewEpoch(EpochType const& epoch, std::string label);
+  void setupNewEpoch(EpochType const& epoch, std::string const& label);
   void readyNewEpoch(EpochType const& epoch);
   void makeRootedHan(
-    EpochType const& epoch, bool is_root, std::string label = ""
+    EpochType const& epoch, bool is_root, std::string const& label = ""
   );
 
 public:

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -143,28 +143,24 @@ public:
    * \brief Create a new rooted epoch
    *
    * \param[in] use_ds whether to use the Dijkstra-Scholten algorithm
-   * \param[in] has_dep whether the current stack epoch is a successor
-   * \param[in] successor optional successor epoch specified explicitly
+   * \param[in] successor successor epoch that waits for this new epoch
    *
    * \return the new epoch
    */
   EpochType makeEpochRooted(
     UseDS use_ds = UseDS{false},
-    UseCurrentEpochAsSuccessor has_dep = UseCurrentEpochAsSuccessor{true},
-    EpochType successor = no_epoch
+    SuccessorEpochCapture successor = SuccessorEpochCapture{}
   );
 
   /**
    * \brief Create a new collective epoch
    *
-   * \param[in] has_dep whether the current stack epoch is a successor
-   * \param[in] successor optional successor epoch specified explicitly
+   * \param[in] successor successor epoch that waits for this new epoch
    *
    * \return the new epoch
    */
   EpochType makeEpochCollective(
-    UseCurrentEpochAsSuccessor has_dep = UseCurrentEpochAsSuccessor{true},
-    EpochType successor = no_epoch
+    SuccessorEpochCapture successor = SuccessorEpochCapture{}
   );
 
   /**
@@ -172,32 +168,27 @@ public:
    *
    * \param[in] label epoch label for debugging purposes
    * \param[in] use_ds whether to use the Dijkstra-Scholten algorithm
-   * \param[in] has_dep whether the current stack epoch is a successor
-   * \param[in] successor optional successor epoch specified explicitly
+   * \param[in] successor successor epoch that waits for this new epoch
    *
    * \return the new epoch
    */
   EpochType makeEpochRooted(
     std::string label,
     UseDS use_ds = UseDS{false},
-    UseCurrentEpochAsSuccessor has_dep = UseCurrentEpochAsSuccessor{true},
-    EpochType successor = no_epoch
+    SuccessorEpochCapture successor = SuccessorEpochCapture{}
   );
 
   /**
    * \brief Create a collective epoch with a label
    *
    * \param[in] label epoch label for debugging purposes
-   * \param[in] is_coll whether to create a collective or rooted epoch
-   * \param[in] has_dep whether the current stack epoch is a successor
-   * \param[in] successor optional successor epoch specified explicitly
+   * \param[in] successor successor epoch that waits for this new epoch
    *
    * \return the new epoch
    */
   EpochType makeEpochCollective(
     std::string label,
-    UseCurrentEpochAsSuccessor has_dep = UseCurrentEpochAsSuccessor{true},
-    EpochType successor = no_epoch
+    SuccessorEpochCapture successor = SuccessorEpochCapture{}
   );
 
   /**
@@ -206,8 +197,7 @@ public:
    * \param[in] label epoch label for debugging purposes
    * \param[in] is_coll whether to create a collective or rooted epoch
    * \param[in] use_ds whether to use the Dijkstra-Scholten algorithm
-   * \param[in] has_dep whether the current stack epoch is a successor
-   * \param[in] successor optional successor epoch specified explicitly
+   * \param[in] successor successor epoch that waits for this new epoch
    *
    * \return the new epoch
    */
@@ -215,8 +205,7 @@ public:
     std::string label,
     bool is_coll,
     UseDS use_ds = UseDS{false},
-    UseCurrentEpochAsSuccessor has_dep = UseCurrentEpochAsSuccessor{true},
-    EpochType successor = no_epoch
+    SuccessorEpochCapture successor = SuccessorEpochCapture{}
   );
 
   void activateEpoch(EpochType const& epoch);
@@ -228,10 +217,10 @@ public:
    * Directly call into a specific type of rooted epoch, can not be overridden
    */
   EpochType makeEpochRootedWave(
-    bool has_dep, EpochType successor, std::string label = ""
+    SuccessorEpochCapture successor, std::string label = ""
   );
   EpochType makeEpochRootedDS(
-    bool has_dep, EpochType successor, std::string label = ""
+    SuccessorEpochCapture successor, std::string label = ""
   );
 
 private:

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -188,7 +188,7 @@ EpochType BaseLB::getMigrationEpoch() const {
 }
 
 EpochType BaseLB::startMigrationCollective() {
-  migration_epoch_ = theTerm()->makeEpochCollective();
+  migration_epoch_ = theTerm()->makeEpochCollective("LB migration");
   theTerm()->addAction(migration_epoch_, [this]{ this->migrationDone(); });
   theMsg()->pushEpoch(migration_epoch_);
   return migration_epoch_;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -182,7 +182,7 @@ void GossipLB::inform() {
   );
 
   bool inform_done = false;
-  auto propagate_epoch = theTerm()->makeEpochCollective();
+  auto propagate_epoch = theTerm()->makeEpochCollective("GossipLB: inform");
   theTerm()->addAction(propagate_epoch, [&inform_done] { inform_done = true; });
 
   // Underloaded start the round
@@ -370,7 +370,7 @@ void GossipLB::decide() {
   double const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
 
   bool decide_done = false;
-  auto lazy_epoch = theTerm()->makeEpochCollective();
+  auto lazy_epoch = theTerm()->makeEpochCollective("GossipLB: decide");
   theTerm()->addAction(lazy_epoch, [&decide_done] { decide_done = true; });
 
   if (is_overloaded_) {

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2147,7 +2147,9 @@ CollectionManager::constructMap(
   CollectionInfo<ColT, IndexT> info(range, is_static, node, new_proxy);
 
   if (!is_static) {
-    auto const& insert_epoch = theTerm()->makeEpochRootedWave(false,no_epoch);
+    auto const& insert_epoch = theTerm()->makeEpochRootedWave(
+      term::SuccessorEpochCapture{no_epoch}
+    );
     theTerm()->finishNoActivateEpoch(insert_epoch);
     info.setInsertEpoch(insert_epoch);
     setupNextInsertTrigger<ColT,IndexT>(new_proxy,insert_epoch);
@@ -2312,7 +2314,9 @@ void CollectionManager::finishedInsertEpoch(
   /*
    *  Add trigger for the next insertion phase/epoch finishing
    */
-  auto const& next_insert_epoch = theTerm()->makeEpochRootedWave(false,no_epoch);
+  auto const& next_insert_epoch = theTerm()->makeEpochRootedWave(
+    term::SuccessorEpochCapture{no_epoch}
+  );
   theTerm()->finishNoActivateEpoch(next_insert_epoch);
   UniversalIndexHolder<>::insertSetEpoch(untyped_proxy,next_insert_epoch);
 

--- a/tests/unit/termination/test_term_cleanup.cc
+++ b/tests/unit/termination/test_term_cleanup.cc
@@ -117,8 +117,12 @@ TEST_F(TestTermCleanup, test_termination_cleanup_2) {
 
   for (int i = 0; i < num_epochs; i++) {
     EpochType const coll_epoch = theTerm()->makeEpochCollective();
-    EpochType const root_epoch = theTerm()->makeEpochRootedDS(false,no_epoch);
-    EpochType const wave_epoch = theTerm()->makeEpochRootedWave(false,no_epoch);
+    EpochType const root_epoch = theTerm()->makeEpochRootedDS(
+      term::SuccessorEpochCapture{no_epoch}
+    );
+    EpochType const wave_epoch = theTerm()->makeEpochRootedWave(
+      term::SuccessorEpochCapture{no_epoch}
+    );
     bool coll_done = false;
     bool root_done = false;
     bool wave_done = false;

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -332,7 +332,7 @@ struct MyObjGroup {
   }
 
   void op1() {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("op1", [=](vt::Index2D idx) {
       auto a = calcVal(1,idx);
       auto b = calcVal(2,idx);
       return backend_proxy(idx).template send<OpMsg, &MyCol::op1>(a,b);
@@ -340,7 +340,7 @@ struct MyObjGroup {
   }
 
   void op2() {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("op2", [=](vt::Index2D idx) {
       auto a = calcVal(3,idx);
       auto b = calcVal(4,idx);
       return backend_proxy(idx).template send<OpMsg, &MyCol::op2>(a,b);
@@ -348,7 +348,7 @@ struct MyObjGroup {
   }
 
   void op3() {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("op3", [=](vt::Index2D idx) {
       std::vector<double> v;
       for (auto i = 0; i < 10; i++) {
         v.push_back(idx.x()*i + idx.y());
@@ -358,7 +358,7 @@ struct MyObjGroup {
   }
 
   void op4() {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("op4", [=](vt::Index2D idx) {
       auto node = vt::theContext()->getNode();
       auto num = vt::theContext()->getNumNodes();
       auto next = node + 1 < num ? node + 1 : 0;
@@ -376,7 +376,7 @@ struct MyObjGroup {
   }
 
   void op5() {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("op5", [=](vt::Index2D idx) {
       auto a = calcVal(7,idx);
       auto b = calcVal(8,idx);
       return backend_proxy(idx).template send<OpMsg, &MyCol::op5>(a,b);
@@ -384,7 +384,7 @@ struct MyObjGroup {
   }
 
   void op6() {
-    chains_->nextStepCollective([=](vt::Index2D idx) {
+    chains_->nextStepCollective("op6", [=](vt::Index2D idx) {
       auto a = calcVal(9,idx);
       auto b = calcVal(10,idx);
       return backend_proxy(idx).template send<OpMsg, &MyCol::op6>(a,b);
@@ -392,7 +392,7 @@ struct MyObjGroup {
   }
 
   void op7() {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("op7", [=](vt::Index2D idx) {
       auto a = calcVal(11,idx);
       auto b = calcVal(12,idx);
       return backend_proxy(idx).template send<OpMsg, &MyCol::op7>(a,b);
@@ -400,7 +400,7 @@ struct MyObjGroup {
   }
 
   void doMigrate() {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("doMigrate", [=](vt::Index2D idx) {
       auto a = calcVal(13,idx);
       auto b = calcVal(14,idx);
       return backend_proxy(idx).template send<OpMsg, &MyCol::doMigrate>(a,b);
@@ -422,7 +422,7 @@ struct MyObjGroup {
   }
 
   void finalCheck(int i) {
-    chains_->nextStep([=](vt::Index2D idx) {
+    chains_->nextStep("finalCheck", [=](vt::Index2D idx) {
       return backend_proxy(idx).template send<FinalMsg, &MyCol::finalCheck>(i);
     });
   }

--- a/tests/unit/termination/test_termination_action_common.impl.h
+++ b/tests/unit/termination/test_termination_action_common.impl.h
@@ -56,12 +56,12 @@ std::vector<vt::EpochType> generateEpochs(int nb, bool rooted, bool useDS) {
   if (rooted) {
     vtAssert(channel::node == channel::root, "Node should be root");
     // create rooted epoch sequence
-    sequence[0] = vt::theTerm()->makeEpochRooted(useDS);
+    sequence[0] = vt::theTerm()->makeEpochRooted(term::UseDS{true});
     vtAssert(channel::root == epoch_manip::node(sequence[0]), "Should be root");
     vtAssert(epoch_manip::isRooted(sequence[0]), "First epoch should be rooted");
 
     for (int i = 1; i < nb; ++i){
-      sequence[i] = vt::theTerm()->makeEpochRooted(useDS);
+      sequence[i] = vt::theTerm()->makeEpochRooted(term::UseDS{true});
       vtAssert(epoch_manip::isRooted(sequence[i]), "Next epoch should be rooted");
     }
   } else /*collective*/ {

--- a/tests/unit/termination/test_termination_action_common.impl.h
+++ b/tests/unit/termination/test_termination_action_common.impl.h
@@ -56,12 +56,12 @@ std::vector<vt::EpochType> generateEpochs(int nb, bool rooted, bool useDS) {
   if (rooted) {
     vtAssert(channel::node == channel::root, "Node should be root");
     // create rooted epoch sequence
-    sequence[0] = vt::theTerm()->makeEpochRooted(term::UseDS{true});
+    sequence[0] = vt::theTerm()->makeEpochRooted(term::UseDS{useDS});
     vtAssert(channel::root == epoch_manip::node(sequence[0]), "Should be root");
     vtAssert(epoch_manip::isRooted(sequence[0]), "First epoch should be rooted");
 
     for (int i = 1; i < nb; ++i){
-      sequence[i] = vt::theTerm()->makeEpochRooted(term::UseDS{true});
+      sequence[i] = vt::theTerm()->makeEpochRooted(term::UseDS{useDS});
       vtAssert(epoch_manip::isRooted(sequence[i]), "Next epoch should be rooted");
     }
   } else /*collective*/ {

--- a/tests/unit/termination/test_termination_action_nested_collect.cc
+++ b/tests/unit/termination/test_termination_action_nested_collect.cc
@@ -50,7 +50,7 @@ struct TestTermNestedCollect : action::BaseFixture {
   void kernel(int depth, EpochType parent) {
     vtAssert(depth > 0, "Wrong depth");
     auto epoch = vt::theTerm()->makeEpochCollective(
-      term::UseCurrentEpochAsSuccessor{true}, parent
+      term::SuccessorEpochCapture{parent}
     );
 
     // all ranks should have the same depth

--- a/tests/unit/termination/test_termination_action_nested_collect.cc
+++ b/tests/unit/termination/test_termination_action_nested_collect.cc
@@ -49,7 +49,9 @@ namespace vt { namespace tests { namespace unit {
 struct TestTermNestedCollect : action::BaseFixture {
   void kernel(int depth, EpochType parent) {
     vtAssert(depth > 0, "Wrong depth");
-    auto epoch = vt::theTerm()->makeEpochCollective(true, parent);
+    auto epoch = vt::theTerm()->makeEpochCollective(
+      term::UseCurrentEpochAsSuccessor{true}, parent
+    );
 
     // all ranks should have the same depth
     vt::theCollective()->barrier();

--- a/tests/unit/termination/test_termination_action_nested_rooted.cc
+++ b/tests/unit/termination/test_termination_action_nested_rooted.cc
@@ -54,7 +54,11 @@ struct TestTermNestedRooted : action::BaseFixture {
     auto epoch = vt::no_epoch;
 
     if (channel::node == channel::root) {
-      epoch = vt::theTerm()->makeEpochRooted(useDS_, true, parent);
+      epoch = vt::theTerm()->makeEpochRooted(
+        term::UseDS{useDS_},
+        term::UseCurrentEpochAsSuccessor{true},
+        parent
+      );
       // check that epoch is effectively rooted
       vtAssert(channel::root == epoch_manip::node(epoch), "Node should be root");
       vtAssert(epoch_manip::isRooted(epoch), "Epoch should be rooted");

--- a/tests/unit/termination/test_termination_action_nested_rooted.cc
+++ b/tests/unit/termination/test_termination_action_nested_rooted.cc
@@ -56,8 +56,7 @@ struct TestTermNestedRooted : action::BaseFixture {
     if (channel::node == channel::root) {
       epoch = vt::theTerm()->makeEpochRooted(
         term::UseDS{useDS_},
-        term::UseCurrentEpochAsSuccessor{true},
-        parent
+        term::SuccessorEpochCapture{parent}
       );
       // check that epoch is effectively rooted
       vtAssert(channel::root == epoch_manip::node(epoch), "Node should be root");


### PR DESCRIPTION
Fixes #723 

Add a new optional parameter when creating a new epoch to specify a label that is dumped in debugging output (DOT files). In order to make this change correctly, a breaking change is made on non-default overloads of `TerminationDetector::makeEpochCollective` and `TerminationDetector::makeEpochRooted` due to char* to bool overload problems.

Thus, a tag class is used to specify/capture if the successor epoch should be the current epoch (or an manual override by the user) or whether a DS epoch should be used. This has the added benefit of making the interface more explicit and less error prone.

[outfile-global.pdf](https://github.com/DARMA-tasking/vt/files/4296367/outfile-global.pdf)

This has potential for beta.6, depending on feedback.
