### PR TITLE
695 LB fix warning in proc stats

### DIFF
--- a/src/vt/vrt/collection/balance/proc_stats.cc
+++ b/src/vt/vrt/collection/balance/proc_stats.cc
@@ -144,7 +144,7 @@ void StatsRestartReader::inputStatsFile(
   fpos_t pos;
   bool finished = false;
   while (!finished) {
-    if (fscanf(pFile, "%zu %c %lu %c %lf", &phaseID, &separator, &elmID,
+    if (fscanf(pFile, "%zu %c %llu %c %lf", &phaseID, &separator, &elmID,
                &separator, &tval) > 0) {
       fgetpos (pFile,&pos);
       fscanf (pFile, "%c", &separator);


### PR DESCRIPTION
Fixes #695 

Fixes this warning:

```
/Users/jliffla/codes/vt/virtual-transport/src/vt/vrt/collection/balance/proc_stats.cc:147:66: warning: format specifies type 'unsigned long *' but the argument has type 'vt::vrt::collection::balance::ElementIDType *' (aka 'unsigned long long *') [-Wformat]
    if (fscanf(pFile, "%zu %c %lu %c %lf", &phaseID, &separator, &elmID,
                              ~~~                                ^~~~~~
                              %llu
1 warning generated.
```