### PR TITLE
713 Rewrite buffering code in collection manager to fix bugs

### DIFF
--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -77,6 +77,7 @@
 #include "vt/vrt/collection/balance/proc_stats.h"
 #include "vt/vrt/collection/balance/lb_common.h"
 #include "vt/runtime/component/component_pack.h"
+#include "vt/vrt/collection/op_buffer.h"
 
 #include <memory>
 #include <vector>
@@ -965,25 +966,6 @@ private:
 
 private:
   using ActionPendingType = std::function<messaging::PendingSend(void)>;
-
- /**
-  *  \brief The type of operation being buffered
-  */
-  enum BufferTypeEnum {
-    Broadcast = 0x1,
-    Send      = 0x2,
-    Reduce    = 0x4
-  };
-
- /**
-  *  \brief List of potential buffer release triggers that can be composed |
-  */
-  enum BufferReleaseEnum {
-    Unreleased            = 0x0, /**< Sentinel value */
-    AfterFullyConstructed = 0x1, /**< After the collection construct reduction */
-    AfterMetaDataKnown    = 0x2, /**< After meta data is known */
-    AfterGroupReady       = 0x4  /**< After the underlying group is created */
-  };
 
   /**
    * \brief Add to the current buffer-release state of a proxy

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -979,17 +979,6 @@ private:
   }
 
   /**
-   * \brief Remove from the current buffer-release state of a proxy
-   *
-   * \param[in] proxy the proxy of the collection
-   * \param[in] release the state to remove from the bits
-   */
-  void removeFromState(VirtualProxyType proxy, BufferReleaseEnum release) {
-    proxy_state_[proxy] =
-      static_cast<BufferReleaseEnum>(proxy_state_[proxy] & ~release);
-  }
-
-  /**
    * \brief Get the current release state bits from the collection
    *
    * \param[in] proxy the proxy of the collection

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -991,19 +991,20 @@ private:
   }
 
   /**
-   * \brief Get ready bits or'ed with the required release bits
+   * \brief Get ready bits AND'ed with the required release bits
    *
    * \param[in] proxy the proxy of the collection
    * \param[in] release the bits to check
    *
-   * \return the current state | release
+   * \return the current state & release
    */
   BufferReleaseEnum getReadyBits(
     VirtualProxyType proxy, BufferReleaseEnum release
   );
 
   /**
-   * \brief Check if the collection is ready given the release bits
+   * \brief Check if the collection is past the stages of setup requested in
+   * release
    *
    * \param[in] proxy the proxy of the collection
    * \param[in] release the bits to check

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3220,7 +3220,7 @@ messaging::PendingSend CollectionManager::bufferOp(
     auto ps = action();
     theMsg()->popEpoch(epoch);
     theTerm()->consume(epoch);
-    return std::move(ps);
+    return ps;
   });
   return messaging::PendingSend{nullptr};
 }
@@ -3231,7 +3231,10 @@ messaging::PendingSend CollectionManager::bufferOpOrExecute(
   EpochType epoch, ActionPendingType action
 ) {
   if (checkReady(proxy, release)) {
-    return action();
+    theMsg()->pushEpoch(epoch);
+    auto ps = action();
+    theMsg()->popEpoch(epoch);
+    return ps;
   } else {
     return bufferOp<ColT>(proxy, type, release, epoch, action);
   }

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3190,9 +3190,7 @@ inline bool CollectionManager::checkReady(
   return getReadyBits(proxy, release) == release;
 }
 
-inline
-typename CollectionManager::BufferReleaseEnum
-CollectionManager::getReadyBits(
+inline BufferReleaseEnum CollectionManager::getReadyBits(
   VirtualProxyType proxy, BufferReleaseEnum release
 ) {
   auto release_state = getState(proxy);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -79,6 +79,7 @@
 #include "vt/collective/reduce/reduce_hash.h"
 #include "vt/runnable/collection.h"
 #include "vt/group/group_headers.h"
+#include "vt/pipe/pipe_headers.h"
 
 #include <tuple>
 #include <utility>
@@ -1065,7 +1066,7 @@ void CollectionManager::reduceMsgExpr(
     "reduceMsg: msg={}\n", print_ptr(raw_msg)
   );
 
-  auto const col_proxy = toProxy.getProxy();
+  auto const col_proxy = proxy.getProxy();
   auto const cur_epoch = theMsg()->getEpochContextMsg(msg);
 
   bufferOpOrExecute<ColT>(
@@ -1130,8 +1131,8 @@ void CollectionManager::reduceMsgExpr(
 
       debug_print(
         vrt_coll, node,
-        "reduceMsg: col_proxy={:x}, seq={}, num_elms={}, tag={}\n",
-        col_proxy, cur_seq, num_elms, tag
+        "reduceMsg: col_proxy={:x}, num_elms={}\n",
+        col_proxy, num_elms
       );
 
       return messaging::PendingSend{nullptr};
@@ -1877,6 +1878,7 @@ template <typename ColT>
    * etc.)
    */
   auto msg = makeMessage<CollectionConsMsg>(proxy);
