### PR TITLE
738 Print memory usage

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -71,6 +71,9 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_print_memory_each_phase = false;
 /*static*/ std::string ArgConfig::vt_print_memory_node  = "0";
 /*static*/ bool        ArgConfig::vt_allow_memory_report_with_ps = false;
+/*static*/ bool        ArgConfig::vt_print_memory_at_threshold = false;
+/*static*/ std::string ArgConfig::vt_print_memory_threshold = "1 GiB";
+/*static*/ int32_t     ArgConfig::vt_print_memory_sched_poll = 100;
 
 /*static*/ bool        ArgConfig::vt_no_warn_stack      = false;
 /*static*/ bool        ArgConfig::vt_no_assert_stack    = false;
@@ -217,15 +220,24 @@ namespace vt { namespace arguments {
   auto mem_phase = "Print memory usage each new phase";
   auto mem_node  = "Node to print memory usage from or \"all\"";
   auto mem_ps    = "Enable memory reporting with PS (warning: forking to query 'ps' may not be scalable)";
+  auto mem_at_thresh = "Print memory usage from scheduler when reaches a threshold increment";
+  auto mem_thresh    = "The threshold increments to print memory usage: \"<value> {GiB,MiB,KiB,B}\"";
+  auto mem_sched     = "The frequency to query the memory threshold check (some memory reporters might be expensive)";
   auto mm = app.add_option("--vt_memory_reporters", vt_memory_reporters, mem_desc, true);
   auto mn = app.add_flag("--vt_print_memory_each_phase", vt_print_memory_each_phase, mem_phase);
   auto mo = app.add_option("--vt_print_memory_node", vt_print_memory_node, mem_node, true);
   auto mp = app.add_flag("--vt_allow_memory_report_with_ps", vt_allow_memory_report_with_ps, mem_ps);
+  auto mq = app.add_flag("--vt_print_memory_at_threshold", vt_print_memory_at_threshold, mem_at_thresh);
+  auto mr = app.add_option("--vt_print_memory_threshold", vt_print_memory_threshold, mem_thresh, true);
+  auto ms = app.add_option("--vt_print_memory_sched_poll", vt_print_memory_sched_poll, mem_sched, true);
   auto memoryGroup = "Memory Usage Reporting";
   mm->group(memoryGroup);
   mn->group(memoryGroup);
   mo->group(memoryGroup);
   mp->group(memoryGroup);
+  mq->group(memoryGroup);
+  mr->group(memoryGroup);
+  ms->group(memoryGroup);
 
 
   /*

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -73,6 +73,9 @@ public:
   static bool vt_print_memory_each_phase;
   static std::string vt_print_memory_node;
   static bool vt_allow_memory_report_with_ps;
+  static bool vt_print_memory_at_threshold;
+  static std::string vt_print_memory_threshold;
+  static int32_t vt_print_memory_sched_poll;
 
   static bool vt_no_warn_stack;
   static bool vt_no_assert_stack;

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -836,6 +836,28 @@ void Runtime::printStartupBanner() {
       auto f16 = opt_to_enable("--vt_print_memory_each_phase", f15);
       fmt::print("{}\t{}{}", vt_pre, f16, reset);
     }
+
+    if (ArgType::vt_print_memory_at_threshold) {
+      auto f15 = fmt::format("Printing memory usage at threshold increment");
+      auto f16 = opt_on("--vt_print_memory_at_threshold", f15);
+      fmt::print("{}\t{}{}", vt_pre, f16, reset);
+
+      auto f17 = fmt::format(
+        "Printing memory usage using threshold: {}",
+        ArgType::vt_print_memory_threshold
+      );
+      auto f18 = opt_on("--vt_print_memory_threshold", f17);
+      fmt::print("{}\t{}{}", vt_pre, f18, reset);
+
+      usage->convertBytesFromString(ArgType::vt_print_memory_threshold);
+
+      auto f19 = fmt::format(
+        "Polling for memory usage threshold every {} scheduler calls",
+        ArgType::vt_print_memory_sched_poll
+      );
+      auto f20 = opt_on("--vt_print_memory_sched_poll", f19);
+      fmt::print("{}\t{}{}", vt_pre, f20, reset);
+    }
   }
 
   if (ArgType::vt_debug_all) {

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -149,7 +149,10 @@ bool Scheduler::shouldCallProgress(
 }
 
 void Scheduler::printMemoryUsage() {
-  if (last_memory_usage_poll_ >= arguments::ArgConfig::vt_print_memory_sched_poll) {
+  if (
+    last_memory_usage_poll_ >=
+    static_cast<std::size_t>(arguments::ArgConfig::vt_print_memory_sched_poll)
+  ) {
     auto usage = vt::util::memory::MemoryUsage::get();
 
     if (usage != nullptr) {

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -105,6 +105,8 @@ struct Scheduler {
   void enqueue(ActionType action);
   void enqueue(PriorityType priority, ActionType action);
 
+  void printMemoryUsage();
+
   template <typename MsgT>
   void enqueue(MsgT* msg, ActionType action);
   template <typename MsgT>
@@ -138,6 +140,10 @@ private:
   TimeType last_progress_time_ = 0.0;
   bool progress_time_enabled_ = false;
   int32_t processed_after_last_progress_ = 0;
+
+  std::size_t last_threshold_memory_usage_ = 0;
+  std::size_t threshold_memory_usage_ = 0;
+  std::size_t last_memory_usage_poll_ = 0;
 };
 
 }} //end namespace vt::scheduler

--- a/src/vt/utils/memory/memory_units.cc
+++ b/src/vt/utils/memory/memory_units.cc
@@ -60,4 +60,13 @@ std::string getMemoryUnitName(MemoryUnitEnum unit) {
   return memory_unit_names[unit];
 }
 
+MemoryUnitEnum getUnitFromString(std::string unit) {
+  for (auto&& elm : memory_unit_names) {
+    if (unit == elm.second) {
+      return elm.first;
+    }
+  }
+  return MemoryUnitEnum::Bytes;
+}
+
 }}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_units.cc
+++ b/src/vt/utils/memory/memory_units.cc
@@ -60,7 +60,7 @@ std::string getMemoryUnitName(MemoryUnitEnum unit) {
   return memory_unit_names[unit];
 }
 
-MemoryUnitEnum getUnitFromString(std::string unit) {
+MemoryUnitEnum getUnitFromString(std::string const& unit) {
   for (auto&& elm : memory_unit_names) {
     if (unit == elm.second) {
       return elm.first;

--- a/src/vt/utils/memory/memory_units.cc
+++ b/src/vt/utils/memory/memory_units.cc
@@ -50,7 +50,7 @@
 namespace vt { namespace util { namespace memory {
 
 std::unordered_map<MemoryUnitEnum, std::string> memory_unit_names = {
-  {MemoryUnitEnum::Bytes,     std::string{"bytes"}},
+  {MemoryUnitEnum::Bytes,     std::string{"B"}},
   {MemoryUnitEnum::Kilobytes, std::string{"KiB"}},
   {MemoryUnitEnum::Megabytes, std::string{"MiB"}},
   {MemoryUnitEnum::Gigabytes, std::string{"GiB"}}

--- a/src/vt/utils/memory/memory_units.h
+++ b/src/vt/utils/memory/memory_units.h
@@ -59,6 +59,7 @@ enum struct MemoryUnitEnum : int8_t {
 };
 
 std::string getMemoryUnitName(MemoryUnitEnum unit);
+MemoryUnitEnum getUnitFromString(std::string unit);
 
 }}} /* end namespace vt::util::memory */
 

--- a/src/vt/utils/memory/memory_units.h
+++ b/src/vt/utils/memory/memory_units.h
@@ -59,7 +59,7 @@ enum struct MemoryUnitEnum : int8_t {
 };
 
 std::string getMemoryUnitName(MemoryUnitEnum unit);
-MemoryUnitEnum getUnitFromString(std::string unit);
+MemoryUnitEnum getUnitFromString(std::string const& unit);
 
 }}} /* end namespace vt::util::memory */
 

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -425,6 +425,18 @@ std::vector<std::string> MemoryUsage::getWorkingReporters() {
   return working;
 }
 
