### PR TITLE
740 Add debugging for buffered messages

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -68,6 +68,7 @@ namespace vt { namespace arguments {
 /*static*/ bool        ArgConfig::vt_print_memory_each_phase = false;
 /*static*/ std::string ArgConfig::vt_print_memory_node  = "0";
 /*static*/ bool        ArgConfig::vt_allow_memory_report_with_ps = false;
+/*static*/ bool        ArgConfig::vt_print_buffered_msgs = false;
 
 /*static*/ bool        ArgConfig::vt_no_warn_stack      = false;
 /*static*/ bool        ArgConfig::vt_no_assert_stack    = false;
@@ -183,13 +184,16 @@ namespace vt { namespace arguments {
   auto quiet  = "Quiet the output from vt (only errors, warnings)";
   auto always = "Colorize output (default)";
   auto never  = "Do not colorize output (overrides --vt_color)";
+  auto buffer = "Print debugging info about buffered messages";
   auto a  = app.add_flag("-c,--vt_color",      vt_color,      always);
   auto b  = app.add_flag("-n,--vt_no_color",   vt_no_color,   never);
   auto a1 = app.add_flag("-q,--vt_quiet",      vt_quiet,      quiet);
+  auto a2 = app.add_flag("--vt_print_buffered_msgs", vt_print_buffered_msgs, buffer);
   auto outputGroup = "Output Control";
   a->group(outputGroup);
   b->group(outputGroup);
   a1->group(outputGroup);
+  a2->group(outputGroup);
   b->excludes(a);
 
   /*

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -73,6 +73,7 @@ public:
   static bool vt_print_memory_each_phase;
   static std::string vt_print_memory_node;
   static bool vt_allow_memory_report_with_ps;
+  static bool vt_print_buffered_msgs;
 
   static bool vt_no_warn_stack;
   static bool vt_no_assert_stack;

--- a/src/vt/topos/location/location.h
+++ b/src/vt/topos/location/location.h
@@ -82,6 +82,7 @@ struct EntityLocationCoord : LocationCoord {
   using PendingLocLookupsType = std::unordered_map<EntityID, ActionListType>;
   using ActionContainerType = std::unordered_map<LocEventID, PendingType>;
   using LocMsgType = LocationMsg<EntityID>;
+  using ArgConfig = arguments::ArgConfig;
 
   template <typename MessageT>
   using EntityMsgType = EntityMsg<EntityID, MessageT>;

--- a/src/vt/topos/location/location.impl.h
+++ b/src/vt/topos/location/location.impl.h
@@ -61,6 +61,9 @@
 
 namespace vt { namespace location {
 
+// buffer ID for tracking buffered messages
+static uint64_t buffer_id_ = 0;
+
 template <typename EntityID>
 EntityLocationCoord<EntityID>::EntityLocationCoord()
   : EntityLocationCoord<EntityID>( LocationManager::cur_loc_inst++ )
@@ -70,7 +73,17 @@ template <typename EntityID>
 EntityLocationCoord<EntityID>::EntityLocationCoord(
   collection_lm_tag_t, LocInstType identifier
 ) : EntityLocationCoord<EntityID>(identifier)
-{ }
+{
+  if (ArgConfig::vt_print_buffered_msgs) {
+    if (buffer_id_ == 0) {
+      // Stamp in the NodeType bits for this_node in the high bits to create a
+      // globally distinct buffer identifier
+      auto node_stamp = static_cast<decltype(buffer_id_)>(theContext()->getNode());
+      node_stamp <<= (sizeof(decltype(buffer_id_)) - sizeof(NodeType)) * 8;
+      buffer_id_ |= node_stamp;
+    }
+  }
+}
 
 template <typename EntityID>
 EntityLocationCoord<EntityID>::EntityLocationCoord(LocInstType const identifier)
@@ -427,7 +440,26 @@ void EntityLocationCoord<EntityID>::routeMsgNode(
 
     theTerm()->produce(epoch);
 
+    auto this_buffer_id_ = buffer_id_++;
+    if (ArgConfig::vt_print_buffered_msgs) {
+      vt_print(
+        location,
+        "routeMsgNode (trigger): buffering {:x} send to id={}, home={}, "
+        "to={}\n",
+        this_buffer_id_, id, home_node, to_node
+      );
+    }
+
     auto trigger_msg_handler_action = [=](EntityID const& hid) {
+      if (ArgConfig::vt_print_buffered_msgs) {
+        vt_print(
+          location,
+          "routeMsgNode (trigger): unbuffering {:x} send to id={}, home={}, "
+          "to={}\n",
+          this_buffer_id_, id, home_node, to_node
+        );
+      }
+
       bool const& has_handler = msg->hasHandler();
       auto const& from = msg->getLocFromNode();
       if (has_handler) {
@@ -481,8 +513,28 @@ void EntityLocationCoord<EntityID>::routeMsgNode(
       );
 
       EntityID id_ = id;
+
+      auto this_buffer_id_2_ = buffer_id_++;
+      if (ArgConfig::vt_print_buffered_msgs) {
+        vt_print(
+          location,
+          "routeMsgNode (no-reg): buffering {:x} send to id={}, home={}, "
+          "to={}\n",
+          this_buffer_id_2_, id_, home_node, to_node
+        );
+      }
+
       // buffer the message here, the entity will be registered in the future
       insertPendingEntityAction(id_, [=](NodeType resolved) {
+        if (ArgConfig::vt_print_buffered_msgs) {
+          vt_print(
+            location,
+            "routeMsgNode (no-reg): unbuffering {:x} send to id={}, home={}, "
+            "to={}\n",
+            this_buffer_id_2_, id_, home_node, to_node
+          );
+        }
+
         auto const& my_node = theContext()->getNode();
 
         debug_print(
@@ -514,7 +566,23 @@ template <typename EntityID>
 void EntityLocationCoord<EntityID>::routeNonEagerAction(
   EntityID const& id, NodeType const& home_node, ActionNodeType action
 ) {
+  auto this_buffer_id_ = buffer_id_++;
+  if (ArgConfig::vt_print_buffered_msgs) {
+    vt_print(
+      location,
+      "getLocation (non-eager): buffering {:x} send to id={}, home={}\n",
+      this_buffer_id_, id, home_node
+    );
+  }
+
   getLocation(id, home_node, [=](NodeType node) {
+    if (ArgConfig::vt_print_buffered_msgs) {
+      vt_print(
+        location,
+        "getLocation (non-eager): unbuffering {:x} send to id={}, home={}, \n",
+        this_buffer_id_, id, home_node
+      );
+    }
     action(node);
   });
 }
@@ -603,8 +671,25 @@ void EntityLocationCoord<EntityID>::routeMsg(
     theMsg()->popEpoch(epoch);
   } else {
     theTerm()->produce(epoch);
+
+    auto this_buffer_id_ = buffer_id_++;
+    if (ArgConfig::vt_print_buffered_msgs) {
+      vt_print(
+        location,
+        "getLocation: buffering {:x} send to id={}, home={}, from={}\n",
+        this_buffer_id_, id, home_node, from_node
+      );
+    }
+
     // non-eager protocol: get location first then send message after resolution
     getLocation(id, home_node, [=](NodeType node) {
+      if (ArgConfig::vt_print_buffered_msgs) {
+        vt_print(
+          location,
+          "getLocation: unbuffering {:x} send to id={}, home={}, from={}\n",
+          this_buffer_id_, id, home_node, from_node
+        );
+      }
       theMsg()->pushEpoch(epoch);
       routeMsgNode<MessageT>(serialize, id, home_node, node, msg);
       theMsg()->popEpoch(epoch);
@@ -727,7 +812,26 @@ template <typename EntityID>
         event_id, epoch
       );
 
+      auto this_buffer_id_ = buffer_id_++;
+      if (ArgConfig::vt_print_buffered_msgs) {
+        vt_print(
+          location,
+          "getLocation (get-loc-han): buffering {:x} send to id={}, home={}, "
+          "ask={}\n",
+          this_buffer_id_, entity, home_node, ask_node
+        );
+      }
+
       loc->getLocation(entity, home_node, [=](NodeType node) {
+        if (ArgConfig::vt_print_buffered_msgs) {
+          vt_print(
+            location,
+            "getLocation (get-loc-han): unbuffering {:x} send to id={}, home={}, "
+            "ask={}\n",
+            this_buffer_id_, entity, home_node, ask_node
+          );
+        }
+
         debug_print(
           location, node,
           "getLocation: (action) event_id={}, epoch={:x}\n",

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -53,6 +53,14 @@ namespace vt { namespace vrt { namespace collection {
 
 CollectionManager::CollectionManager() {
   balance::LBManager::init();
+
+  if (ArgType::vt_print_buffered_msgs) {
+    // Stamp in the NodeType bits for this_node in the high bits to create a
+    // globally distinct buffer identifier
+    auto node_stamp = static_cast<decltype(buffer_id_)>(theContext()->getNode());
+    node_stamp <<= (sizeof(decltype(buffer_id_)) - sizeof(NodeType)) * 8;
+    buffer_id_ |= node_stamp;
+  }
 }
 
 /*virtual*/ CollectionManager::~CollectionManager() {

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -878,6 +878,7 @@ private:
   std::unordered_map<VirtualProxyType,ActionType> release_lb_ = {};
   balance::ElementIDType cur_context_temp_elm_id_ = balance::no_element_id;
   balance::ElementIDType cur_context_perm_elm_id_ = balance::no_element_id;
+  uint64_t buffer_id_ = 0;
 };
 
 // These are static variables in class templates because Intel 18

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1547,9 +1547,26 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
       toProxy.getCollectionProxy()
     );
 
+    auto this_buffer_id_ = buffer_id_++;
+    if (ArgType::vt_print_buffered_msgs) {
+      vt_print(
+        vrt_coll,
+        "not ready: buffering {:x} send to col_proxy={:x}, elm={}\n",
+        this_buffer_id_, col_proxy, elm_proxy.getIndex()
+      );
+    }
+
     theTerm()->produce(cur_epoch);
 
     iter->second.push_back([=](VirtualProxyType /*ignored*/){
+      if (ArgType::vt_print_buffered_msgs) {
+        vt_print(
+          vrt_coll,
+          "ready: unbuffering {:x} send to col_proxy={:x}, elm={}\n",
+          this_buffer_id_, col_proxy, elm_proxy.getIndex()
+        );
+      }
+
       theMsg()->pushEpoch(cur_epoch);
       theCollection()->sendMsgUntypedHandler<MsgT,ColT,IdxT>(
         toProxy, msg.get(), handler, member, false


### PR DESCRIPTION
Fixes #740 

New argument `--vt_print_buffered_msgs` will print every time a message is buffered and unbuffered with a unique global identifier and region in the code where it was buffered.