### PR TITLE
726 Trace memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 
 include(cmake/turn_on_warnings.cmake)
 
+include(cmake/check_system_functions.cmake)
+
 set(VIRTUAL_TRANSPORT_LIBRARY vt CACHE INTERNAL "" FORCE )
 set(FCONTEXT_LIBRARY fcontext)
 

--- a/cmake/check_system_functions.cmake
+++ b/cmake/check_system_functions.cmake
@@ -1,0 +1,30 @@
+
+include(CheckIncludeFiles)
+include(CheckFunctionExists)
+include(CheckSymbolExists)
+include(CheckLibraryExists)
+
+check_include_files(malloc.h vt_has_malloc_h)
+check_include_files(malloc/malloc.h vt_has_malloc_malloc_h)
+check_include_files(mach/mach.h vt_has_mach_mach_h)
+check_include_files(sys/resource.h vt_has_sys_resource_h)
+check_include_files(unistd.h vt_has_unistd_h)
+check_include_files(inttypes.h vt_has_inttypes_h)
+
+check_function_exists(mstats vt_has_mstats)
+check_function_exists(popen vt_has_popen)
+check_function_exists(pclose vt_has_pclose)
+check_function_exists(sbrk vt_has_sbrk)
+check_function_exists(getpid vt_has_getpid)
+
+set(CMAKE_REQUIRED_INCLUDES "malloc.h")
+check_function_exists(mallinfo vt_has_mallinfo)
+
+set(CMAKE_REQUIRED_INCLUDES "sys/resource.h")
+check_function_exists(getrusage vt_has_getrusage)
+
+set(CMAKE_REQUIRED_INCLUDES "sys/sysinfo.h")
+check_function_exists(sysinfo vt_has_sysinfo)
+
+set(CMAKE_REQUIRED_INCLUDES "mach/mach.h")
+check_function_exists(mach_task_self vt_has_mach_task_self)

--- a/cmake/check_system_functions.cmake
+++ b/cmake/check_system_functions.cmake
@@ -16,6 +16,7 @@ check_function_exists(popen vt_has_popen)
 check_function_exists(pclose vt_has_pclose)
 check_function_exists(sbrk vt_has_sbrk)
 check_function_exists(getpid vt_has_getpid)
+check_function_exists(sysconf vt_has_sysconf)
 
 set(CMAKE_REQUIRED_INCLUDES "malloc.h")
 check_function_exists(mallinfo vt_has_mallinfo)

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -83,3 +83,4 @@
 #cmakedefine vt_has_sys_resource_h
 #cmakedefine vt_has_unistd_h
 #cmakedefine vt_has_inttypes_h
+#cmakedefine vt_has_sysconf

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -67,3 +67,19 @@
 #define vt_feature_cmake_priorities          @vt_feature_cmake_priorities@
 #define vt_feature_cmake_fcontext            @vt_feature_cmake_fcontext@
 #define vt_feature_cmake_test_trace_on       @vt_feature_cmake_test_trace_on@
+
+#cmakedefine vt_has_malloc_h
+#cmakedefine vt_has_malloc_malloc_h
+#cmakedefine vt_has_mach_mach_h
+#cmakedefine vt_has_mstats
+#cmakedefine vt_has_popen
+#cmakedefine vt_has_pclose
+#cmakedefine vt_has_sbrk
+#cmakedefine vt_has_mallinfo
+#cmakedefine vt_has_getrusage
+#cmakedefine vt_has_sysinfo
+#cmakedefine vt_has_mach_task_self
+#cmakedefine vt_has_getpid
+#cmakedefine vt_has_sys_resource_h
+#cmakedefine vt_has_unistd_h
+#cmakedefine vt_has_inttypes_h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set(
       serialization/sizing
     utils/demangle utils/container utils/bits utils/mutex
     utils/hash utils/atomic utils/tls utils/static_checks utils/string
+    utils/memory
     registry/auto
       registry/auto/functor registry/auto/map registry/auto/collection
       registry/auto/vc registry/auto/rdma registry/auto/index

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -65,6 +65,8 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_no_terminate       = false;
 /*static*/ std::string ArgConfig::vt_memory_reporters   =
   "mstats,machinfo,selfstat,sbrk,mallinfo,getrusage,ps";
+/*static*/ bool        ArgConfig::vt_print_memory_each_phase = false;
+/*static*/ std::string ArgConfig::vt_print_memory_node  = "0";
 
 /*static*/ bool        ArgConfig::vt_no_warn_stack      = false;
 /*static*/ bool        ArgConfig::vt_no_assert_stack    = false;
