### PR TITLE
665 - Unify Message Lifetimes / MsgPtr

### DIFF
--- a/src/vt/collective/barrier/barrier.cc
+++ b/src/vt/collective/barrier/barrier.cc
@@ -213,7 +213,7 @@ void Barrier::barrierUp(
 
   if (is_ready) {
     if (not is_root) {
-      auto msg = makeSharedMessage<BarrierMsg>(is_named, barrier, is_wait);
+      auto msg = makeMessage<BarrierMsg>(is_named, barrier, is_wait);
       // system-level barriers can choose to skip the termination protocol
       if (skip_term) {
         theMsg()->markAsTermMessage(msg);
@@ -222,9 +222,9 @@ void Barrier::barrierUp(
         barrier, node,
         "barrierUp: barrier={}\n", barrier
       );
-      theMsg()->sendMsg<BarrierMsg, barrierUp>(parent, msg);
+      theMsg()->sendMsg<BarrierMsg, barrierUp>(parent, msg.get());
     } else {
-      auto msg = makeSharedMessage<BarrierMsg>(is_named, barrier, is_wait);
+      auto msg = makeMessage<BarrierMsg>(is_named, barrier, is_wait);
       // system-level barriers can choose to skip the termination protocol
       if (skip_term) {
         theMsg()->markAsTermMessage(msg);
@@ -233,7 +233,7 @@ void Barrier::barrierUp(
         barrier, node,
         "barrierDown: barrier={}\n", barrier
       );
-      theMsg()->broadcastMsg<BarrierMsg, barrierDown>(msg);
+      theMsg()->broadcastMsg<BarrierMsg, barrierDown>(msg.get());
       barrierDown(is_named, is_wait, barrier);
     }
   }

--- a/src/vt/collective/scatter/scatter.cc
+++ b/src/vt/collective/scatter/scatter.cc
@@ -93,7 +93,7 @@ void Scatter::scatterIn(ScatterMsg* msg) {
   Tree::foreachChild([&](NodeType child) {
     auto const& num_children = getNumTotalChildren(child) + 1;
     auto const& child_bytes_size = num_children * elm_size;
-    auto child_msg = makeSharedMessageSz<ScatterMsg>(
+    auto child_msg = makeMessageSz<ScatterMsg>(
       child_bytes_size, child_bytes_size, elm_size
     );
     debug_print(
@@ -102,10 +102,10 @@ void Scatter::scatterIn(ScatterMsg* msg) {
       child, num_children, child_bytes_size
     );
     auto const child_remaining_size = thePool()->remainingSize(
-      reinterpret_cast<void*>(child_msg)
+      reinterpret_cast<void*>(child_msg.get())
     );
     child_msg->user_han = user_handler;
-    auto ptr = reinterpret_cast<char*>(child_msg) + sizeof(ScatterMsg);
+    auto ptr = reinterpret_cast<char*>(child_msg.get()) + sizeof(ScatterMsg);
     debug_print(
       scatter, node,
       "Scatter::scatterIn: child={}, num_children={}, elm_size={}, "
@@ -116,7 +116,7 @@ void Scatter::scatterIn(ScatterMsg* msg) {
     std::memcpy(ptr, in_ptr, child_bytes_size);
     in_ptr += child_bytes_size;
     theMsg()->sendMsgSz<ScatterMsg,scatterHandler>(
-      child, child_msg, sizeof(ScatterMsg) + child_bytes_size
+      child, child_msg.get(), sizeof(ScatterMsg) + child_bytes_size
     );
   });
   auto active_fn = auto_registry::getAutoHandler(user_handler);

--- a/src/vt/event/event.cc
+++ b/src/vt/event/event.cc
@@ -105,7 +105,7 @@ EventType AsyncEvent::attachAction(EventType const& event, ActionType callable) 
     holder.attachAction(trigger);
 
     auto const& owning_node = getOwningNode(event);
-    auto msg = makeSharedMessage<EventCheckFinishedMsg>(
+    auto msg = makeMessage<EventCheckFinishedMsg>(
       event, this_node, event_id
     );
 
@@ -116,7 +116,7 @@ EventType AsyncEvent::attachAction(EventType const& event, ActionType callable) 
     );
 
     theMsg()->sendMsg<EventCheckFinishedMsg, checkEventFinished>(
-      owning_node, msg
+      owning_node, msg.get()
     );
   }
     break;
@@ -148,11 +148,11 @@ EventType AsyncEvent::attachAction(EventType const& event, ActionType callable) 
   );
 
   auto send_back_fun = [=]{
-    auto msg_send = makeSharedMessage<EventFinishedMsg>(event, msg->event_back_);
+    auto msg_send = makeMessage<EventFinishedMsg>(event, msg->event_back_);
     auto send_back = theEvent()->getOwningNode(msg->event_back_);
     vtAssertExpr(send_back == msg->sent_from_node_);
     theMsg()->sendMsg<EventFinishedMsg, eventFinished>(
-      send_back, msg_send
+      send_back, msg_send.get()
     );
   };
 

--- a/src/vt/event/event_record.cc
+++ b/src/vt/event/event_record.cc
@@ -91,7 +91,7 @@ bool EventRecord::testMPIEventReady() {
 
   bool const mpiready = flag == 1;
 
-  if (mpiready and msg_ != nullptr and isSharedMessage(msg_.get())) {
+  if (mpiready and msg_ != nullptr) {
     debug_print_verbose(
       active, node,
       "testMPIEventRead: deref: msg={}\n",

--- a/src/vt/group/collective/group_collective_finished.cc
+++ b/src/vt/group/collective/group_collective_finished.cc
@@ -63,11 +63,11 @@ void InfoColl::CollSetupFinished::operator()(FinishedReduceMsg* msg) {
   auto const& this_node = theContext()->getNode();
   auto info = iter->second.get();
   if (info->known_root_node_ != this_node) {
-    auto nmsg = makeSharedMessage<GroupOnlyMsg>(
+    auto nmsg = makeMessage<GroupOnlyMsg>(
       msg->getGroup(),info->new_tree_cont_
     );
     theMsg()->sendMsg<GroupOnlyMsg,InfoColl::newTreeHan>(
-      info->known_root_node_,nmsg
+      info->known_root_node_,nmsg.get()
     );
   } else {
     info->newTree(-1);

--- a/src/vt/group/collective/group_info_collective.cc
+++ b/src/vt/group/collective/group_info_collective.cc
@@ -210,10 +210,10 @@ void InfoColl::setupCollective() {
   if (collective_->getInitialChildren() == 0) {
     auto const& size = static_cast<NodeType>(is_in_group ? 1 : 0);
     auto const& child = theContext()->getNode();
-    auto msg = makeSharedMessage<GroupCollectiveMsg>(
+    auto msg = makeMessage<GroupCollectiveMsg>(
       group_, up_tree_cont_, in_group, size, child
     );
-    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(parent, msg);
+    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(parent, msg.get());
   }
 }
 
@@ -316,10 +316,10 @@ void InfoColl::upTree() {
       auto const& extra = static_cast<GroupCollectiveMsg::CountType>(
         msg_in_group.size()-1
       );
-      auto msg = makeSharedMessage<GroupCollectiveMsg>(
+      auto msg = makeMessage<GroupCollectiveMsg>(
         group,new_root_cont_,true,subtree_zero,root_node,0,extra
       );
-      theMsg()->sendMsg<GroupCollectiveMsg,newRootHan>(root_node, msg);
+      theMsg()->sendMsg<GroupCollectiveMsg,newRootHan>(root_node, msg.get());
 
       for (std::size_t i = 1; i < msg_list.size(); i++) {
         debug_print(
@@ -356,10 +356,10 @@ void InfoColl::upTree() {
       subtree_, total_subtree
     );
 
-    auto cmsg = makeSharedMessage<GroupCollectiveMsg>(
+    auto cmsg = makeMessage<GroupCollectiveMsg>(
       group,op,is_in_group,total_subtree,child,level
     );
-    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, cmsg);
+    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, cmsg.get());
 
     for (auto&& msg : msg_in_group) {
       span_children_.push_back(msg->getChild());
@@ -385,10 +385,10 @@ void InfoColl::upTree() {
       subtree_
     );
 
-    auto msg = makeSharedMessage<GroupCollectiveMsg>(
+    auto msg = makeMessage<GroupCollectiveMsg>(
       group,op,is_in_group,static_cast<NodeType>(subtree_),child,0,extra
     );
-    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg);
+    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg.get());
     /*
      *  Forward all the children messages up the tree (up to 2 of them)
      */
@@ -415,10 +415,10 @@ void InfoColl::upTree() {
       subtree_, total_subtree
     );
 
-    auto msg = makeSharedMessage<GroupCollectiveMsg>(
+    auto msg = makeMessage<GroupCollectiveMsg>(
       group,op,is_in_group,total_subtree,child,0,extra
     );
-    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg);
+    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg.get());
     theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg_in_group[0].get());
   } else {
     vtAssertExpr(msg_in_group.size() > 2);
@@ -453,10 +453,10 @@ void InfoColl::upTree() {
       subtree_, total_subtree
     );
 
-    auto msg = makeSharedMessage<GroupCollectiveMsg>(
+    auto msg = makeMessage<GroupCollectiveMsg>(
       group,op,is_in_group,total_subtree,child,0,extra
     );
-    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg);
+    theMsg()->sendMsg<GroupCollectiveMsg,upHan>(p, msg.get());
 
     debug_print(
       group, node,
@@ -611,14 +611,14 @@ void InfoColl::downTree(GroupCollectiveMsg* msg) {
   } else {
     auto const& num = collective_->span_children_.size();
     auto const& child = collective_->span_children_[msg->getChild() % num];
-    auto nmsg = makeSharedMessage<GroupCollectiveMsg>(*msg);
-    theMsg()->sendMsg<GroupCollectiveMsg,downHan>(child,nmsg);
+    auto nmsg = makeMessage<GroupCollectiveMsg>(*msg);
+    theMsg()->sendMsg<GroupCollectiveMsg,downHan>(child,nmsg.get());
     ++send_down_;
   }
 
   auto const& group_ = getGroupID();
-  auto nmsg = makeSharedMessage<GroupOnlyMsg>(group_,down_tree_fin_cont_);
-  theMsg()->sendMsg<GroupOnlyMsg,downFinishedHan>(from,nmsg);
+  auto nmsg = makeMessage<GroupOnlyMsg>(group_,down_tree_fin_cont_);
+  theMsg()->sendMsg<GroupOnlyMsg,downFinishedHan>(from,nmsg.get());
 }
 
 void InfoColl::newTree(NodeType const& parent) {
@@ -654,8 +654,8 @@ void InfoColl::sendDownNewTree() {
       "InfoColl::sendDownNewTree: group={:x}, sending to child={}\n",
       group_, c
     );
-    auto msg = makeSharedMessage<GroupOnlyMsg>(group_,new_tree_cont_);
-    theMsg()->sendMsg<GroupOnlyMsg,newTreeHan>(c,msg);
+    auto msg = makeMessage<GroupOnlyMsg>(group_,new_tree_cont_);
+    theMsg()->sendMsg<GroupOnlyMsg,newTreeHan>(c,msg.get());
   }
 }
 
@@ -693,10 +693,10 @@ void InfoColl::finalize() {
         group_, c
       );
 
-      auto msg = makeSharedMessage<GroupOnlyMsg>(
+      auto msg = makeMessage<GroupOnlyMsg>(
         group_,finalize_cont_,known_root_node_,is_default_group_
       );
-      theMsg()->sendMsg<GroupOnlyMsg,finalizeHan>(c,msg);
+      theMsg()->sendMsg<GroupOnlyMsg,finalizeHan>(c,msg.get());
     }
 
     if (!is_in_group) {

--- a/src/vt/group/global/group_default.impl.h
+++ b/src/vt/group/global/group_default.impl.h
@@ -64,9 +64,9 @@ template <typename MsgT, ActiveTypedFnType<MsgT>* handler>
     envelopeSetTag(msg.get()->env, phase);
     handler(msg.get());
   } else {
-    auto msg = makeSharedMessage<MsgT>();
+    auto msg = makeMessage<MsgT>();
     envelopeSetTag(msg->env, phase);
-    theMsg()->sendMsg<MsgT, handler>(node, msg);
+    theMsg()->sendMsg<MsgT, handler>(node, msg.get());
   }
 }
 

--- a/src/vt/group/group_info.impl.h
+++ b/src/vt/group/group_info.impl.h
@@ -115,8 +115,10 @@ template <typename MsgT>
 
     if (op_id != no_op_id) {
       // Send back message
-      auto retmsg = makeSharedMessage<GroupOnlyMsg>(group, op_id);
-      theMsg()->sendMsg<GroupOnlyMsg, Info::groupTriggerHandler>(parent, retmsg);
+      auto retmsg = makeMessage<GroupOnlyMsg>(group, op_id);
+      theMsg()->sendMsg<GroupOnlyMsg, Info::groupTriggerHandler>(
+        parent, retmsg.get()
+      );
     }
   } else {
     debug_print(

--- a/src/vt/lb/instrumentation/centralized/collect.cc
+++ b/src/vt/lb/instrumentation/centralized/collect.cc
@@ -107,9 +107,11 @@ namespace vt { namespace lb { namespace instrumentation {
   return startReduce(phase);
 }
 
-/*static*/ CollectMsg* CentralCollect::collectStats(LBPhaseType const& phase) {
+/*static*/ MsgSharedPtr<CollectMsg> CentralCollect::collectStats(
+  LBPhaseType const& phase
+) {
   auto const& node = theContext()->getNode();
-  auto msg = makeSharedMessage<CollectMsg>(phase);
+  auto msg = makeMessage<CollectMsg>(phase);
   auto node_cont_iter = msg->entries_.find(node);
   vtAssert(
     node_cont_iter == msg->entries_.end(),
@@ -150,7 +152,7 @@ namespace vt { namespace lb { namespace instrumentation {
   auto msg = CentralCollect::collectStats(phase);
   theCollective()->global()->
     reduce<CollectMsg, CentralCollect::centralizedCollect>(
-      root, msg
+      root, msg.get()
     );
 }
 

--- a/src/vt/lb/instrumentation/centralized/collect.h
+++ b/src/vt/lb/instrumentation/centralized/collect.h
@@ -56,7 +56,7 @@ namespace vt { namespace lb { namespace instrumentation {
 struct CentralCollect {
   static void startReduce(LBPhaseType const& phase);
   static void reduceCurrentPhase();
-  static CollectMsg* collectStats(LBPhaseType const& phase);
+  static MsgSharedPtr<CollectMsg> collectStats(LBPhaseType const& phase);
   static void collectFinished(
     LBPhaseType const& phase, ProcContainerType const& entries
   );

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -437,8 +437,8 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    *     // collective invocation across nodes
    *     HandlerType const han = registerNewHandler(my_handler);
    *
-   *     MyMsg* msg = makeSharedMessage<MyMsg>(156);
-   *     theMsg()->sendMsg(29, han, msg);
+   *     auto msg = makeMessage<MyMsg>(156);
+   *     theMsg()->sendMsg(29, han, msg.get());
    *   }
    * \endcode
    * @{

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -179,6 +179,7 @@ struct BufferedActiveMsg {
 };
 
 /**
+ * \internal
  * \struct ActiveMessenger active.h vt/messaging/active.h
  *
  * \brief Core component of VT used to send messages.
@@ -230,7 +231,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   std::string name() override { return "ActiveMessenger"; }
 
   /**
-   * \internal
    * \brief Mark a message as a termination message.
    *
    * Used to ignore certain messages for the sake of termination detection
@@ -239,13 +239,13 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    *
    * \param[in] msg the message to mark as a termination message
    */
-  template <typename MsgT>
-  void markAsTermMessage(MsgT* msg);
+  template <typename MsgPtrT>
+  void markAsTermMessage(MsgPtrT const msg);
 
   /**
    * \brief Mark a message as a location message
    *
-   * \param[in,out] msg  the message to mark as a location message
+   * \param[in] msg the message to mark as a location message
    */
   template <typename MsgPtrT>
   void markAsLocationMessage(MsgPtrT const msg);
@@ -253,7 +253,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   /**
    * \brief Mark a message as a serialization control message
    *
-   * \param[in,out] msg  the message to mark as a serialization control message
+   * \param[in] msg the message to mark as a serialization control message
    */
   template <typename MsgPtrT>
   void markAsSerialMsgMessage(MsgPtrT const msg);
@@ -261,13 +261,12 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   /**
    * \brief Mark a message as a collection message
    *
-   * \param[in,out] msg  the message to mark as a collection message
+   * \param[in] msg the message to mark as a collection message
    */
   template <typename MsgPtrT>
   void markAsCollectionMessage(MsgPtrT const msg);
 
   /**
-   * \internal
    * \brief Set the epoch in the envelope of a message
    *
    * \param[in] msg the message to mark the epoch on (envelope must be able to hold)
@@ -286,13 +285,10 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   template <typename MsgT>
   void setTagMessage(MsgT* msg, TagType tag);
 
-  template <typename MessageT>
-  ActiveMessenger::PendingSendType sendMsgCopyableImpl(
-    NodeType dest,
-    HandlerType han,
-    MsgSharedPtr<MessageT>& msg,
-    ByteType msg_size,
-    TagType tag
+  template <typename MsgPtrT>
+  trace::TraceEventIDType makeTraceCreationSend(
+    MsgPtrT msg, HandlerType const handler, auto_registry::RegistryTypeEnum type,
+    MsgSizeType msg_size, bool is_bcast
   );
 
   // With serialization, the correct method is resolved via SFINAE.
@@ -411,6 +407,15 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
 #endif
     return sendMsgCopyableImpl<MessageT>(dest, han, msg, msg_size, tag);
   }
+
+  template <typename MessageT>
+  ActiveMessenger::PendingSendType sendMsgCopyableImpl(
+    NodeType dest,
+    HandlerType han,
+    MsgSharedPtr<MessageT>& msg,
+    ByteType msg_size,
+    TagType tag
+  );
 
   /**
    * \defgroup preregister Basic Active Message Send with Pre-Registered Handler
@@ -1483,12 +1488,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   void clearListeners() {
     send_listen_.clear();
   }
-
-  template <typename MsgPtrT>
-  trace::TraceEventIDType makeTraceCreationSend(
-    MsgPtrT msg, HandlerType const handler, auto_registry::RegistryTypeEnum type,
-    MsgSizeType msg_size, bool is_bcast
-  );
 
 private:
   bool testPendingActiveMsgAsyncRecv();

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -58,8 +58,8 @@ namespace vt { namespace messaging {
 constexpr ByteType msgsize_not_specified = -1;
 constexpr NodeType broadcast_dest = uninitialized_destination;
 
-template <typename MsgT>
-void ActiveMessenger::markAsTermMessage(MsgT* msg) {
+template <typename MsgPtrT>
+void ActiveMessenger::markAsTermMessage(MsgPtrT const msg) {
   setTermType(msg->env);
 #if backend_check_enabled(priorities)
   envelopeSetPriority(msg->env, sys_min_priority);
@@ -91,6 +91,16 @@ void ActiveMessenger::markAsCollectionMessage(MsgPtrT const msg) {
 #endif
 }
 
+template <typename MsgT>
+void ActiveMessenger::setEpochMessage(MsgT* msg, EpochType epoch) {
+  envelopeSetEpoch(msg->env, epoch);
+}
+
+template <typename MsgT>
+void ActiveMessenger::setTagMessage(MsgT* msg, TagType tag) {
+  envelopeSetTag(msg->env, tag);
+}
+
 template <typename MsgPtrT>
 trace::TraceEventIDType ActiveMessenger::makeTraceCreationSend(
   MsgPtrT msg, HandlerType const handler, auto_registry::RegistryTypeEnum type,
@@ -108,16 +118,6 @@ trace::TraceEventIDType ActiveMessenger::makeTraceCreationSend(
   #else
     return trace::no_trace_event;
   #endif
-}
-
-template <typename MsgT>
-void ActiveMessenger::setEpochMessage(MsgT* msg, EpochType epoch) {
-  envelopeSetEpoch(msg->env, epoch);
-}
-
-template <typename MsgT>
-void ActiveMessenger::setTagMessage(MsgT* msg, TagType tag) {
-  envelopeSetTag(msg->env, tag);
 }
 
 template <typename MessageT>

--- a/src/vt/messaging/envelope/envelope_base.h
+++ b/src/vt/messaging/envelope/envelope_base.h
@@ -79,18 +79,21 @@ struct ActiveEnvelope {
   /// The associated group: may imply a non-standard spanning tree or node subset
   GroupType group       : group_num_bits;
 
-# if backend_check_enabled(priorities)
+#if backend_check_enabled(priorities)
   /// The priority level for this message, used to interpret \c PriorityType
   PriorityLevelType priority_level : priority_level_num_bits;
   /// Bitmask that represents the priority this should be processed as
   PriorityType      priority       : priority_num_bits;
-# endif
+#endif
 
-# if backend_check_enabled(trace_enabled)
+#if backend_check_enabled(trace_enabled)
   /// The trace event for the message for tracking dependencies
   trace::TraceEventIDType trace_event : trace::trace_event_num_bits;
   bool trace_rt_enabled               : 1;
-# endif
+#endif
+
+  /// True iff serialization is performed (through to base type).
+  bool has_been_serialized : 1;
 };
 
 }} /* end namespace vt::messaging */

--- a/src/vt/messaging/envelope/envelope_extended.h
+++ b/src/vt/messaging/envelope/envelope_extended.h
@@ -54,7 +54,7 @@
 namespace vt { namespace messaging {
 
 // Envelope type requirements:
-// - All envelops must have an 'ActiveEnvelope env' field as the FIRST field.
+// - All envelopes must have an 'ActiveEnvelope env' field as the FIRST field.
 
 /** \file */
 

--- a/src/vt/messaging/envelope/envelope_extended.h
+++ b/src/vt/messaging/envelope/envelope_extended.h
@@ -54,7 +54,7 @@
 namespace vt { namespace messaging {
 
 // Envelope type requirements:
-// - All envelops must have an 'ActiveEnvelope env' field.
+// - All envelops must have an 'ActiveEnvelope env' field as the FIRST field.
 
 /** \file */
 

--- a/src/vt/messaging/envelope/envelope_extended.h
+++ b/src/vt/messaging/envelope/envelope_extended.h
@@ -53,6 +53,9 @@
 
 namespace vt { namespace messaging {
 
+// Envelope type requirements:
+// - All envelops must have an 'ActiveEnvelope env' field.
+
 /** \file */
 
 /**
@@ -69,7 +72,7 @@ struct EpochActiveEnvelope {
 };
 
 /**
- * \struct EpochActiveEnvelope
+ * \struct TagActiveEnvelope
  *
  * \brief Extended envelope that holds a tag, contains all of \c ActiveEnvelope
  */
@@ -81,7 +84,7 @@ struct TagActiveEnvelope {
 };
 
 /**
- * \struct EpochActiveEnvelope
+ * \struct EpochTagActiveEnvelope
  *
  * \brief Extended envelope that holds an epoch and tag, contains all of \c
  * ActiveEnvelope

--- a/src/vt/messaging/envelope/envelope_extended_util.impl.h
+++ b/src/vt/messaging/envelope/envelope_extended_util.impl.h
@@ -99,20 +99,23 @@ inline void envelopeSetTag(Env& env, TagType const& tag) {
 inline void envelopeInitEmpty(EpochEnvelope& env) {
   envelopeInit(env);
   setEpochType(env);
+
   envelopeSetEpoch(env, no_epoch);
 }
 
 inline void envelopeInitEmpty(TagEnvelope& env) {
   envelopeInit(env);
   setTagType(env);
+
   envelopeSetTag(env, no_tag);
 }
 
 inline void envelopeInitEmpty(EpochTagEnvelope& env) {
   envelopeInit(env);
   setEpochType(env);
-  envelopeSetEpoch(env, no_epoch);
   setTagType(env);
+
+  envelopeSetEpoch(env, no_epoch);
   envelopeSetTag(env, no_tag);
 }
 

--- a/src/vt/messaging/envelope/envelope_ref.impl.h
+++ b/src/vt/messaging/envelope/envelope_ref.impl.h
@@ -52,12 +52,35 @@ namespace vt {
 
 template <typename Env>
 inline void envelopeRef(Env& env) {
-  (reinterpret_cast<Envelope*>(&env))->ref++;
+  Envelope* envp = reinterpret_cast<Envelope*>(&env);
+
+  vtAssert(
+    envp->ref != not_shared_message,
+    "'Not shared message' encountered on message ref-increment. "
+    "This is can be caused by explicitly using 'new Message(..)' "
+    "instead of a MsgPtr/makeMessage/makeSharedMessage construct."
+  );
+  vtAssertInfo(
+    envp->ref >= 0 and envp->ref < 100,
+    "Bad ref-count on message ref-increment. "
+    "Message ref-count must never be negative and cannnot exceed limit (100).",
+    static_cast<RefType>(envp->ref)
+  );
+
+  envp->ref++;
 }
 
 template <typename Env>
 inline RefType envelopeDeref(Env& env) {
-  return --(reinterpret_cast<Envelope*>(&env))->ref;
+  Envelope* envp = reinterpret_cast<Envelope*>(&env);
+
+  vtAssertInfo(
+    envp->ref >= 1,
+    "Bad ref-count on message ref-decrement.",
+    static_cast<RefType>(envp->ref)
+  );
+
+  return --(envp->ref);
 }
 
 } /* end namespace vt */

--- a/src/vt/messaging/envelope/envelope_set.h
+++ b/src/vt/messaging/envelope/envelope_set.h
@@ -197,6 +197,15 @@ template <typename Env>
 inline void envelopeSetTraceRuntimeEnabled(Env& env, bool is_trace_enabled);
 #endif
 
+/**
+ * \brief Set whether this message's base serializer has been called.
+ *
+ * \param[in,out] env the envelope
+ * \param[in] has_been_serialized value indicating message is serialized
+ */
+template <typename Env>
+inline void envelopeSetHasBeenSerialized(Env& env, bool has_been_serialized);
+
 } /* end namespace vt */
 
 #include "vt/messaging/envelope/envelope_set.impl.h"

--- a/src/vt/messaging/envelope/envelope_set.impl.h
+++ b/src/vt/messaging/envelope/envelope_set.impl.h
@@ -130,6 +130,11 @@ inline void envelopeSetTraceRuntimeEnabled(Env& env, bool is_trace_enabled) {
 }
 #endif
 
+template <typename Env>
+inline void envelopeSetHasBeenSerialized(Env& env, bool has_been_serialized) {
+  reinterpret_cast<Envelope*>(&env)->has_been_serialized = has_been_serialized;
+}
+
 } /* end namespace vt */
 
 #endif /*INCLUDED_MESSAGING_ENVELOPE_ENVELOPE_SET_IMPL_H*/

--- a/src/vt/messaging/envelope/envelope_setup.impl.h
+++ b/src/vt/messaging/envelope/envelope_setup.impl.h
@@ -66,14 +66,15 @@ inline void envelopeInit(Env& env) {
   envelopeSetHandler(env, uninitialized_handler);
   envelopeSetRef(env, not_shared_message);
   envelopeSetGroup(env);
-# if backend_check_enabled(priorities)
+#if backend_check_enabled(priorities)
   envelopeSetPriority(env, min_priority);
   envelopeSetPriorityLevel(env, 0);
-# endif
-# if backend_check_enabled(trace_enabled)
+#endif
+#if backend_check_enabled(trace_enabled)
   envelopeSetTraceRuntimeEnabled(env, true);
   envelopeSetTraceEvent(env, trace::no_trace_event);
-# endif
+#endif
+  envelopeSetHasBeenSerialized(env, false);
 }
 
 inline void envelopeInitEmpty(Envelope& env) {

--- a/src/vt/messaging/envelope/envelope_test.h
+++ b/src/vt/messaging/envelope/envelope_test.h
@@ -120,6 +120,14 @@ inline bool envelopeIsEpochType(Env const& env);
 template <typename Env>
 inline bool envelopeIsTagType(Env const& env);
 
+/**
+ * \brief Test if the message's base serializer has been called.
+ *
+ * \param[in] env the envelope
+ */
+template <typename Env>
+inline bool envelopeHasBeenSerialized(Env& env);
+
 }} //end namespace vt::messaging
 
 #include "vt/messaging/envelope/envelope_test.impl.h"

--- a/src/vt/messaging/envelope/envelope_test.impl.h
+++ b/src/vt/messaging/envelope/envelope_test.impl.h
@@ -88,6 +88,11 @@ inline bool envelopeIsTagType(Env const& env) {
     (1 << eEnvType::EnvTagType);
 }
 
+template <typename Env>
+inline bool envelopeHasBeenSerialized(Env& env) {
+  return reinterpret_cast<Envelope const*>(&env)->has_been_serialized;
+}
+
 }} //end namespace vt::messaging
 
 #endif /*INCLUDED_MESSAGING_ENVELOPE_ENVELOPE_TEST_IMPL_H*/

--- a/src/vt/messaging/message/message.h
+++ b/src/vt/messaging/message/message.h
@@ -80,19 +80,15 @@ template <typename EnvelopeT>
 struct ActiveMsg : BaseMsg {
   using EnvelopeType = EnvelopeT;
 
-  /*
-   * Be careful here: `has_owner_' needs to precede the EnvelopeType because
-   * this field may be accessed in contexts where the EnvelopeType is not yet
-   * checked/determined
-   */
-
-  bool has_owner_ = false;      /**< For smart pointers tracking ownership  */
-
   // Used to track if the message has been serialized.
   // TODO - include only in debug + serialize-enabled VT builds?
   bool base_serialize_called_ = false;
 
-  EnvelopeType env;             /**< The envelope for the message */
+  /*
+   * \internal
+   * \brief The envelope metadata for the message.
+   */
+  EnvelopeType env;
 
   /**
    * \brief Construct an empty message; initializes the envelope state.
@@ -203,7 +199,6 @@ struct ActiveMsg : BaseMsg {
   void serialize(SerializerT& s) {
     base_serialize_called_ = true;
     // n.b. not actually used, as extracted during transmission.
-    s | has_owner_;
     s | env;
   }
 

--- a/src/vt/messaging/message/message.h
+++ b/src/vt/messaging/message/message.h
@@ -80,14 +80,11 @@ template <typename EnvelopeT>
 struct ActiveMsg : BaseMsg {
   using EnvelopeType = EnvelopeT;
 
-  // Used to track if the message has been serialized.
-  // TODO - include only in debug + serialize-enabled VT builds?
-  bool base_serialize_called_ = false;
-
   /*
    * \internal
    * \brief The envelope metadata for the message.
    */
+  // n.b. Should be first member even if can't guarantee standard layout.
   EnvelopeType env;
 
   /**
@@ -197,8 +194,10 @@ struct ActiveMsg : BaseMsg {
    */
   template <typename SerializerT>
   void serialize(SerializerT& s) {
-    base_serialize_called_ = true;
-    // n.b. not actually used, as extracted during transmission.
+    envelopeSetHasBeenSerialized(env, true);
+    // There is some (pipe) code that currently requires the envelope to
+    // be serialized for correct operation; this may be fixed, in which
+    // case it might be possible to omit envelope serialization here.
     s | env;
   }
 

--- a/src/vt/messaging/message/message.h
+++ b/src/vt/messaging/message/message.h
@@ -91,6 +91,10 @@ struct ActiveMsg : BaseMsg {
    * \brief Construct an empty message; initializes the envelope state.
    */
   ActiveMsg() {
+    // This is here for legacy reasons (which current allow detection of when
+    // a message has not been created correctly). With just this base
+    // setup, a vtAssert will fail when the message is attempted to be sent.
+    // Proper initialization happens in 'makeMessage' calls.
     envelopeInitEmpty(env);
 
     debug_print(

--- a/src/vt/messaging/message/refs.h
+++ b/src/vt/messaging/message/refs.h
@@ -57,9 +57,6 @@ void messageRef(MsgT* msg);
 template <typename MsgT>
 void messageDeref(MsgT* msg);
 
-template <typename MsgT>
-bool isSharedMessage(MsgT* msg);
-
 } /* end namespace vt */
 
 #include "vt/messaging/message/refs.impl.h"

--- a/src/vt/messaging/message/refs.impl.h
+++ b/src/vt/messaging/message/refs.impl.h
@@ -88,11 +88,6 @@ void messageDeref(MsgT* msg) {
   }
 }
 
-template <typename MsgT>
-bool isSharedMessage(MsgT* msg) {
-  return envelopeGetRef(msg->env) != not_shared_message;
-}
-
 } /* end namespace vt */
 
 #endif /*INCLUDED_MESSAGING_MESSAGE_REFS_IMPL_H*/

--- a/src/vt/messaging/message/shared_message.h
+++ b/src/vt/messaging/message/shared_message.h
@@ -65,6 +65,7 @@ namespace vt {
  * message promotion should generally not be relied upon.
  */
 template <typename MsgT, typename... Args>
+[[deprecated("Use makeMessage instead")]]
 MsgT* makeSharedMessage(Args&&... args);
 
 /**
@@ -80,10 +81,10 @@ MsgT* makeSharedMessage(Args&&... args);
  * message promotion should generally not be relied upon.
  */
 template <typename MsgT, typename... Args>
+[[deprecated("Use makeMessageSz instead")]]
 MsgT* makeSharedMessageSz(std::size_t size, Args&&... args);
 
 /**
- * \deprecated Use \c makeMesssage.
  * \brief Create a new message.
  *
  * Create a new message already wrapped in a MsgPtr.
@@ -96,7 +97,6 @@ template <typename MsgT, typename... Args>
 MsgPtr<MsgT> makeMessage(Args&&... args);
 
 /**
- * \deprecated Use \c makeMesssage.
  * \brief Create a new message, of a size.
  *
  * Create a new message already wrapped in a MsgPtr.
@@ -107,10 +107,6 @@ MsgPtr<MsgT> makeMessage(Args&&... args);
  */
 template <typename MsgT, typename... Args>
 MsgPtr<MsgT> makeMessageSz(std::size_t size, Args&&... args);
-
-template <typename MsgT, typename... Args>
-[[deprecated("Use makeMessage instead")]]
-MsgPtr<MsgT> makeMsg(Args&&... args);
 
 } //end namespace vt
 

--- a/src/vt/messaging/message/shared_message.h
+++ b/src/vt/messaging/message/shared_message.h
@@ -52,30 +52,65 @@
 
 namespace vt {
 
+/**
+ * \deprecated Use \c makeMesssage.
+ * \brief Create a new 'raw' message.
+ *
+ * Create a new message and initialize internal state.
+ * The arguments are forwarded down to the underlying message's constructor.
+ *
+ * \warning
+ * The returned pointer represents a leaked object until 'promoted' to a MsgPtr.
+ * While \c theMsg send API will automatically perform a promotion, automatic
+ * message promotion should generally not be relied upon.
+ */
 template <typename MsgT, typename... Args>
 MsgT* makeSharedMessage(Args&&... args);
 
+/**
+ * \deprecated Use \c makeMesssage.
+ * \brief Create a new 'raw' message, of a given size.
+ *
+ * Create a new message and initialize internal state.
+ * The arguments are forwarded down to the underlying message's constructor.
+ *
+ * \warning
+ * The returned pointer represents a leaked object until 'promoted' to a MsgPtr.
+ * While \c theMsg send API will automatically perform a promotion, automatic
+ * message promotion should generally not be relied upon.
+ */
 template <typename MsgT, typename... Args>
 MsgT* makeSharedMessageSz(std::size_t size, Args&&... args);
 
+/**
+ * \deprecated Use \c makeMesssage.
+ * \brief Create a new message.
+ *
+ * Create a new message already wrapped in a MsgPtr.
+ * The arguments are forwarded down to the underlying message's constructor.
+ *
+ * The lifetime of the message is controlled by MsgPtr and will be destroyed
+ * when the returned MsgPtr (and all copies of such) are destroyed.
+ */
 template <typename MsgT, typename... Args>
-MsgSharedPtr<MsgT> makeMessage(Args&&... args);
+MsgPtr<MsgT> makeMessage(Args&&... args);
+
+/**
+ * \deprecated Use \c makeMesssage.
+ * \brief Create a new message, of a size.
+ *
+ * Create a new message already wrapped in a MsgPtr.
+ * The arguments are forwarded down to the underlying message's constructor.
+ *
+ * The lifetime of the message is controlled by MsgPtr and will be destroyed
+ * when the returned MsgPtr (and all copies of such) are destroyed.
+ */
+template <typename MsgT, typename... Args>
+MsgPtr<MsgT> makeMessageSz(std::size_t size, Args&&... args);
 
 template <typename MsgT, typename... Args>
-MsgSharedPtr<MsgT> makeMessageSz(std::size_t size, Args&&... args);
-
-///[obsolete] Use makeMessage instead.
-template <typename MsgT, typename... Args>
-MsgSharedPtr<MsgT> makeMsg(Args&&... args);
-
-template <typename MsgT>
-void messageConvertToShared(MsgT* msg);
-
-template <typename MsgT>
-void messageSetUnmanaged(MsgT* msg);
-
-template <typename MsgT>
-void messageResetDeserdes(MsgSharedPtr<MsgT> const& msg);
+[[deprecated("Use makeMessage instead")]]
+MsgPtr<MsgT> makeMsg(Args&&... args);
 
 } //end namespace vt
 

--- a/src/vt/messaging/message/shared_message.h
+++ b/src/vt/messaging/message/shared_message.h
@@ -63,6 +63,10 @@ namespace vt {
  * The returned pointer represents a leaked object until 'promoted' to a MsgPtr.
  * While \c theMsg send API will automatically perform a promotion, automatic
  * message promotion should generally not be relied upon.
+ *
+ * \param[in] args forwarded message arguments for constructor
+ *
+ * \return a bare message pointer
  */
 template <typename MsgT, typename... Args>
 [[deprecated("Use makeMessage instead")]]
@@ -79,6 +83,11 @@ MsgT* makeSharedMessage(Args&&... args);
  * The returned pointer represents a leaked object until 'promoted' to a MsgPtr.
  * While \c theMsg send API will automatically perform a promotion, automatic
  * message promotion should generally not be relied upon.
+ *
+ * \param[in] size extra requested size at the end of message
+ * \param[in] args forwarded message arguments for constructor
+ *
+ * \return a bare message pointer
  */
 template <typename MsgT, typename... Args>
 [[deprecated("Use makeMessageSz instead")]]
@@ -92,6 +101,10 @@ MsgT* makeSharedMessageSz(std::size_t size, Args&&... args);
  *
  * The lifetime of the message is controlled by MsgPtr and will be destroyed
  * when the returned MsgPtr (and all copies of such) are destroyed.
+ *
+ * \param[in] args forwarded message arguments for constructor
+ *
+ * \return a shared message pointer
  */
 template <typename MsgT, typename... Args>
 MsgPtr<MsgT> makeMessage(Args&&... args);
@@ -104,6 +117,11 @@ MsgPtr<MsgT> makeMessage(Args&&... args);
  *
  * The lifetime of the message is controlled by MsgPtr and will be destroyed
  * when the returned MsgPtr (and all copies of such) are destroyed.
+ *
+ * \param[in] size extra requested size at the end of message
+ * \param[in] args forwarded message arguments for constructor
+ *
+ * \return a shared message pointer
  */
 template <typename MsgT, typename... Args>
 MsgPtr<MsgT> makeMessageSz(std::size_t size, Args&&... args);

--- a/src/vt/messaging/message/shared_message.impl.h
+++ b/src/vt/messaging/message/shared_message.impl.h
@@ -52,7 +52,7 @@
 
 namespace vt {
 
-namespace {
+namespace detail {
 
 /**
  * \internal \brief Create a bare message. Only the system should ever call this
@@ -89,7 +89,7 @@ MsgT* makeMessageSzImpl(std::size_t size, Args&&... args) {
   return msg;
 }
 
-} /* end anon namespace */
+} /* end detail namespace */
 
 template <typename MsgT, typename... Args>
 MsgT* makeSharedMessage(Args&&... args) {
@@ -116,13 +116,13 @@ MsgT* makeSharedMessageSz(std::size_t size, Args&&... args) {
 template <typename MsgT, typename... Args>
 MsgPtr<MsgT> makeMessage(Args&&... args) {
   // RVO / copy-elision guaranteed
-  return MsgPtr<MsgT>{makeMessageImpl<MsgT>(std::forward<Args>(args)...)};
+  return MsgPtr<MsgT>{detail::makeMessageImpl<MsgT>(std::forward<Args>(args)...)};
 }
 
 template <typename MsgT, typename... Args>
 MsgPtr<MsgT> makeMessageSz(std::size_t size, Args&&... args) {
   // RVO / copy-elision guaranteed
-  return MsgPtr<MsgT>{makeMessageSzImpl<MsgT>(size, std::forward<Args>(args)...)};
+  return MsgPtr<MsgT>{detail::makeMessageSzImpl<MsgT>(size, std::forward<Args>(args)...)};
 }
 
 } //end namespace vt

--- a/src/vt/messaging/message/shared_message.impl.h
+++ b/src/vt/messaging/message/shared_message.impl.h
@@ -86,12 +86,6 @@ MsgPtr<MsgT> makeMessageSz(std::size_t size, Args&&... args) {
   return MsgPtr<MsgT>{makeSharedMessageSz<MsgT>(size, std::forward<Args>(args)...)};
 }
 
-template <typename MsgT, typename... Args>
-[[deprecated("Use makeMessage instead")]]
-MsgPtr<MsgT> makeMsg(Args&&... args) {
-  return makeMessage<MsgT>(std::forward<Args>(args)...);
-}
-
 } //end namespace vt
 
 #endif /*INCLUDED_MESSAGING_MESSAGE_SHARED_MESSAGE_IMPL_H*/

--- a/src/vt/messaging/message/shared_message.impl.h
+++ b/src/vt/messaging/message/shared_message.impl.h
@@ -57,6 +57,8 @@ MsgT* makeSharedMessage(Args&&... args) {
   MsgT* msg = new MsgT{std::forward<Args>(args)...};
   // n.b. do NOT actually take a ref here.
   // True ownership only starts in MsgPtr.
+  // Double-initialization of an envelope is problematic.
+  //envelopeInitEmpty(msg->env);
   envelopeSetRef(msg->env, 0);
   return msg;
 }
@@ -66,6 +68,8 @@ MsgT* makeSharedMessageSz(std::size_t size, Args&&... args) {
   MsgT* msg = new (size) MsgT{std::forward<Args>(args)...};
   // n.b. do NOT actually take a ref here.
   // True ownership only starts in MsgPtr.
+  // Double-initialization of an envelope is problematic.
+  //envelopeInitEmpty(msg->env);
   envelopeSetRef(msg->env, 0);
   return msg;
 }

--- a/src/vt/messaging/message/shared_message.impl.h
+++ b/src/vt/messaging/message/shared_message.impl.h
@@ -75,7 +75,7 @@ MsgT* makeMessageImpl(Args&&... args) {
  * \internal \brief Create a bare message with defined size (used when extra
  * bytes are requested). Only the system should ever call this function.
  *
- * \param[in] size requested size
+ * \param[in] size extra requested size at the end of message
  * \param[in] args forwarded message arguments for constructor
  *
  * \return bare message pointer with \c size extra bytes on the end

--- a/src/vt/messaging/message/smart_ptr.h
+++ b/src/vt/messaging/message/smart_ptr.h
@@ -262,25 +262,45 @@ private:
 
 }} /* end namespace vt::messaging */
 
+
+// Expose public/common types in vt:: namespace.
 namespace vt {
 
-// For historic reasons;
-// Functionality is now part of MsgSharedPtr
+/**
+ * \internal
+ * \obsolete Use \c MsgPtr<T>, for which is is an alias.
+ */
 template <typename T>
 using MsgVirtualPtr = messaging::MsgSharedPtr<T>;
 
-// For historic reasons;
-// Functionality is now part of MsgSharedPtr
+/**
+ * \internal
+ * \obsolete Use \c MsgPtr<ShortMessage>, or as appropriate.
+ */
 using MsgVirtualPtrAny = messaging::MsgSharedPtr<ShortMessage>;
 
+/**
+ * \internal
+ * \obsolete Use \c MsgPtr<T>, for which is is an alias.
+ */
 template <typename T>
 using MsgSharedPtr = messaging::MsgSharedPtr<T>;
 
+/**
+ * \brief Wrapper to manage Active Messages.
+ *
+ * A MsgPtr represents a 'shared pointer like' object wrapping a
+ * message that correcly manages reference-counts to order to
+ * eliminate memory leaks.
+ */
+template <typename T>
+using MsgPtr = messaging::MsgSharedPtr<T>;
+
 /// Steal ownership of the message (no ref-increase).
 template <typename T>
-inline MsgSharedPtr<T> promoteMsgOwner(T* const msg) {
+inline MsgPtr<T> promoteMsgOwner(T* const msg) {
   msg->has_owner_ = true;
-  return MsgSharedPtr<T>{msg,false};
+  return MsgPtr<T>{msg,false};
 }
 
 /// Take additional ownership of the message (increase message ref).
@@ -288,19 +308,19 @@ inline MsgSharedPtr<T> promoteMsgOwner(T* const msg) {
 // TODO: eliminate if possible as it has confusing semantics
 // with overload and is duplicated by copy/move ctors.
 template <typename T>
-inline MsgSharedPtr<T> promoteMsg(MsgSharedPtr<T> msg) {
+inline MsgPtr<T> promoteMsg(MsgPtr<T> msg) {
   vtAssert(msg->has_owner_, "promoteMsg shared ptr must have owner");
-  return MsgSharedPtr<T>{msg.get(),true};
+  return MsgPtr<T>{msg.get(),true};
 }
 
 /// If the message does not have an owner, steal ownership (no ref-increase).
 /// Otherwise, take additional ownership (increate message ref).
 template <typename T>
-inline MsgSharedPtr<T> promoteMsg(T* msg) {
+inline MsgPtr<T> promoteMsg(T* msg) {
   if (!msg->has_owner_) {
     return promoteMsgOwner(msg);
   } else {
-    return MsgSharedPtr<T>{msg,true};
+    return MsgPtr<T>{msg,true};
   }
 }
 

--- a/src/vt/messaging/message/smart_ptr.h
+++ b/src/vt/messaging/message/smart_ptr.h
@@ -102,8 +102,14 @@ struct MsgSharedPtr final {
 
   MsgSharedPtr(std::nullptr_t) {}
 
+  MsgSharedPtr(T* in) {
+    init(in, true, &statics::Holder::TypedMsgPtrImpls<T>);
+  }
+
   MsgSharedPtr(T* in, bool takeRef) {
     init(in, takeRef, statics::Holder::getImpl<T>());
+  }
+
   }
 
   // Overload to retain ORIGINAL type-erased implementation.
@@ -172,10 +178,9 @@ struct MsgSharedPtr final {
   }
 
   friend std::ostream& operator<<(std::ostream&os, MsgSharedPtr<T> const& m) {
-    auto nrefs = m.ptr_ && m.shared_ ? envelopeGetRef(m.get()->env) : -1;
+    auto nrefs = envelopeGetRef(m.get()->env);
     return os << "MsgSharedPtr("
               <<              m.ptr_    << ","
-              << "shared=" << m.shared_ << ","
               << "ref="    << nrefs
               << ")";
   }
@@ -192,49 +197,43 @@ private:
 
     ptr_ = msgPtr;
     impl_ = impl;
-    bool shared = (shared_ = isSharedMessage<T>(msgPtr));
 
-    if (shared) {
-      vtAssertInfo(
-        envelopeGetRef(msgPtr->env) > 0, "Bad Ref (before ref)",
-        shared, envelopeGetRef(msgPtr->env)
-      );
-      debug_print(
-        pool, node,
-        "MsgSmartPtr: (auto) init(), ptr={}, envRef={}, takeRef={} address={}\n",
-        print_ptr(msgPtr), envelopeGetRef(msgPtr->env), takeRef, print_ptr(this)
-      );
+    vtAssertInfo(
+      envelopeGetRef(msgPtr->env) >= 0, "Bad Message Ref (before ref)",
+      envelopeGetRef(msgPtr->env)
+    );
+    debug_print(
+      pool, node,
+      "MsgSmartPtr: (auto) init(), ptr={}, envRef={}, takeRef={} address={}\n",
+      print_ptr(msgPtr), envelopeGetRef(msgPtr->env), takeRef, print_ptr(this)
+    );
 
-      if (takeRef) {
-        // Could be moved to type-erased impl..
-        messageRef(msgPtr);
-      }
+    if (takeRef) {
+      // Could be moved to type-erased impl..
+      messageRef(msgPtr);
     }
   }
 
   /// Clear all internal state. Effectively destructor in operation,
   /// with guarantee that init() can be used again after.
   void clear() {
-    bool shared = shared_;
-
-    if (shared) {
-      assert("shared -> message ptr" && ptr_);
-      T* msgPtr = get();
-
-      vtAssertInfo(
-        envelopeGetRef(msgPtr->env) > 0, "Bad Ref (before deref)",
-        shared, envelopeGetRef(msgPtr->env)
-      );
-      debug_print(
-        pool, node,
-        "MsgSmartPtr: (auto) clear(), ptr={}, envRef={}, address={}\n",
-        print_ptr(msgPtr), envelopeGetRef(msgPtr->env), print_ptr(this)
-      );
-
-      impl_->messageDeref(msgPtr);
-
-      shared_ = false;
+    if (not ptr_) {
+      return;
     }
+
+    T* msgPtr = get();
+
+    vtAssertInfo(
+      envelopeGetRef(msgPtr->env) >= 1, "Bad Message Ref (before deref)",
+      envelopeGetRef(msgPtr->env)
+    );
+    debug_print(
+      pool, node,
+      "MsgSmartPtr: (auto) clear(), ptr={}, envRef={}, address={}\n",
+      print_ptr(msgPtr), envelopeGetRef(msgPtr->env), print_ptr(this)
+    );
+
+    impl_->messageDeref(msgPtr);
 
     ptr_ = nullptr;
   }
@@ -242,19 +241,14 @@ private:
   /// Move. Must be invoked on fresh/clear state.
   void moveFrom(MsgSharedPtr<T>&& in) {
     ptr_ = in.ptr_;
-    shared_ = in.shared_;
     impl_ = in.impl_;
     // clean take - nullify/prevent other cleanup
     in.ptr_ = nullptr;
-    in.shared_ = false;
   }
 
 private:
   // Underlying raw message - access as correct type via get()
   BaseMsgType* ptr_ = nullptr;
-  // Is this a shared message?
-  // If so, then it will have a deref done on delete.
-  bool shared_      = false;
   // Type-erased implementation support.
   // Object has a STATIC LIFETIME / is not owned / should not be deleted.
   MsgPtrImplBase* impl_ = nullptr;
@@ -296,32 +290,28 @@ using MsgSharedPtr = messaging::MsgSharedPtr<T>;
 template <typename T>
 using MsgPtr = messaging::MsgSharedPtr<T>;
 
-/// Steal ownership of the message (no ref-increase).
+/// Obsolete form - do not use.
+/// There is no direct replacement; has_owner_ is removed.
 template <typename T>
+[[deprecated("Do not use: no direct replacement")]]
 inline MsgPtr<T> promoteMsgOwner(T* const msg) {
-  msg->has_owner_ = true;
   return MsgPtr<T>{msg,false};
 }
 
 /// Obsolete form - do not use.
-/// In the iterim change calls to promotMsg(T*), guarded
-/// by an appropriate has_owner_ assert if reelvant.
+/// There is no direct replacement; has_owner_ is removed
+/// and the semantic operation differed from promoteMsg(T*).
 template <typename T>
-[[deprecated("Do not use: different smantic meaning")]]
+[[deprecated("Do not use: no direct repalcement")]]
 inline MsgPtr<T> promoteMsg(MsgPtr<T> msg) {
-  vtAssert(msg->has_owner_, "promoteMsg shared ptr must have owner");
-  return MsgPtr<T>{msg.get(),true};
+  return MsgPtr<T>{msg.get()};
 }
 
-/// If the message does not have an owner, steal ownership (no ref-increase).
-/// Otherwise, take additional ownership (increate message ref).
+/// Wrap a Msg* in a MsgPtr<Msg>, increasing ref-ownership.
+/// This is the same as using MsgPtr<T>{T*} directly.
 template <typename T>
 inline MsgPtr<T> promoteMsg(T* msg) {
-  if (!msg->has_owner_) {
-    return promoteMsgOwner(msg);
-  } else {
-    return MsgPtr<T>{msg,true};
-  }
+  return MsgPtr<T>{msg};
 }
 
 } /* end namespace vt */

--- a/src/vt/messaging/message/smart_ptr.h
+++ b/src/vt/messaging/message/smart_ptr.h
@@ -103,22 +103,16 @@ struct MsgSharedPtr final {
   MsgSharedPtr(std::nullptr_t) {}
 
   MsgSharedPtr(T* in) {
-    init(in, true, &statics::Holder::TypedMsgPtrImpls<T>);
-  }
-
-  MsgSharedPtr(T* in, bool takeRef) {
-    init(in, takeRef, statics::Holder::getImpl<T>());
-  }
-
+    init(in, statics::Holder::getImpl<T>());
   }
 
   // Overload to retain ORIGINAL type-erased implementation.
-  MsgSharedPtr(T* in, bool takeRef, MsgPtrImplBase* impl) {
-    init(in, takeRef, impl);
+  MsgSharedPtr(T* in, MsgPtrImplBase* impl) {
+    init(in, impl);
   }
 
   MsgSharedPtr(MsgSharedPtr<T> const& in) {
-    init(in.get(), true, in.impl_);
+    init(in.get(), in.impl_);
   }
 
   MsgSharedPtr(MsgSharedPtr<T>&& in) {
@@ -132,7 +126,7 @@ struct MsgSharedPtr final {
 
   MsgSharedPtr<T>& operator=(MsgSharedPtr<T> const& in) {
     clear();
-    init(in.get(), true, in.impl_);
+    init(in.get(), in.impl_);
     return *this;
   }
 
@@ -155,7 +149,7 @@ struct MsgSharedPtr final {
   template <typename U>
   MsgSharedPtr<U> to() const {
     return MsgSharedPtr<U>(
-      reinterpret_cast<U*>(ptr_), true,
+      reinterpret_cast<U*>(ptr_),
       /*N.B. retain ORIGINAL-type implementation*/ impl_);
   }
 
@@ -187,10 +181,10 @@ struct MsgSharedPtr final {
 
 private:
 
-  /// Performs state-ownership, optionally taking an additional message ref.
+  /// Performs state-ownership, always taking an additional message ref.
   /// Should probably be called every constructor; must ONLY be
   /// called from fresh (zero-init member) or clear() state.
-  void init(T* msgPtr, bool takeRef, MsgPtrImplBase* impl) {
+  void init(T* msgPtr, MsgPtrImplBase* impl) {
     assert("given message" && msgPtr);
     assert("not initialized" && not ptr_);
     assert("given impl" && impl);
@@ -198,20 +192,8 @@ private:
     ptr_ = msgPtr;
     impl_ = impl;
 
-    vtAssertInfo(
-      envelopeGetRef(msgPtr->env) >= 0, "Bad Message Ref (before ref)",
-      envelopeGetRef(msgPtr->env)
-    );
-    debug_print(
-      pool, node,
-      "MsgSmartPtr: (auto) init(), ptr={}, envRef={}, takeRef={} address={}\n",
-      print_ptr(msgPtr), envelopeGetRef(msgPtr->env), takeRef, print_ptr(this)
-    );
-
-    if (takeRef) {
-      // Could be moved to type-erased impl..
-      messageRef(msgPtr);
-    }
+    // Could be moved to type-erased impl..
+    messageRef(msgPtr);
   }
 
   /// Clear all internal state. Effectively destructor in operation,
@@ -222,16 +204,6 @@ private:
     }
 
     T* msgPtr = get();
-
-    vtAssertInfo(
-      envelopeGetRef(msgPtr->env) >= 1, "Bad Message Ref (before deref)",
-      envelopeGetRef(msgPtr->env)
-    );
-    debug_print(
-      pool, node,
-      "MsgSmartPtr: (auto) clear(), ptr={}, envRef={}, address={}\n",
-      print_ptr(msgPtr), envelopeGetRef(msgPtr->env), print_ptr(this)
-    );
 
     impl_->messageDeref(msgPtr);
 
@@ -295,20 +267,26 @@ using MsgPtr = messaging::MsgSharedPtr<T>;
 template <typename T>
 [[deprecated("Do not use: no direct replacement")]]
 inline MsgPtr<T> promoteMsgOwner(T* const msg) {
-  return MsgPtr<T>{msg,false};
+  return MsgPtr<T>{msg};
 }
 
 /// Obsolete form - do not use.
 /// There is no direct replacement; has_owner_ is removed
 /// and the semantic operation differed from promoteMsg(T*).
 template <typename T>
-[[deprecated("Do not use: no direct repalcement")]]
+[[deprecated("Do not use: no direct replacement")]]
 inline MsgPtr<T> promoteMsg(MsgPtr<T> msg) {
   return MsgPtr<T>{msg.get()};
 }
 
-/// Wrap a Msg* in a MsgPtr<Msg>, increasing ref-ownership.
-/// This is the same as using MsgPtr<T>{T*} directly.
+/**
+ * \brief Wrap a message as a MsgPtr<Msg>, increasing ref-ownership.
+ *
+ * This is the same as using MsgPtr<T>{T*} directly.
+ * The primary usage is in historic call-sites as new code should prefer
+ * using \c makeMessage (and accepting a MsgPtr) instead of creating
+ * a raw message first.
+ */
 template <typename T>
 inline MsgPtr<T> promoteMsg(T* msg) {
   return MsgPtr<T>{msg};

--- a/src/vt/messaging/message/smart_ptr.h
+++ b/src/vt/messaging/message/smart_ptr.h
@@ -234,7 +234,7 @@ namespace vt {
 
 /**
  * \internal
- * \obsolete Use \c MsgPtr<T>, for which is is an alias.
+ * \obsolete Use \c MsgPtr<T>, for which this is an alias.
  */
 template <typename T>
 using MsgVirtualPtr = messaging::MsgSharedPtr<T>;
@@ -247,7 +247,7 @@ using MsgVirtualPtrAny = messaging::MsgSharedPtr<ShortMessage>;
 
 /**
  * \internal
- * \obsolete Use \c MsgPtr<T>, for which is is an alias.
+ * \obsolete Use \c MsgPtr<T>, for which this is an alias.
  */
 template <typename T>
 using MsgSharedPtr = messaging::MsgSharedPtr<T>;

--- a/src/vt/messaging/message/smart_ptr.h
+++ b/src/vt/messaging/message/smart_ptr.h
@@ -303,11 +303,11 @@ inline MsgPtr<T> promoteMsgOwner(T* const msg) {
   return MsgPtr<T>{msg,false};
 }
 
-/// Take additional ownership of the message (increase message ref).
-/// The message must already have an owner.
-// TODO: eliminate if possible as it has confusing semantics
-// with overload and is duplicated by copy/move ctors.
+/// Obsolete form - do not use.
+/// In the iterim change calls to promotMsg(T*), guarded
+/// by an appropriate has_owner_ assert if reelvant.
 template <typename T>
+[[deprecated("Do not use: different smantic meaning")]]
 inline MsgPtr<T> promoteMsg(MsgPtr<T> msg) {
   vtAssert(msg->has_owner_, "promoteMsg shared ptr must have owner");
   return MsgPtr<T>{msg.get(),true};

--- a/src/vt/objgroup/manager.cc
+++ b/src/vt/objgroup/manager.cc
@@ -56,7 +56,7 @@ ObjGroupProxyType ObjGroupManager::getProxy(ObjGroupProxyType proxy) {
   return proxy;
 }
 
-void ObjGroupManager::dispatch(MsgVirtualPtrAny msg, HandlerType han) {
+void ObjGroupManager::dispatch(MsgSharedPtr<ShortMessage> msg, HandlerType han) {
   // Extract the control-bit sequence from the handler
   auto const ctrl = HandlerManager::getHandlerControl(han);
   auto const type_idx = auto_registry::getAutoHandlerObjTypeIdx(han);
@@ -109,7 +109,7 @@ ObjGroupProxyType ObjGroupManager::makeCollectiveImpl(
   return proxy;
 }
 
-void dispatchObjGroup(MsgVirtualPtrAny msg, HandlerType han) {
+void dispatchObjGroup(MsgSharedPtr<ShortMessage> msg, HandlerType han) {
   debug_print(
     objgroup, node,
     "dispatchObjGroup: han={:x}\n", han
@@ -117,7 +117,9 @@ void dispatchObjGroup(MsgVirtualPtrAny msg, HandlerType han) {
   return theObjGroup()->dispatch(msg,han);
 }
 
-void scheduleMsg(MsgVirtualPtrAny msg, HandlerType han, EpochType epoch) {
+void scheduleMsg(
+  MsgSharedPtr<ShortMessage> msg, HandlerType han, EpochType epoch
+) {
   // Produce here, consume when the dispatcher actually runs---it might be
   // delayed
   theTerm()->produce(epoch);

--- a/src/vt/objgroup/manager.fwd.h
+++ b/src/vt/objgroup/manager.fwd.h
@@ -52,13 +52,15 @@ namespace vt { namespace objgroup {
 
 struct ObjGroupManager;
 
-void dispatchObjGroup(MsgVirtualPtrAny msg, HandlerType han);
+void dispatchObjGroup(MsgSharedPtr<ShortMessage> msg, HandlerType han);
 
 template <typename MsgT>
 void send(MsgSharedPtr<MsgT> msg, HandlerType han, NodeType node);
 template <typename MsgT>
 void broadcast(MsgSharedPtr<MsgT> msg, HandlerType han);
-void scheduleMsg(MsgVirtualPtrAny msg, HandlerType han, EpochType epoch);
+void scheduleMsg(
+  MsgSharedPtr<ShortMessage> msg, HandlerType han, EpochType epoch
+);
 
 }} /* end namespace vt::objgroup */
 

--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -77,7 +77,7 @@ struct ObjGroupManager : runtime::component::Component<ObjGroupManager> {
   using HolderBasePtrType   = std::unique_ptr<HolderBaseType>;
   using DispatchBaseType    = dispatch::DispatchBase;
   using DispatchBasePtrType = std::unique_ptr<DispatchBaseType>;
-  using MsgContainerType    = std::vector<MsgVirtualPtrAny>;
+  using MsgContainerType    = std::vector<MsgSharedPtr<ShortMessage>>;
   using BaseProxyListType   = std::set<ObjGroupProxyType>;
 
   ObjGroupManager() = default;
@@ -169,7 +169,7 @@ struct ObjGroupManager : runtime::component::Component<ObjGroupManager> {
   /*
    * Dispatch to a live obj group pointer with a handler
    */
-  void dispatch(MsgVirtualPtrAny msg, HandlerType han);
+  void dispatch(MsgSharedPtr<ShortMessage> msg, HandlerType han);
 
   /*
    * Untyped calls for broadcasting or sending msgs to an obj group
@@ -190,7 +190,9 @@ struct ObjGroupManager : runtime::component::Component<ObjGroupManager> {
   void registerBaseCollective(ProxyType<ObjT> proxy);
   ObjGroupProxyType getProxy(ObjGroupProxyType proxy);
 
-  friend void scheduleMsg(MsgVirtualPtrAny msg, HandlerType han, EpochType ep);
+  friend void scheduleMsg(
+    MsgSharedPtr<ShortMessage> msg, HandlerType han, EpochType ep
+  );
 
 private:
   ObjGroupProxyType makeCollectiveImpl(

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -82,7 +82,7 @@ public:
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
   void broadcast(MsgT* msg) const;
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
-  void broadcast(MsgSharedPtr<MsgT> msg) const;
+  void broadcast(MsgPtr<MsgT> msg) const;
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn, typename... Args>
   void broadcast(Args&&... args) const;
 

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -58,13 +58,14 @@ namespace vt { namespace objgroup { namespace proxy {
 
 template <typename ObjT>
 template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
-void Proxy<ObjT>::broadcast(MsgT* msg) const {
-  return broadcast<MsgT,fn>(promoteMsg(msg));
+void Proxy<ObjT>::broadcast(MsgT* inmsg) const {
+  MsgPtr<MsgT> msg = promoteMsg(inmsg);
+  return broadcast<MsgT,fn>(msg);
 }
 
 template <typename ObjT>
 template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
-void Proxy<ObjT>::broadcast(MsgSharedPtr<MsgT> msg) const {
+void Proxy<ObjT>::broadcast(MsgPtr<MsgT> msg) const {
   auto proxy = Proxy<ObjT>(*this);
   theObjGroup()->broadcast<ObjT,MsgT,fn>(proxy,msg);
 }
@@ -83,7 +84,10 @@ void Proxy<ObjT>::reduce(
   MsgPtrT inmsg, Callback<MsgT> cb, ReduceStamp stamp
 ) const {
   auto proxy = Proxy<ObjT>(*this);
-  auto msg = promoteMsg(inmsg);
+  // Force promoteMsg(Msg*) to avoid special-case overload behavior
+  // which is now deprecated. The issue is caused because inmsg can be either
+  // Msg* or MsgPtr<Msg> based on call sites.
+  MsgPtr<MsgT> msg = promoteMsg(static_cast<MsgT*>(inmsg));
   msg->setCallback(cb);
   return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,stamp);
 }
@@ -95,7 +99,7 @@ template <
 >
 void Proxy<ObjT>::reduce(MsgPtrT inmsg, ReduceStamp stamp) const {
   auto proxy = Proxy<ObjT>(*this);
-  auto msg = promoteMsg(inmsg);
+  MsgPtr<MsgT> msg = promoteMsg(static_cast<MsgT*>(inmsg));
   return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,stamp);
 }
 
@@ -103,7 +107,7 @@ template <typename ObjT>
 template <typename MsgPtrT, typename MsgT, ActiveTypedFnType<MsgT> *f>
 void Proxy<ObjT>::reduce(MsgPtrT inmsg, ReduceStamp stamp) const {
   auto proxy = Proxy<ObjT>(*this);
-  auto msg = promoteMsg(inmsg);
+  MsgPtr<MsgT> msg = promoteMsg(inmsg);
   return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,stamp);
 }
 

--- a/src/vt/pipe/callback/anon/callback_anon.impl.h
+++ b/src/vt/pipe/callback/anon/callback_anon.impl.h
@@ -80,9 +80,9 @@ CallbackAnon<MsgT>::triggerDispatch(SignalDataType* data, PipeType const& pid) {
   if (this_node == pipe_node) {
     triggerPipe(pid);
   } else {
-    auto msg = makeSharedMessage<CallbackMsg>(pid);
+    auto msg = makeMessage<CallbackMsg>(pid);
     theMsg()->sendMsg<CallbackMsg,triggerCallbackHan>(
-      pipe_node, msg
+      pipe_node, msg.get()
     );
   }
 }

--- a/src/vt/pipe/callback/anon/callback_anon_tl.cc
+++ b/src/vt/pipe/callback/anon/callback_anon_tl.cc
@@ -65,9 +65,9 @@ void CallbackAnonTypeless::triggerVoid(PipeType const& pipe) {
   if (this_node == pipe_node) {
     theCB()->triggerPipe(pipe);
   } else {
-    auto msg = makeSharedMessage<CallbackMsg>(pipe,true);
+    auto msg = makeMessage<CallbackMsg>(pipe,true);
     theMsg()->sendMsg<CallbackMsg,PipeManager::triggerCallbackHan>(
-      pipe_node, msg
+      pipe_node, msg.get()
     );
   }
 }

--- a/src/vt/pipe/callback/callback_handler_bcast.h
+++ b/src/vt/pipe/callback/callback_handler_bcast.h
@@ -75,8 +75,8 @@ private:
   void trigger_(SignalDataType* data) override {
     theMsg()->broadcastMsg<MsgT,f>(data);
     if (include_root_) {
-      auto nmsg = makeSharedMessage<SignalDataType*>(*data);
-      f(nmsg);
+      auto nmsg = makeMessage<SignalDataType*>(*data);
+      f(nmsg.get());
     }
   }
 

--- a/src/vt/pipe/callback/handler_bcast/callback_bcast_tl.cc
+++ b/src/vt/pipe/callback/handler_bcast/callback_bcast_tl.cc
@@ -67,8 +67,8 @@ void CallbackBcastTypeless::triggerVoid(PipeType const& pipe) {
     "include_sender_={}\n",
     pipe, this_node, include_sender_
   );
-  auto msg = makeSharedMessage<CallbackMsg>(pipe);
-  theMsg()->broadcastMsg<CallbackMsg>(handler_,msg);
+  auto msg = makeMessage<CallbackMsg>(pipe);
+  theMsg()->broadcastMsg<CallbackMsg>(handler_,msg.get());
   if (include_sender_) {
     runnable::RunnableVoid::run(handler_,this_node);
   }

--- a/src/vt/pipe/callback/handler_send/callback_send.impl.h
+++ b/src/vt/pipe/callback/handler_send/callback_send.impl.h
@@ -91,8 +91,8 @@ CallbackSend<MsgT>::triggerDispatch(SignalDataType* data, PipeType const& pid) {
   if (this_node == send_node_) {
     runnable::RunnableVoid::run(handler_,this_node);
   } else {
-    auto msg = makeSharedMessage<CallbackMsg>(pid);
-    theMsg()->sendMsg<CallbackMsg>(send_node_, handler_, msg);
+    auto msg = makeMessage<CallbackMsg>(pid);
+    theMsg()->sendMsg<CallbackMsg>(send_node_, handler_, msg.get());
   }
 }
 

--- a/src/vt/pipe/callback/handler_send/callback_send_tl.cc
+++ b/src/vt/pipe/callback/handler_send/callback_send_tl.cc
@@ -69,8 +69,8 @@ void CallbackSendTypeless::triggerVoid(PipeType const& pipe) {
   if (this_node == send_node_) {
     runnable::RunnableVoid::run(handler_,this_node);
   } else {
-    auto msg = makeSharedMessage<CallbackMsg>(pipe);
-    theMsg()->sendMsg<CallbackMsg>(send_node_, handler_, msg);
+    auto msg = makeMessage<CallbackMsg>(pipe);
+    theMsg()->sendMsg<CallbackMsg>(send_node_, handler_, msg.get());
   }
 }
 

--- a/src/vt/pipe/interface/remote_container.impl.h
+++ b/src/vt/pipe/interface/remote_container.impl.h
@@ -100,17 +100,17 @@ RemoteContainer<MsgT,TupleT>::triggerDirect(CallbackT cb, MsgU* data) {
     "RemoteContainer: (typed) invoke trigger: pipe={:x}, multi={}, ptr={}\n",
     pid, multi_callback, print_ptr(data)
   );
-  MsgSharedPtr<MsgT> cur_msg = promoteMsg(data);
 
-  /*
-   *  Make a copy of the message for each callback trigger because the callback
-   *  trigger may send/bcast messages, thus a copy must be made
-   */
   if (multi_callback) {
-    cur_msg = makeMessage<MsgT>(*data);
+    /*
+     *  Make a copy of the message for each callback trigger because the callback
+     *  trigger may send/bcast messages, thus a copy must be made
+     */
+    auto cur_msg = makeMessage<MsgT>(*data);
+    cb.trigger(cur_msg.get(),pid);
+  } else {
+    cb.trigger(data,pid);
   }
-
-  cb.trigger(cur_msg.get(),pid);
 }
 
 template <typename MsgT, typename TupleT>

--- a/src/vt/pipe/interface/remote_container.impl.h
+++ b/src/vt/pipe/interface/remote_container.impl.h
@@ -100,7 +100,7 @@ RemoteContainer<MsgT,TupleT>::triggerDirect(CallbackT cb, MsgU* data) {
     "RemoteContainer: (typed) invoke trigger: pipe={:x}, multi={}, ptr={}\n",
     pid, multi_callback, print_ptr(data)
   );
-  MsgT* cur_msg = data;
+  MsgSharedPtr<MsgT> cur_msg = promoteMsg(data);
 
   /*
    *  Make a copy of the message for each callback trigger because the callback

--- a/src/vt/pipe/interface/remote_container.impl.h
+++ b/src/vt/pipe/interface/remote_container.impl.h
@@ -107,15 +107,10 @@ RemoteContainer<MsgT,TupleT>::triggerDirect(CallbackT cb, MsgU* data) {
    *  trigger may send/bcast messages, thus a copy must be made
    */
   if (multi_callback) {
-    cur_msg = makeSharedMessage<MsgT>(*data);
-    messageRef(cur_msg);
+    cur_msg = makeMessage<MsgT>(*data);
   }
 
-  cb.trigger(cur_msg,pid);
-
-  if (multi_callback) {
-    messageDeref(cur_msg);
-  }
+  cb.trigger(cur_msg.get(),pid);
 }
 
 template <typename MsgT, typename TupleT>

--- a/src/vt/runnable/general.h
+++ b/src/vt/runnable/general.h
@@ -53,7 +53,9 @@ namespace vt {
 
 namespace objgroup {
 
-void scheduleMsg(MsgVirtualPtrAny msg, HandlerType han, EpochType epoch);
+void scheduleMsg(
+  MsgSharedPtr<ShortMessage> msg, HandlerType han, EpochType epoch
+);
 
 } /* end namespace objgroup */
 
@@ -70,7 +72,9 @@ struct Runnable {
     TagType in_tag = no_tag
   );
 
-  friend void objgroup::scheduleMsg(MsgVirtualPtrAny msg, HandlerType han, EpochType epoch);
+  friend void objgroup::scheduleMsg(
+    MsgSharedPtr<ShortMessage> msg, HandlerType han, EpochType epoch
+  );
 
 private:
   // Dispatch for object groups: handler with node-local object ptr

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -64,11 +64,11 @@ namespace vt { namespace serialization {
 
 template <typename MsgT>
 static MsgPtr<MsgT> deserializeFullMessage(SerialByteType* source) {
-  auto msg = makeSharedMessage<MsgT>();
-  checkpoint::deserializeInPlace<MsgT>(source, msg);
+  auto msg = makeMessage<MsgT>();
+  checkpoint::deserializeInPlace<MsgT>(source, msg.get());
   // Reset ref-count to 0 (don't accept any deserialized value)
   envelopeSetRef(msg->env, 0);
-  return promoteMsg(msg);
+  return msg;
 }
 
 template <typename UserMsgT>

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -64,11 +64,11 @@ namespace vt { namespace serialization {
 
 template <typename MsgT>
 static MsgPtr<MsgT> deserializeFullMessage(SerialByteType* source) {
-  auto msg = makeMessage<MsgT>();
-  checkpoint::deserializeInPlace<MsgT>(source, msg.get());
+  auto msg = detail::makeMessageImpl<MsgT>();
+  checkpoint::deserializeInPlace<MsgT>(source, msg);
   // Reset ref-count to 0 (don't accept any deserialized value)
   envelopeSetRef(msg->env, 0);
-  return msg;
+  return promoteMsg(msg);
 }
 
 template <typename UserMsgT>

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -403,7 +403,9 @@ template <typename MsgT, typename BaseT>
           "serialMsgHandler: local msg: handler={}\n", typed_handler
         );
 
-        return messaging::PendingSend(msg, [=](MsgVirtualPtr<BaseMsgType> in){
+        MsgVirtualPtr<BaseMsgType> base_msg = msg.template to<BaseMsgType>();
+        ByteType msg_sz = sizeof(MsgT);
+        return messaging::PendingSend(base_msg, msg_sz, [=](MsgVirtualPtr<BaseMsgType> in){
           runnable::Runnable<MsgT>::run(typed_handler,nullptr,msg.get(),node);
         });
       }

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -208,7 +208,7 @@ template <typename MsgT, typename BaseT>
   SizeType ptr_size = 0;
   auto sys_size = sizeof(typename decltype(sys_msg)::MsgType);
 
-  msg_ptr->base_serialize_called_ = false;
+  envelopeSetHasBeenSerialized(msg->env, false);
 
   auto serialized_msg = checkpoint::serialize(
     *msg.get(), [&](SizeType size) -> SerialByteType* {
@@ -226,13 +226,12 @@ template <typename MsgT, typename BaseT>
   );
 
   vtAssertInfo(
-    msg_ptr->base_serialize_called_,
+    envelopeHasBeenSerialized(msg->env),
     "A message was serialized that did not correctly serialize parents."
     " All serialized messages are required to call serialize on the"
-    " message's parent type. See 'msg_serialize_parent'. typeid.name={}",
+    " message's parent type. See 'msg_serialize_parent'.",
     typeid(MsgT).name()
   );
-  msg_ptr->base_serialize_called_ = false;
 
   auto const& group_ = envelopeGetGroup(msg->env);
 
@@ -323,7 +322,7 @@ template <typename MsgT, typename BaseT>
   SerialByteType* ptr = nullptr;
   SizeType ptr_size = 0;
 
-  msg_ptr->base_serialize_called_ = false;
+  envelopeSetHasBeenSerialized(msg->env, false);
 
   auto serialized_msg = checkpoint::serialize(
     *msg.get(), [&](SizeType size) -> SerialByteType* {
@@ -342,13 +341,12 @@ template <typename MsgT, typename BaseT>
   );
 
   vtAssertInfo(
-    msg_ptr->base_serialize_called_,
+    envelopeHasBeenSerialized(msg->env),
     "A message was serialized that did not correctly serialize parents."
     " All serialized messages are required to call serialize on the"
-    " message's parent type. See 'msg_serialize_parent'. typeid.name={}",
+    " message's parent type. See 'msg_serialize_parent'.",
     typeid(MsgT).name()
   );
-  msg_ptr->base_serialize_called_ = false;
 
   //fmt::print("ptr_size={}\n", ptr_size);
 

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -53,6 +53,7 @@
 #include "vt/runnable/general.h"
 #include "vt/serialization/messaging/serialized_data_msg.h"
 #include "vt/serialization/messaging/serialized_messenger.h"
+#include "vt/messaging/envelope/envelope_set.h" // envelopeSetRef
 
 #include <tuple>
 #include <type_traits>
@@ -61,6 +62,14 @@
 
 namespace vt { namespace serialization {
 
+template <typename MsgT>
+static MsgPtr<MsgT> deserializeFullMessage(SerialByteType* source, size_t len) {
+  auto msg = makeSharedMessage<MsgT>();
+  checkpoint::deserializeInPlace<MsgT>(source, msg);
+  // Reset ref-count to 0 (don't accept any deserialized value)
+  envelopeSetRef(msg->env, 0);
+  return promoteMsg(msg);
+}
 
 template <typename UserMsgT>
 /*static*/ void SerializedMessenger::serialMsgHandlerBcast(
@@ -76,11 +85,12 @@ template <typename UserMsgT>
     group_, handler, ptr_size
   );
 
-  auto ptr_offset =
-    reinterpret_cast<char*>(sys_msg) + sizeof(SerialWrapperMsgType<UserMsgT>);
-  auto user_msg = makeMessage<UserMsgT>();
-  checkpoint::deserializeInPlace<UserMsgT>(ptr_offset,user_msg.get());
-  messageResetDeserdes(user_msg);
+  auto ptr_offset = reinterpret_cast<char*>(sys_msg)
+    + sizeof(SerialWrapperMsgType<UserMsgT>);
+  auto msg_data = ptr_offset;
+  auto msg_size = ptr_size;
+  auto user_msg = deserializeFullMessage<UserMsgT>(msg_data, msg_size);
+
   runnable::Runnable<UserMsgT>::run(
     handler, nullptr, user_msg.get(), sys_msg->from_node
   );
@@ -112,11 +122,10 @@ template <typename UserMsgT>
     recv_tag, sys_msg->from_node,
     [handler,recv_tag,node,epoch,is_valid_epoch]
     (RDMA_GetType ptr, ActionType action){
-      // be careful here not to use "msg", it is no longer valid
-      auto raw_ptr = reinterpret_cast<SerialByteType*>(std::get<0>(ptr));
-      auto msg = makeMessage<UserMsgT>();
-      checkpoint::deserializeInPlace<UserMsgT>(raw_ptr, msg.get());
-      messageResetDeserdes(msg);
+      // be careful here not to use "sys_msg", it is no longer valid
+      auto msg_data = reinterpret_cast<SerialByteType*>(std::get<0>(ptr));
+      auto msg_size = std::get<1>(ptr);
+      auto msg = deserializeFullMessage<UserMsgT>(msg_data, msg_size);
 
       debug_print(
         serial_msg, node,
@@ -145,11 +154,9 @@ template <typename UserMsgT, typename BaseEagerMsgT>
 ) {
   auto const handler = sys_msg->handler;
 
-  auto user_msg = makeMessage<UserMsgT>();
-  checkpoint::deserializeInPlace<UserMsgT>(
-    sys_msg->payload.data(), user_msg.get()
-  );
-  messageResetDeserdes(user_msg);
+  auto msg_data = sys_msg->payload.data();
+  auto msg_size = sys_msg->bytes;
+  auto user_msg = deserializeFullMessage<UserMsgT>(msg_data, msg_size);
 
   auto const& group_ = envelopeGetGroup(sys_msg->env);
 
@@ -387,9 +394,9 @@ template <typename MsgT, typename BaseT>
           dest, sys_msg.get(), send_serialized
         );
       } else {
-        auto user_msg = makeMessage<MsgT>();
-        checkpoint::deserializeInPlace<MsgT>(ptr, user_msg.get());
-        messageResetDeserdes(user_msg);
+        auto msg_data = ptr;
+        auto msg_size = ptr_size;
+        auto user_msg = deserializeFullMessage<MsgT>(msg_data, msg_size);
 
         debug_print(
           serial_msg, node,

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -397,9 +397,9 @@ template <typename MsgT, typename BaseT>
           "serialMsgHandler: local msg: handler={}\n", typed_handler
         );
 
-        MsgVirtualPtr<BaseMsgType> base_msg = msg.template to<BaseMsgType>();
+        auto base_msg = msg.template to<BaseMsgType>();
         ByteType msg_sz = sizeof(MsgT);
-        return messaging::PendingSend(base_msg, msg_sz, [=](MsgVirtualPtr<BaseMsgType> in){
+        return messaging::PendingSend(base_msg, msg_sz, [=](MsgPtr<BaseMsgType> in){
           runnable::Runnable<MsgT>::run(typed_handler,nullptr,msg.get(),node);
         });
       }

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -61,6 +61,7 @@
 
 namespace vt { namespace serialization {
 
+
 template <typename UserMsgT>
 /*static*/ void SerializedMessenger::serialMsgHandlerBcast(
   SerialWrapperMsgType<UserMsgT>* sys_msg

--- a/src/vt/termination/dijkstra-scholten/comm.cc
+++ b/src/vt/termination/dijkstra-scholten/comm.cc
@@ -64,9 +64,9 @@ namespace vt { namespace term { namespace ds {
   );
   auto const node = theContext()->getNode();
   vtAssertExpr(successor != node);
-  auto msg = makeSharedMessage<AckMsg>(epoch,node,successor,count);
+  auto msg = makeMessage<AckMsg>(epoch,node,successor,count);
   theMsg()->markAsTermMessage(msg);
-  theMsg()->sendMsg<AckMsg,requestAckHan>(successor,msg);
+  theMsg()->sendMsg<AckMsg,requestAckHan>(successor,msg.get());
 }
 
 /*static*/ void StateDS::acknowledge(
@@ -79,9 +79,9 @@ namespace vt { namespace term { namespace ds {
   );
   auto const node = theContext()->getNode();
   vtAssertExpr(predecessor != node);
-  auto msg = makeSharedMessage<AckMsg>(epoch,node,predecessor,count);
+  auto msg = makeMessage<AckMsg>(epoch,node,predecessor,count);
   theMsg()->markAsTermMessage(msg);
-  theMsg()->sendMsg<AckMsg,acknowledgeHan>(predecessor,msg);
+  theMsg()->sendMsg<AckMsg,acknowledgeHan>(predecessor,msg.get());
 }
 
 /*static*/ void StateDS::rootTerminated(EpochType epoch) {

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -435,16 +435,16 @@ bool TerminationDetector::propagateEpoch(TermStateType& state) {
     );
 
     if (not is_root) {
-      auto msg = makeSharedMessage<TermCounterMsg>(
+      auto msg = makeMessage<TermCounterMsg>(
         state.getEpoch(), state.g_prod1, state.g_cons1
       );
       theMsg()->markAsTermMessage(msg);
-      theMsg()->sendMsg<TermCounterMsg, propagateEpochHandler>(parent, msg);
+      theMsg()->sendMsg<TermCounterMsg, propagateEpochHandler>(parent, msg.get());
 
       debug_print_verbose(
         term, node,
         "propagateEpoch: sending to parent: {}, msg={}, epoch={:x}, wave={}\n",
-        parent, print_ptr(msg), state.getEpoch(), state.getCurWave()
+        parent, print_ptr(msg.get()), state.getEpoch(), state.getCurWave()
       );
     } else /*if (is_root) */ {
       is_term =
@@ -482,9 +482,9 @@ bool TerminationDetector::propagateEpoch(TermStateType& state) {
       }
 
       if (is_term) {
-        auto msg = makeSharedMessage<TermMsg>(state.getEpoch());
+        auto msg = makeMessage<TermMsg>(state.getEpoch());
         theMsg()->markAsTermMessage(msg);
-        theMsg()->broadcastMsg<TermMsg, epochTerminatedHandler>(msg);
+        theMsg()->broadcastMsg<TermMsg, epochTerminatedHandler>(msg.get());
 
         state.setTerminated();
 
@@ -511,9 +511,9 @@ bool TerminationDetector::propagateEpoch(TermStateType& state) {
           state.getEpoch(), state.getCurWave()
         );
 
-        auto msg = makeSharedMessage<TermMsg>(state.getEpoch(), state.getCurWave());
+        auto msg = makeMessage<TermMsg>(state.getEpoch(), state.getCurWave());
         theMsg()->markAsTermMessage(msg);
-        theMsg()->broadcastMsg<TermMsg, epochContinueHandler>(msg);
+        theMsg()->broadcastMsg<TermMsg, epochContinueHandler>(msg.get());
       }
     }
 
@@ -988,9 +988,9 @@ EpochType TerminationDetector::makeEpochRootedWave(
    *  Broadcast new rooted epoch to all other nodes to start processing this
    *  epoch
    */
-  auto msg = makeSharedMessage<TermMsg>(epoch);
+  auto msg = makeMessage<TermMsg>(epoch);
   theMsg()->markAsTermMessage(msg);
-  theMsg()->broadcastMsg<TermMsg,makeRootedHandler>(msg);
+  theMsg()->broadcastMsg<TermMsg,makeRootedHandler>(msg.get());
 
   /*
    *  Setup the new rooted epoch locally on the root node (this node)

--- a/src/vt/topos/location/location.impl.h
+++ b/src/vt/topos/location/location.impl.h
@@ -170,12 +170,12 @@ void EntityLocationCoord<EntityID>::registerEntity(
       );
 
       auto const& ask_node = uninitialized_destination;
-      auto msg = makeSharedMessage<LocMsgType>(
+      auto msg = makeMessage<LocMsgType>(
         this_inst, id, no_location_event_id, ask_node, home
       );
       msg->setResolvedNode(this_node);
       theMsg()->markAsLocationMessage(msg);
-      theMsg()->sendMsg<LocMsgType, updateLocation>(home, msg);
+      theMsg()->sendMsg<LocMsgType, updateLocation>(home, msg.get());
     }
   }
 }
@@ -366,11 +366,11 @@ void EntityLocationCoord<EntityID>::getLocation(
     if (not rec_exists) {
       if (home_node != this_node) {
         auto const& event_id = fst_location_event_id++;
-        auto msg = makeSharedMessage<LocMsgType>(
+        auto msg = makeMessage<LocMsgType>(
           this_inst, id, event_id, this_node, home_node
         );
         theMsg()->markAsLocationMessage(msg);
-        theMsg()->sendMsg<LocMsgType, getLocationHandler>(home_node, msg);
+        theMsg()->sendMsg<LocMsgType, getLocationHandler>(home_node, msg.get());
         // save a pending action when information about location arrives
         pending_actions_.emplace(
           std::piecewise_construct,
@@ -811,12 +811,12 @@ template <typename EntityID>
           event_id, epoch
         );
 
-        auto msg2 = makeSharedMessage<LocMsgType>(
+        auto msg2 = makeMessage<LocMsgType>(
           inst, entity, event_id, ask_node, home_node
         );
         msg2->setResolvedNode(node);
         theMsg()->markAsLocationMessage(msg2);
-        theMsg()->sendMsg<LocMsgType, updateLocation>(ask_node, msg2);
+        theMsg()->sendMsg<LocMsgType, updateLocation>(ask_node, msg2.get());
       });
       theMsg()->popEpoch(epoch);
       theTerm()->consume(epoch);

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -149,8 +149,8 @@ void GreedyLB::reduceCollect() {
   );
   using MsgType = GreedyCollectMsg;
   auto cb = vt::theCB()->makeSend<GreedyLB, MsgType, &GreedyLB::collectHandler>(proxy[0]);
-  auto msg = makeSharedMessage<MsgType>(load_over,this_load);
-  proxy.template reduce<collective::PlusOp<GreedyPayload>>(msg,cb);
+  auto msg = makeMessage<MsgType>(load_over,this_load);
+  proxy.template reduce<collective::PlusOp<GreedyPayload>>(msg.get(),cb);
 }
 
 void GreedyLB::runBalancer(

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -83,8 +83,8 @@ void CollectionManager::startPhaseRooted(
   ActionFinishedLBType fn, PhaseType lb_phase
 ) {
 #if backend_check_enabled(lblite)
-  auto msg = makeSharedMessage<StartRootedMsg>(lb_phase);
-  theMsg()->broadcastMsg<StartRootedMsg, startRootedBroadcast>(msg);
+  auto msg = makeMessage<StartRootedMsg>(lb_phase);
+  theMsg()->broadcastMsg<StartRootedMsg, startRootedBroadcast>(msg.get());
   startPhaseCollective(fn, lb_phase);
 #else
   if (fn != nullptr) {

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1482,7 +1482,10 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
 
   if (imm_context) {
     theTerm()->produce(cur_epoch);
-    return messaging::PendingSend(msg, [=](MsgVirtualPtr<BaseMsgType> inner_msg){
+
+    MsgVirtualPtr<BaseMsgType> base_msg = msg.template to<BaseMsgType>();
+    ByteType msg_sz = sizeof(MsgT);
+    return messaging::PendingSend(base_msg, msg_sz, [=](MsgVirtualPtr<BaseMsgType> inner_msg){
       schedule([=]{
         theMsg()->pushEpoch(cur_epoch);
         theCollection()->sendMsgUntypedHandler<MsgT,ColT,IdxT>(

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -676,9 +676,11 @@ template <typename>
     msg->proxy, msg->isRoot(), msg->getGroup()
   );
   if (msg->isRoot()) {
-    auto nmsg = makeSharedMessage<CollectionGroupMsg>(*msg);
+    auto nmsg = makeMessage<CollectionGroupMsg>(*msg);
     theMsg()->markAsCollectionMessage(nmsg);
-    theMsg()->broadcastMsg<CollectionGroupMsg,collectionGroupFinishedHan>(nmsg);
+    theMsg()->broadcastMsg<CollectionGroupMsg,collectionGroupFinishedHan>(
+      nmsg.get()
+    );
   }
 }
 
@@ -2347,13 +2349,13 @@ void CollectionManager::finishedInsertEpoch(
   theTerm()->finishNoActivateEpoch(next_insert_epoch);
   UniversalIndexHolder<>::insertSetEpoch(untyped_proxy,next_insert_epoch);
 
-  auto msg = makeSharedMessage<UpdateInsertMsg<ColT,IndexT>>(
+  auto msg = makeMessage<UpdateInsertMsg<ColT,IndexT>>(
     proxy,next_insert_epoch
   );
   theMsg()->markAsCollectionMessage(msg);
   theMsg()->broadcastMsg<
     UpdateInsertMsg<ColT,IndexT>,updateInsertEpochHandler
-  >(msg);
+  >(msg.get());
 
   /*
    *  Start building the a new group for broadcasts and reductions over the
@@ -2453,11 +2455,11 @@ template <typename ColT, typename IndexT>
 
   if (node != uninitialized_destination) {
     auto send = [untyped_proxy,node]{
-      auto smsg = makeSharedMessage<ActInsertMsg<ColT,IndexT>>(untyped_proxy);
+      auto smsg = makeMessage<ActInsertMsg<ColT,IndexT>>(untyped_proxy);
       theMsg()->markAsCollectionMessage(smsg);
       theMsg()->sendMsg<
         ActInsertMsg<ColT,IndexT>,actInsertHandler<ColT,IndexT>
-      >(node,smsg);
+      >(node,smsg.get());
     };
     return theCollection()->finishedInserting<ColT,IndexT>(msg->proxy_, send);
   } else {
@@ -2508,10 +2510,10 @@ void CollectionManager::finishedInserting(
     }
   } else {
     auto node = insert_action ? this_node : uninitialized_destination;
-    auto msg = makeSharedMessage<DoneInsertMsg<ColT,IndexT>>(proxy,node);
+    auto msg = makeMessage<DoneInsertMsg<ColT,IndexT>>(proxy,node);
     theMsg()->markAsCollectionMessage(msg);
     theMsg()->sendMsg<DoneInsertMsg<ColT,IndexT>,doneInsertHandler<ColT,IndexT>>(
-      cons_node,msg
+      cons_node,msg.get()
     );
   }
 }
@@ -2643,14 +2645,14 @@ void CollectionManager::insert(
       IdxContextHolder::clear();
     } else {
       auto const& cur_epoch = theMsg()->getEpoch();
-      auto msg = makeSharedMessage<InsertMsg<ColT,IndexT>>(
+      auto msg = makeMessage<InsertMsg<ColT,IndexT>>(
         proxy,max_idx,idx,insert_node,mapped_node,insert_epoch,cur_epoch
       );
       theTerm()->produce(insert_epoch,1,insert_node);
       theTerm()->produce(cur_epoch,1,insert_node);
       theMsg()->markAsCollectionMessage(msg);
       theMsg()->sendMsg<InsertMsg<ColT,IndexT>,insertHandler<ColT,IndexT>>(
-        insert_node,msg
+        insert_node,msg.get()
       );
     }
   } else {
@@ -2784,13 +2786,13 @@ MigrateStatus CollectionManager::migrateOut(
 
    using MigrateMsgType = MigrateMsg<ColT, IndexT>;
 
-   auto msg = makeSharedMessage<MigrateMsgType>(
+   auto msg = makeMessage<MigrateMsgType>(
      proxy, this_node, dest, map_fn, range, &typed_col_ref
    );
 
    theMsg()->sendMsg<
      MigrateMsgType, MigrateHandlers::migrateInHandler<ColT, IndexT>
-   >(dest, msg);
+   >(dest, msg.get());
 
    theLocMan()->getCollectionLM<ColT, IndexT>(col_proxy)->entityMigrated(
      proxy, dest
@@ -3169,7 +3171,7 @@ void CollectionManager::nextPhase(
 ) {
   using namespace balance;
   using MsgType = PhaseMsg<ColT>;
-  auto msg = makeSharedMessage<MsgType>(cur_phase, proxy, true, false);
+  auto msg = makeMessage<MsgType>(cur_phase, proxy, true, false);
   auto const instrument = false;
 
   debug_print(
@@ -3214,7 +3216,7 @@ void CollectionManager::nextPhase(
   #endif
 
   theCollection()->broadcastMsg<MsgType,ElementStats::syncNextPhase<ColT>>(
-    proxy, msg, instrument
+    proxy, msg.get(), instrument
   );
 }
 

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1485,9 +1485,9 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   if (imm_context) {
     theTerm()->produce(cur_epoch);
 
-    MsgVirtualPtr<BaseMsgType> base_msg = msg.template to<BaseMsgType>();
+    auto base_msg = msg.template to<BaseMsgType>();
     ByteType msg_sz = sizeof(MsgT);
-    return messaging::PendingSend(base_msg, msg_sz, [=](MsgVirtualPtr<BaseMsgType> inner_msg){
+    return messaging::PendingSend(base_msg, msg_sz, [=](MsgPtr<BaseMsgType> inner_msg){
       schedule([=]{
         theMsg()->pushEpoch(cur_epoch);
         theCollection()->sendMsgUntypedHandler<MsgT,ColT,IdxT>(

--- a/src/vt/vrt/context/context_vrtmanager.impl.h
+++ b/src/vt/vrt/context/context_vrtmanager.impl.h
@@ -138,6 +138,9 @@ template <typename VcT, typename MsgT, ActiveVrtTypedFnType<MsgT, VcT> *f>
 messaging::PendingSend VirtualContextManager::sendSerialMsg(
   VirtualProxyType const& toProxy, MsgT *const msg
 ) {
+  MsgVirtualPtr<BaseMsgType> base_msg = promoteMsg(msg).template to<BaseMsgType>();
+  ByteType msg_sz = sizeof(MsgT);
+
   if (theContext()->getWorker() == worker_id_comm_thread) {
     NodeType const& home_node = VirtualProxyBuilder::getVirtualNode(toProxy);
     // register the user's handler
@@ -155,9 +158,8 @@ messaging::PendingSend VirtualContextManager::sendSerialMsg(
     using SerialMsgT = SerializedEagerMsg<MsgT, VirtualMessage>;
 
     // route the message to the destination using the location manager
-    auto promoted_msg = promoteMsg(msg);
     messaging::PendingSend pending(
-      promoted_msg, [=](MsgVirtualPtr<BaseMsgType> mymsg){
+      base_msg, msg_sz, [=](MsgVirtualPtr<BaseMsgType> mymsg){
         // Uses special implementation overload not exposed in theMsg..
         MsgT* typed_msg = reinterpret_cast<MsgT*>(mymsg.get());
         auto sendSerialHan = auto_registry::makeAutoHandler<MsgT,virtualTypedMsgHandler<MsgT>>(nullptr);
@@ -185,9 +187,8 @@ messaging::PendingSend VirtualContextManager::sendSerialMsg(
     );
     return pending;
   } else {
-    auto promoted_msg = promoteMsg(msg);
     return messaging::PendingSend(
-      promoted_msg, [=](MsgVirtualPtr<BaseMsgType> mymsg) {
+      base_msg, msg_sz, [=](MsgVirtualPtr<BaseMsgType> mymsg) {
         theWorkerGrp()->enqueueCommThread([=]{
           auto typed_msg = reinterpret_cast<MsgT*>(mymsg.get());
           theVirtualManager()->sendSerialMsg<VcT, MsgT, f>(toProxy, typed_msg);
@@ -325,12 +326,15 @@ messaging::PendingSend VirtualContextManager::sendMsg(
     print_ptr(msg.get()), han, home_node
   );
 
-  return messaging::PendingSend(
-    msg, [=](MsgVirtualPtr<BaseMsgType> mymsg){
-    // route the message to the destination using the location manager
+  MsgVirtualPtr<BaseMsgType> base_msg = msg.template to<BaseMsgType>();
+  ByteType msg_sz = sizeof(MsgT);
+  return messaging::PendingSend(base_msg, msg_sz,
+    [=](MsgVirtualPtr<BaseMsgType> mymsg){
+      // route the message to the destination using the location manager
       auto msg_shared = promoteMsg(reinterpret_cast<MsgT*>(mymsg.get()));
       theLocMan()->vrtContextLoc->routeMsg(toProxy, home_node, msg_shared);
-  });
+    }
+  );
 }
 
 }}  // end namespace vt::vrt

--- a/src/vt/vrt/context/context_vrtmanager.impl.h
+++ b/src/vt/vrt/context/context_vrtmanager.impl.h
@@ -104,11 +104,11 @@ template <typename SysMsgT>
     auto const& request_id = info.req_id;
 
     new_proxy = theVirtualManager()->generateNewProxy();
-    auto send_msg = makeSharedMessage<VirtualProxyRequestMsg>(
+    auto send_msg = makeMessage<VirtualProxyRequestMsg>(
       cons_node, req_node, request_id, new_proxy
     );
     theMsg()->sendMsg<VirtualProxyRequestMsg, sendBackVirtualProxyHan>(
-      req_node, send_msg
+      req_node, send_msg.get()
     );
   }
 
@@ -205,8 +205,7 @@ VirtualProxyType VirtualContextManager::makeVirtualRemote(
   using ArgsTupleType = std::tuple<typename std::decay<Args>::type...>;
   using MsgType = VrtConstructMsg<RemoteVrtInfo, ArgsTupleType, VrtContextT>;
 
-  auto sys_msg =
-    makeSharedMessage<MsgType>(ArgsTupleType{std::forward<Args>(args)...});
+  auto sys_msg = makeMessage<MsgType>(ArgsTupleType{std::forward<Args>(args)...});
 
   auto const& this_node = theContext()->getNode();
   std::unique_ptr<RemoteVrtInfo> info = nullptr;
@@ -233,7 +232,7 @@ VirtualProxyType VirtualContextManager::makeVirtualRemote(
 
   sys_msg->info = *info.get();
 
-  theMsg()->sendMsg<MsgType,remoteConstructVrt<MsgType>>(dest, sys_msg);
+  theMsg()->sendMsg<MsgType,remoteConstructVrt<MsgType>>(dest, sys_msg.get());
 
   return return_proxy;
 }

--- a/tests/perf/ping_pong.cc
+++ b/tests/perf/ping_pong.cc
@@ -104,9 +104,9 @@ static void finishedPing(FinishedPingMsg<num_bytes>* msg) {
   printTiming(num_bytes);
 
   if (num_bytes != max_bytes) {
-    auto pmsg = makeSharedMessage<PingMsg<num_bytes * 2>>();
+    auto pmsg = makeMessage<PingMsg<num_bytes * 2>>();
     theMsg()->sendMsg<PingMsg<num_bytes * 2>, pingPong>(
-      pong_node, pmsg
+      pong_node, pmsg.get()
     );
   }
 }
@@ -132,9 +132,9 @@ static void pingPong(PingMsg<num_bytes>* in_msg) {
   #endif
 
   if (cnt >= num_pings) {
-    auto msg = makeSharedMessage<FinishedPingMsg<num_bytes>>(num_bytes);
+    auto msg = makeMessage<FinishedPingMsg<num_bytes>>(num_bytes);
     theMsg()->sendMsg<FinishedPingMsg<num_bytes>, finishedPing>(
-      0, msg
+      0, msg.get()
     );
   } else {
     NodeType const next =
@@ -145,8 +145,8 @@ static void pingPong(PingMsg<num_bytes>* in_msg) {
         next, in_msg, [=]{ /*delete in_msg;*/ }
       );
     #else
-      auto m = makeSharedMessage<PingMsg<num_bytes>>(cnt + 1);
-      theMsg()->sendMsg<PingMsg<num_bytes>, pingPong>(next, m);
+      auto m = makeMessage<PingMsg<num_bytes>>(cnt + 1);
+      theMsg()->sendMsg<PingMsg<num_bytes>, pingPong>(next, m.get());
     #endif
   }
 }
@@ -168,8 +168,8 @@ int main(int argc, char** argv) {
   startTime = MPI_Wtime();
 
   if (my_node == 0) {
-    auto m = makeSharedMessage<PingMsg<min_bytes>>();
-    theMsg()->sendMsg<PingMsg<min_bytes>, pingPong>(pong_node, m);
+    auto m = makeMessage<PingMsg<min_bytes>>();
+    theMsg()->sendMsg<PingMsg<min_bytes>, pingPong>(pong_node, m.get());
   }
 
   while (!rt->isTerminated()) {

--- a/tests/unit/active/test_active_bcast_put.cc
+++ b/tests/unit/active/test_active_bcast_put.cc
@@ -123,9 +123,9 @@ TEST_P(TestActiveBroadcastPut, test_type_safe_active_fn_bcast2) {
   if (root < num_nodes) {
     if (my_node == root) {
       for (int i = 0; i < num_msg_sent; i++) {
-        auto msg = makeSharedMessage<PutTestMessage>();
+        auto msg = makeMessage<PutTestMessage>();
         msg->setPut(&put_payload[0], put_size * sizeof(int));
-        theMsg()->broadcastMsg<PutTestMessage, test_handler>(msg);
+        theMsg()->broadcastMsg<PutTestMessage, test_handler>(msg.get());
       }
     }
 

--- a/tests/unit/active/test_active_broadcast.cc
+++ b/tests/unit/active/test_active_broadcast.cc
@@ -97,8 +97,8 @@ TEST_P(TestActiveBroadcast, test_type_safe_active_fn_bcast2) {
   if (root < num_nodes) {
     if (my_node == root) {
       for (int i = 0; i < num_msg_sent; i++) {
-        auto msg = makeSharedMessage<TestMsg>();
-        theMsg()->broadcastMsg<TestMsg, test_handler>(msg);
+        auto msg = makeMessage<TestMsg>();
+        theMsg()->broadcastMsg<TestMsg, test_handler>(msg.get());
       }
     }
 

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -137,8 +137,8 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send) {
       #if DEBUG_TEST_HARNESS_PRINT
         fmt::print("{}: sendMsg: i={}\n", my_node, i);
       #endif
-      auto msg = makeSharedMessage<TestMsg>();
-      theMsg()->sendMsg<TestMsg, test_handler>(1, msg);
+      auto msg = makeMessage<TestMsg>();
+      theMsg()->sendMsg<TestMsg, test_handler>(1, msg.get());
     }
   } else if (my_node == to_node) {
     theTerm()->addAction([=]{
@@ -163,13 +163,13 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send_small_put) {
 
   if (my_node == from_node) {
     for (int i = 0; i < num_msg_sent; i++) {
-      auto msg = makeSharedMessage<PutTestMessage>();
+      auto msg = makeMessage<PutTestMessage>();
       msg->setPut(&test_vec[0], sizeof(int)*test_vec.size());
       #if DEBUG_TEST_HARNESS_PRINT
         fmt::print("{}: sendMsg: (put) i={}\n", my_node, i);
       #endif
       theMsg()->sendMsg<PutTestMessage, test_handler_2>(
-        1, msg
+        1, msg.get()
       );
     }
   }
@@ -191,13 +191,13 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send_large_put) {
 
   if (my_node == from_node) {
     for (int i = 0; i < num_msg_sent; i++) {
-      auto msg = makeSharedMessage<PutTestMessage>();
+      auto msg = makeMessage<PutTestMessage>();
       msg->setPut(&test_vec_2[0], sizeof(int)*test_vec_2.size());
       #if DEBUG_TEST_HARNESS_PRINT
         fmt::print("{}: sendMsg: (put) i={}\n", my_node, i);
       #endif
       theMsg()->sendMsg<PutTestMessage, test_handler_3>(
-        1, msg
+        1, msg.get()
       );
     }
   }

--- a/tests/unit/active/test_active_send_put.cc
+++ b/tests/unit/active/test_active_send_put.cc
@@ -105,14 +105,14 @@ TEST_P(TestActiveSendPut, test_active_fn_send_put_param) {
   }
 
   if (my_node == from_node) {
-    auto msg = makeSharedMessage<PutTestMessage>(
+    auto msg = makeMessage<PutTestMessage>(
       static_cast<int>(test_vec_2.size())
     );
     msg->setPut(&test_vec_2[0], sizeof(int)*test_vec_2.size());
     #if DEBUG_TEST_HARNESS_PRINT
       fmt::print("{}: sendMsg: (put) i={}\n", my_node, i);
     #endif
-    theMsg()->sendMsg<PutTestMessage, test_handler>(1, msg);
+    theMsg()->sendMsg<PutTestMessage, test_handler>(1, msg.get());
   }
 
   // Spin here so test_vec does not go out of scope before the send completes

--- a/tests/unit/collection/test_broadcast.cc
+++ b/tests/unit/collection/test_broadcast.cc
@@ -128,16 +128,16 @@ TYPED_TEST_P(TestBroadcast, test_broadcast_1) {
     auto range = TestIndex(col_size);
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = theCollection()->construct<ColType>(range);
-    auto msg = makeSharedMessage<MsgType>(args);
+    auto msg = makeMessage<MsgType>(args);
     proxy.template broadcast<
       MsgType,
       BroadcastHandlers<ColType>::handler
-    >(msg);
+    >(msg.get());
 
-    auto msg2 = makeSharedMessage<MsgType>(args);
+    auto msg2 = makeMessage<MsgType>(args);
     theCollection()->broadcastMsg<
       MsgType,BroadcastHandlers<ColType>::handler
-    >(proxy, msg2);
+    >(proxy, msg2.get());
   }
 }
 

--- a/tests/unit/collection/test_collection_construct_common.h
+++ b/tests/unit/collection/test_collection_construct_common.h
@@ -151,11 +151,11 @@ TYPED_TEST_P(TestConstruct, test_construct_1) {
     auto rng = TestIndex(col_size);
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = ConstructParams<ColType,TestParamType>::constructTup(rng,args);
-    auto msg = makeSharedMessage<MsgType>();
+    auto msg = makeMessage<MsgType>();
     proxy.template broadcast<
       MsgType,
       ConstructHandlers::handler<ColType,MsgType>
-    >(msg);
+    >(msg.get());
   }
 }
 
@@ -170,11 +170,11 @@ TYPED_TEST_P(TestConstructDist, test_construct_distributed_1) {
   auto proxy = ConstructParams<ColType,TestParamType>::constructTupCollective(
     rng,args
   );
-  auto msg = makeSharedMessage<MsgType>();
+  auto msg = makeMessage<MsgType>();
   proxy.template broadcast<
     MsgType,
     ConstructHandlers::handler<ColType,MsgType>
-  >(msg);
+  >(msg.get());
 }
 
 REGISTER_TYPED_TEST_SUITE_P(TestConstruct,     test_construct_1);

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -92,14 +92,14 @@ struct FinishedWork {
 /*static*/ void DestroyTest::work(WorkMsg* msg, DestroyTest* col) {
   auto proxy = col->getCollectionProxy();
   // ::fmt::print("work idx={}, proxy={:x}\n", col->getIndex(), proxy.getProxy());
-  auto reduce_msg = makeSharedMessage<CollReduceMsg>(proxy);
+  auto reduce_msg = makeMessage<CollReduceMsg>(proxy);
   theCollection()->reduceMsg<
     DestroyTest,
     CollReduceMsg,
     CollReduceMsg::template msgHandler<
       CollReduceMsg, collective::PlusOp<collective::NoneType>, FinishedWork
     >
-  >(proxy,reduce_msg);
+  >(proxy,reduce_msg.get());
 }
 
 struct TestDestroy : TestParallelHarness { };
@@ -112,9 +112,9 @@ TEST_F(TestDestroy, test_destroy_1) {
   if (this_node == 0) {
     auto const& range = Index1D(num_nodes * num_elms_per_node);
     auto proxy = theCollection()->construct<DestroyTest>(range);
-    auto msg = makeSharedMessage<WorkMsg>();
+    auto msg = makeMessage<WorkMsg>();
     // ::fmt::print("broadcasting proxy={:x}\n", proxy.getProxy());
-    proxy.broadcast<WorkMsg,DestroyTest::work>(msg);
+    proxy.broadcast<WorkMsg,DestroyTest::work>(msg.get());
   }
   theTerm()->addAction([]{
     // ::fmt::print("num destroyed={}\n", num_destroyed);

--- a/tests/unit/collection/test_index_types.cc
+++ b/tests/unit/collection/test_index_types.cc
@@ -107,12 +107,12 @@ TYPED_TEST_P(TestCollectionIndexTypes, test_collection_index_1) {
     auto range = IndexType(static_cast<BaseIndexType>(col_size));
     auto proxy = theCollection()->construct<ColType>(range);
     for (BaseIndexType i = 0; i < static_cast<BaseIndexType>(col_size); i++) {
-      auto msg = makeSharedMessage<MsgType>(34);
+      auto msg = makeMessage<MsgType>(34);
       if (i % 2 == 0) {
-        proxy[i].template send<MsgType,&ColType::handler>(msg);
+        proxy[i].template send<MsgType,&ColType::handler>(msg.get());
       } else {
         theCollection()->sendMsg<MsgType,&ColType::handler>(
-          proxy[i], msg
+          proxy[i], msg.get()
         );
       }
     }

--- a/tests/unit/collection/test_insert.cc
+++ b/tests/unit/collection/test_insert.cc
@@ -170,8 +170,8 @@ TEST_F(TestInsert, test_insert_send_dense_node_1) {
     auto proxy = theCollection()->construct<InsertTest>(range);
     for (auto i = 0; i < range.x(); i++) {
       proxy[i].insert((this_node + 1) % num_nodes);
-      auto msg = makeSharedMessage<WorkMsg>();
-      proxy[i].send<WorkMsg,&InsertTest::work>(msg);
+      auto msg = makeMessage<WorkMsg>();
+      proxy[i].send<WorkMsg,&InsertTest::work>(msg.get());
       // ::fmt::print("sending to {}\n", i);
     }
   }
@@ -195,8 +195,8 @@ TEST_F(TestInsert, test_insert_send_sparse_node_1) {
     auto proxy = theCollection()->construct<InsertTest>(range);
     for (auto i = 0; i < range.x(); i+=16) {
       proxy[i].insert((this_node + 1) % num_nodes);
-      auto msg = makeSharedMessage<WorkMsg>();
-      proxy[i].send<WorkMsg,&InsertTest::work>(msg);
+      auto msg = makeMessage<WorkMsg>();
+      proxy[i].send<WorkMsg,&InsertTest::work>(msg.get());
     }
   }
   theTerm()->addAction([=]{

--- a/tests/unit/collection/test_lb_lite.cc
+++ b/tests/unit/collection/test_lb_lite.cc
@@ -155,22 +155,22 @@ struct FinishedIter {
     col->assertValues();
   }
   auto proxy = col->getCollectionProxy();
-  auto reduce_msg = makeSharedMessage<IterReduceMsg>(proxy,iter);
+  auto reduce_msg = makeMessage<IterReduceMsg>(proxy,iter);
   theCollection()->reduceMsg<
     LBTest,
     IterReduceMsg,
     IterReduceMsg::template msgHandler<
       IterReduceMsg, collective::PlusOp<collective::NoneType>, FinishedIter
     >
-  >(proxy, reduce_msg);
+  >(proxy, reduce_msg.get());
 }
 
 static void startIter(int32_t const iter, ColProxyType proxy) {
   ::fmt::print(
     "startIter: iter={}, cur_iter={}\n", iter, iter
   );
-  auto msg = makeSharedMessage<IterMsg>(iter);
-  proxy.broadcast<IterMsg,LBTest::iterWork>(msg);
+  auto msg = makeMessage<IterMsg>(iter);
+  proxy.broadcast<IterMsg,LBTest::iterWork>(msg.get());
 }
 
 struct TestLB : TestParallelHarness { };

--- a/tests/unit/collection/test_reduce_collection.cc
+++ b/tests/unit/collection/test_reduce_collection.cc
@@ -59,19 +59,19 @@ TEST_P(TestReduceCollection, test_reduce_op) {
     auto size = (reduce_case == 5 ? collect_size * 4 : collect_size);
     auto const& range = Index1D(size);
     auto proxy = theCollection()->construct<MyCol>(range);
-    auto msg = makeSharedMessage<ColMsg>(my_node);
+    auto msg = makeMessage<ColMsg>(my_node);
 
     switch (reduce_case) {
-      case 0: proxy.broadcast<ColMsg, colHanBasic>(msg); break;
-      case 1: proxy.broadcast<ColMsg, colHanVec>(msg); break;
-      case 2: proxy.broadcast<ColMsg, colHanVecProxy>(msg); break;
-      case 3: proxy.broadcast<ColMsg, colHanVecProxyCB>(msg); break;
-      case 4: proxy.broadcast<ColMsg, colHanNoneCB>(msg); break;
+    case 0: proxy.broadcast<ColMsg, colHanBasic>(msg.get()); break;
+    case 1: proxy.broadcast<ColMsg, colHanVec>(msg.get()); break;
+    case 2: proxy.broadcast<ColMsg, colHanVecProxy>(msg.get()); break;
+    case 3: proxy.broadcast<ColMsg, colHanVecProxyCB>(msg.get()); break;
+    case 4: proxy.broadcast<ColMsg, colHanNoneCB>(msg.get()); break;
 
       #if ENABLE_REDUCE_EXPR_CALLBACK
-        case 5: proxy.broadcast<ColMsg, colHanPartial>(msg); break;
-        case 6: proxy.broadcast<ColMsg, colHanPartialMulti>(msg); break;
-        case 7: proxy.broadcast<ColMsg, colHanPartialProxy>(msg); break;
+    case 5: proxy.broadcast<ColMsg, colHanPartial>(msg.get()); break;
+    case 6: proxy.broadcast<ColMsg, colHanPartialMulti>(msg.get()); break;
+    case 7: proxy.broadcast<ColMsg, colHanPartialProxy>(msg.get()); break;
       #endif
       default: vtAbort("Failure: should not be reached");
     }

--- a/tests/unit/collection/test_reduce_collection_handler.h
+++ b/tests/unit/collection/test_reduce_collection_handler.h
@@ -61,7 +61,7 @@ void colHanBasic(ColMsg* msg, MyCol* col) {
     print_ptr(col), idx.x(), col->getIndex().x()
   );
 
-  auto reduce_msg = vt::makeSharedMessage<MyReduceMsg>(idx.x());
+  auto reduce_msg = vt::makeMessage<MyReduceMsg>(idx.x());
   auto proxy = col->getProxy();
   debug_print(reduce, node, "msg->num={}\n", reduce_msg->num);
 
@@ -69,7 +69,7 @@ void colHanBasic(ColMsg* msg, MyCol* col) {
 
   vt::theCollection()->reduceMsg<
     MyCol, MyReduceMsg, reducePlus<expected>
-  >(proxy, reduce_msg);
+  >(proxy, reduce_msg.get());
 }
 
 void colHanVec(ColMsg* msg, MyCol* col) {
@@ -80,7 +80,7 @@ void colHanVec(ColMsg* msg, MyCol* col) {
     print_ptr(col), idx.x(), col->getIndex().x()
   );
 
-  auto reduce_msg = vt::makeSharedMessage<SysMsgVec>(static_cast<double>(idx.x()));
+  auto reduce_msg = vt::makeMessage<SysMsgVec>(static_cast<double>(idx.x()));
   auto proxy = col->getProxy();
   debug_print(
     reduce, node,
@@ -91,7 +91,7 @@ void colHanVec(ColMsg* msg, MyCol* col) {
     MyCol,
     SysMsgVec,
     SysMsgVec::msgHandler<SysMsgVec, vt::collective::PlusOp<VectorPayload>, CheckVec>
-  >(proxy, reduce_msg);
+  >(proxy, reduce_msg.get());
 }
 
 void colHanVecProxy(ColMsg* msg, MyCol* col) {
@@ -102,13 +102,13 @@ void colHanVecProxy(ColMsg* msg, MyCol* col) {
     print_ptr(col), idx.x(), col->getIndex().x()
   );
 
-  auto reduce_msg = vt::makeSharedMessage<SysMsgVec>(static_cast<double>(idx.x()));
+  auto reduce_msg = vt::makeMessage<SysMsgVec>(static_cast<double>(idx.x()));
   auto proxy = col->getCollectionProxy();
   debug_print(
     reduce, node,
     "msg->vec.size={}\n", reduce_msg->getConstVal().vec.size()
   );
-  proxy.reduce<vt::collective::PlusOp<VectorPayload>, CheckVec>(reduce_msg);
+  proxy.reduce<vt::collective::PlusOp<VectorPayload>, CheckVec>(reduce_msg.get());
 }
 
 void colHanVecProxyCB(ColMsg* msg, MyCol* col) {
@@ -119,7 +119,7 @@ void colHanVecProxyCB(ColMsg* msg, MyCol* col) {
     print_ptr(col), idx.x(), col->getIndex().x()
   );
 
-  auto reduce_msg = vt::makeSharedMessage<SysMsgVec>(static_cast<double>(idx.x()));
+  auto reduce_msg = vt::makeMessage<SysMsgVec>(static_cast<double>(idx.x()));
   auto proxy = col->getCollectionProxy();
   debug_print(
     reduce, node,
@@ -128,7 +128,7 @@ void colHanVecProxyCB(ColMsg* msg, MyCol* col) {
 
   auto cb = vt::theCB()->makeSend<CheckVec>(0);
   vtAssertExpr(cb.valid());
-  proxy.reduce<vt::collective::PlusOp<VectorPayload>>(reduce_msg,cb);
+  proxy.reduce<vt::collective::PlusOp<VectorPayload>>(reduce_msg.get(),cb);
 }
 
 void colHanNoneCB(ColMsg* msg, MyCol* col) {
@@ -158,7 +158,7 @@ void colHanPartial(ColMsg* msg, MyCol* col) {
     print_ptr(col), idx.x(), col->getIndex().x()
   );
 
-  auto reduce_msg = makeSharedMessage<MyReduceMsg>(idx.x());
+  auto reduce_msg = makeMessage<MyReduceMsg>(idx.x());
   auto proxy = col->getProxy();
   debug_print(reduce, node, "msg->num={}\n", reduce_msg->num);
 
@@ -167,7 +167,7 @@ void colHanPartial(ColMsg* msg, MyCol* col) {
   theCollection()->reduceMsgExpr<
     MyCol, MyReduceMsg, reducePlus<expected>
   >(
-    proxy,reduce_msg, [](Index1D const idx) -> bool {
+    proxy,reduce_msg.get(), [](Index1D const idx) -> bool {
       return idx.x() < index_tresh;
     }
   );
@@ -183,7 +183,7 @@ void colHanPartialMulti(ColMsg* msg, MyCol* col) {
     print_ptr(col), idx.x(), col->getIndex().x()
   );
 
-  auto reduce_msg = makeSharedMessage<MyReduceMsg>(idx.x());
+  auto reduce_msg = makeMessage<MyReduceMsg>(idx.x());
   auto proxy = col->getProxy();
   debug_print(reduce, node, "msg->num={}\n", reduce_msg->num);
 
@@ -199,7 +199,7 @@ void colHanPartialMulti(ColMsg* msg, MyCol* col) {
   theCollection()->reduceMsgExpr<
     MyCol, MyReduceMsg, reducePlus<collect_size,false>
   >(
-    proxy,reduce_msg, [=](Index1D const idx) -> bool {
+    proxy,reduce_msg.get(), [=](Index1D const idx) -> bool {
       return idx.x() % index_tresh == grouping;
     }, no_epoch, grouping
   );
@@ -214,12 +214,12 @@ void colHanPartialProxy(ColMsg* msg, MyCol* col) {
     print_ptr(col), idx.x(), col->getIndex().x()
   );
 
-  auto reduce_msg = makeSharedMessage<MyReduceMsg>(idx.x());
+  auto reduce_msg = makeMessage<MyReduceMsg>(idx.x());
   auto proxy = col->getCollectionProxy();
   debug_print(reduce, node, "msg->num={}\n", reduce_msg->num);
 
   proxy.reduceExpr< MyReduceMsg, reducePlus<index_tresh> >(
-    reduce_msg, [](Index1D const& idx) -> bool {
+    reduce_msg.get(), [](Index1D const& idx) -> bool {
       return idx.x() < index_tresh;
     }
   );

--- a/tests/unit/collection/test_send.cc
+++ b/tests/unit/collection/test_send.cc
@@ -150,13 +150,13 @@ TYPED_TEST_P(TestCollectionSend, test_collection_send_1) {
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = theCollection()->construct<ColType>(range);
     for (int i = 0; i < col_size; i++) {
-      auto msg = makeSharedMessage<MsgType>(args);
+      auto msg = makeMessage<MsgType>(args);
       //proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg);
       if (i % 2 == 0) {
-        proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg);
+        proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg.get());
       } else {
         theCollection()->sendMsg<MsgType,SendHandlers<ColType>::handler>(
-          proxy[i], msg
+          proxy[i], msg.get()
         );
       }
     }
@@ -175,13 +175,13 @@ TYPED_TEST_P(TestCollectionSendMem, test_collection_send_ptm_1) {
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = theCollection()->construct<ColType>(range);
     for (int i = 0; i < col_size; i++) {
-      auto msg = makeSharedMessage<MsgType>(args);
+      auto msg = makeMessage<MsgType>(args);
       //proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg);
       if (i % 2 == 0) {
-        proxy[i].template send<MsgType,&ColType::handler>(msg);
+        proxy[i].template send<MsgType,&ColType::handler>(msg.get());
       } else {
         theCollection()->sendMsg<MsgType,&ColType::handler>(
-          proxy[i], msg
+          proxy[i], msg.get()
         );
       }
     }

--- a/tests/unit/collection/test_send.cc
+++ b/tests/unit/collection/test_send.cc
@@ -89,6 +89,7 @@ struct ColMsg : CollectionMessage<TestCol<Args...>> {
   template <typename SerializerT>
   void serialize(SerializerT& s) {
     s | tup;
+    MessageParentType::serialize(s);
   }
 
   TupleType tup;

--- a/tests/unit/context/context_vrtmessage_test.cc
+++ b/tests/unit/context/context_vrtmessage_test.cc
@@ -87,10 +87,11 @@ TEST_F(TestVirtualContextMessage, Construction_and_API) {
   auto const& my_node = theContext()->getNode();
 
   auto vrtc1 = theVirtualManager()->makeVirtual<HelloVirtualContext>(10);
-  MyHelloMsg* msg = new MyHelloMsg(my_node);
 
-  theVirtualManager()->sendMsg<HelloVirtualContext, MyHelloMsg, myWorkHandler>
-    (my_node, makeSharedMessage<MyHelloMsg>());
+  auto in_msg = makeMessage<MyHelloMsg>();
+  theVirtualManager()->sendMsg<HelloVirtualContext, MyHelloMsg, myWorkHandler>(
+    my_node, in_msg.get()
+  );
 
 
   EXPECT_EQ(theVirtualManager()->getCurrentIdent(), 1);

--- a/tests/unit/group/test_group.cc
+++ b/tests/unit/group/test_group.cc
@@ -79,9 +79,9 @@ TEST_F(TestGroup, test_group_range_construct_1) {
     theGroup()->newGroup(
       std::move(list), [](GroupType group){
         fmt::print("Group is created: group={:x}\n", group);
-        auto msg = makeSharedMessage<TestMsg>();
+        auto msg = makeMessage<TestMsg>();
         envelopeSetGroup(msg->env, group);
-        theMsg()->broadcastMsg<TestMsg,groupHandler>(msg);
+        theMsg()->broadcastMsg<TestMsg,groupHandler>(msg.get());
       }
     );
   }
@@ -106,9 +106,9 @@ TEST_F(TestGroup, test_group_range_construct_2) {
     theGroup()->newGroup(
       std::move(list), [](GroupType group){
         fmt::print("Group is created: group={:x}\n", group);
-        auto msg = makeSharedMessage<TestMsg>();
+        auto msg = makeMessage<TestMsg>();
         envelopeSetGroup(msg->env, group);
-        theMsg()->broadcastMsg<TestMsg,groupHandler>(msg);
+        theMsg()->broadcastMsg<TestMsg,groupHandler>(msg.get());
       }
     );
   }
@@ -132,9 +132,9 @@ TEST_F(TestGroup, test_group_collective_construct_1) {
       auto const& is_default_group = theGroup()->groupDefault(group);
       EXPECT_EQ(in_group, node_filter);
       EXPECT_EQ(is_default_group, false);
-      auto msg = makeSharedMessage<TestMsg>();
+      auto msg = makeMessage<TestMsg>();
       envelopeSetGroup(msg->env, group);
-      theMsg()->broadcastMsg<TestMsg,groupHandler>(msg);
+      theMsg()->broadcastMsg<TestMsg,groupHandler>(msg.get());
     }
   );
   theTerm()->addAction([=]{
@@ -158,9 +158,9 @@ TEST_F(TestGroup, test_group_collective_construct_1) {
 //       ::fmt::print("{}: new group collective lambda\n", this_node);
 //       EXPECT_EQ(in_group, node_filter);
 //       EXPECT_EQ(is_default_group, false);
-//       auto msg = makeSharedMessage<TestMsg>();
+//       auto msg = makeMessage<TestMsg>();
 //       envelopeSetGroup(msg->env, group);
-//       theMsg()->broadcastMsg<TestMsg,groupHandler>(msg);
+//       theMsg()->broadcastMsg<TestMsg,groupHandler>(msg.get());
 //     }
 //   );
 //   theTerm()->addAction([=]{

--- a/tests/unit/location/test_location.cc
+++ b/tests/unit/location/test_location.cc
@@ -350,8 +350,8 @@ TYPED_TEST_P(TestLocationRoute, test_route_entity) {
     // send long messages for entity
     using MsgType = location::EntityMsg;
     bool is_long = std::is_same<TypeParam,location::LongMsg>::value;
-    auto msg = vt::makeSharedMessage<MsgType>(entity, my_node, is_long);
-    vt::theMsg()->broadcastMsg<MsgType, location::routeTestHandler<TypeParam>>(msg);
+    auto msg = vt::makeMessage<MsgType>(entity, my_node, is_long);
+    vt::theMsg()->broadcastMsg<MsgType, location::routeTestHandler<TypeParam>>(msg.get());
 
     while (msg_count < nb_nodes - 1) { vt::runScheduler(); }
 

--- a/tests/unit/mapping/test_mapping_registry.cc
+++ b/tests/unit/mapping/test_mapping_registry.cc
@@ -111,13 +111,13 @@ TEST_F(TestMappingRegistry, test_mapping_block_1d_registry) {
 
   if (my_node == 0) {
     auto map_han = auto_registry::makeAutoHandlerMap<Index1D, map_fn>();
-    auto msg = makeSharedMessage<TestMsg>(map_han);
+    auto msg = makeMessage<TestMsg>(map_han);
     msg->is_block = true;
-    theMsg()->broadcastMsg<TestMsg, test_handler>(msg);
+    theMsg()->broadcastMsg<TestMsg, test_handler>(msg.get());
 
     auto map_han2 = auto_registry::makeAutoHandlerMap<Index1D, map_fn2>();
-    auto msg2 = makeSharedMessage<TestMsg>(map_han2);
-    theMsg()->broadcastMsg<TestMsg, test_handler>(msg2);
+    auto msg2 = makeMessage<TestMsg>(map_han2);
+    theMsg()->broadcastMsg<TestMsg, test_handler>(msg2.get());
   }
 }
 

--- a/tests/unit/memory/test_memory_lifetime.cc
+++ b/tests/unit/memory/test_memory_lifetime.cc
@@ -172,14 +172,12 @@ TEST_F(TestMemoryLifetime, test_active_send_normal_lifetime_1) {
     auto const next_node = this_node + 1 < num_nodes ? this_node + 1 : 0;
     for (int i = 0; i < num_msgs_sent; i++) {
       auto msg = makeMessage<NormalTestMsg>();
-      envelopeRef(msg->env);
       theMsg()->sendMsg<NormalTestMsg, normalHan>(next_node, msg.get());
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
         theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
-        envelopeDeref(msg->env);
       });
     }
 
@@ -224,14 +222,12 @@ TEST_F(TestMemoryLifetime, test_active_bcast_normal_lifetime_1) {
   if (num_nodes > 1) {
     for (int i = 0; i < num_msgs_sent; i++) {
       auto msg = makeMessage<NormalTestMsg>();
-      envelopeRef(msg->env);
       theMsg()->broadcastMsg<NormalTestMsg, normalHan>(msg.get());
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
         theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
-        envelopeDeref(msg->env);
       });
     }
 

--- a/tests/unit/memory/test_memory_lifetime.cc
+++ b/tests/unit/memory/test_memory_lifetime.cc
@@ -123,8 +123,8 @@ TEST_F(TestMemoryLifetime, test_active_send_serial_lifetime_1) {
   if (num_nodes > 1) {
     auto const next_node = this_node + 1 < num_nodes ? this_node + 1 : 0;
     for (int i = 0; i < num_msgs_sent; i++) {
-      auto msg = makeSharedMessage<SerialTestMsg>();
-      theMsg()->sendMsg<SerialTestMsg, serialHan>(next_node, msg);
+      auto msg = makeMessage<SerialTestMsg>();
+      theMsg()->sendMsg<SerialTestMsg, serialHan>(next_node, msg.get());
     }
     for (int i = 0; i < num_msgs_sent; i++) {
       auto msg = makeMessage<SerialTestMsg>();
@@ -146,8 +146,8 @@ TEST_F(TestMemoryLifetime, test_active_bcast_serial_lifetime_1) {
 
   if (num_nodes > 1) {
     for (int i = 0; i < num_msgs_sent; i++) {
-      auto msg = makeSharedMessage<SerialTestMsg>();
-      theMsg()->broadcastMsg<SerialTestMsg, serialHan>(msg);
+      auto msg = makeMessage<SerialTestMsg>();
+      theMsg()->broadcastMsg<SerialTestMsg, serialHan>(msg.get());
     }
     for (int i = 0; i < num_msgs_sent; i++) {
       auto msg = makeMessage<SerialTestMsg>();
@@ -171,9 +171,9 @@ TEST_F(TestMemoryLifetime, test_active_send_normal_lifetime_1) {
   if (num_nodes > 1) {
     auto const next_node = this_node + 1 < num_nodes ? this_node + 1 : 0;
     for (int i = 0; i < num_msgs_sent; i++) {
-      auto msg = makeSharedMessage<NormalTestMsg>();
+      auto msg = makeMessage<NormalTestMsg>();
       envelopeRef(msg->env);
-      theMsg()->sendMsg<NormalTestMsg, normalHan>(next_node, msg);
+      theMsg()->sendMsg<NormalTestMsg, normalHan>(next_node, msg.get());
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
@@ -223,9 +223,9 @@ TEST_F(TestMemoryLifetime, test_active_bcast_normal_lifetime_1) {
 
   if (num_nodes > 1) {
     for (int i = 0; i < num_msgs_sent; i++) {
-      auto msg = makeSharedMessage<NormalTestMsg>();
+      auto msg = makeMessage<NormalTestMsg>();
       envelopeRef(msg->env);
-      theMsg()->broadcastMsg<NormalTestMsg, normalHan>(msg);
+      theMsg()->broadcastMsg<NormalTestMsg, normalHan>(msg.get());
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear

--- a/tests/unit/pipe/test_callback_bcast.cc
+++ b/tests/unit/pipe/test_callback_bcast.cc
@@ -80,8 +80,8 @@ static int32_t called = 0;
 
 struct TestCallbackBcast : TestParallelHarness {
   static void testHandler(CallbackDataMsg* msg) {
-    auto nmsg = makeSharedMessage<DataMsg>(1,2,3);
-    msg->cb_.send(nmsg);
+    auto nmsg = makeMessage<DataMsg>(1,2,3);
+    msg->cb_.send(nmsg.get());
   }
   static void testHandlerEmpty(CallbackMsg* msg) {
     msg->cb_.send();
@@ -116,8 +116,8 @@ TEST_F(TestCallbackBcast, test_callback_bcast_1) {
   theCollective()->barrier();
 
   auto cb = theCB()->makeBcast<DataMsg,callbackFn>();
-  auto nmsg = makeSharedMessage<DataMsg>(1,2,3);
-  cb.send(nmsg);
+  auto nmsg = makeMessage<DataMsg>(1,2,3);
+  cb.send(nmsg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 100 * theContext()->getNumNodes());
@@ -130,8 +130,8 @@ TEST_F(TestCallbackBcast, test_callback_bcast_2) {
   theCollective()->barrier();
 
   auto cb = theCB()->makeBcast<CallbackFunctor>();
-  auto nmsg = makeSharedMessage<DataMsg>(1,2,3);
-  cb.send(nmsg);
+  auto nmsg = makeMessage<DataMsg>(1,2,3);
+  cb.send(nmsg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 200 * theContext()->getNumNodes());
@@ -161,8 +161,8 @@ TEST_F(TestCallbackBcast, test_callback_bcast_remote_1) {
 
   auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
   auto cb = theCB()->makeBcast<DataMsg,callbackFn>();
-  auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+  auto msg = makeMessage<CallbackDataMsg>(cb);
+  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 100 * theContext()->getNumNodes());
@@ -179,8 +179,8 @@ TEST_F(TestCallbackBcast, test_callback_bcast_remote_2) {
 
   auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
   auto cb = theCB()->makeBcast<CallbackFunctor>();
-  auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+  auto msg = makeMessage<CallbackDataMsg>(cb);
+  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 200 * theContext()->getNumNodes());
@@ -197,8 +197,8 @@ TEST_F(TestCallbackBcast, test_callback_bcast_remote_3) {
 
   auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
   auto cb = theCB()->makeBcast<CallbackFunctorEmpty>();
-  auto msg = makeSharedMessage<CallbackMsg>(cb);
-  theMsg()->sendMsg<CallbackMsg, testHandlerEmpty>(next, msg);
+  auto msg = makeMessage<CallbackMsg>(cb);
+  theMsg()->sendMsg<CallbackMsg, testHandlerEmpty>(next, msg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 300 * theContext()->getNumNodes());

--- a/tests/unit/pipe/test_callback_bcast_collection.cc
+++ b/tests/unit/pipe/test_callback_bcast_collection.cc
@@ -78,8 +78,8 @@ struct CallbackDataMsg : vt::Message {
 
 struct TestCallbackBcastCollection : TestParallelHarness {
   static void testHandler(CallbackDataMsg* msg) {
-    auto nmsg = makeSharedMessage<DataMsg>(8,9,10);
-    msg->cb_.send(nmsg);
+    auto nmsg = makeMessage<DataMsg>(8,9,10);
+    msg->cb_.send(nmsg.get());
   }
   static void testHandlerEmpty(CallbackMsg* msg) {
     msg->cb_.send();
@@ -135,8 +135,8 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_1) {
     auto const& range = Index1D(32);
     auto proxy = theCollection()->construct<TestCol>(range);
     auto cb = theCB()->makeBcast<TestCol,DataMsg,&TestCol::cb1>(proxy);
-    auto nmsg = makeSharedMessage<DataMsg>(8,9,10);
-    cb.send(nmsg);
+    auto nmsg = makeMessage<DataMsg>(8,9,10);
+    cb.send(nmsg.get());
 
     theTerm()->addAction([=]{
       proxy.destroy();
@@ -157,8 +157,8 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_2) {
     auto proxy = theCollection()->construct<TestCol>(range);
     auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeBcast<TestCol,DataMsg,&TestCol::cb2>(proxy);
-    auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-    theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+    auto msg = makeMessage<CallbackDataMsg>(cb);
+    theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
     theTerm()->addAction([=]{
       proxy.destroy();
@@ -179,8 +179,8 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_3) {
     auto proxy = theCollection()->construct<TestCol>(range);
     auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeBcast<TestCol,DataMsg,cb3>(proxy);
-    auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-    theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+    auto msg = makeMessage<CallbackDataMsg>(cb);
+    theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
     theTerm()->addAction([=]{
       proxy.destroy();

--- a/tests/unit/pipe/test_callback_func.cc
+++ b/tests/unit/pipe/test_callback_func.cc
@@ -90,8 +90,8 @@ TEST_F(TestCallbackFunc, test_callback_func_2) {
 
   if (this_node == 0) {
     auto cb = theCB()->makeFunc([]{ called = 400; });
-    auto msg = makeSharedMessage<CallbackMsg>(cb);
-    theMsg()->sendMsg<CallbackMsg, test_handler>(1, msg);
+    auto msg = makeMessage<CallbackMsg>(cb);
+    theMsg()->sendMsg<CallbackMsg, test_handler>(1, msg.get());
 
     theTerm()->addAction([=]{
       EXPECT_EQ(called, 400);

--- a/tests/unit/pipe/test_callback_func_ctx.cc
+++ b/tests/unit/pipe/test_callback_func_ctx.cc
@@ -87,8 +87,8 @@ static int32_t called = 0;
 struct TestCallbackFuncCtx : TestParallelHarness {
   static void test_handler(CallbackDataMsg* msg) {
     auto const& n = theContext()->getNode();
-    auto nmsg = makeSharedMessage<DataMsg>(n+1,n+2,n+3);
-    msg->cb_.send(nmsg);
+    auto nmsg = makeMessage<DataMsg>(n+1,n+2,n+3);
+    msg->cb_.send(nmsg.get());
   }
 };
 
@@ -130,8 +130,8 @@ TEST_F(TestCallbackFuncCtx, test_callback_func_ctx_2) {
     }
   );
   //fmt::print("{}: next={}\n", this_node, next);
-  auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, test_handler>(next, msg);
+  auto msg = makeMessage<CallbackDataMsg>(cb);
+  theMsg()->sendMsg<CallbackDataMsg, test_handler>(next, msg.get());
 
   theTerm()->addAction([=]{
     //fmt::print("{}: called={}\n", this_node, called);

--- a/tests/unit/pipe/test_callback_send.cc
+++ b/tests/unit/pipe/test_callback_send.cc
@@ -80,8 +80,8 @@ static int32_t called = 0;
 
 struct TestCallbackSend : TestParallelHarness {
   static void testHandler(CallbackDataMsg* msg) {
-    auto nmsg = makeSharedMessage<DataMsg>(1,2,3);
-    msg->cb_.send(nmsg);
+    auto nmsg = makeMessage<DataMsg>(1,2,3);
+    msg->cb_.send(nmsg.get());
   }
   static void testHandlerEmpty(CallbackMsg* msg) {
     msg->cb_.send();
@@ -115,8 +115,8 @@ TEST_F(TestCallbackSend, test_callback_send_1) {
 
   called = 0;
   auto cb = theCB()->makeSend<DataMsg,callbackFn>(this_node);
-  auto nmsg = makeSharedMessage<DataMsg>(1,2,3);
-  cb.send(nmsg);
+  auto nmsg = makeMessage<DataMsg>(1,2,3);
+  cb.send(nmsg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 100);
@@ -127,8 +127,8 @@ TEST_F(TestCallbackSend, test_callback_send_2) {
   auto const& this_node = theContext()->getNode();
   called = 0;
   auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
-  auto nmsg = makeSharedMessage<DataMsg>(1,2,3);
-  cb.send(nmsg);
+  auto nmsg = makeMessage<DataMsg>(1,2,3);
+  cb.send(nmsg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 200);
@@ -153,8 +153,8 @@ TEST_F(TestCallbackSend, test_callback_send_remote_1) {
   called = 0;
   auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
   auto cb = theCB()->makeSend<DataMsg,callbackFn>(this_node);
-  auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+  auto msg = makeMessage<CallbackDataMsg>(cb);
+  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 100);
@@ -168,8 +168,8 @@ TEST_F(TestCallbackSend, test_callback_send_remote_2) {
   called = 0;
   auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
   auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
-  auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+  auto msg = makeMessage<CallbackDataMsg>(cb);
+  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 200);
@@ -183,8 +183,8 @@ TEST_F(TestCallbackSend, test_callback_send_remote_3) {
   called = 0;
   auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
   auto cb = theCB()->makeSend<CallbackFunctorEmpty>(this_node);
-  auto msg = makeSharedMessage<CallbackMsg>(cb);
-  theMsg()->sendMsg<CallbackMsg, testHandlerEmpty>(next, msg);
+  auto msg = makeMessage<CallbackMsg>(cb);
+  theMsg()->sendMsg<CallbackMsg, testHandlerEmpty>(next, msg.get());
 
   theTerm()->addAction([=]{
     EXPECT_EQ(called, 300);

--- a/tests/unit/pipe/test_callback_send_collection.cc
+++ b/tests/unit/pipe/test_callback_send_collection.cc
@@ -78,8 +78,8 @@ struct CallbackDataMsg : vt::Message {
 
 struct TestCallbackSendCollection : TestParallelHarness {
   static void testHandler(CallbackDataMsg* msg) {
-    auto nmsg = makeSharedMessage<DataMsg>(8,9,10);
-    msg->cb_.send(nmsg);
+    auto nmsg = makeMessage<DataMsg>(8,9,10);
+    msg->cb_.send(nmsg.get());
   }
   static void testHandlerEmpty(CallbackMsg* msg) {
     msg->cb_.send();
@@ -135,12 +135,12 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
     for (auto i = 0; i < 32; i++) {
       if (i % 2 == 0) {
         auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb1>(proxy(i));
-        auto nmsg = makeSharedMessage<DataMsg>(8,9,10);
-        cb.send(nmsg);
+        auto nmsg = makeMessage<DataMsg>(8,9,10);
+        cb.send(nmsg.get());
       } else {
         auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb2>(proxy(i));
-        auto nmsg = makeSharedMessage<DataMsg>(8,9,10);
-        cb.send(nmsg);
+        auto nmsg = makeMessage<DataMsg>(8,9,10);
+        cb.send(nmsg.get());
       }
     }
 
@@ -166,12 +166,12 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
       auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
       if (i % 2 == 0) {
         auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb1>(proxy(i));
-        auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-        theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+        auto msg = makeMessage<CallbackDataMsg>(cb);
+        theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
       } else {
         auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb2>(proxy(i));
-        auto msg = makeSharedMessage<CallbackDataMsg>(cb);
-        theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg);
+        auto msg = makeMessage<CallbackDataMsg>(cb);
+        theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
       }
     }
 
@@ -192,12 +192,12 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
     for (auto i = 0; i < 32; i++) {
       if (i % 2 == 0) {
         auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb1>(proxy(i));
-        auto nmsg = makeSharedMessage<DataMsg>(8,9,10);
-        cb.send(nmsg);
+        auto nmsg = makeMessage<DataMsg>(8,9,10);
+        cb.send(nmsg.get());
       } else {
         auto cb = theCB()->makeSend<TestCol,DataMsg,cb3>(proxy(i));
-        auto nmsg = makeSharedMessage<DataMsg>(8,9,10);
-        cb.send(nmsg);
+        auto nmsg = makeMessage<DataMsg>(8,9,10);
+        cb.send(nmsg.get());
       }
     }
 

--- a/tests/unit/pool/test_pool.cc
+++ b/tests/unit/pool/test_pool.cc
@@ -76,9 +76,10 @@ void TestPool::testPoolFun(TestMsg<num_bytes>* prev_msg) {
     fmt::print("testPoolFun: num_bytes={}\n", num_bytes);
   #endif
 
-  auto msg = makeSharedMessage<TestMsg<num_bytes * 2>>();
-  testPoolFun<num_bytes * 2>(msg);
-  delete msg;
+  {
+    auto msg = makeMessage<TestMsg<num_bytes * 2>>();
+    testPoolFun<num_bytes * 2>(msg.get());
+  }
 }
 
 template <>
@@ -90,9 +91,10 @@ TEST_F(TestPool, pool_message_alloc) {
   auto const& my_node = theContext()->getNode();
 
   if (my_node == 0) {
-    auto msg = makeSharedMessage<TestMsg<min_bytes>>();
-    testPoolFun<min_bytes>(msg);
-    delete msg;
+    {
+      auto msg = makeMessage<TestMsg<min_bytes>>();
+      testPoolFun<min_bytes>(msg.get());
+    }
   }
 }
 

--- a/tests/unit/pool/test_pool_message_sizes.cc
+++ b/tests/unit/pool/test_pool_message_sizes.cc
@@ -101,14 +101,14 @@ void TestPoolMessageSizes::testPoolFun(TestMsg<num_bytes>* prev_msg) {
     this_node == from_node ? to_node : from_node;
 
   if (count < max_test_count) {
-    auto msg = makeSharedMessage<TestMsg<num_bytes>>();
+    auto msg = makeMessage<TestMsg<num_bytes>>();
     theMsg()->sendMsg<TestMsg<num_bytes>, testPoolFun>(
-      next, msg
+      next, msg.get()
     );
   } else {
-    auto msg = makeSharedMessage<TestMsg<num_bytes * 2>>();
+    auto msg = makeMessage<TestMsg<num_bytes * 2>>();
     theMsg()->sendMsg<TestMsg<num_bytes * 2>, testPoolFun>(
-      next, msg
+      next, msg.get()
     );
     count = 0;
   }
@@ -123,9 +123,9 @@ TEST_F(TestPoolMessageSizes, pool_message_sizes_alloc) {
   auto const& my_node = theContext()->getNode();
 
   if (my_node == 0) {
-    auto msg = makeSharedMessage<TestMsg<min_bytes>>();
+    auto msg = makeMessage<TestMsg<min_bytes>>();
     theMsg()->sendMsg<TestMsg<min_bytes>, testPoolFun>(
-      to_node, msg
+      to_node, msg.get()
     );
   }
 }

--- a/tests/unit/sequencer/test_sequencer.cc
+++ b/tests/unit/sequencer/test_sequencer.cc
@@ -163,7 +163,8 @@ TEST_F(TestSequencer, test_single_wait) {
   #endif
 
   if (my_node == 1) {
-    theMsg()->sendMsg<TestMsg, testSeqHan>(0, makeSharedMessage<TestMsg>());
+    auto msg = makeMessage<TestMsg>();
+    theMsg()->sendMsg<TestMsg, testSeqHan>(0, msg.get());
   }
 
   if (my_node == 0) {
@@ -187,8 +188,9 @@ TEST_F(TestSequencer, test_single_wait_tagged) {
       testSingleTaggedWaitFn(-1);
     });
   } else if (my_node == 1) {
+    auto msg = makeMessage<TestMsg>();
     theMsg()->sendMsg<TestMsg, testSeqTaggedHan>(
-      0, makeSharedMessage<TestMsg>(), single_tag
+      0, msg.get(), single_tag
     );
   }
 }
@@ -204,11 +206,13 @@ TEST_F(TestSequencer, test_multi_wait) {
       testMultiWaitFn(-1);
     });
   } else if (my_node == 1) {
+    auto msg1 = makeMessage<TestMsg>();
     theMsg()->sendMsg<TestMsg, testSeqMultiHan>(
-      0, makeSharedMessage<TestMsg>()
+      0, msg1.get()
     );
+    auto msg2 = makeMessage<TestMsg>();
     theMsg()->sendMsg<TestMsg, testSeqMultiHan>(
-      0, makeSharedMessage<TestMsg>()
+      0, msg2.get()
     );
   }
 }
@@ -224,11 +228,13 @@ TEST_F(TestSequencer, test_multi_wait_tagged) {
       testMultiTaggedWaitFn(-1);
     });
   } else if (my_node == 1) {
+    auto msg1 = makeMessage<TestMsg>();
     theMsg()->sendMsg<TestMsg, testSeqMultiTaggedHan>(
-      0, makeSharedMessage<TestMsg>(), single_tag
+      0, msg1.get(), single_tag
     );
+    auto msg2 = makeMessage<TestMsg>();
     theMsg()->sendMsg<TestMsg, testSeqMultiTaggedHan>(
-      0, makeSharedMessage<TestMsg>(), single_tag_2
+      0, msg2.get(), single_tag_2
     );
   }
 }

--- a/tests/unit/sequencer/test_sequencer_extensive.cc
+++ b/tests/unit/sequencer/test_sequencer_extensive.cc
@@ -109,15 +109,16 @@ static constexpr CountType const max_seq_depth = 8;
       CountType in[param_size] = {                                      \
         wait_cnt, wait_pre, wait_post, seg_cnt, depth                   \
       };                                                                \
-      auto msg = makeSharedMessage<NumWaitsMsg>(in);                    \
+      auto msg = makeMessage<NumWaitsMsg>(in);                          \
       theMsg()->sendMsg<NumWaitsMsg, numWaitHan>(                       \
-        (NODE), msg                                                     \
+        (NODE), msg.get()                                               \
       );                                                                \
       auto const total = (wait_cnt * seg_cnt) + wait_pre + wait_post;   \
       for (CountType i = 0; i < total; i++) {                           \
         TagType const tag = (IS_TAG) ? i+1 : no_tag;                    \
+        auto nmsg = makeMessage<MSG_TYPE>();                            \
         theMsg()->sendMsg<MSG_TYPE, SEQ_HAN>(                           \
-          (NODE), makeSharedMessage<MSG_TYPE>(), tag                    \
+          (NODE), nmsg.get(), tag                                       \
         );                                                              \
       }                                                                 \
     }                                                                   \

--- a/tests/unit/sequencer/test_sequencer_for.cc
+++ b/tests/unit/sequencer/test_sequencer_for.cc
@@ -105,9 +105,8 @@ TEST_F(TestSequencerFor, test_for) {
 
   for (int i = 0; i < end_range; i++) {
     if (my_node == 1) {
-      theMsg()->sendMsg<TestMsg, testSeqForHan>(
-        0, makeSharedMessage<TestMsg>()
-      );
+      auto msg = makeMessage<TestMsg>();
+      theMsg()->sendMsg<TestMsg, testSeqForHan>(0, msg.get());
     }
   }
 

--- a/tests/unit/sequencer/test_sequencer_nested.cc
+++ b/tests/unit/sequencer/test_sequencer_nested.cc
@@ -270,8 +270,9 @@ struct TestSequencerNested : TestParallelHarness {
     for (int i = 0; i < (NUM_MSGS); i++) {                              \
       TagType const tag = (IS_TAG) ? i+1 : no_tag;                      \
       if ((NODE) == 1) {                                                \
+        auto msg = makeMessage<MSG_TYPE>();                             \
         theMsg()->sendMsg<MSG_TYPE, SEQ_HAN>(                           \
-          0, makeSharedMessage<MSG_TYPE>(), tag                         \
+          0, msg.get(), tag                                             \
         );                                                              \
       }                                                                 \
     }                                                                   \

--- a/tests/unit/sequencer/test_sequencer_parallel.cc
+++ b/tests/unit/sequencer/test_sequencer_parallel.cc
@@ -156,7 +156,8 @@ TEST_P(TestSequencerParallelParam, test_seq_parallel_param) {
 
   for (CountType i = 0; i < par_count; i++) {
     if (node == 1) {
-      theMsg()->sendMsg<TestMsg, seqParHanN>(0, makeSharedMessage<TestMsg>());
+      auto msg = makeMessage<TestMsg>();
+      theMsg()->sendMsg<TestMsg, seqParHanN>(0, msg.get());
     }
   }
 
@@ -322,8 +323,9 @@ struct TestSequencerParallel : TestParallelHarness {
     for (int i = 0; i < (NUM_MSGS); i++) {                            \
       TagType const tag = (IS_TAG) ? i+1 : no_tag;                    \
       if ((NODE) == 1) {                                              \
+      auto msg = makeMessage<MSG_TYPE>();                             \
         theMsg()->sendMsg<MSG_TYPE, SEQ_HAN>(                         \
-          0, makeSharedMessage<MSG_TYPE>(), tag                       \
+          0, msg.get(), tag                                           \
         );                                                            \
       }                                                               \
     }                                                                 \

--- a/tests/unit/sequencer/test_sequencer_vrt.cc
+++ b/tests/unit/sequencer/test_sequencer_vrt.cc
@@ -192,8 +192,9 @@ TEST_F(TestSequencerVirtual, test_seq_vc_1) {
 
     theVirtualSeq()->sequenced(seq_id, testSeqFn1);
 
+    auto msg = makeMessage<TestMsg>();
     theVirtualManager()->sendMsg<VirtualType, TestMsg, testSeqHan1>(
-      proxy, makeSharedMessage<TestMsg>()
+      proxy, msg.get()
     );
 
     theTerm()->addAction([=]{
@@ -215,8 +216,9 @@ TEST_F(TestSequencerVirtual, test_seq_vc_2) {
     theVirtualSeq()->sequenced(seq_id, testSeqFn2);
 
     for (int i = 0; i < 2; i++) {
+      auto msg = makeMessage<TestMsg>();
       theVirtualManager()->sendMsg<VirtualType, TestMsg, testSeqHan2>(
-        proxy, makeSharedMessage<TestMsg>()
+        proxy, msg.get()
       );
     }
 
@@ -243,11 +245,13 @@ TEST_F(TestSequencerVirtual, test_seq_vc_distinct_inst_3) {
     theVirtualSeq()->sequenced(seq_id_a, testSeqFn3a);
     theVirtualSeq()->sequenced(seq_id_b, testSeqFn3b);
 
+    auto msg1 = makeMessage<TestMsg>();
     theVirtualManager()->sendMsg<VirtualType, TestMsg, testSeqHan3>(
-      proxy_a, makeSharedMessage<TestMsg>()
+      proxy_a, msg1.get()
     );
+    auto msg2 = makeMessage<TestMsg>();
     theVirtualManager()->sendMsg<VirtualType, TestMsg, testSeqHan3>(
-      proxy_b, makeSharedMessage<TestMsg>()
+      proxy_b, msg2.get()
     );
 
     // @todo: fix this it is getting triggered early (a termination detector

--- a/tests/unit/serialization/test_serialize_messenger.cc
+++ b/tests/unit/serialization/test_serialize_messenger.cc
@@ -105,10 +105,10 @@ TEST_F(TestSerialMessenger, test_serial_messenger_1) {
 
   if (theContext()->getNumNodes() > 1) {
     if (my_node == 0) {
-      auto msg = makeSharedMessage<MyDataMsg>();
+      auto msg = makeMessage<MyDataMsg>();
       msg->init();
       auto han = auto_registry::makeAutoHandler<MyDataMsg,myDataMsgHan>(nullptr);
-      SerializedMessenger::sendSerialMsg<MyDataMsg>(1, msg, han);
+      SerializedMessenger::sendSerialMsg<MyDataMsg>(1, msg.get(), han);
     }
   }
 }
@@ -118,10 +118,10 @@ TEST_F(TestSerialMessenger, test_serial_messenger_bcast_1) {
 
   if (theContext()->getNumNodes() > 1) {
     if (my_node == 0) {
-      auto msg = makeSharedMessage<MyDataMsg>();
+      auto msg = makeMessage<MyDataMsg>();
       msg->init();
       auto han = auto_registry::makeAutoHandler<MyDataMsg,myDataMsgHan>(nullptr);
-      SerializedMessenger::broadcastSerialMsg<MyDataMsg>(msg, han);
+      SerializedMessenger::broadcastSerialMsg<MyDataMsg>(msg.get(), han);
     }
   }
 }

--- a/tests/unit/serialization/test_serialize_messenger_virtual.cc
+++ b/tests/unit/serialization/test_serialize_messenger_virtual.cc
@@ -105,9 +105,11 @@ TEST_F(TestSerialMessengerVirtual, test_serial_messenger_1) {
 
   if (my_node == 0) {
     auto proxy = theVirtualManager()->makeVirtual<TestCtx>();
-    auto msg = makeSharedMessage<DataMsg>();
+    auto msg = makeMessage<DataMsg>();
     msg->init();
-    theVirtualManager()->sendSerialMsg<TestCtx, DataMsg, testHandler>(proxy, msg);
+    theVirtualManager()->sendSerialMsg<TestCtx, DataMsg, testHandler>(
+      proxy, msg.get()
+    );
   }
 }
 

--- a/tests/unit/termination/test_term_chaining.cc
+++ b/tests/unit/termination/test_term_chaining.cc
@@ -69,8 +69,8 @@ struct TestTermChaining : TestParallelHarness {
     handler_count = 12;
 
     EXPECT_EQ(theContext()->getNode(), 1);
-    auto msg2 = makeSharedMessage<TestMsg>();
-    theMsg()->sendMsg<TestMsg, test_handler_response>(0, msg2);
+    auto msg2 = makeMessage<TestMsg>();
+    theMsg()->sendMsg<TestMsg, test_handler_response>(0, msg2.get());
   }
 
   static void test_handler_response(TestMsg* msg) {
@@ -86,8 +86,8 @@ struct TestTermChaining : TestParallelHarness {
 
     EXPECT_EQ(handler_count, 12);
     handler_count++;
-    auto msg2 = makeSharedMessage<TestMsg>();
-    theMsg()->sendMsg<TestMsg, test_handler_chained>(0, msg2);
+    auto msg2 = makeMessage<TestMsg>();
+    theMsg()->sendMsg<TestMsg, test_handler_chained>(0, msg2.get());
   }
 
   static void test_handler_chained(TestMsg* msg) {
@@ -101,15 +101,19 @@ struct TestTermChaining : TestParallelHarness {
   static void start_chain() {
     EpochType epoch1 = theTerm()->makeEpochRooted();
     vt::theMsg()->pushEpoch(epoch1);
-    auto msg = makeSharedMessage<TestMsg>();
-    chain.add(epoch1, theMsg()->sendMsg<TestMsg, test_handler_reflector>(1, msg));
+    auto msg = makeMessage<TestMsg>();
+    chain.add(
+      epoch1, theMsg()->sendMsg<TestMsg, test_handler_reflector>(1, msg.get())
+    );
     vt::theMsg()->popEpoch(epoch1);
     vt::theTerm()->finishedEpoch(epoch1);
 
     EpochType epoch2 = theTerm()->makeEpochRooted();
     vt::theMsg()->pushEpoch(epoch2);
-    auto msg2 = makeSharedMessage<TestMsg>();
-    chain.add(epoch2, theMsg()->sendMsg<TestMsg, test_handler_chainer>(1, msg2));
+    auto msg2 = makeMessage<TestMsg>();
+    chain.add(
+      epoch2, theMsg()->sendMsg<TestMsg, test_handler_chainer>(1, msg2.get())
+    );
     vt::theMsg()->popEpoch(epoch2);
     vt::theTerm()->finishedEpoch(epoch2);
 

--- a/tests/unit/termination/test_termination_channel_counting.impl.h
+++ b/tests/unit/termination/test_termination_channel_counting.impl.h
@@ -63,24 +63,24 @@ void sendMsg(vt::NodeType dst, int count, vt::EpochType ep) {
   vtAssert(dst != vt::uninitialized_destination, "Invalid destination");
   vtAssert(dst != node, "Invalid destination");
 
-  auto msg = makeSharedMessage<Msg>(node, dst, count, ep);
+  auto msg = makeMessage<Msg>(node, dst, count, ep);
   if (ep != vt::no_epoch) {
     vt::envelopeSetEpoch(msg->env,ep);
   }
-  vt::theMsg()->sendMsg<Msg,handler>(dst,msg);
+  vt::theMsg()->sendMsg<Msg,handler>(dst,msg.get());
 }
 
 // note: only for basic messages,
 // but different handlers may be used.
 template<vt::ActiveTypedFnType<BasicMsg>* handler>
 void broadcast(int count, vt::EpochType ep) {
-  auto msg = makeSharedMessage<BasicMsg>(
+  auto msg = makeMessage<BasicMsg>(
     node, vt::uninitialized_destination, count, ep
   );
   if (ep != vt::no_epoch) {
     vt::envelopeSetEpoch(msg->env,ep);
   }
-  vt::theMsg()->broadcastMsg<BasicMsg,handler>(msg);
+  vt::theMsg()->broadcastMsg<BasicMsg,handler>(msg.get());
 
   for (auto&& active : data[ep].count_) {
     auto const& dst = active.first;

--- a/tests/unit/termination/test_termination_reset.cc
+++ b/tests/unit/termination/test_termination_reset.cc
@@ -75,8 +75,8 @@ TEST_F(TestTermReset, test_termination_reset_1) {
   }
 
   if (this_node == 0) {
-    auto msg = makeSharedMessage<TestMsg>();
-    theMsg()->broadcastMsg<TestMsg, test_handler>(msg);
+    auto msg = makeMessage<TestMsg>();
+    theMsg()->broadcastMsg<TestMsg, test_handler>(msg.get());
   } else if (this_node == 1) {
     theTerm()->addAction([=]{
       EXPECT_EQ(handler_count, 10);
@@ -91,8 +91,8 @@ TEST_F(TestTermReset, test_termination_reset_1) {
   theCollective()->barrier();
 
   if (this_node == 1) {
-    auto msg = makeSharedMessage<TestMsg>();
-    theMsg()->broadcastMsg<TestMsg, test_handler>(msg);
+    auto msg = makeMessage<TestMsg>();
+    theMsg()->broadcastMsg<TestMsg, test_handler>(msg.get());
   } else if (this_node == 0) {
     theTerm()->addAction([=]{
       EXPECT_EQ(handler_count, 10);

--- a/tutorial/tutorial_1b.h
+++ b/tutorial/tutorial_1b.h
@@ -116,8 +116,8 @@ static inline void activeMessageNode() {
 
   if (this_node == 0) {
     NodeType const to_node = 1;
-    auto msg = ::vt::makeSharedMessage<MyMsg>(29,32);
-    ::vt::theMsg()->sendMsg<MyMsg,msgHandlerA>(to_node, msg);
+    auto msg = ::vt::makeMessage<MyMsg>(29,32);
+    ::vt::theMsg()->sendMsg<MyMsg,msgHandlerA>(to_node, msg.get());
   }
 }
 
@@ -142,8 +142,8 @@ static void msgHandlerA(MyMsg* msg) {
    * invocation uses the functor style send.
    */
   NodeType const to_node = 0;
-  auto msg2 = ::vt::makeSharedMessage<MyMsg>(10,20);
-  ::vt::theMsg()->sendMsg<MsgHandlerB>(to_node, msg2);
+  auto msg2 = ::vt::makeMessage<MyMsg>(10,20);
+  ::vt::theMsg()->sendMsg<MsgHandlerB>(to_node, msg2.get());
 }
 
 void MsgHandlerB::operator()(MyMsg* msg) {

--- a/tutorial/tutorial_1c.h
+++ b/tutorial/tutorial_1c.h
@@ -134,10 +134,10 @@ static inline void activeMessageSerialization() {
 
   if (this_node == 0) {
     NodeType const to_node = 1;
-    auto msg = ::vt::makeSharedMessage<ParticleMsg>(1,2,3);
+    auto msg = ::vt::makeMessage<ParticleMsg>(1,2,3);
     msg->particles.push_back(Particle{10,11,12});
     msg->particles.push_back(Particle{13,14,15});
-    ::vt::theMsg()->sendMsg<ParticleMsg,msgSerialA>(to_node, msg);
+    ::vt::theMsg()->sendMsg<ParticleMsg,msgSerialA>(to_node, msg.get());
   }
 }
 

--- a/tutorial/tutorial_1d.h
+++ b/tutorial/tutorial_1d.h
@@ -80,8 +80,8 @@ static inline void activeMessageBroadcast() {
    */
 
   if (this_node == 0) {
-    auto msg = ::vt::makeSharedMessage<MyDataMsg>(1.0,2.0,3.0);
-    ::vt::theMsg()->broadcastMsg<MyDataMsg,msgHandlerX>(msg);
+    auto msg = ::vt::makeMessage<MyDataMsg>(1.0,2.0,3.0);
+    ::vt::theMsg()->broadcastMsg<MyDataMsg,msgHandlerX>(msg.get());
   }
 }
 

--- a/tutorial/tutorial_1e.h
+++ b/tutorial/tutorial_1e.h
@@ -76,9 +76,9 @@ static inline void activeMessageGroupRoot() {
     // message will arrive on the set of nodes included in the group
     auto id = theGroup()->newGroup(std::move(range), [](GroupType group_id){
       fmt::print("Group is created: id={:x}\n", group_id);
-      auto msg = makeSharedMessage<MySimpleMsg>();
+      auto msg = makeMessage<MySimpleMsg>();
       envelopeSetGroup(msg->env, group_id);
-      theMsg()->broadcastMsg<MySimpleMsg,msgHandlerGroupA>(msg);
+      theMsg()->broadcastMsg<MySimpleMsg,msgHandlerGroupA>(msg.get());
     });
     // The `id' that is returned from the newGroup invocation, can be used
     // anywhere in the system to broadcast (multicast) to this group.

--- a/tutorial/tutorial_1f.h
+++ b/tutorial/tutorial_1f.h
@@ -82,9 +82,9 @@ static inline void activeMessageGroupCollective() {
       // In this example, node 1 broadcasts to the group of even nodes
       auto const my_node = ::vt::theContext()->getNode();
       if (my_node == 1) {
-        auto msg = makeSharedMessage<MySimpleMsg2>();
+        auto msg = makeMessage<MySimpleMsg2>();
         envelopeSetGroup(msg->env, group_id);
-        theMsg()->broadcastMsg<MySimpleMsg2,msgHandlerGroupB>(msg);
+        theMsg()->broadcastMsg<MySimpleMsg2,msgHandlerGroupB>(msg.get());
       }
     }
   );

--- a/tutorial/tutorial_1g.h
+++ b/tutorial/tutorial_1g.h
@@ -112,29 +112,29 @@ static inline void activeMessageCallback() {
     // Example of a void lambda callback
     {
       auto cb = ::vt::theCB()->makeFunc(void_fn);
-      auto msg = ::vt::makeSharedMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg);
+      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
+      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg.get());
     }
 
     // Example of active message handler callback with send node
     {
       auto cb = ::vt::theCB()->makeSend<DataMsg,callbackHandler>(cb_node);
-      auto msg = ::vt::makeSharedMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg);
+      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
+      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg.get());
     }
 
     // Example of active message handler callback with broadcast
     {
       auto cb = ::vt::theCB()->makeBcast<DataMsg,callbackBcastHandler>();
-      auto msg = ::vt::makeSharedMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg);
+      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
+      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg.get());
     }
 
     // Example of context callback
     {
       auto cb = ::vt::theCB()->makeFunc<DataMsg,MyContext>(&ctx, callbackCtx);
-      auto msg = ::vt::makeSharedMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg);
+      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
+      ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node,msg.get());
     }
   }
 }
@@ -145,9 +145,9 @@ static void getCallbackHandler(MsgWithCallback* msg) {
   ::fmt::print("getCallbackHandler: triggered on node={}\n", cur_node);
 
   // Create a msg to trigger to callback
-  auto data_msg = ::vt::makeSharedMessage<DataMsg>();
+  auto data_msg = ::vt::makeMessage<DataMsg>();
   // Send the callback with the message
-  msg->cb.send(data_msg);
+  msg->cb.send(data_msg.get());
 }
 
 }} /* end namespace vt::tutorial */

--- a/tutorial/tutorial_1h.h
+++ b/tutorial/tutorial_1h.h
@@ -84,13 +84,13 @@ static inline void activeMessageReduce() {
 
   NodeType const root_reduce_node = 0;
 
-  auto reduce_msg = ::vt::makeSharedMessage<ReduceDataMsg>();
+  auto reduce_msg = ::vt::makeMessage<ReduceDataMsg>();
 
   // Get a reference to the value to set it in this reduce msg
   reduce_msg->getVal() = 50;
 
   ::vt::theCollective()->global()->reduce<ReduceOp,ReduceResult>(
-    root_reduce_node, reduce_msg
+    root_reduce_node, reduce_msg.get()
   );
 }
 

--- a/tutorial/tutorial_2a.h
+++ b/tutorial/tutorial_2a.h
@@ -92,12 +92,12 @@ static inline void collection() {
 
     // Broadcast a message to the entire collection. The msgHandler will be
     // invoked on every element to the collection
-    auto msg = ::vt::makeSharedMessage<MyCollMsg>();
-    proxy.broadcast<MyCollMsg,&MyCol::msgHandler>(msg);
+    auto msg = ::vt::makeMessage<MyCollMsg>();
+    proxy.broadcast<MyCollMsg,&MyCol::msgHandler>(msg.get());
 
     // Send a message to the 5th element of the collection
-    auto msg2 = ::vt::makeSharedMessage<MyCollMsg>();
-    proxy[5].send<MyCollMsg,&MyCol::msgHandler>(msg2);
+    auto msg2 = ::vt::makeMessage<MyCollMsg>();
+    proxy[5].send<MyCollMsg,&MyCol::msgHandler>(msg2.get());
   }
 }
 

--- a/tutorial/tutorial_2b.h
+++ b/tutorial/tutorial_2b.h
@@ -94,13 +94,13 @@ void ReduceCol::reduceHandler(ColRedMsg* msg) {
   using ReduceOp = vt::collective::PlusOp<int32_t>;
 
   auto proxy = getCollectionProxy();
-  auto reduce_msg = makeSharedMessage<ReduceMsg>();
+  auto reduce_msg = makeMessage<ReduceMsg>();
 
   // Get a reference to the value to set it in this reduce msg
   reduce_msg->getVal() = 100;
 
   // Invoke the reduce!
-  proxy.reduce<ReduceOp,PrintReduceResult>(reduce_msg);
+  proxy.reduce<ReduceOp,PrintReduceResult>(reduce_msg.get());
 }
 
 // Tutorial code to demonstrate reducing a collection
@@ -122,8 +122,8 @@ static inline void collectionReduce() {
 
     // Broadcast a message to the entire collection. The reduceHandler will be
     // invoked on every element to the collection
-    auto msg = ::vt::makeSharedMessage<ColRedMsg>();
-    proxy.broadcast<ColRedMsg,&ReduceCol::reduceHandler>(msg);
+    auto msg = ::vt::makeMessage<ColRedMsg>();
+    proxy.broadcast<ColRedMsg,&ReduceCol::reduceHandler>(msg.get());
   }
 }
 

--- a/tutorial/tutorial_3a.h
+++ b/tutorial/tutorial_3a.h
@@ -76,9 +76,9 @@ static inline void activeMessageTerm() {
   auto const new_epoch = theTerm()->makeEpochCollective();
 
   if (this_node == 0) {
-    auto msg = vt::makeSharedMessage<ExampleMsg>(8);
+    auto msg = vt::makeMessage<ExampleMsg>(8);
     envelopeSetEpoch(msg->env, new_epoch);
-    vt::theMsg()->sendMsg<ExampleMsg,recurHandler>(this_node+1,msg);
+    vt::theMsg()->sendMsg<ExampleMsg,recurHandler>(this_node+1,msg.get());
   }
 
   // Any node that wishes to have a notification on termination for a given
@@ -115,8 +115,8 @@ static void recurHandler(ExampleMsg* msg) {
         this_node, i, next_node, num_send
       );
 
-      auto msg_send = vt::makeSharedMessage<ExampleMsg>(msg->ttl);
-      vt::theMsg()->sendMsg<ExampleMsg,recurHandler>(next_node,msg_send);
+      auto msg_send = vt::makeMessage<ExampleMsg>(msg->ttl);
+      vt::theMsg()->sendMsg<ExampleMsg,recurHandler>(next_node,msg_send.get());
     }
   }
 }


### PR DESCRIPTION
Unifies message ownership lifetime, including detection of invalid message creation.

The primary purpose of these changes is to simplify the message tracking and work to a consistent/unified usage of 'MsgPtr' aka SharedMsgPtr.

Following change will be to accept MsgPtr uniformly at sendMsg level and deprecate/switch code to use makeMessage.

(There were additional changes relating to ensuring the buffers to MPI_Isend were not re-used too early. However, I've pulled them out of this PR as there were additional complexity and it only solved half the issue.)