+  theMsg()->markAsCollectionMessage(msg);
   auto const& root = 0;
   debug_print(
     vrt_coll, node,

--- a/src/vt/vrt/collection/messages/system_create.h
+++ b/src/vt/vrt/collection/messages/system_create.h
@@ -83,8 +83,8 @@ struct CollectionCreateMsg : ::vt::Message {
   }
 };
 
-struct CollectionConsMsg : ::vt::collective::reduce::ReduceMsg {
-  using MessageParentType = ::vt::collective::reduce::ReduceMsg;
+struct CollectionConsMsg : ::vt::collective::ReduceNoneMsg {
+  using MessageParentType = ::vt::collective::ReduceNoneMsg;
   vt_msg_serialize_prohibited();
 
   CollectionConsMsg() = default;

--- a/src/vt/vrt/collection/op_buffer.h
+++ b/src/vt/vrt/collection/op_buffer.h
@@ -1,0 +1,98 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                 op_buffer.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_VRT_COLLECTION_OP_BUFFER_H
+#define INCLUDED_VT_VRT_COLLECTION_OP_BUFFER_H
+
+#include "vt/config.h"
+
+namespace vt { namespace vrt { namespace collection {
+
+/**
+ *  \brief The type of operation being buffered
+ */
+enum BufferTypeEnum {
+  Broadcast = 0x1,
+  Send      = 0x2,
+  Reduce    = 0x4
+};
+
+/**
+ *  \brief List of potential buffer release triggers that can be composed |
+ */
+enum BufferReleaseEnum {
+  Unreleased            = 0x0, /**< Sentinel value */
+  AfterFullyConstructed = 0x1, /**< After the collection construct reduction */
+  AfterMetaDataKnown    = 0x2, /**< After meta data is known */
+  AfterGroupReady       = 0x4  /**< After the underlying group is created */
+};
+
+}}} /* end namespace vt::vrt::collection */
+
+namespace std {
+
+using BufferTypeEnum = vt::vrt::collection::BufferTypeEnum;
+using BufferReleaseEnum = vt::vrt::collection::BufferReleaseEnum;
+
+template <>
+struct hash<BufferTypeEnum> {
+  size_t operator()(BufferTypeEnum in) const {
+    using UnderType = typename std::underlying_type<BufferTypeEnum>::type;
+    auto const val = static_cast<UnderType>(in);
+    return std::hash<UnderType>()(val);
+  }
+};
+
+template <>
+struct hash<BufferReleaseEnum> {
+  size_t operator()(BufferReleaseEnum in) const {
+    using UnderType = typename std::underlying_type<BufferReleaseEnum>::type;
+    auto const val = static_cast<UnderType>(in);
+    return std::hash<UnderType>()(val);
+  }
+};
+
+} /* end namespace std */
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_OP_BUFFER_H*/


### PR DESCRIPTION
Fixes #713 

Fixes a non-deterministic bug in running the tutorial with group creation racing with other setup processes. 

Rewrite the collection buffering code to be more consistent

This fixes the bug after running the `tutorial` thousands of times without failure with these changes.