+std::size_t MemoryUsage::convertBytesFromString(std::string const& in) {
+  double val = 0.0;
+  std::string units = "";
+  std::istringstream iss(in);
+  iss >> val >> units;
+  auto unit = getUnitFromString(units);
+  for (int8_t i = 0; i < static_cast<int8_t>(unit); i++) {
+    val *= 1024.0;
+  }
+  return static_cast<std::size_t>(val);
+}
+
 bool MemoryUsage::hasWorkingReporter() const {
   return first_valid_reporter_ != -1;
 }

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -126,6 +126,8 @@ struct MemoryUsage {
 
   std::vector<std::string> getWorkingReporters();
 
+  std::size_t convertBytesFromString(std::string const& in);
+
   static MemoryUsage* get();
 
   static void initialize();

--- a/tests/perf/memory_checker.cc
+++ b/tests/perf/memory_checker.cc
@@ -75,11 +75,13 @@ int main(int argc, char** argv) {
     for (int i = 0; i < 32; i++) {
       allocateAndTouch(1024 * 1024 * 64);
       fmt::print("After alloc {} MiB: {}\n", (i + 1) * 64, usage->getUsageAll());
+      vt::runScheduler();
     }
 
     for (int i = 0; i < 32; i++) {
       deallocate();
       fmt::print("After de-alloc {} MiB: {}\n", (32 * 64) - (i + 1) * 64, usage->getUsageAll());
+      vt::runScheduler();
     }
   }
 


### PR DESCRIPTION
Fixes #738 

In EMPIRE, @nlslatt and I realized that it would help to be able to see when memory usage crosses some threshold increment to track if memory usage is blowing up.

Add three new opt-in arguments:
* `--vt_print_memory_at_threshold` : enable prints at a memory threshold
* `--vt_print_memory_sched_poll=100` : check memory usage every 100 scheduler polls (certain memory reporters can be expensive so this gives control to the user)
* `--vt_print_memory_threshold="1.2 GiB"` : whenever the first memory usage reporter crosses an increment of 1.2 GiB (up or down), VT will print to screen the current usage

Prints look like this (run for ever 1 GiB):
```
vt: [0] general: Memory usage (+) mstats=1028.92 machinfo=1047.39 getrusage=1047.39 (MiB)
vt: [0] general: Memory usage (-) mstats=900.919 machinfo=2071.4 getrusage=2071.4 (MiB)
```