@@ -206,10 +208,16 @@ namespace vt { namespace arguments {
   /*
    * Flags for controlling memory usage reporting
    */
-  auto mem_desc = "List of memory reporters to query in order of precedence";
+  auto mem_desc  = "List of memory reporters to query in order of precedence";
+  auto mem_phase = "Print memory usage each new phase";
+  auto mem_node  = "Node to print memory usage from or \"all\"";
   auto mm = app.add_option("--vt_memory_reporters", vt_memory_reporters, mem_desc, true);
+  auto mn = app.add_flag("--vt_print_memory_each_phase", vt_print_memory_each_phase, mem_phase);
+  auto mo = app.add_option("--vt_print_memory_node", vt_print_memory_node, mem_node, true);
   auto memoryGroup = "Memory Usage Reporting";
   mm->group(memoryGroup);
+  mn->group(memoryGroup);
+  mo->group(memoryGroup);
 
 
   /*

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -197,7 +197,7 @@ namespace vt { namespace arguments {
   auto d = app.add_flag("--vt_no_SIGINT",    vt_no_sigint,    no_sigint);
   auto e = app.add_flag("--vt_no_SIGSEGV",   vt_no_sigsegv,   no_sigsegv);
   auto f = app.add_flag("--vt_no_terminate", vt_no_terminate, no_terminate);
-  auto signalGroup = "Signa Handling";
+  auto signalGroup = "Signal Handling";
   d->group(signalGroup);
   e->group(signalGroup);
   f->group(signalGroup);

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -63,6 +63,8 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_no_sigint          = false;
 /*static*/ bool        ArgConfig::vt_no_sigsegv         = false;
 /*static*/ bool        ArgConfig::vt_no_terminate       = false;
+/*static*/ std::string ArgConfig::vt_memory_reporters   =
+  "mstats,machinfo,selfstat,sbrk,mallinfo,getrusage,ps";
 
 /*static*/ bool        ArgConfig::vt_no_warn_stack      = false;
 /*static*/ bool        ArgConfig::vt_no_assert_stack    = false;
@@ -199,6 +201,15 @@ namespace vt { namespace arguments {
   d->group(signalGroup);
   e->group(signalGroup);
   f->group(signalGroup);
+
+
+  /*
+   * Flags for controlling memory usage reporting
+   */
+  auto mem_desc = "List of memory reporters to query in order of precedence";
+  auto mm = app.add_option("--vt_memory_reporters", vt_memory_reporters, mem_desc, true);
+  auto memoryGroup = "Memory Usage Reporting";
+  mm->group(memoryGroup);
 
 
   /*

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -67,6 +67,7 @@ namespace vt { namespace arguments {
   "mstats,machinfo,selfstat,sbrk,mallinfo,getrusage,ps";
 /*static*/ bool        ArgConfig::vt_print_memory_each_phase = false;
 /*static*/ std::string ArgConfig::vt_print_memory_node  = "0";
+/*static*/ bool        ArgConfig::vt_allow_memory_report_with_ps = false;
 
 /*static*/ bool        ArgConfig::vt_no_warn_stack      = false;
 /*static*/ bool        ArgConfig::vt_no_assert_stack    = false;
@@ -212,13 +213,16 @@ namespace vt { namespace arguments {
   auto mem_desc  = "List of memory reporters to query in order of precedence";
   auto mem_phase = "Print memory usage each new phase";
   auto mem_node  = "Node to print memory usage from or \"all\"";
+  auto mem_ps    = "Enable memory reporting with PS (warning: forking to query 'ps' may not be scalable)";
   auto mm = app.add_option("--vt_memory_reporters", vt_memory_reporters, mem_desc, true);
   auto mn = app.add_flag("--vt_print_memory_each_phase", vt_print_memory_each_phase, mem_phase);
   auto mo = app.add_option("--vt_print_memory_node", vt_print_memory_node, mem_node, true);
+  auto mp = app.add_flag("--vt_allow_memory_report_with_ps", vt_allow_memory_report_with_ps, mem_ps);
   auto memoryGroup = "Memory Usage Reporting";
   mm->group(memoryGroup);
   mn->group(memoryGroup);
   mo->group(memoryGroup);
+  mp->group(memoryGroup);
 
 
   /*

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -89,6 +89,7 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_trace_sys_serial_msg = false;
 /*static*/ bool        ArgConfig::vt_trace_spec           = false;
 /*static*/ std::string ArgConfig::vt_trace_spec_file      = "";
+/*static*/ bool        ArgConfig::vt_trace_memory_usage   = false;
 
 
 /*static*/ bool        ArgConfig::vt_lb                 = false;
@@ -264,6 +265,7 @@ namespace vt { namespace arguments {
   auto tsyssmsg  = "Trace system serialization manager events";
   auto tspec     = "Enable trace spec file (defines which phases tracing is on)";
   auto tspecfile = "File containing trace spec; --vt_trace_spec to enable";
+  auto tmemusage = "Trace memory usage using first memory reporter";
   auto n  = app.add_flag("--vt_trace",              vt_trace,           trace);
   auto nm = app.add_flag("--vt_trace_mpi",          vt_trace_mpi,       trace_mpi);
   auto o  = app.add_option("--vt_trace_file",       vt_trace_file,      tfile, "");
@@ -278,6 +280,7 @@ namespace vt { namespace arguments {
   auto qz = app.add_flag("--vt_trace_sys_serial_msg", vt_trace_sys_serial_msg, tsyssmsg);
   auto qza = app.add_flag("--vt_trace_spec",          vt_trace_spec,           tspec);
   auto qzb = app.add_option("--vt_trace_spec_file",   vt_trace_spec_file,      tspecfile, "");
+  auto qzc = app.add_flag("--vt_trace_memory_usage",  vt_trace_memory_usage,   tmemusage);
   auto traceGroup = "Tracing Configuration";
   n->group(traceGroup);
   nm->group(traceGroup);
@@ -292,6 +295,7 @@ namespace vt { namespace arguments {
   qz->group(traceGroup);
   qza->group(traceGroup);
   qzb->group(traceGroup);
+  qzc->group(traceGroup);
 
 
   /*

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -64,7 +64,7 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_no_sigsegv         = false;
 /*static*/ bool        ArgConfig::vt_no_terminate       = false;
 /*static*/ std::string ArgConfig::vt_memory_reporters   =
-  "mstats,machinfo,selfstat,sbrk,mallinfo,getrusage,ps";
+  "mstats,machinfo,selfstat,selfstatm,sbrk,mallinfo,getrusage,ps";
 /*static*/ bool        ArgConfig::vt_print_memory_each_phase = false;
 /*static*/ std::string ArgConfig::vt_print_memory_node  = "0";
 /*static*/ bool        ArgConfig::vt_allow_memory_report_with_ps = false;

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -72,6 +72,7 @@ public:
   static std::string vt_memory_reporters;
   static bool vt_print_memory_each_phase;
   static std::string vt_print_memory_node;
+  static bool vt_allow_memory_report_with_ps;
 
   static bool vt_no_warn_stack;
   static bool vt_no_assert_stack;

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -70,6 +70,8 @@ public:
   static bool vt_no_sigsegv;
   static bool vt_no_terminate;
   static std::string vt_memory_reporters;
+  static bool vt_print_memory_each_phase;
+  static std::string vt_print_memory_node;
 
   static bool vt_no_warn_stack;
   static bool vt_no_assert_stack;

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -94,6 +94,7 @@ public:
   static int32_t vt_trace_flush_size;
   static bool vt_trace_spec;
   static std::string vt_trace_spec_file;
+  static bool vt_trace_memory_usage;
 
   static bool vt_lb;
   static bool vt_lb_file;

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -69,6 +69,7 @@ public:
   static bool vt_no_sigint;
   static bool vt_no_sigsegv;
   static bool vt_no_terminate;
+  static std::string vt_memory_reporters;
 
   static bool vt_no_warn_stack;
   static bool vt_no_assert_stack;

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -630,6 +630,11 @@ void Runtime::printStartupBanner() {
         fmt::print("{}\t{}{}", vt_pre, f12, reset);
       }
     }
+    if (ArgType::vt_trace_memory_usage) {
+      auto f11 = fmt::format("Tracing memory usage");
+      auto f12 = opt_on("--vt_trace_memory_usage", f11);
+      fmt::print("{}\t{}{}", vt_pre, f12, reset);
+    }
   }
   #endif
 

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -68,6 +68,7 @@
 #include "vt/configs/arguments/args.h"
 #include "vt/configs/error/stack_out.h"
 #include "vt/configs/error/pretty_print_stack.h"
+#include "vt/utils/memory/memory_usage.h"
 
 #include <memory>
 #include <iostream>
@@ -777,6 +778,41 @@ void Runtime::printStartupBanner() {
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
   }
 
+  if (ArgType::vt_memory_reporters != "") {
+    auto f11 = fmt::format(
+      "Memory usage checker precedence: {}",
+      ArgType::vt_memory_reporters
+    );
+    auto f12 = opt_on("--vt_memory_reporters", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
+
+    auto usage = util::memory::MemoryUsage::get();
+
+    std::string working_str = "";
+    auto working_reporters = usage->getWorkingReporters();
+    for (std::size_t i = 0; i < working_reporters.size(); i++) {
+      working_str += working_reporters[i];
+      if (i != working_reporters.size() - 1) {
+        working_str += ",";
+      }
+    }
+    auto f13 = fmt::format(
+      "{}Working memory reporters:{} {}{}{}\n",
+      green, reset, magenta, working_str, reset
+    );
+    fmt::print("{}\t{}{}", vt_pre, f13, reset);
+
+    auto all_usage_str = usage->getUsageAll();
+    if (all_usage_str != "") {
+      auto f14 = fmt::format(
+        "{}Initial memory usage:{} {}\n",
+        green, reset, all_usage_str
+      );
+      fmt::print("{}\t{}{}", vt_pre, f14, reset);
+    }
+  }
+
+
   if (ArgType::vt_debug_all) {
     auto f11 = fmt::format("All debug prints are on (if enabled compile-time)");
     auto f12 = opt_on("--vt_debug_all", f11);
@@ -1086,6 +1122,9 @@ void Runtime::finalizeContext() {
 void Runtime::initializeComponents() {
   debug_print(runtime, node, "begin: initializeComponents\n");
 
+  // Initialize the memory usage tracker on each node
+  util::memory::MemoryUsage::initialize();
+
   // Helper components: not allowed to send messages during construction
   theRegistry = std::make_unique<registry::Registry>();
   theEvent = std::make_unique<event::AsyncEvent>();
@@ -1260,6 +1299,9 @@ void Runtime::finalizeComponents() {
   // Initialize individual memory pool for each worker
   thePool->destroyWorkerPools();
   thePool = nullptr;
+
+  // Finalize memory usage component
+  util::memory::MemoryUsage::finalize();
 
   debug_print(runtime, node, "end: finalizeComponents\n");
 }

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -418,6 +418,12 @@ void Runtime::printStartupBanner() {
       green, reset, compile, magenta, opt, reset, reset
     );
   };
+  auto opt_to_enable = [=](std::string opt, std::string compile) -> std::string {
+    return fmt::format(
+      "{}Default:{} {}, use {}{}{} to enable{}\n",
+      green, reset, compile, magenta, opt, reset, reset
+    );
+  };
 
   auto f8 = fmt::format("{}Runtime Configuration:{}\n", green, reset);
   fmt::print("{}{}{}", vt_pre, f8, reset);
@@ -788,30 +794,47 @@ void Runtime::printStartupBanner() {
 
     auto usage = util::memory::MemoryUsage::get();
 
-    std::string working_str = "";
     auto working_reporters = usage->getWorkingReporters();
-    for (std::size_t i = 0; i < working_reporters.size(); i++) {
-      working_str += working_reporters[i];
-      if (i != working_reporters.size() - 1) {
-        working_str += ",";
+    if (working_reporters.size() > 0) {
+      std::string working_str = "";
+      for (std::size_t i = 0; i < working_reporters.size(); i++) {
+        working_str += working_reporters[i];
+        if (i != working_reporters.size() - 1) {
+          working_str += ",";
+        }
+      }
+      auto f13 = fmt::format(
+        "{}Working memory reporters:{} {}{}{}\n",
+        green, reset, magenta, working_str, reset
+      );
+      fmt::print("{}\t{}{}", vt_pre, f13, reset);
+
+      auto all_usage_str = usage->getUsageAll();
+      if (all_usage_str != "") {
+        auto f14 = fmt::format(
+          "{}Initial memory usage:{} {}\n",
+          green, reset, all_usage_str
+        );
+        fmt::print("{}\t{}{}", vt_pre, f14, reset);
       }
     }
-    auto f13 = fmt::format(
-      "{}Working memory reporters:{} {}{}{}\n",
-      green, reset, magenta, working_str, reset
-    );
-    fmt::print("{}\t{}{}", vt_pre, f13, reset);
 
-    auto all_usage_str = usage->getUsageAll();
-    if (all_usage_str != "") {
-      auto f14 = fmt::format(
-        "{}Initial memory usage:{} {}\n",
-        green, reset, all_usage_str
+    if (ArgType::vt_print_memory_each_phase) {
+      auto f15 = fmt::format("Printing memory usage each phase");
+      auto f16 = opt_on("--vt_print_memory_each_phase", f15);
+      fmt::print("{}\t{}{}", vt_pre, f16, reset);
+
+      auto f17 = fmt::format(
+        "Printing memory usage from node: {}", ArgType::vt_print_memory_node
       );
-      fmt::print("{}\t{}{}", vt_pre, f14, reset);
+      auto f18 = opt_on("--vt_print_memory_node", f17);
+      fmt::print("{}\t{}{}", vt_pre, f18, reset);
+    } else {
+      auto f15 = fmt::format("Memory usage printing disabled");
+      auto f16 = opt_to_enable("--vt_print_memory_each_phase", f15);
+      fmt::print("{}\t{}{}", vt_pre, f16, reset);
     }
   }
-
 
   if (ArgType::vt_debug_all) {
     auto f11 = fmt::format("All debug prints are on (if enabled compile-time)");

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -161,6 +161,11 @@ struct Trace {
     TraceEventIDType const event = no_trace_event
   );
 
+  void addMemoryEvent(
+    std::size_t memory,
+    double const time = getCurrentTime()
+  );
+
   TraceEventIDType messageCreation(
     TraceEntryIDType const ep, TraceMsgLenType const len,
     double const time = getCurrentTime()
@@ -230,6 +235,10 @@ private:
   /// or no_trace_event if not accepted (eg. no tracing on node).
   /// The log object is invalidated after the call.
   TraceEventIDType logEvent(LogType&& log);
+
+  std::size_t getTracesSize() const {
+    return traces_.size() * sizeof(Log);
+  }
 
 private:
   /*

--- a/src/vt/trace/trace_log.h
+++ b/src/vt/trace/trace_log.h
@@ -293,6 +293,14 @@ struct Log final {
   {
   }
 
+  // Memory usage event, could create another union type here, but hardly seems
+  // worth it; re-use SysData
+  Log(
+    double in_time, TraceConstantsType in_type, std::size_t in_memory_bytes
+  ) : time(in_time), type(in_type),
+      data(Data::SysData{in_memory_bytes})
+  { }
+
   inline Data::UserData const& user_data() const {
     assert(data.user.data_type == LogDataType::user && "Expecting user data-type");
     return data.user;

--- a/src/vt/utils/memory/memory_reporter.h
+++ b/src/vt/utils/memory/memory_reporter.h
@@ -1,0 +1,59 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                              memory_reporter.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_UTILS_MEMORY_MEMORY_REPORTER_H
+#define INCLUDED_VT_UTILS_MEMORY_MEMORY_REPORTER_H
+
+#include "vt/config.h"
+
+namespace vt { namespace util { namespace memory {
+
+struct Reporter {
+  virtual std::size_t getUsage() = 0;
+  virtual std::string getName() = 0;
+};
+
+}}} /* end namespace vt::util::memory */
+
+#endif /*INCLUDED_VT_UTILS_MEMORY_MEMORY_REPORTER_H*/

--- a/src/vt/utils/memory/memory_units.cc
+++ b/src/vt/utils/memory/memory_units.cc
@@ -45,6 +45,8 @@
 #include "vt/config.h"
 #include "vt/utils/memory/memory_units.h"
 
+#include <unordered_map>
+
 namespace vt { namespace util { namespace memory {
 
 std::unordered_map<MemoryUnitEnum, std::string> memory_unit_names = {
@@ -53,5 +55,9 @@ std::unordered_map<MemoryUnitEnum, std::string> memory_unit_names = {
   {MemoryUnitEnum::Megabytes, std::string{"MB"}},
   {MemoryUnitEnum::Gigabytes, std::string{"GB"}}
 };
+
+std::string getMemoryUnitName(MemoryUnitEnum unit) {
+  return memory_unit_names[unit];
+}
 
 }}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_units.cc
+++ b/src/vt/utils/memory/memory_units.cc
@@ -51,9 +51,9 @@ namespace vt { namespace util { namespace memory {
 
 std::unordered_map<MemoryUnitEnum, std::string> memory_unit_names = {
   {MemoryUnitEnum::Bytes,     std::string{"bytes"}},
-  {MemoryUnitEnum::Kilobytes, std::string{"kB"}},
-  {MemoryUnitEnum::Megabytes, std::string{"MB"}},
-  {MemoryUnitEnum::Gigabytes, std::string{"GB"}}
+  {MemoryUnitEnum::Kilobytes, std::string{"KiB"}},
+  {MemoryUnitEnum::Megabytes, std::string{"MiB"}},
+  {MemoryUnitEnum::Gigabytes, std::string{"GiB"}}
 };
 
 std::string getMemoryUnitName(MemoryUnitEnum unit) {

--- a/src/vt/utils/memory/memory_units.cc
+++ b/src/vt/utils/memory/memory_units.cc
@@ -1,0 +1,57 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               memory_units.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include "vt/config.h"
+#include "vt/utils/memory/memory_units.h"
+
+namespace vt { namespace util { namespace memory {
+
+std::unordered_map<MemoryUnitEnum, std::string> memory_unit_names = {
+  {MemoryUnitEnum::Bytes,     std::string{"bytes"}},
+  {MemoryUnitEnum::Kilobytes, std::string{"kB"}},
+  {MemoryUnitEnum::Megabytes, std::string{"MB"}},
+  {MemoryUnitEnum::Gigabytes, std::string{"GB"}}
+};
+
+}}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_units.h
+++ b/src/vt/utils/memory/memory_units.h
@@ -48,7 +48,6 @@
 #include "vt/config.h"
 
 #include <string>
-#include <unordered_map>
 
 namespace vt { namespace util { namespace memory {
 
@@ -59,7 +58,7 @@ enum struct MemoryUnitEnum : int8_t {
   Gigabytes = 3
 };
 
-extern std::unordered_map<MemoryUnitEnum, std::string> memory_unit_names;
+std::string getMemoryUnitName(MemoryUnitEnum unit);
 
 }}} /* end namespace vt::util::memory */
 

--- a/src/vt/utils/memory/memory_units.h
+++ b/src/vt/utils/memory/memory_units.h
@@ -1,0 +1,66 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                memory_units.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_UTILS_MEMORY_MEMORY_UNITS_H
+#define INCLUDED_VT_UTILS_MEMORY_MEMORY_UNITS_H
+
+#include "vt/config.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace vt { namespace util { namespace memory {
+
+enum struct MemoryUnitEnum : int8_t {
+  Bytes     = 0,
+  Kilobytes = 1,
+  Megabytes = 2,
+  Gigabytes = 3
+};
+
+extern std::unordered_map<MemoryUnitEnum, std::string> memory_unit_names;
+
+}}} /* end namespace vt::util::memory */
+
+#endif /*INCLUDED_VT_UTILS_MEMORY_MEMORY_UNITS_H*/

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -95,13 +95,13 @@ std::size_t Sbrk::getUsage() {
 # if defined(vt_has_sbrk)
 #   pragma GCC diagnostic push
 #   pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    if (!inited) {
-      sbrkinit = reinterpret_cast<uintptr_t>(sbrk(0));
-      inited = true;
+    if (!inited_) {
+      sbrkinit_ = reinterpret_cast<uintptr_t>(sbrk(0));
+      inited_ = true;
     }
     uintptr_t sbrknow = reinterpret_cast<uintptr_t>(sbrk(0));
 #   pragma GCC diagnostic pop
-    return static_cast<std::size_t>(sbrknow - sbrkinit);
+    return static_cast<std::size_t>(sbrknow - sbrkinit_);
 # else
     return 0;
 # endif
@@ -185,14 +185,14 @@ std::string MachTaskInfo::getName() {
 }
 
 std::size_t Stat::getUsage() {
-  if (failed) {
+  if (failed_) {
     return 0;
   }
 
   std::size_t vsz = 0; /* should remain 0 on failure */
   FILE *f = fopen("/proc/self/stat", "r");
   if (!f) {
-    failed = true;
+    failed_ = true;
     return 0;
   }
   for (int i = 0; i < 22; i++) {
@@ -202,7 +202,7 @@ std::size_t Stat::getUsage() {
   fclose(f);
 
   if (!vsz) {
-    failed = true;
+    failed_ = true;
   }
   return vsz;
 }

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -176,9 +176,9 @@ std::size_t MachTaskInfo::getUsage() {
 # endif
 }
 
-  std::string MachTaskInfo::getName() {
-    return "machinfo";
-  }
+std::string MachTaskInfo::getName() {
+  return "machinfo";
+}
 
 std::size_t Stat::getUsage() {
   if (failed) {

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -113,14 +113,18 @@ std::string Sbrk::getName() {
 
 std::size_t PS::getUsage() {
 # if defined(vt_has_popen) && defined(vt_has_pclose) && defined(vt_has_getpid)
-    auto cmd = fmt::format("/bin/ps -o rss= -p {}", getpid());
-    FILE* p = popen(cmd.c_str(), "r");
-    std::size_t vsz = 0;
-    if (p) {
-      fscanf(p, "%zu", &vsz);
-      pclose(p);
+    if (arguments::ArgConfig::vt_allow_memory_report_with_ps) {
+      auto cmd = fmt::format("/bin/ps -o rss= -p {}", getpid());
+      FILE* p = popen(cmd.c_str(), "r");
+      std::size_t vsz = 0;
+      if (p) {
+        fscanf(p, "%zu", &vsz);
+        pclose(p);
+      }
+      return vsz * 1024;
+    } else {
+      return 0;
     }
-    return vsz * 1024;
 # else
     return 0;
 # endif

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -260,10 +260,9 @@ MemoryUsage::MemoryUsage() {
 
   // Prime each reporter, determine if we have a working reporter
   for (auto&& r : reporters_) {
-    if (r->getUsage() != 0) {
-      has_working_ = true;
-    }
+    r->getUsage();
   }
+  getFirstUsage();
 }
 
 std::size_t MemoryUsage::getAverageUsage() {
@@ -291,15 +290,13 @@ std::size_t MemoryUsage::getFirstUsage() {
       usage = r->getUsage();
       //fmt::print("reporter: {} usage: {}\n", r->getName(), usage);
       if (usage) {
+        first_valid_reporter_ = cur_elm;
         break;
       }
       cur_elm++;
     }
-    first_valid_reporter_ = cur_elm;
   } else {
-    if (first_valid_reporter_ < reporters_.size()) {
-      usage = reporters_[first_valid_reporter_]->getUsage();
-    }
+    usage = reporters_[first_valid_reporter_]->getUsage();
   }
   return usage;
 }
@@ -352,7 +349,7 @@ std::vector<std::string> MemoryUsage::getWorkingReporters() {
 }
 
 bool MemoryUsage::hasWorkingReporter() const {
-  return has_working_;
+  return first_valid_reporter_ != -1;
 }
 
 /*static*/ void MemoryUsage::initialize() {

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -152,7 +152,12 @@ std::size_t Getrusage::getUsage() {
 # if defined(vt_has_getrusage)
     struct rusage usage;
     getrusage(RUSAGE_SELF, &usage);
-    return usage.ru_maxrss;
+    // On BSD, units are in KiB, on mach it's in bytes
+#   if defined(__APPLE__) && defined(__MACH__)
+      return usage.ru_maxrss;
+#   else
+      return usage.ru_maxrss * 1024;
+#   endif
 # else
     return 0;
 # endif

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -360,7 +360,7 @@ std::size_t MemoryUsage::getFirstUsage() {
 
 std::string MemoryUsage::getFirstReporter() {
   getFirstUsage();
-  if (first_valid_reporter_ < reporters_.size() and first_valid_reporter_ != -1) {
+  if (first_valid_reporter_ != -1) {
     return reporters_[first_valid_reporter_]->getName();
   } else {
     return "<no-valid-reporter>";

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -248,6 +248,13 @@ MemoryUsage::MemoryUsage() {
     auto iter = name_map.find(r);
     if (iter != name_map.end()) {
       reporters_.emplace_back(std::move(all_reporters[iter->second]));
+    } else {
+      if (theContext()->getNode() == 0) {
+        auto warning = fmt::format(
+          "Invalid memory reporter specified: {}", r
+        );
+        vtWarn(warning);
+      }
     }
   }
 

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -1,0 +1,355 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               memory_usage.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include "vt/config.h"
+#include "vt/utils/memory/memory_usage.h"
+
+#include <vector>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <istream>
+#include <cstdio>
+
+#if defined(vt_has_malloc_h)
+# include <malloc.h>
+#endif
+
+#if defined(vt_has_malloc_malloc_h)
+# include <malloc/malloc.h>
+#endif
+
+#if defined(vt_has_mach_mach_h)
+# include <mach/mach.h>
+#endif
+
+#if defined(vt_has_sys_resource_h)
+# include <sys/resource.h>
+#endif
+
+#if defined(vt_has_unistd_h)
+# include <unistd.h>
+#endif
+
+#if defined(vt_has_inttypes_h)
+# include <inttypes.h>
+#endif
+
+namespace vt { namespace util { namespace memory {
+
+std::size_t Mstats::getUsage() {
+# if defined(vt_has_mstats)
+    struct mstats ms = mstats();
+    return ms.bytes_used;
+# else
+    return 0;
+# endif
+}
+
+std::string Mstats::getName() {
+  return "mstats";
+}
+
+std::size_t Sbrk::getUsage() {
+# if defined(vt_has_sbrk)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    if (!inited) {
+      sbrkinit = reinterpret_cast<uintptr_t>(sbrk(0));
+      inited = true;
+    }
+    uintptr_t sbrknow = reinterpret_cast<uintptr_t>(sbrk(0));
+#   pragma GCC diagnostic pop
+    return static_cast<std::size_t>(sbrknow - sbrkinit);
+# else
+    return 0;
+# endif
+}
+
+std::string Sbrk::getName() {
+  return "sbrk";
+}
+
+std::size_t PS::getUsage() {
+# if defined(vt_has_popen) && defined(vt_has_pclose) && defined(vt_has_getpid)
+    auto cmd = fmt::format("/bin/ps -o rss= -p {}", getpid());
+    FILE* p = popen(cmd.c_str(), "r");
+    std::size_t vsz = 0;
+    if (p) {
+      fscanf(p, "%zu", &vsz);
+      pclose(p);
+    }
+    return vsz * 1024;
+# else
+    return 0;
+# endif
+}
+
+std::string PS::getName() {
+  return "ps";
+}
+
+std::size_t Mallinfo::getUsage() {
+# if defined(vt_has_mallinfo) && defined(vt_has_malloc_h)
+    struct mallinfo mi = mallinfo();
+    return mi.uordblks;
+# else
+    return 0;
+# endif
+}
+
+std::string Mallinfo::getName() {
+  return "mallinfo";
+}
+
+std::size_t Getrusage::getUsage() {
+# if defined(vt_has_getrusage)
+    struct rusage usage;
+    getrusage(RUSAGE_SELF, &usage);
+    return usage.ru_maxrss;
+# else
+    return 0;
+# endif
+}
+
+std::string Getrusage::getName() {
+  return "getrusage";
+}
+
+std::size_t MachTaskInfo::getUsage() {
+# if defined(vt_has_mach_task_self)
+    struct mach_task_basic_info info;
+    mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
+    if (
+      task_info(
+        mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info,
+        &info_count
+      ) != KERN_SUCCESS
+    ) {
+      return 0;
+    } else {
+      return static_cast<std::size_t>(info.resident_size);
+    }
+# else
+    return 0;
+# endif
+}
+
+  std::string MachTaskInfo::getName() {
+    return "machinfo";
+  }
+
+std::size_t Stat::getUsage() {
+  if (failed) {
+    return 0;
+  }
+
+  std::size_t vsz = 0; /* should remain 0 on failure */
+  FILE *f = fopen("/proc/self/stat", "r");
+  if (!f) {
+    failed = true;
+    return 0;
+  }
+  for (int i = 0; i < 22; i++) {
+    fscanf(f, "%*s");
+  }
+  fscanf(f, "%zu", &vsz);
+  fclose(f);
+
+  if (!vsz) {
+    failed = true;
+  }
+  return vsz;
+}
+
+std::string Stat::getName() {
+  return "selfstat";
+}
+
+struct CommaDelimit : std::string {};
+
+std::istream& operator>>(std::istream& is, CommaDelimit& output) {
+  std::getline(is, output, ',');
+  return is;
+}
+
+MemoryUsage::MemoryUsage() {
+  std::vector<std::unique_ptr<Reporter>> all_reporters;
+
+  // Register all the memory reporters
+  all_reporters.emplace_back(std::make_unique<Mstats>());
+  all_reporters.emplace_back(std::make_unique<MachTaskInfo>());
+  all_reporters.emplace_back(std::make_unique<Stat>());
+  all_reporters.emplace_back(std::make_unique<Sbrk>());
+  all_reporters.emplace_back(std::make_unique<Mallinfo>());
+  all_reporters.emplace_back(std::make_unique<Getrusage>());
+  all_reporters.emplace_back(std::make_unique<PS>());
+
+  std::string pred = arguments::ArgConfig::vt_memory_reporters;
+  std::istringstream iss(pred);
+  std::vector<std::string> results(
+    std::istream_iterator<CommaDelimit>{iss},
+    std::istream_iterator<CommaDelimit>{}
+  );
+
+  std::unordered_map<std::string, int> name_map;
+  int cur = 0;
+  for (auto&& r : all_reporters) {
+    name_map[r->getName()] = cur;
+    cur++;
+  }
+
+  for (auto&& r : results) {
+    auto iter = name_map.find(r);
+    if (iter != name_map.end()) {
+      reporters_.emplace_back(std::move(all_reporters[iter->second]));
+    }
+  }
+
+  // Prime each reporter
+  for (auto&& r : reporters_) {
+    r->getUsage();
+  }
+}
+
+std::size_t MemoryUsage::getAverageUsage() {
+  std::size_t usage = 0;
+  std::size_t num_valid = 0;
+  for (auto&& r : reporters_) {
+    auto rusage = r->getUsage();
+    if (rusage != 0) {
+      usage += rusage;
+      num_valid++;
+    }
+  }
+  if (num_valid != 0) {
+    return usage / num_valid;
+  } else {
+    return 0;
+  }
+}
+
+std::size_t MemoryUsage::getFirstUsage() {
+  std::size_t usage = 0;
+  if (first_valid_reporter_ == -1) {
+    int cur_elm = 0;
+    for (auto&& r : reporters_) {
+      usage = r->getUsage();
+      //fmt::print("reporter: {} usage: {}\n", r->getName(), usage);
+      if (usage) {
+        break;
+      }
+      cur_elm++;
+    }
+    first_valid_reporter_ = cur_elm;
+  } else {
+    if (first_valid_reporter_ < reporters_.size()) {
+      usage = reporters_[first_valid_reporter_]->getUsage();
+    }
+  }
+  return usage;
+}
+
+std::string MemoryUsage::getFirstReporter() {
+  getFirstUsage();
+  if (first_valid_reporter_ < reporters_.size() and first_valid_reporter_ != -1) {
+    return reporters_[first_valid_reporter_]->getName();
+  } else {
+    return "<no-valid-reporter>";
+  }
+}
+
+std::string MemoryUsage::getUsageAll(bool pretty, MemoryUnitEnum unit) {
+  std::string builder = "";
+  std::size_t num_valid = 0;
+  for (auto&& r : reporters_) {
+    auto rusage = r->getUsage();
+    if (rusage != 0) {
+      double dusage = static_cast<double>(rusage);
+      for (int8_t i = 0; i < static_cast<int8_t>(unit); i++) {
+        dusage /= 1024.0;
+      }
+      builder += fmt::format(
+        "{}{}{}={}{:.6g}{} ",
+        pretty ? debug::green() : "",
+        r->getName(),
+        pretty ? debug::reset() : "",
+        pretty ? debug::magenta() : "",
+        dusage,
+        pretty ? debug::reset() : ""
+      );
+      num_valid++;
+    }
+  }
+  if (num_valid > 0) {
+    builder += fmt::format("({})", memory_unit_names[unit]);
+  }
+  return builder;
+}
+
+std::vector<std::string> MemoryUsage::getWorkingReporters() {
+  std::vector<std::string> working;
+  for (auto&& r : reporters_) {
+    if (r->getUsage() != 0) {
+      working.push_back(r->getName());
+    }
+  }
+  return working;
+}
+
+/*static*/ void MemoryUsage::initialize() {
+  impl_ = std::make_unique<MemoryUsage>();
+}
+
+/*static*/ void MemoryUsage::finalize() {
+  impl_ = nullptr;
+}
+
+/*static*/ MemoryUsage* MemoryUsage::get() {
+  return impl_.get();
+}
+
+/*static*/ std::unique_ptr<MemoryUsage> MemoryUsage::impl_ = nullptr;
+
+}}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -138,7 +138,8 @@ std::string PS::getName() {
 std::size_t Mallinfo::getUsage() {
 # if defined(vt_has_mallinfo) && defined(vt_has_malloc_h)
     struct mallinfo mi = mallinfo();
-    return mi.uordblks;
+    unsigned int blocks = mi.uordblks;
+    return static_cast<std::size_t>(blocks);
 # else
     return 0;
 # endif

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -115,7 +115,7 @@ std::string Sbrk::getName() {
 std::size_t PS::getUsage() {
 # if defined(vt_has_popen) && defined(vt_has_pclose) && defined(vt_has_getpid)
     if (arguments::ArgConfig::vt_allow_memory_report_with_ps) {
-      auto cmd = fmt::format("/bin/ps -o rss= -p {}", getpid());
+      auto cmd = fmt::format("/bin/ps -o vsz= -p {}", getpid());
       FILE* p = popen(cmd.c_str(), "r");
       std::size_t vsz = 0;
       if (p) {

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -247,9 +247,11 @@ MemoryUsage::MemoryUsage() {
     }
   }
 
-  // Prime each reporter
+  // Prime each reporter, determine if we have a working reporter
   for (auto&& r : reporters_) {
-    r->getUsage();
+    if (r->getUsage() != 0) {
+      has_working_ = true;
+    }
   }
 }
 
@@ -336,6 +338,10 @@ std::vector<std::string> MemoryUsage::getWorkingReporters() {
     }
   }
   return working;
+}
+
+bool MemoryUsage::hasWorkingReporter() const {
+  return has_working_;
 }
 
 /*static*/ void MemoryUsage::initialize() {

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -218,10 +218,10 @@ std::size_t StatM::getUsage() {
     return 0;
   }
 
-  std::size_t to_ignore = 0;
-  std::size_t resident = 0;
   std::ifstream buffer("/proc/self/statm");
   if (buffer.good()) {
+    std::size_t to_ignore = 0;
+    std::size_t resident = 0;
     buffer >> to_ignore >> resident;
     buffer.close();
 

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -329,7 +329,7 @@ std::string MemoryUsage::getUsageAll(bool pretty, MemoryUnitEnum unit) {
     }
   }
   if (num_valid > 0) {
-    builder += fmt::format("({})", memory_unit_names[unit]);
+    builder += fmt::format("({})", getMemoryUnitName(unit));
   }
   return builder;
 }

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -124,7 +124,6 @@ private:
 
   std::vector<std::unique_ptr<Reporter>> reporters_;
   int first_valid_reporter_ = -1;
-  bool has_working_ = false;
 };
 
 }}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -109,6 +109,8 @@ struct MemoryUsage {
     bool pretty = true, MemoryUnitEnum unit = MemoryUnitEnum::Megabytes
   );
 
+  bool hasWorkingReporter() const;
+
   std::vector<std::string> getWorkingReporters();
 
   static MemoryUsage* get();
@@ -122,6 +124,7 @@ private:
 
   std::vector<std::unique_ptr<Reporter>> reporters_;
   int first_valid_reporter_ = -1;
+  bool has_working_ = false;
 };
 
 }}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -1,0 +1,129 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                memory_usage.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_UTILS_MEMORY_MEMORY_USAGE_H
+#define INCLUDED_VT_UTILS_MEMORY_MEMORY_USAGE_H
+
+#include "vt/config.h"
+#include "vt/utils/memory/memory_units.h"
+#include "vt/utils/memory/memory_reporter.h"
+
+#include <string>
+#include <memory>
+
+namespace vt { namespace util { namespace memory {
+
+struct Mstats : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+};
+
+struct Sbrk : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+
+private:
+  bool inited = false;
+  uintptr_t sbrkinit = 0;
+};
+
+struct PS : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+};
+
+struct Mallinfo : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+};
+
+struct Getrusage : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+};
+
+struct MachTaskInfo : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+};
+
+struct Stat : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+
+private:
+  bool failed = false;
+};
+
+struct MemoryUsage {
+  MemoryUsage();
+
+  std::size_t getAverageUsage();
+
+  std::size_t getFirstUsage();
+
+  std::string getFirstReporter();
+
+  std::string getUsageAll(
+    bool pretty = true, MemoryUnitEnum unit = MemoryUnitEnum::Megabytes
+  );
+
+  std::vector<std::string> getWorkingReporters();
+
+  static MemoryUsage* get();
+
+  static void initialize();
+
+  static void finalize();
+
+private:
+  static std::unique_ptr<MemoryUsage> impl_;
+
+  std::vector<std::unique_ptr<Reporter>> reporters_;
+  int first_valid_reporter_ = -1;
+};
+
+}}} /* end namespace vt::util::memory */
+
+#endif /*INCLUDED_VT_UTILS_MEMORY_MEMORY_USAGE_H*/

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -64,8 +64,8 @@ struct Sbrk : Reporter {
   std::string getName() override;
 
 private:
-  bool inited = false;
-  uintptr_t sbrkinit = 0;
+  bool inited_ = false;
+  uintptr_t sbrkinit_ = 0;
 };
 
 struct PS : Reporter {
@@ -93,7 +93,7 @@ struct Stat : Reporter {
   std::string getName() override;
 
 private:
-  bool failed = false;
+  bool failed_ = false;
 };
 
 struct MemoryUsage {

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -96,6 +96,14 @@ private:
   bool failed_ = false;
 };
 
+struct StatM : Reporter {
+  std::size_t getUsage() override;
+  std::string getName() override;
+
+private:
+  bool failed_ = false;
+};
+
 struct MemoryUsage {
   MemoryUsage();
 

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -55,6 +55,7 @@
 #include "vt/vrt/collection/balance/statsmaplb/statsmaplb.h"
 #include "vt/vrt/collection/messages/system_create.h"
 #include "vt/vrt/collection/manager.fwd.h"
+#include "vt/utils/memory/memory_usage.h"
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
@@ -266,6 +267,22 @@ void LBManager::unregisterListenerAfterLB(int element) {
     listeners_.size() > static_cast<std::size_t>(element), "Listener must exist"
   );
   listeners_[element] = nullptr;
+}
+
+void LBManager::printMemoryUsage(PhaseType phase) {
+  auto this_node = theContext()->getNode();
+  if (
+    "all" == arguments::ArgConfig::vt_print_memory_node or
+     std::to_string(this_node) == arguments::ArgConfig::vt_print_memory_node
+  ) {
+    auto usage = util::memory::MemoryUsage::get();
+    if (usage->hasWorkingReporter()) {
+      auto memory_usage_str = fmt::format(
+        "Memory Usage: phase={}: {}\n", phase, usage->getUsageAll()
+      );
+      vt_print(gen, memory_usage_str);
+    }
+  }
 }
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -270,17 +270,19 @@ void LBManager::unregisterListenerAfterLB(int element) {
 }
 
 void LBManager::printMemoryUsage(PhaseType phase) {
-  auto this_node = theContext()->getNode();
-  if (
-    "all" == arguments::ArgConfig::vt_print_memory_node or
-     std::to_string(this_node) == arguments::ArgConfig::vt_print_memory_node
-  ) {
-    auto usage = util::memory::MemoryUsage::get();
-    if (usage->hasWorkingReporter()) {
-      auto memory_usage_str = fmt::format(
-        "Memory Usage: phase={}: {}\n", phase, usage->getUsageAll()
-      );
-      vt_print(gen, memory_usage_str);
+  if (arguments::ArgConfig::vt_print_memory_each_phase) {
+    auto this_node = theContext()->getNode();
+    if (
+      "all" == arguments::ArgConfig::vt_print_memory_node or
+      std::to_string(this_node) == arguments::ArgConfig::vt_print_memory_node
+    ) {
+      auto usage = util::memory::MemoryUsage::get();
+      if (usage->hasWorkingReporter()) {
+        auto memory_usage_str = fmt::format(
+          "Memory Usage: phase={}: {}\n", phase, usage->getUsageAll()
+        );
+        vt_print(gen, memory_usage_str);
+      }
     }
   }
 }

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.h
@@ -105,17 +105,20 @@ protected:
   void releaseNow(PhaseType phase);
 
 public:
+  void printMemoryUsage(PhaseType phase);
   void setTraceEnabledNextPhase(PhaseType phase);
 
   template <typename MsgT>
   void sysLB(MsgT* msg) {
     debug_print(lb, node, "sysLB\n");
+    printMemoryUsage(msg->phase_);
     setTraceEnabledNextPhase(msg->phase_);
     return collectiveImpl(msg->phase_, msg->lb_, msg->manual_, msg->num_collections_);
   }
   template <typename MsgT>
   void sysReleaseLB(MsgT* msg) {
     debug_print(lb, node, "sysReleaseLB\n");
+    printMemoryUsage(msg->phase_);
     setTraceEnabledNextPhase(msg->phase_);
     return releaseImpl(msg->phase_, msg->num_collections_);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,11 @@ set(PROJECT_TEST_UNIT_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/unit)
 set(PROJECT_TEST_PERF_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/perf)
 set(PROJECT_GTEST_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/googletest/googletest/include)
 
-set(PROJECT_PERF_TESTS ping_pong)
+set(
+  PROJECT_PERF_TESTS
+  ping_pong
+  memory_checker
+)
 
 set(
   UNIT_TEST_SUBDIRS_LIST

--- a/tests/perf/memory_checker.cc
+++ b/tests/perf/memory_checker.cc
@@ -1,0 +1,93 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                              memory_checker.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <vt/utils/memory/memory_usage.h>
+
+std::vector<int32_t*> ptrs;
+
+void allocateAndTouch(std::size_t num_bytes) {
+  auto ptr = new int32_t[num_bytes / 4];
+  for (std::size_t i = 0; i < num_bytes / 4; i++) {
+    ptr[i] = 20 * i + 23;
+  }
+  ptrs.push_back(ptr);
+}
+
+void deallocate() {
+  if (ptrs.size() > 0) {
+    auto ptr = ptrs.back();
+    ptrs.pop_back();
+    delete [] ptr;
+  }
+}
+
+int main(int argc, char** argv) {
+  vt::initialize(argc, argv);
+
+  auto this_node = vt::theContext()->getNode();
+
+  if (this_node == 0) {
+    auto usage = vt::util::memory::MemoryUsage::get();
+    fmt::print("Initial: {}\n", usage->getUsageAll());
+
+    for (int i = 0; i < 32; i++) {
+      allocateAndTouch(1024 * 1024 * 64);
+      fmt::print("After alloc {} MiB: {}\n", (i + 1) * 64, usage->getUsageAll());
+    }
+
+    for (int i = 0; i < 32; i++) {
+      deallocate();
+      fmt::print("After de-alloc {} MiB: {}\n", (32 * 64) - (i + 1) * 64, usage->getUsageAll());
+    }
+  }
+
+  while (!vt::rt->isTerminated()) {
+    vt::runScheduler();
+  }
+
+  vt::finalize();
+
+  return 0;
+}


### PR DESCRIPTION
There isn't a good general way to get memory usage across all platforms. Thus, I've added a host of methods for reporting memory usage that are protected by cmake system checks before they get enabled. The user can specify a precedence order for the memory reporters with the flag `--vt_memory_reporters`. The default order is `mstats,machinfo,selfstat,sbrk,mallinfo,getrusage,ps`.

Additionally, there is a flag for enabling memory usage prints after each phase 
`--vt_print_memory_each_phase` along with which node the user wants to be informed about 
`--vt_print_memory_node`. Those phase prints look something like this:

<img width="858" alt="Screen Shot 2020-03-06 at 7 49 57 PM" src="https://user-images.githubusercontent.com/3324465/76136185-b0675b80-5fe3-11ea-992c-ee337fd57f5b.png">

With all this in place, I now have a new option to trace memory usage also, enabled with the flag: 
`--vt_trace_memory_usage`. The highest priority working memory reporter return value gets output to the trace files every begin and end processing. We eventually might want to reduce the frequency, but this was how we were using it in the EMPIRE hacks.

At startup, VT give some info about the reporters and precedence order requested and what was found to be working on the given architecture, along with initial values for memory usage at startup:

<img width="1067" alt="Screen Shot 2020-03-06 at 7 52 49 PM" src="https://user-images.githubusercontent.com/3324465/76136230-2e2b6700-5fe4-11ea-9349-fd25e84c66ec.png">

Fixes #726 

