### PR TITLE
764 abstract components

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,8 @@ set(
       topos/index/dense topos/index/traits topos/index/printer
     topos/mapping
       topos/mapping/seed topos/mapping/dense
+    runtime
+      runtime/component
     vrt/base vrt/proxy vrt/context
     vrt/collection
       vrt/collection/types vrt/collection/messages vrt/collection/proxy_builder

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -85,6 +85,7 @@ struct CollectiveAlg :
   //----------------------------------------------------------------------------
   //----------------------------------------------------------------------------
 
+  std::string name() override { return "Collective"; }
 };
 
 using ReduceMsg = reduce::ReduceMsg;

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -53,6 +53,7 @@
 #include "vt/collective/reduce/reduce.h"
 #include "vt/collective/scatter/scatter.h"
 #include "vt/utils/hash/hash_tuple.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <unordered_map>
 
@@ -61,6 +62,7 @@ namespace vt { namespace collective {
 constexpr CollectiveAlgType const fst_collective_alg = 1;
 
 struct CollectiveAlg :
+    runtime::component::Component<CollectiveAlg>,
     virtual reduce::Reduce,
     virtual barrier::Barrier,
     virtual scatter::Scatter

--- a/src/vt/context/context.cc
+++ b/src/vt/context/context.cc
@@ -67,7 +67,7 @@ Context::Context(int argc, char** argv, bool const is_interop, MPI_Comm* comm) {
     MPI_Init(&argc, &argv);
   }
 
-  if (comm != nullptr) {
+  if (comm != nullptr and *comm != MPI_COMM_NULL) {
     communicator_ = *comm;
   } else {
     communicator_ = MPI_COMM_WORLD;

--- a/src/vt/context/context.cc
+++ b/src/vt/context/context.cc
@@ -110,12 +110,12 @@ DeclareClassOutsideInitTLS(Context, WorkerIDType, thisWorker_, no_worker_id)
 namespace vt { namespace debug {
 
 NodeType preNode() {
-  return ::vt::curRT != nullptr and ::vt::curRT->live() ?
+  return ::vt::curRT != nullptr and ::vt::curRT->isLive() ?
     theContext()->getNode() :
     -1;
 }
 NodeType preNodes() {
-  return ::vt::curRT != nullptr and ::vt::curRT->live() ?
+  return ::vt::curRT != nullptr and ::vt::curRT->isLive() ?
     theContext()->getNumNodes() :
     -1;
 }

--- a/src/vt/context/context.cc
+++ b/src/vt/context/context.cc
@@ -43,6 +43,7 @@
 */
 
 #include "vt/context/context.h"
+#include "vt/runtime/runtime.h"
 
 #include <string>
 #include <cstring>
@@ -109,10 +110,14 @@ DeclareClassOutsideInitTLS(Context, WorkerIDType, thisWorker_, no_worker_id)
 namespace vt { namespace debug {
 
 NodeType preNode() {
-  return ::vt::curRT != nullptr ? theContext()->getNode() : -1;
+  return ::vt::curRT != nullptr and ::vt::curRT->live() ?
+    theContext()->getNode() :
+    -1;
 }
 NodeType preNodes() {
-  return ::vt::curRT != nullptr ? theContext()->getNumNodes() : -1;
+  return ::vt::curRT != nullptr and ::vt::curRT->live() ?
+    theContext()->getNumNodes() :
+    -1;
 }
 
 }} /* end namespace vt::debug */

--- a/src/vt/context/context.h
+++ b/src/vt/context/context.h
@@ -142,11 +142,6 @@ struct Context : runtime::component::Component<Context> {
   /// Used to manage protected access for other VT runtime components
   friend struct ContextAttorney;
 
-  /**
-   * \brief Return the name of the component
-   *
-   * \return the name
-   */
   std::string name() override { return "Context"; }
 
 protected:

--- a/src/vt/context/context.h
+++ b/src/vt/context/context.h
@@ -142,6 +142,13 @@ struct Context : runtime::component::Component<Context> {
   /// Used to manage protected access for other VT runtime components
   friend struct ContextAttorney;
 
+  /**
+   * \brief Return the name of the component
+   *
+   * \return the name
+   */
+  std::string name() override { return "Context"; }
+
 protected:
   /// Set the number of workers through the attorney (internal)
   void setNumWorkers(WorkerCountType const worker_count) {

--- a/src/vt/context/context.h
+++ b/src/vt/context/context.h
@@ -49,6 +49,7 @@
 #include <mpi.h>
 
 #include "vt/config.h"
+#include "vt/runtime/component/component_pack.h"
 #include "vt/context/context_attorney_fwd.h"
 #include "vt/utils/tls/tls.h"
 
@@ -67,7 +68,7 @@ namespace vt {  namespace ctx {
  * the node on which a handler is executing or the number of nodes. It provides
  * functionality analogous to \c MPI_Comm_size and \c MPI_Comm_rank.
  */
-struct Context {
+struct Context : runtime::component::Component<Context> {
   /// Constructor with interop and args, not called by the user directly
   Context(int argc, char** argv, bool const interop, MPI_Comm* comm = nullptr);
 

--- a/src/vt/event/event.cc
+++ b/src/vt/event/event.cc
@@ -187,9 +187,9 @@ void AsyncEvent::cleanup() {
   event_container_.clear();
 }
 
-bool AsyncEvent::progress() {
+int AsyncEvent::progress() {
   theEvent()->testEventsTrigger();
-  return false;
+  return 0;
 }
 
 bool AsyncEvent::isLocalTerm() {

--- a/src/vt/event/event.cc
+++ b/src/vt/event/event.cc
@@ -179,7 +179,7 @@ EventType AsyncEvent::attachAction(EventType const& event, ActionType callable) 
 
 /*virtual*/ AsyncEvent::~AsyncEvent() { }
 
-void AsyncEvent::cleanup() {
+void AsyncEvent::finalize() {
   while (polling_event_container_.size() > 0) {
     testEventsTrigger();
   }

--- a/src/vt/event/event.h
+++ b/src/vt/event/event.h
@@ -86,7 +86,7 @@ struct AsyncEvent : runtime::component::PollableComponent<AsyncEvent> {
   virtual ~AsyncEvent();
 
   void initialize() override;
-  void cleanup();
+  void finalize() override;
   EventType createEvent(EventRecordTypeType const& type, NodeType const& node);
   EventRecordType& getEvent(EventType const& event);
   NodeType getOwningNode(EventType const& event);

--- a/src/vt/event/event.h
+++ b/src/vt/event/event.h
@@ -46,6 +46,7 @@
 #define INCLUDED_EVENT_EVENT_H
 
 #include "vt/config.h"
+#include "vt/runtime/component/component_pack.h"
 #include "vt/context/context.h"
 #include "vt/event/event_record.h"
 #include "vt/event/event_id.h"
@@ -68,7 +69,7 @@ enum class EventState : int8_t {
   EventRemote = 3
 };
 
-struct AsyncEvent {
+struct AsyncEvent : runtime::component::PollableComponent<AsyncEvent> {
   using EventRecordTypeType = eEventRecord;
   using EventManagerType = EventIDManager;
   using EventStateType = EventState;
@@ -84,7 +85,7 @@ struct AsyncEvent {
 
   virtual ~AsyncEvent();
 
-  void initialize();
+  void initialize() override;
   void cleanup();
   EventType createEvent(EventRecordTypeType const& type, NodeType const& node);
   EventRecordType& getEvent(EventType const& event);
@@ -99,7 +100,7 @@ struct AsyncEvent {
   EventStateType testEventComplete(EventType const& event);
   EventType attachAction(EventType const& event, ActionType callable);
   void testEventsTrigger(int const& num_events = num_check_actions);
-  bool progress();
+  int progress() override;
   bool isLocalTerm();
 
   static void eventFinished(EventFinishedMsg* msg);

--- a/src/vt/event/event.h
+++ b/src/vt/event/event.h
@@ -106,6 +106,8 @@ struct AsyncEvent : runtime::component::PollableComponent<AsyncEvent> {
   static void eventFinished(EventFinishedMsg* msg);
   static void checkEventFinished(EventCheckFinishedMsg* msg);
 
+  std::string name() override { return "AsyncEvent"; }
+
 private:
   // next event id
   EventType cur_event_ = 0;

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -61,6 +61,7 @@
 #include "vt/activefn/activefn.h"
 #include "vt/collective/tree/tree.h"
 #include "vt/collective/reduce/reduce.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <memory>
 #include <unordered_map>
@@ -71,7 +72,7 @@
 
 namespace vt { namespace group {
 
-struct GroupManager {
+struct GroupManager : runtime::component::Component<GroupManager> {
   using RegionType = region::Region;
   using RegionPtrType = std::unique_ptr<RegionType>;
   using GroupInfoType = Info;

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -97,6 +97,8 @@ struct GroupManager : runtime::component::Component<GroupManager> {
     cleanup_actions_.clear();
   }
 
+  std::string name() override { return "GroupManager"; }
+
   void setupDefaultGroup();
 
   GroupType newGroup(

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -905,7 +905,7 @@ bool ActiveMessenger::testPendingDataMsgAsyncRecv() {
   );
 }
 
-bool ActiveMessenger::progress() {
+int ActiveMessenger::progress() {
   bool const started_irecv_active_msg = tryProcessIncomingActiveMsg();
   bool const started_irecv_data_msg = tryProcessDataMsgRecv();
   processMaybeReadyHanTag();

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -226,6 +226,14 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    */
   virtual ~ActiveMessenger();
 
+
+  /**
+   * \brief Return the name of the component
+   *
+   * \return the name
+   */
+  std::string name() override { return "ActiveMessenger"; }
+
   /**
    * \internal
    * \brief Mark a message as a termination message.

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -227,11 +227,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   virtual ~ActiveMessenger();
 
 
-  /**
-   * \brief Return the name of the component
-   *
-   * \return the name
-   */
   std::string name() override { return "ActiveMessenger"; }
 
   /**

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -62,6 +62,7 @@
 #include "vt/registry/auto/auto_registry_interface.h"
 #include "vt/trace/trace_common.h"
 #include "vt/utils/static_checks/functor.h"
+#include "vt/runtime/component/component_pack.h"
 
 #if backend_check_enabled(trace_enabled)
   #include "vt/trace/trace_headers.h"
@@ -193,7 +194,7 @@ struct BufferedActiveMsg {
  *  - \ref functorsend
  *  - \ref sendpayload
  */
-struct ActiveMessenger {
+struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> {
   using BufferedMsgType      = BufferedActiveMsg;
   using MessageType          = ShortMessage;
   using CountType            = int32_t;
@@ -1157,7 +1158,7 @@ struct ActiveMessenger {
    *
    * \return whether any action was taken (progress was made)
    */
-  bool progress();
+  int progress() override;
 
   /**
    * \internal

--- a/src/vt/objgroup/manager.cc
+++ b/src/vt/objgroup/manager.cc
@@ -109,8 +109,8 @@ ObjGroupProxyType ObjGroupManager::makeCollectiveImpl(
   return proxy;
 }
 
-bool ObjGroupManager::progress() {
-  return false;
+int ObjGroupManager::progress() {
+  return 0;
 }
 
 void dispatchObjGroup(MsgVirtualPtrAny msg, HandlerType han) {

--- a/src/vt/objgroup/manager.cc
+++ b/src/vt/objgroup/manager.cc
@@ -109,10 +109,6 @@ ObjGroupProxyType ObjGroupManager::makeCollectiveImpl(
   return proxy;
 }
 
-int ObjGroupManager::progress() {
-  return 0;
-}
-
 void dispatchObjGroup(MsgVirtualPtrAny msg, HandlerType han) {
   debug_print(
     objgroup, node,

--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -46,6 +46,7 @@
 #define INCLUDED_VT_OBJGROUP_MANAGER_H
 
 #include "vt/config.h"
+#include "vt/runtime/component/component_pack.h"
 #include "vt/objgroup/common.h"
 #include "vt/objgroup/manager.fwd.h"
 #include "vt/objgroup/proxy/proxy_objgroup.h"
@@ -65,7 +66,7 @@
 
 namespace vt { namespace objgroup {
 
-struct ObjGroupManager {
+struct ObjGroupManager : runtime::component::PollableComponent<ObjGroupManager> {
   template <typename ObjT>
   using ProxyType           = proxy::Proxy<ObjT>;
   template <typename ObjT>
@@ -170,7 +171,7 @@ struct ObjGroupManager {
   /*
    * Run the progress function to push along postponed events (such as self sends)
    */
-  bool progress();
+  int progress() override;
 
   /*
    * Untyped calls for broadcasting or sending msgs to an obj group

--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -82,6 +82,13 @@ struct ObjGroupManager : runtime::component::Component<ObjGroupManager> {
 
   ObjGroupManager() = default;
 
+  /**
+   * \brief Return the name of the component
+   *
+   * \return the name
+   */
+  std::string name() override { return "ObjGroupManager"; }
+
   /*
    * Creation of a new object group across the distributed system. For now,
    * these use the default group which includes all the nodes in the

--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -66,7 +66,7 @@
 
 namespace vt { namespace objgroup {
 
-struct ObjGroupManager : runtime::component::PollableComponent<ObjGroupManager> {
+struct ObjGroupManager : runtime::component::Component<ObjGroupManager> {
   template <typename ObjT>
   using ProxyType           = proxy::Proxy<ObjT>;
   template <typename ObjT>
@@ -167,11 +167,6 @@ struct ObjGroupManager : runtime::component::PollableComponent<ObjGroupManager> 
    * Dispatch to a live obj group pointer with a handler
    */
   void dispatch(MsgVirtualPtrAny msg, HandlerType han);
-
-  /*
-   * Run the progress function to push along postponed events (such as self sends)
-   */
-  int progress() override;
 
   /*
    * Untyped calls for broadcasting or sending msgs to an obj group

--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -82,11 +82,6 @@ struct ObjGroupManager : runtime::component::Component<ObjGroupManager> {
 
   ObjGroupManager() = default;
 
-  /**
-   * \brief Return the name of the component
-   *
-   * \return the name
-   */
   std::string name() override { return "ObjGroupManager"; }
 
   /*

--- a/src/vt/parameterization/parameterization.h
+++ b/src/vt/parameterization/parameterization.h
@@ -130,6 +130,13 @@ static void dataMessageHandler(DataMsg<Tuple>* msg) {
 
 struct Param : runtime::component::Component<Param> {
 
+  /**
+   * \brief Return the name of the component
+   *
+   * \return the name
+   */
+  std::string name() override { return "Param"; }
+
   template <typename... Args>
   void sendDataTuple(
     NodeType const& dest, HandlerType const& han, std::tuple<Args...>&& tup

--- a/src/vt/parameterization/parameterization.h
+++ b/src/vt/parameterization/parameterization.h
@@ -130,11 +130,6 @@ static void dataMessageHandler(DataMsg<Tuple>* msg) {
 
 struct Param : runtime::component::Component<Param> {
 
-  /**
-   * \brief Return the name of the component
-   *
-   * \return the name
-   */
   std::string name() override { return "Param"; }
 
   template <typename... Args>

--- a/src/vt/parameterization/parameterization.h
+++ b/src/vt/parameterization/parameterization.h
@@ -51,6 +51,7 @@
 #include "vt/registry/auto/auto_registry_interface.h"
 #include "vt/utils/static_checks/all_true.h"
 #include "vt/parameterization/param_meta.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <tuple>
 #include <utility>
@@ -127,7 +128,7 @@ static void dataMessageHandler(DataMsg<Tuple>* msg) {
 #endif
 }
 
-struct Param {
+struct Param : runtime::component::Component<Param> {
 
   template <typename... Args>
   void sendDataTuple(

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -58,6 +58,7 @@
 #include "vt/activefn/activefn.h"
 #include "vt/objgroup/proxy/proxy_objgroup.h"
 #include "vt/objgroup/proxy/proxy_objgroup_elm.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <unordered_map>
 #include <functional>
@@ -73,8 +74,10 @@ struct FunctorTraits {
   static constexpr auto const has_no_msg_type = FunctorNoMsgType::value;
 };
 
-struct PipeManager : PipeManagerTL, PipeManagerTyped {
-
+struct PipeManager
+  : runtime::component::Component<PipeManager>,
+    PipeManagerTL, PipeManagerTyped
+{
   template <typename FunctorT>
   using GetMsgType = typename util::FunctorExtractor<FunctorT>::MessageType;
   using Void = V;

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -84,6 +84,8 @@ struct PipeManager
 
   PipeManager();
 
+  std::string name() override { return "PipeManager"; }
+
   template <typename MsgT, typename ContextT>
   Callback<MsgT> makeFunc(ContextT* ctx, FuncMsgCtxType<MsgT, ContextT> fn);
   template <typename ContextT>

--- a/src/vt/pool/pool.cc
+++ b/src/vt/pool/pool.cc
@@ -258,7 +258,7 @@ void Pool::initWorkerPools(WorkerCountType const& num_workers) {
   #endif
 }
 
-void Pool::destroyWorkerPools() {
+void Pool::finalize() {
   #if backend_check_enabled(memory_pool)
     s_msg_worker_.clear();
     m_msg_worker_.clear();

--- a/src/vt/pool/pool.h
+++ b/src/vt/pool/pool.h
@@ -75,6 +75,8 @@ struct Pool : runtime::component::Component<Pool> {
 
   Pool();
 
+  std::string name() override { return "MemoryPool"; }
+
   void* alloc(size_t const& num_bytes, size_t oversize = 0);
   void dealloc(void* const buf);
   ePoolSize getPoolType(size_t const& num_bytes, size_t const& oversize);

--- a/src/vt/pool/pool.h
+++ b/src/vt/pool/pool.h
@@ -83,7 +83,7 @@ struct Pool : runtime::component::Component<Pool> {
   bool active_env() const;
 
   void initWorkerPools(WorkerCountType const& num_workers);
-  void destroyWorkerPools();
+  void finalize() override;
 
 private:
   /*

--- a/src/vt/pool/pool.h
+++ b/src/vt/pool/pool.h
@@ -46,6 +46,7 @@
 #define INCLUDED_POOL_POOL_H
 
 #include "vt/config.h"
+#include "vt/runtime/component/component_pack.h"
 #include "vt/pool/static_sized/memory_pool_equal.h"
 #include "vt/pool/header/pool_header.h"
 
@@ -56,7 +57,7 @@
 
 namespace vt { namespace pool {
 
-struct Pool {
+struct Pool : runtime::component::Component<Pool> {
   using SizeType = size_t;
   using HeaderType = Header;
   using HeaderManagerType = HeaderManager;

--- a/src/vt/rdma/rdma.h
+++ b/src/vt/rdma/rdma.h
@@ -66,12 +66,14 @@
 
 #include "vt/rdma/collection/rdma_collection_fwd.h"
 
+#include "vt/runtime/component/component_pack.h"
+
 #include <unordered_map>
 #include <cassert>
 
 namespace vt { namespace rdma {
 
-struct RDMAManager {
+struct RDMAManager : runtime::component::Component<RDMAManager> {
   using RDMA_BitsType = Bits;
   using RDMA_StateType = State;
   using RDMA_TypeType = Type;

--- a/src/vt/rdma/rdma.h
+++ b/src/vt/rdma/rdma.h
@@ -99,6 +99,8 @@ struct RDMAManager : runtime::component::Component<RDMAManager> {
   using RDMA_PutTypedFunctionType =
     RDMA_StateType::RDMA_PutTypedFunctionType<MsgType>;
 
+  std::string name() override { return "RDMAManager"; }
+
   template <typename T>
   void putTypedData(
     RDMA_HandleType const& rdma_handle, T ptr,

--- a/src/vt/rdmahandle/manager.cc
+++ b/src/vt/rdmahandle/manager.cc
@@ -52,13 +52,13 @@ void Manager::destroy() {
   vt::theObjGroup()->destroyCollective(proxy_);
 }
 
-void Manager::initialize(ProxyType in_proxy) {
+void Manager::setup(ProxyType in_proxy) {
   proxy_ = in_proxy;
 }
 
 /*static*/ typename Manager::ProxyType Manager::construct() {
   auto proxy = vt::theObjGroup()->makeCollective<Manager>();
-  proxy.get()->initialize(proxy);
+  proxy.get()->setup(proxy);
   return proxy;
 }
 

--- a/src/vt/rdmahandle/manager.cc
+++ b/src/vt/rdmahandle/manager.cc
@@ -56,10 +56,11 @@ void Manager::setup(ProxyType in_proxy) {
   proxy_ = in_proxy;
 }
 
-/*static*/ typename Manager::ProxyType Manager::construct() {
-  auto proxy = vt::theObjGroup()->makeCollective<Manager>();
+/*static*/ std::unique_ptr<Manager> Manager::construct() {
+  auto ptr = std::make_unique<Manager>();
+  auto proxy = vt::theObjGroup()->makeCollective<Manager>(ptr.get());
   proxy.get()->setup(proxy);
-  return proxy;
+  return std::move(ptr);
 }
 
 }} /* end namespace vt::rdma */

--- a/src/vt/rdmahandle/manager.cc
+++ b/src/vt/rdmahandle/manager.cc
@@ -48,7 +48,7 @@
 
 namespace vt { namespace rdma {
 
-void Manager::destroy() {
+void Manager::finalize() {
   vt::theObjGroup()->destroyCollective(proxy_);
 }
 

--- a/src/vt/rdmahandle/manager.cc
+++ b/src/vt/rdmahandle/manager.cc
@@ -60,7 +60,7 @@ void Manager::setup(ProxyType in_proxy) {
   auto ptr = std::make_unique<Manager>();
   auto proxy = vt::theObjGroup()->makeCollective<Manager>(ptr.get());
   proxy.get()->setup(proxy);
-  return std::move(ptr);
+  return ptr;
 }
 
 }} /* end namespace vt::rdma */

--- a/src/vt/rdmahandle/manager.h
+++ b/src/vt/rdmahandle/manager.h
@@ -89,7 +89,7 @@ struct Manager : runtime::component::Component<Manager> {
   /**
    * \brief Destroy the component, called when VT is finalized
    */
-  void destroy();
+  void finalize() override;
 
 private:
   /**

--- a/src/vt/rdmahandle/manager.h
+++ b/src/vt/rdmahandle/manager.h
@@ -221,7 +221,7 @@ private:
   }
 
 public:
-  static ProxyType construct();
+  static std::unique_ptr<Manager> construct();
 
 private:
   /// Current collective handle for a given objgroup proxy

--- a/src/vt/rdmahandle/manager.h
+++ b/src/vt/rdmahandle/manager.h
@@ -56,6 +56,7 @@
 #include "vt/pipe/pipe_manager.h"
 #include "vt/topos/mapping/dense/dense.h"
 #include "vt/rdmahandle/handle_set.h"
+#include "vt/runtime/component/component_pack.h"
 
 namespace vt { namespace rdma {
 
@@ -78,7 +79,7 @@ struct InformRDMAMsg;
  *
  * \brief RDMA Handle Manager for creation of node- or index-level handles
  */
-struct Manager {
+struct Manager : runtime::component::Component<Manager> {
   using ProxyType       = vt::objgroup::proxy::Proxy<Manager>;
   using ElemToHandle    = std::unordered_map<int64_t, RDMA_HandleType>;
   using HandleToManager = std::unordered_map<RDMA_HandleType, ObjGroupProxyType>;
@@ -92,11 +93,11 @@ struct Manager {
 
 private:
   /**
-   * \internal \brief Initialize the manager with the objgroup proxy
+   * \internal \brief Setup the manager with the objgroup proxy
    *
    * \param[in] in_proxy the manager instance's proxy
    */
-  void initialize(ProxyType in_proxy);
+  void setup(ProxyType in_proxy);
 
   /**
    * \internal \brief Finish constructing a handle after coordinating each node on

--- a/src/vt/rdmahandle/manager.h
+++ b/src/vt/rdmahandle/manager.h
@@ -87,6 +87,13 @@ struct Manager : runtime::component::Component<Manager> {
   Manager() = default;
 
   /**
+   * \brief Return the name of the component
+   *
+   * \return the name
+   */
+  std::string name() override { return "HandleRDMA"; }
+
+  /**
    * \brief Destroy the component, called when VT is finalized
    */
   void finalize() override;

--- a/src/vt/rdmahandle/manager.h
+++ b/src/vt/rdmahandle/manager.h
@@ -86,11 +86,6 @@ struct Manager : runtime::component::Component<Manager> {
 
   Manager() = default;
 
-  /**
-   * \brief Return the name of the component
-   *
-   * \return the name
-   */
   std::string name() override { return "HandleRDMA"; }
 
   /**

--- a/src/vt/registry/registry.h
+++ b/src/vt/registry/registry.h
@@ -66,6 +66,8 @@ struct Registry : runtime::component::Component<Registry> {
 
   Registry() = default;
 
+  std::string name() override { return "Registry"; }
+
   HandlerType registerNewHandler(
     ActiveClosureFnType fn, TagType const& tag = no_tag,
     bool const& is_collective = false

--- a/src/vt/registry/registry.h
+++ b/src/vt/registry/registry.h
@@ -52,10 +52,11 @@
 #include "vt/config.h"
 #include "vt/activefn/activefn.h"
 #include "vt/handler/handler.h"
+#include "vt/runtime/component/component.h"
 
 namespace vt { namespace registry {
 
-struct Registry {
+struct Registry : runtime::component::Component<Registry> {
   using HandlerManagerType = HandlerManager;
   using HandlerBitsType = eHandlerBits;
   using TaggerHandlerType = std::tuple<TagType, HandlerType>;

--- a/src/vt/runtime/component/base.h
+++ b/src/vt/runtime/component/base.h
@@ -45,7 +45,6 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
 
-#include "vt/config.h"
 #include "vt/runtime/component/diagnostic.h"
 #include "vt/runtime/component/bufferable.h"
 #include "vt/runtime/component/progressable.h"

--- a/src/vt/runtime/component/base.h
+++ b/src/vt/runtime/component/base.h
@@ -1,0 +1,414 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                    base.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
+#define INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
+
+#include "vt/config.h"
+
+#include <vector>
+#include <tuple>
+
+namespace vt { namespace runtime { namespace registry {
+
+using AutoHandlerType = auto_registry::AutoHandlerType;
+using RegistryType = std::vector<std::tuple<int,std::vector<int>>>;
+
+inline RegistryType& getRegistry() {
+  static RegistryType reg;
+  return reg;
+}
+
+template <typename ObjT>
+struct Registrar {
+  Registrar() {
+    auto& reg = getRegistry();
+    index = reg.size();
+    reg.emplace_back(std::make_tuple(index,std::vector<int>{}));
+  }
+  AutoHandlerType index;
+};
+
+template <typename ObjT>
+struct Type {
+  static AutoHandlerType const idx;
+};
+
+template <typename ObjT>
+AutoHandlerType const Type<ObjT>::idx = Registrar<ObjT>().index;
+
+inline std::vector<int>& getIdx(AutoHandlerType han) {
+  return std::get<1>(getRegistry().at(han));
+}
+
+template <typename ObjT>
+inline AutoHandlerType makeIdx() {
+  return Type<ObjT>::idx;
+}
+
+}}} /* end namespace vt::runtime::registry */
+
+
+
+namespace vt { namespace runtime { namespace component {
+
+template <typename... Args>
+struct AddDep;
+
+template <typename U, typename... Args>
+struct AddDep<U, Args...> {
+  static void add(registry::AutoHandlerType t) {
+    auto u = registry::makeIdx<U>();
+    registry::getIdx(t).push_back(u);
+    AddDep<Args...>::add(t);
+  }
+};
+
+template <>
+struct AddDep<> {
+  static void add(registry::AutoHandlerType t) {
+  }
+};
+
+
+struct ComponentRegistry {
+
+  template <typename U, typename... Args>
+  static void addDep(registry::AutoHandlerType t);
+
+  template <typename T, typename... Deps>
+  static void dependsOn() {
+    auto t = registry::makeIdx<T>();
+    AddDep<Deps...>::add(t);
+  }
+
+};
+
+
+struct Diagnostic {
+  virtual void dumpState() = 0;
+  // @todo diagnostics
+};
+
+struct Bufferable {
+  // @todo interface for buffering
+};
+
+
+struct Progressable {
+  virtual int progress() = 0;
+};
+
+struct BaseComponent : Diagnostic, Bufferable, Progressable {
+  virtual bool pollable() = 0;
+  virtual void initialize() = 0;
+  virtual void finalize() = 0;
+
+  virtual ~BaseComponent() { }
+};
+
+template <typename... Deps>
+struct DepsPack { };
+
+
+template <typename T>
+struct ComponentTraits {
+  template <typename U, typename = decltype(U::construct())>
+  static std::true_type test(int);
+
+  template <typename U>
+  static std::false_type test(...);
+
+  static constexpr bool hasConstruct = decltype(test<T>(0))::value;
+};
+
+template <typename T>
+struct Component : BaseComponent {
+
+  Component() = default;
+
+  template <typename... Deps>
+  Component(DepsPack<Deps...>) {
+    ComponentRegistry::dependsOn<T, Deps...>();
+  }
+
+  /// Traits for objgroup components which have a specialized static construct
+  template <typename U>
+  using hasCons = typename std::enable_if<ComponentTraits<U>::hasConstruct, T>::type;
+  template <typename U>
+  using hasNoCons = typename std::enable_if<not ComponentTraits<U>::hasConstruct, T>::type;
+
+  template <typename... Args, typename U = T>
+  static std::unique_ptr<T> staticInit(Args&&... args, hasCons<U>* = nullptr) {
+    return T::construct(std::forward<Args>(args)...);
+  }
+
+  template <typename... Args, typename U = T>
+  static std::unique_ptr<T> staticInit(Args&&... args, hasNoCons<U>* = nullptr) {
+    return std::make_unique<T>(std::forward<Args>(args)...);
+  }
+
+  bool pollable() override {
+    return false;
+  }
+
+  void initialize() override { }
+  void finalize() override { }
+
+  // Default empty progress function
+  int progress() override { return 0; }
+
+  void dumpState() override {
+    /* here to compile, should be implemented by each component*/
+  }
+};
+
+template <typename T>
+struct PollableComponent : Component<T> {
+
+  bool pollable() override {
+    return true;
+  }
+
+  // Fail if progress method not overridden by user
+  int progress() override {
+    vtAssert(false, "PollableComponent should have a progress function");
+    return 0;
+  }
+
+};
+
+
+
+struct Test3 final : PollableComponent<Test3> {
+  Test3(int a, int b) : PollableComponent<Test3>() { }
+
+  static std::unique_ptr<Test3> construct(int a, int b) {
+    return std::make_unique<Test3>(a, b);
+  }
+
+  int progress() override {
+    // implement progress function
+    return 0;
+  };
+};
+
+struct Test2 : Component<Test2> {
+  Test2() : Component<Test2>() { }
+};
+
+struct Test1 : Component<Test1> {
+  Test1() : Component<Test1>() { }
+};
+
+struct TestA : Component<TestA> {
+  TestA() : Component<TestA>() { }
+};
+
+struct ComponentPack {
+
+  template <typename T, typename... Deps>
+  registry::AutoHandlerType registerComponent(DepsPack<Deps...>) {
+    ComponentRegistry::dependsOn<T, Deps...>();
+    auto idx = registry::makeIdx<T>();
+    registered_components_.push_back(idx);
+    return idx;
+  }
+
+// private:
+
+//   template <typename T, typename Tuple, typename... Args>
+//   std::unique_ptr<T> make(std::tuple<Args...>&& tup) {
+//     static constexpr auto size = std::tuple_size<Tuple>::value;
+//     static constexpr auto seq = std::make_index_sequence<size>{};
+//     return makeImpl<T, Tuple>(std::forward<std::tuple<Args...>>(tup), seq);
+//   }
+
+//   template <typename T, typename Tuple, typename... Args, size_t... I>
+//   std::unique_ptr<T> makeImpl(std::tuple<Args...>&& tup, std::index_sequence<I...> seq) {
+//     return T::template staticInit<Args...>(
+//       std::forward<typename std::tuple_element<I,Tuple>::type>(
+//         std::get<I>(tup)
+//       )...
+//     );
+//   }
+
+public:
+
+  template <typename T, typename... Args>
+  void add(Args&&... args) {
+    auto idx = registry::makeIdx<T>();
+    construct_components_.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(idx),
+      std::forward_as_tuple(
+        //[this, args = std::make_tuple(std::forward<Args>(args)...)]() mutable {
+        [=]() mutable {
+          auto ptr = T::template staticInit<Args...>(std::forward<Args>(args)...);
+          // auto ptr = make<T, std::tuple<Args...>>(std::forward<std::tuple<Args...>>(args));
+          if (ptr->pollable()) {
+            pollable_components_.emplace_back(ptr.get());
+          }
+          ptr->initialize();
+          added_components_.emplace_back(std::move(ptr));
+        }
+      )
+    );
+  }
+
+  void topoSort() {
+    std::stack<int> order;
+    fmt::print("registered={}\n",registered_components_.size());
+    auto visited = std::make_unique<bool[]>(registered_components_.size());
+    for (std::size_t i = 0; i < registered_components_.size(); i++) {
+      if (visited[i] == false) {
+        topoSortImpl(i, order, visited.get());
+      }
+    }
+
+    while (not order.empty()) {
+      auto top = order.top();
+      fmt::print("top = {}\n", top);
+      order.pop();
+
+      auto iter = construct_components_.find(top);
+      if (iter != construct_components_.end()) {
+        fmt::print("found {}\n", top);
+        iter->second();
+      } else {
+        fmt::print("not found {}\n", top);
+      }
+    }
+  }
+
+private:
+  void topoSortImpl(int v, std::stack<int>& order, bool* visited) {
+    fmt::print("impl v={}\n",v);
+    visited[v] = true;
+
+    auto v_list = registry::getIdx(v);
+    for (auto&& vp : v_list) {
+      if (not visited[vp]) {
+        topoSortImpl(vp, order, visited);
+      }
+    }
+
+    order.push(v);
+  }
+
+  void finalize() {
+  }
+
+private:
+  std::vector<registry::AutoHandlerType> registered_components_;
+  std::unordered_map<registry::AutoHandlerType, ActionType> construct_components_;
+  std::vector<std::unique_ptr<BaseComponent>> added_components_;
+  std::vector<Progressable*> pollable_components_;
+};
+
+void run() {
+  ComponentPack p;
+  p.registerComponent<TestA>(DepsPack<>{});
+  p.registerComponent<Test1>(DepsPack<>{});
+  p.registerComponent<Test2>(DepsPack<Test3,TestA>{});
+  p.registerComponent<Test3>(DepsPack<Test1,TestA>{});
+
+
+  // Registrations
+  // p.registerComponent<MemoryUsage>(DepsPack<>{});
+  // p.registerComponent<Registry>(DepsPack<>{});
+  // p.registerComponent<Pool>(DepsPack<>{});
+  // p.registerComponent<Event>(DepsPack<>{});
+  // p.registerComponent<ActiveMessenger>(DepsPack<Event, Pool, Registry>{});
+  // p.registerComponent<ObjGroup>(DepsPack<ActiveMessenger, Pool>{});
+  // p.registerComponent<Trace>(DepsPack<Scheduler, ActiveMessenger>{});
+  // p.registerComponent<Scheduler>(DepsPack<MemoryUsage>{});
+  // p.registerComponent<TerminationDetector>(DepsPack<ActiveMessenger>{});
+  // p.registerComponent<CollectiveAlg>(DepsPack<ActiveMessenger>{});
+  // p.registerComponent<GroupManager>(DepsPack<ActiveMessenger, CollectiveAlg>{});
+  // p.registerComponent<PipeManager>(DepsPack<ActiveMessenger, CollectiveAlg, ObjGroup, CollectionManager>{});
+  // p.registerComponent<RDMAManager>(DepsPack<ActiveMessenger>{});
+  // p.registerComponent<Param>(DepsPack<ActiveMessenger>{});
+  // p.registerComponent<Sequencer>(DepsPack<ActiveMessenger>{});
+  // p.registerComponent<SequencerVirtual>(DepsPack<VirtualContextManager, Sequencer>{});
+  // p.registerComponent<VirtualContextManager>(DepsPack<ActiveMessenger, Scheduler>{});
+  // p.registerComponent<CollectionManager>(DepsPack<ActiveMessenger, GroupManager, Scheduler>{});
+  // p.registerComponent<HandleRDMA>(DepsPack<ActiveMessenger, CollectionManager, ObjGroup>{});
+
+
+
+  p.add<Test1>();
+  p.add<Test2>();
+  p.add<Test3>(10, 20);
+  p.add<TestA>();
+
+  p.topoSort();
+
+
+  auto t1 = registry::makeIdx<Test1>();
+  auto t2 = registry::makeIdx<Test2>();
+  auto t3 = registry::makeIdx<Test3>();
+  auto t4 = registry::makeIdx<TestA>();
+
+  fmt::print("Test 1={}, 2={}, 3={}, A={}\n", t1, t2, t3, t4);
+
+
+  auto v1 = registry::getIdx(t1);
+  auto v2 = registry::getIdx(t2);
+  auto v3 = registry::getIdx(t3);
+
+  for (auto&& elm : v1) {
+    fmt::print("Test1={}, deps={}\n", t1, elm);
+  }
+  for (auto&& elm : v2) {
+    fmt::print("Test2={}, deps={}\n", t2, elm);
+  }
+  for (auto&& elm : v3) {
+    fmt::print("Test3={}, deps={}\n", t3, elm);
+  }
+}
+
+}}} /* end namespace vt::runtime::component */
+
+#endif /*INCLUDED_VT_RUNTIME_COMPONENT_BASE_H*/

--- a/src/vt/runtime/component/base.h
+++ b/src/vt/runtime/component/base.h
@@ -51,14 +51,44 @@
 
 namespace vt { namespace runtime { namespace component {
 
+/**
+ * \struct BaseComponent base.h vt/runtime/component/base.h
+ *
+ * \brief The abstract \c BaseComponent for VT runtime component pack
+ */
 struct BaseComponent : Diagnostic, Bufferable, Progressable {
+  /**
+   * \struct DepsPack
+   *
+   * \brief Set of component types that given component is dependent on
+   */
   template <typename... Deps>
   struct DepsPack { };
 
+  /**
+   * \internal \brief Initialize the component. Invoked after the constructor
+   * fires during the startup sequence
+   */
   virtual void initialize() = 0;
+
+  /**
+   * \internal \brief Finalize the component. Invoked before the destructor
+   * fires during the shutdown sequence
+   */
   virtual void finalize() = 0;
 
+  /**
+   * \internal \brief Returns whether the component should be polled by the
+   * scheduler
+   *
+   * \return whether the component is pollable
+   */
   virtual bool pollable() = 0;
+
+  /**
+   * \internal \brief Invoked after all components are constructed and the
+   * runtime is live
+   */
   virtual void startup() = 0;
 
   virtual ~BaseComponent() { }

--- a/src/vt/runtime/component/base.h
+++ b/src/vt/runtime/component/base.h
@@ -49,6 +49,8 @@
 #include "vt/runtime/component/bufferable.h"
 #include "vt/runtime/component/progressable.h"
 
+#include <string>
+
 namespace vt { namespace runtime { namespace component {
 
 /**
@@ -90,6 +92,11 @@ struct BaseComponent : Diagnostic, Bufferable, Progressable {
    * runtime is live
    */
   virtual void startup() = 0;
+
+  /**
+   * \internal \brief Get the name of the component
+   */
+  virtual std::string name() = 0;
 
   virtual ~BaseComponent() { }
 };

--- a/src/vt/runtime/component/bufferable.h
+++ b/src/vt/runtime/component/bufferable.h
@@ -45,8 +45,6 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_BUFFERABLE_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_BUFFERABLE_H
 
-#include "vt/config.h"
-
 namespace vt { namespace runtime { namespace component {
 
 struct Bufferable {

--- a/src/vt/runtime/component/bufferable.h
+++ b/src/vt/runtime/component/bufferable.h
@@ -47,6 +47,12 @@
 
 namespace vt { namespace runtime { namespace component {
 
+/**
+ * \struct Bufferable bufferable.h vt/runtime/component/bufferable.h
+ *
+ * \brief The abstract \c Bufferable trait for delaying operations generically
+ * across VT components
+ */
 struct Bufferable {
   // @todo interface for buffering
 };

--- a/src/vt/runtime/component/bufferable.h
+++ b/src/vt/runtime/component/bufferable.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                    base.h
+//                                 bufferable.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,29 +42,17 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
-#define INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
+#if !defined INCLUDED_VT_RUNTIME_COMPONENT_BUFFERABLE_H
+#define INCLUDED_VT_RUNTIME_COMPONENT_BUFFERABLE_H
 
 #include "vt/config.h"
-#include "vt/runtime/component/diagnostic.h"
-#include "vt/runtime/component/bufferable.h"
-#include "vt/runtime/component/progressable.h"
 
 namespace vt { namespace runtime { namespace component {
 
-struct BaseComponent : Diagnostic, Bufferable, Progressable {
-  template <typename... Deps>
-  struct DepsPack { };
-
-  virtual void initialize() = 0;
-  virtual void finalize() = 0;
-
-  virtual bool pollable() = 0;
-  virtual void startup() = 0;
-
-  virtual ~BaseComponent() { }
+struct Bufferable {
+  // @todo interface for buffering
 };
 
 }}} /* end namespace vt::runtime::component */
 
-#endif /*INCLUDED_VT_RUNTIME_COMPONENT_BASE_H*/
+#endif /*INCLUDED_VT_RUNTIME_COMPONENT_BUFFERABLE_H*/

--- a/src/vt/runtime/component/component.h
+++ b/src/vt/runtime/component/component.h
@@ -177,7 +177,7 @@ struct PollableComponent : Component<T> {
    * \return number of units processed---zero
    */
   virtual int progress() override {
-    vtAbort("PollableComponent should have a progress function");
+    vtAbort("PollableComponent should override the empty progress function");
     return 0;
   }
 

--- a/src/vt/runtime/component/component.h
+++ b/src/vt/runtime/component/component.h
@@ -55,56 +55,127 @@
 
 namespace vt { namespace runtime { namespace component {
 
+/**
+ * \struct Component component.h vt/runtime/component/component.h
+ *
+ * \brief \c Component class for a generic VT runtime module, CRTP'ed over the
+ * component's actual type
+ */
 template <typename T>
 struct Component : BaseComponent {
 
   Component() = default;
 
+  /**
+   * \brief Constructor for a new component with the appropriate typed
+   * dependencies
+   *
+   * \param[in] DepsPack a pack of typed dependencies for the given component
+   * that it depends on
+   *
+   * \return the new component
+   */
   template <typename... Deps>
   Component(DepsPack<Deps...>) {
     ComponentRegistry::dependsOn<T, Deps...>();
   }
 
-  /// Traits for objgroup components which have a specialized static construct
+  /// Trait for components that have a specialized static construct method (used
+  /// for objgroups)
   template <typename U>
   using hasCons = typename std::enable_if<ComponentTraits<U>::hasConstruct, T>::type;
+
+  /// Trait for components that do not have a specialized static construct method
   template <typename U>
   using hasNoCons = typename std::enable_if<not ComponentTraits<U>::hasConstruct, T>::type;
 
+  /**
+   * \brief Construct the component with the specialized construct method
+   *
+   * \param[in] args the arguments to forward to the component's constructor
+   *
+   * \return unique pointer to the the component
+   */
   template <typename... Args, typename U = T>
   static std::unique_ptr<T> staticInit(Args&&... args, hasCons<U>* = nullptr) {
     return T::construct(std::forward<Args>(args)...);
   }
 
+  /**
+   * \brief Construct the component with normal component constructor
+   *
+   * \param[in] args the arguments to forward to the component's constructor
+   *
+   * \return unique pointer to the the component
+   */
   template <typename... Args, typename U = T>
   static std::unique_ptr<T> staticInit(Args&&... args, hasNoCons<U>* = nullptr) {
     return std::make_unique<T>(std::forward<Args>(args)...);
   }
 
+  /**
+   * \brief Whether the component requires the scheduler to poll
+   *
+   * \return default component is not pollable
+   */
   bool pollable() override {
     return false;
   }
 
+  /**
+   * \brief Empty default overridden initialize method
+   */
   virtual void initialize() override { }
+
+  /**
+   * \brief Empty default overridden finalize method
+   */
   virtual void finalize() override { }
+
+  /**
+   * \brief Empty default overridden startup method
+   */
   virtual void startup() override { }
 
-  // Default empty progress function
+  /**
+   * \brief Empty default overridden progress method
+   *
+   * \return no units processed
+   */
   virtual int progress() override { return 0; }
 
-  void dumpState() override {
-    /* here to compile, should be implemented by each component*/
-  }
+  /**
+   * \brief Empty default diagnostic dump state
+   */
+  void dumpState() override { }
 };
 
+/**
+ * \struct PollableComponent component.h vt/runtime/component/component.h
+ *
+ * \brief \c Component class for a generic, pollable VT runtime module, CRTP'ed
+ * over the component's actual type. A pollable component will be registered
+ * with the VT scheduler to ensure it makes progress.
+ */
 template <typename T>
 struct PollableComponent : Component<T> {
 
+  /**
+   * \brief Whether the component requires the scheduler to poll
+   *
+   * \return pollable component returns true to indicate progress function to be
+   * invoked
+   */
   bool pollable() override {
     return true;
   }
 
-  // Fail if progress method not overridden by user
+  /**
+   * \brief Override progress function to force user to supply a real
+   * function. Abort if the user does not.
+   *
+   * \return number of units processed---zero
+   */
   virtual int progress() override {
     vtAbort("PollableComponent should have a progress function");
     return 0;

--- a/src/vt/runtime/component/component.h
+++ b/src/vt/runtime/component/component.h
@@ -51,6 +51,8 @@
 #include "vt/runtime/component/component_traits.h"
 #include "vt/runtime/component/base.h"
 
+#include <memory>
+
 namespace vt { namespace runtime { namespace component {
 
 template <typename T>
@@ -104,7 +106,7 @@ struct PollableComponent : Component<T> {
 
   // Fail if progress method not overridden by user
   virtual int progress() override {
-    vtAssert(false, "PollableComponent should have a progress function");
+    //vtAssert(false, "PollableComponent should have a progress function");
     return 0;
   }
 

--- a/src/vt/runtime/component/component.h
+++ b/src/vt/runtime/component/component.h
@@ -45,7 +45,7 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_H
 
-#include "vt/config.h"
+#include "vt/configs/error/hard_error.h"
 #include "vt/runtime/component/component_registry.h"
 #include "vt/runtime/component/component_dep.h"
 #include "vt/runtime/component/component_traits.h"
@@ -106,7 +106,7 @@ struct PollableComponent : Component<T> {
 
   // Fail if progress method not overridden by user
   virtual int progress() override {
-    //vtAssert(false, "PollableComponent should have a progress function");
+    vtAbort("PollableComponent should have a progress function");
     return 0;
   }
 

--- a/src/vt/runtime/component/component.h
+++ b/src/vt/runtime/component/component.h
@@ -147,7 +147,7 @@ struct Component : BaseComponent {
   /**
    * \brief Empty default diagnostic dump state
    */
-  void dumpState() override { }
+  virtual void dumpState() override { }
 };
 
 /**

--- a/src/vt/runtime/component/component_dep.h
+++ b/src/vt/runtime/component/component_dep.h
@@ -45,7 +45,6 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_DEP_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_DEP_H
 
-#include "vt/config.h"
 #include "vt/runtime/component/component_registry.h"
 
 namespace vt { namespace runtime { namespace component {

--- a/src/vt/runtime/component/component_dep.h
+++ b/src/vt/runtime/component/component_dep.h
@@ -57,7 +57,7 @@ template <typename U, typename... Args>
 struct AddDep<U, Args...> {
   static void add(registry::AutoHandlerType t) {
     auto u = registry::makeIdx<U>();
-    registry::getIdx(t).push_back(u);
+    registry::getIdx(t).insert(u);
     AddDep<Args...>::add(t);
   }
 };

--- a/src/vt/runtime/component/component_pack.cc
+++ b/src/vt/runtime/component/component_pack.cc
@@ -1,0 +1,159 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                              component_pack.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_CC
+#define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_CC
+
+#include "vt/runtime/component/component_pack.h"
+
+namespace vt { namespace runtime { namespace component {
+
+void ComponentPack::construct() {
+  // Topologically sort the components based on dependences to generate a
+  // valid startup order
+  auto order = topoSort();
+
+  // Construct the components, and fire off initialize
+  while (not order.empty()) {
+    auto next = order.back();
+    //fmt::print("constructing = {}\n", next);
+    order.pop_back();
+
+    auto iter = construct_components_.find(next);
+    if (iter != construct_components_.end()) {
+      iter->second();
+    } else {
+      vtAbort("Could not find component to construct");
+    }
+  }
+
+  // Run the startup now that all components are live
+  for (auto&& c : live_components_) {
+    c->startup();
+  }
+
+  live_ = true;
+}
+
+ComponentPack::~ComponentPack() {
+  destruct();
+}
+
+void ComponentPack::destruct() {
+  live_ = false;
+  pollable_components_.clear();
+  while (live_components_.size() > 0) {
+    live_components_.back()->finalize();
+    live_components_.pop_back();
+  }
+}
+
+int ComponentPack::progress() {
+  int total = 0;
+  for (auto&& pollable : pollable_components_) {
+    total += pollable->progress();
+  }
+  return total;
+}
+
+std::list<int> ComponentPack::topoSort() {
+  std::list<int> order;
+  //fmt::print("added size={}\n", added_components_.size());
+  auto visited = std::make_unique<bool[]>(registered_components_.size());
+  for (std::size_t i = 0; i < registered_components_.size(); i++) {
+    auto added_iter = added_components_.find(i);
+    if (added_iter != added_components_.end()) {
+      if (visited[i] == false) {
+        topoSortImpl(i, order, visited.get());
+      }
+    }
+  }
+
+  detectCycles(order.front());
+
+  return order;
+}
+
+void ComponentPack::topoSortImpl(int v, std::list<int>& order, bool* visited) {
+  //fmt::print("impl v={}\n",v);
+  visited[v] = true;
+
+  auto v_list = registry::getIdx(v);
+  for (auto&& vp : v_list) {
+    //fmt::print("v={} vp={}, size={}\n",v,vp,v_list.size());
+    auto iter = added_components_.find(vp);
+    if (iter == added_components_.end()) {
+      //fmt::print("Adding component automatically due to dependencies\n");
+    }
+    if (not visited[vp]) {
+      topoSortImpl(vp, order, visited);
+    }
+  }
+
+  order.push_front(v);
+}
+
+void ComponentPack::detectCycles(int root) {
+  std::list<int> stack;
+  detectCyclesImpl(stack, root);
+}
+
+void ComponentPack::detectCyclesImpl(std::list<int>& stack, int dep) {
+  for (auto&& prev_dep : stack) {
+    if (prev_dep == dep) {
+      vtAbort("Cycle found in dependencies of registered components\n");
+    }
+  }
+
+  stack.push_back(dep);
+  auto vl = registry::getIdx(dep);
+  for (auto&& vp : vl) {
+    detectCyclesImpl(stack, vp);
+  }
+  stack.pop_back();
+}
+
+}}} /* end namespace vt::runtime::component */
+
+#endif /*INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_CC*/

--- a/src/vt/runtime/component/component_pack.cc
+++ b/src/vt/runtime/component/component_pack.cc
@@ -57,7 +57,6 @@ void ComponentPack::construct() {
   // Construct the components, and fire off initialize
   while (not order.empty()) {
     auto next = order.back();
-    //fmt::print("constructing = {}\n", next);
     order.pop_back();
 
     auto iter = construct_components_.find(next);
@@ -84,6 +83,12 @@ void ComponentPack::destruct() {
   live_ = false;
   pollable_components_.clear();
   while (live_components_.size() > 0) {
+    debug_print(
+      runtime, node,
+      "ComponentPack: finalizing component={}\n",
+      live_components_.back()->name()
+    );
+
     live_components_.back()->finalize();
     live_components_.pop_back();
   }

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -143,10 +143,17 @@ public:
     live_ = true;
   }
 
+  ~ComponentPack() {
+    destruct();
+  }
+
   void destruct() {
     live_ = false;
     pollable_components_.clear();
-    live_components_.clear();
+    while (live_components_.size() > 0) {
+      live_components_.back()->finalize();
+      live_components_.pop_back();
+    }
   }
 
 private:

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -160,6 +160,8 @@ private:
   bool live_ = false;
   /// List of registered components
   std::vector<registry::AutoHandlerType> registered_components_;
+  /// Set of registered components to make it idempotent
+  std::unordered_set<registry::AutoHandlerType> registered_set_;
   /// Set of added components to be constructed
   std::unordered_set<registry::AutoHandlerType> added_components_;
   /// Bound constructors for components

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -155,6 +155,14 @@ public:
     }
   }
 
+  int progress() {
+    int total = 0;
+    for (auto&& pollable : pollable_components_) {
+      total += pollable->progress();
+    }
+    return total;
+  }
+
 private:
   std::list<int> topoSort() {
     std::list<int> order;

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -1,0 +1,229 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               component_pack.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_H
+#define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_H
+
+#include "vt/config.h"
+#include "vt/runtime/component/component.h"
+
+#include <list>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace vt { namespace runtime { namespace component {
+
+struct ComponentPack {
+
+  template <typename T, typename... Deps, typename... Cons>
+  registry::AutoHandlerType registerComponent(
+    T** ref, typename BaseComponent::DepsPack<Deps...>, Cons&&... cons
+  ) {
+    ComponentRegistry::dependsOn<T, Deps...>();
+    auto idx = registry::makeIdx<T>();
+    //fmt::print("register: i={} size={}\n", idx, sizeof...(Deps));
+    registered_components_.push_back(idx);
+    construct_components_.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(idx),
+      std::forward_as_tuple(
+        //[this, args = std::make_tuple(std::forward<Args>(args)...)]() mutable {
+        [ref,this,cons...]() mutable {
+          auto ptr = T::template staticInit<Cons...>(std::forward<Cons>(cons)...);
+          // auto ptr = make<T, std::tuple<Args...>>(std::forward<std::tuple<Args...>>(args));
+
+          // Set the reference for access outside
+          if (ref != nullptr) {
+            *ref = ptr.get();
+          }
+
+          // Add to pollable for the progress function to be triggered
+          if (ptr->pollable()) {
+            pollable_components_.emplace_back(ptr.get());
+          }
+
+          ptr->initialize();
+          live_components_.emplace_back(std::move(ptr));
+        }
+      )
+    );
+    return idx;
+  }
+
+// private:
+//   template <typename T, typename Tuple, typename... Args>
+//   std::unique_ptr<T> make(std::tuple<Args...>&& tup) {
+//     static constexpr auto size = std::tuple_size<Tuple>::value;
+//     static constexpr auto seq = std::make_index_sequence<size>{};
+//     return makeImpl<T, Tuple>(std::forward<std::tuple<Args...>>(tup), seq);
+//   }
+
+//   template <typename T, typename Tuple, typename... Args, size_t... I>
+//   std::unique_ptr<T> makeImpl(std::tuple<Args...>&& tup, std::index_sequence<I...> seq) {
+//     return T::template staticInit<Args...>(
+//       std::forward<typename std::tuple_element<I,Tuple>::type>(
+//         std::get<I>(tup)
+//       )...
+//     );
+//   }
+
+public:
+
+  template <typename T>
+  void add() {
+    auto idx = registry::makeIdx<T>();
+    added_components_.insert(idx);
+  }
+
+  void construct() {
+    // Topologically sort the components based on dependences to generate a
+    // valid startup order
+    auto order = topoSort();
+
+    // Construct the components, and fire off initialize
+    while (not order.empty()) {
+      auto next = order.back();
+      fmt::print("constructing = {}\n", next);
+      order.pop_back();
+
+      auto iter = construct_components_.find(next);
+      if (iter != construct_components_.end()) {
+        iter->second();
+      } else {
+        vtAbort("Could not find component to construct");
+      }
+    }
+
+    // Run the startup now that all components are live
+    for (auto&& c : live_components_) {
+      c->startup();
+    }
+
+    live_ = true;
+  }
+
+  void destruct() {
+    live_ = false;
+    pollable_components_.clear();
+    live_components_.clear();
+  }
+
+private:
+  std::list<int> topoSort() {
+    std::list<int> order;
+    fmt::print("added size={}\n", added_components_.size());
+    auto visited = std::make_unique<bool[]>(registered_components_.size());
+    for (std::size_t i = 0; i < registered_components_.size(); i++) {
+      auto added_iter = added_components_.find(i);
+      if (added_iter != added_components_.end()) {
+        if (visited[i] == false) {
+          topoSortImpl(i, order, visited.get());
+        }
+      }
+    }
+
+    detectCycles(order.front());
+
+    return order;
+  }
+
+  void topoSortImpl(int v, std::list<int>& order, bool* visited) {
+    fmt::print("impl v={}\n",v);
+    visited[v] = true;
+
+    auto v_list = registry::getIdx(v);
+    for (auto&& vp : v_list) {
+      fmt::print("v={} vp={}, size={}\n",v,vp,v_list.size());
+      auto iter = added_components_.find(vp);
+      if (iter == added_components_.end()) {
+        fmt::print("Adding component automatically due to dependencies\n");
+      }
+      if (not visited[vp]) {
+        topoSortImpl(vp, order, visited);
+      }
+    }
+
+    order.push_front(v);
+  }
+
+  void detectCycles(int root) {
+    std::list<int> stack;
+    detectCyclesImpl(stack, root);
+  }
+
+  void detectCyclesImpl(std::list<int>& stack, int dep) {
+    for (auto&& prev_dep : stack) {
+      if (prev_dep == dep) {
+        vtAbort("Cycle found in dependencies of registered components\n");
+      }
+    }
+
+    stack.push_back(dep);
+    auto vl = registry::getIdx(dep);
+    for (auto&& vp : vl) {
+      detectCyclesImpl(stack, vp);
+    }
+    stack.pop_back();
+  }
+
+  bool live() const { return live_; }
+  bool registrationsDone() const { return registrations_done_; }
+  void finishRegistration() { registrations_done_ = true; }
+
+private:
+  bool registrations_done_ = false;
+  bool live_ = false;
+  std::vector<registry::AutoHandlerType> registered_components_;
+  std::unordered_set<registry::AutoHandlerType> added_components_;
+  std::unordered_map<registry::AutoHandlerType, ActionType> construct_components_;
+  std::vector<std::unique_ptr<BaseComponent>> live_components_;
+  std::vector<Progressable*> pollable_components_;
+};
+
+template <typename... Ts>
+using Deps = typename BaseComponent::DepsPack<Ts...>;
+
+}}} /* end namespace vt::runtime::component */
+
+#endif /*INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_H*/

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -153,7 +153,7 @@ public:
    *
    * \return whether it is live
    */
-  bool live() const { return live_; }
+  bool isLive() const { return live_; }
 
 private:
   /// Whether the pack is live

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -214,6 +214,7 @@ private:
     stack.pop_back();
   }
 
+public:
   bool live() const { return live_; }
   bool registrationsDone() const { return registrations_done_; }
   void finishRegistration() { registrations_done_ = true; }

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -45,7 +45,6 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_H
 
-#include "vt/config.h"
 #include "vt/runtime/component/component.h"
 
 #include <list>

--- a/src/vt/runtime/component/component_pack.impl.h
+++ b/src/vt/runtime/component/component_pack.impl.h
@@ -55,7 +55,12 @@ registry::AutoHandlerType ComponentPack::registerComponent(
 ) {
   ComponentRegistry::dependsOn<T, Deps...>();
   auto idx = registry::makeIdx<T>();
-  registered_components_.push_back(idx);
+
+  if (registered_set_.find(idx) == registered_set_.end()) {
+    registered_set_.insert(idx);
+    registered_components_.push_back(idx);
+  }
+
   construct_components_.emplace(
     std::piecewise_construct,
     std::forward_as_tuple(idx),

--- a/src/vt/runtime/component/component_pack.impl.h
+++ b/src/vt/runtime/component/component_pack.impl.h
@@ -63,6 +63,12 @@ registry::AutoHandlerType ComponentPack::registerComponent(
       [ref,this,cons...]() mutable {
         auto ptr = T::template staticInit<Cons...>(std::forward<Cons>(cons)...);
 
+        debug_print(
+          runtime, node,
+          "ComponentPack: constructed component={}, pollable={}\n",
+          ptr->name(), ptr->pollable()
+        );
+
         // Set the reference for access outside
         if (ref != nullptr) {
           *ref = ptr.get();

--- a/src/vt/runtime/component/component_registry.h
+++ b/src/vt/runtime/component/component_registry.h
@@ -45,7 +45,7 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_REGISTRY_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_REGISTRY_H
 
-#include "vt/config.h"
+#include "vt/configs/types/types_type.h"
 
 #include <vector>
 #include <tuple>

--- a/src/vt/runtime/component/component_registry.h
+++ b/src/vt/runtime/component/component_registry.h
@@ -49,11 +49,12 @@
 
 #include <vector>
 #include <tuple>
+#include <unordered_set>
 
 namespace vt { namespace runtime { namespace component { namespace registry {
 
 using AutoHandlerType = HandlerType;
-using RegistryType = std::vector<std::tuple<int,std::vector<int>>>;
+using RegistryType = std::vector<std::tuple<int,std::unordered_set<int>>>;
 
 inline RegistryType& getRegistry() {
   static RegistryType reg;
@@ -65,7 +66,7 @@ struct Registrar {
   Registrar() {
     auto& reg = getRegistry();
     index = reg.size();
-    reg.emplace_back(std::make_tuple(index,std::vector<int>{}));
+    reg.emplace_back(std::make_tuple(index,std::unordered_set<int>{}));
   }
   AutoHandlerType index;
 };
@@ -78,7 +79,7 @@ struct Type {
 template <typename ObjT>
 AutoHandlerType const Type<ObjT>::idx = Registrar<ObjT>().index;
 
-inline std::vector<int>& getIdx(AutoHandlerType han) {
+inline std::unordered_set<int>& getIdx(AutoHandlerType han) {
   return std::get<1>(getRegistry().at(han));
 }
 

--- a/src/vt/runtime/component/component_traits.h
+++ b/src/vt/runtime/component/component_traits.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                    base.h
+//                              component_traits.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,29 +42,24 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
-#define INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
+#if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_TRAITS_H
+#define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_TRAITS_H
 
 #include "vt/config.h"
-#include "vt/runtime/component/diagnostic.h"
-#include "vt/runtime/component/bufferable.h"
-#include "vt/runtime/component/progressable.h"
 
 namespace vt { namespace runtime { namespace component {
 
-struct BaseComponent : Diagnostic, Bufferable, Progressable {
-  template <typename... Deps>
-  struct DepsPack { };
+template <typename T>
+struct ComponentTraits {
+  template <typename U, typename = decltype(U::construct())>
+  static std::true_type test(int);
 
-  virtual void initialize() = 0;
-  virtual void finalize() = 0;
+  template <typename U>
+  static std::false_type test(...);
 
-  virtual bool pollable() = 0;
-  virtual void startup() = 0;
-
-  virtual ~BaseComponent() { }
+  static constexpr bool hasConstruct = decltype(test<T>(0))::value;
 };
 
 }}} /* end namespace vt::runtime::component */
 
-#endif /*INCLUDED_VT_RUNTIME_COMPONENT_BASE_H*/
+#endif /*INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_TRAITS_H*/

--- a/src/vt/runtime/component/component_traits.h
+++ b/src/vt/runtime/component/component_traits.h
@@ -45,7 +45,7 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_TRAITS_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_TRAITS_H
 
-#include "vt/config.h"
+#include <type_traits>
 
 namespace vt { namespace runtime { namespace component {
 

--- a/src/vt/runtime/component/diagnostic.h
+++ b/src/vt/runtime/component/diagnostic.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                    base.h
+//                                 diagnostic.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,29 +42,18 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
-#define INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
+#if !defined INCLUDED_VT_RUNTIME_COMPONENT_DIAGNOSTIC_H
+#define INCLUDED_VT_RUNTIME_COMPONENT_DIAGNOSTIC_H
 
 #include "vt/config.h"
-#include "vt/runtime/component/diagnostic.h"
-#include "vt/runtime/component/bufferable.h"
-#include "vt/runtime/component/progressable.h"
 
 namespace vt { namespace runtime { namespace component {
 
-struct BaseComponent : Diagnostic, Bufferable, Progressable {
-  template <typename... Deps>
-  struct DepsPack { };
-
-  virtual void initialize() = 0;
-  virtual void finalize() = 0;
-
-  virtual bool pollable() = 0;
-  virtual void startup() = 0;
-
-  virtual ~BaseComponent() { }
+struct Diagnostic {
+  virtual void dumpState() = 0;
+  // @todo diagnostics
 };
 
 }}} /* end namespace vt::runtime::component */
 
-#endif /*INCLUDED_VT_RUNTIME_COMPONENT_BASE_H*/
+#endif /*INCLUDED_VT_RUNTIME_COMPONENT_DIAGNOSTIC_H*/

--- a/src/vt/runtime/component/diagnostic.h
+++ b/src/vt/runtime/component/diagnostic.h
@@ -47,6 +47,12 @@
 
 namespace vt { namespace runtime { namespace component {
 
+/**
+ * \struct Diagnostic diagnostic.h vt/runtime/component/diagnostic.h
+ *
+ * \brief The abstract \c Diagnostic trait for outputting debugging state
+ * information generically across VT components
+ */
 struct Diagnostic {
   virtual void dumpState() = 0;
   // @todo diagnostics

--- a/src/vt/runtime/component/diagnostic.h
+++ b/src/vt/runtime/component/diagnostic.h
@@ -45,8 +45,6 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_DIAGNOSTIC_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_DIAGNOSTIC_H
 
-#include "vt/config.h"
-
 namespace vt { namespace runtime { namespace component {
 
 struct Diagnostic {

--- a/src/vt/runtime/component/progressable.h
+++ b/src/vt/runtime/component/progressable.h
@@ -45,8 +45,6 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_PROGRESSABLE_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_PROGRESSABLE_H
 
-#include "vt/config.h"
-
 namespace vt { namespace runtime { namespace component {
 
 struct Progressable {

--- a/src/vt/runtime/component/progressable.h
+++ b/src/vt/runtime/component/progressable.h
@@ -47,6 +47,12 @@
 
 namespace vt { namespace runtime { namespace component {
 
+/**
+ * \struct Progressable progressable.h vt/runtime/component/progressable.h
+ *
+ * \brief The abstract \c Progressable trait for pollable components to make
+ * progress from the scheduler
+ */
 struct Progressable {
   virtual int progress() = 0;
 };

--- a/src/vt/runtime/component/progressable.h
+++ b/src/vt/runtime/component/progressable.h
@@ -54,6 +54,12 @@ namespace vt { namespace runtime { namespace component {
  * progress from the scheduler
  */
 struct Progressable {
+
+  /**
+   * \brief Progress function for incremental polling
+   *
+   * \return the number of units executed---zero if no progress was made
+   */
   virtual int progress() = 0;
 };
 

--- a/src/vt/runtime/component/progressable.h
+++ b/src/vt/runtime/component/progressable.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                    base.h
+//                                progressable.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,29 +42,17 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
-#define INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
+#if !defined INCLUDED_VT_RUNTIME_COMPONENT_PROGRESSABLE_H
+#define INCLUDED_VT_RUNTIME_COMPONENT_PROGRESSABLE_H
 
 #include "vt/config.h"
-#include "vt/runtime/component/diagnostic.h"
-#include "vt/runtime/component/bufferable.h"
-#include "vt/runtime/component/progressable.h"
 
 namespace vt { namespace runtime { namespace component {
 
-struct BaseComponent : Diagnostic, Bufferable, Progressable {
-  template <typename... Deps>
-  struct DepsPack { };
-
-  virtual void initialize() = 0;
-  virtual void finalize() = 0;
-
-  virtual bool pollable() = 0;
-  virtual void startup() = 0;
-
-  virtual ~BaseComponent() { }
+struct Progressable {
+  virtual int progress() = 0;
 };
 
 }}} /* end namespace vt::runtime::component */
 
-#endif /*INCLUDED_VT_RUNTIME_COMPONENT_BASE_H*/
+#endif /*INCLUDED_VT_RUNTIME_COMPONENT_PROGRESSABLE_H*/

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1015,13 +1015,15 @@ bool Runtime::finalize(bool const force_now) {
     fflush(stdout);
     fflush(stderr);
     sync();
+    // This destroys and finalizes all components in proper reverse
+    // initialization order
     p_ = nullptr;
     sync();
     sync();
     if (is_zero) {
       printShutdownBanner(num_units, coll_epochs);
     }
-    finalizeContext();
+    finalizeMPI();
     finalized_ = true;
     return true;
   } else {
@@ -1173,7 +1175,7 @@ void Runtime::setup() {
   debug_print(runtime, node, "end: setup\n");
 }
 
-void Runtime::finalizeContext() {
+void Runtime::finalizeMPI() {
   MPI_Barrier(*communicator_);
 
   if (not is_interop_) {

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -94,7 +94,7 @@ Runtime::Runtime(
 )  : instance_(in_instance), runtime_active_(false), is_interop_(interop_mode),
      num_workers_(in_num_workers),
      communicator_(
-       in_comm == nullptr ? nullptr : std::make_unique<MPI_Comm>(*communicator_)
+       in_comm == nullptr ? nullptr : std::make_unique<MPI_Comm>(*in_comm)
      ),
      user_argc_(argc),
      user_argv_(argv)

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1017,7 +1017,7 @@ bool Runtime::finalize(bool const force_now) {
     sync();
     // This destroys and finalizes all components in proper reverse
     // initialization order
-    p_ = nullptr;
+    p_.reset(nullptr);
     sync();
     sync();
     if (is_zero) {

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1218,7 +1218,8 @@ void Runtime::initializeComponents() {
 
 # if backend_check_enabled(trace_enabled)
   p_->registerComponent<trace::Trace>(&theTrace, Deps<
-      ctx::Context // Everything depends on theContext
+      ctx::Context,    // Everything depends on theContext
+      sched::Scheduler // Depends on scheduler for triggers
     >{},
     user_argc_ == 0 ? "prog" : user_argv_[0]
   );

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1261,7 +1261,7 @@ void Runtime::initializeComponents() {
       ctx::Context,               // Everything depends on theContext
       messaging::ActiveMessenger, // Depends on active messenger to send msgs
       sched::Scheduler,           // Depends on scheduler
-      term::TerminationDetector,  // Depends on TD for idle callbacks
+      term::TerminationDetector   // Depends on TD for idle callbacks
     >{}
   );
 

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1195,26 +1195,24 @@ void Runtime::initializeComponents() {
   using component::ComponentPack;
   using component::Deps;
 
-  ComponentPack p;
-
-  p.registerComponent<ctx::Context>(
+  p_.registerComponent<ctx::Context>(
     &theContext, Deps<>{},
     user_argc_, user_argv_, is_interop_, communicator_
   );
 
-  p.registerComponent<util::memory::MemoryUsage>(&theMemUsage, Deps<
+  p_.registerComponent<util::memory::MemoryUsage>(&theMemUsage, Deps<
     ctx::Context // Everything depends on theContext
   >{});
 
-  p.registerComponent<registry::Registry>(&theRegistry, Deps<
+  p_.registerComponent<registry::Registry>(&theRegistry, Deps<
     ctx::Context // Everything depends on theContext
   >{});
 
-  p.registerComponent<pool::Pool>(&thePool, Deps<
+  p_.registerComponent<pool::Pool>(&thePool, Deps<
     ctx::Context // Everything depends on theContext
   >{});
 
-  p.registerComponent<event::AsyncEvent>(&theEvent, Deps<
+  p_.registerComponent<event::AsyncEvent>(&theEvent, Deps<
 #   if backend_check_enabled(trace_enabled)
     trace::Trace,  // For trace user event registrations
 #   endif
@@ -1223,21 +1221,21 @@ void Runtime::initializeComponents() {
   >{});
 
 # if backend_check_enabled(trace_enabled)
-  p.registerComponent<trace::Trace>(&theTrace, Deps<
+  p_.registerComponent<trace::Trace>(&theTrace, Deps<
       ctx::Context // Everything depends on theContext
     >{},
     user_argc_ == 0 ? "prog" : user_argv_[0]
   );
 # endif
 
-  p.registerComponent<objgroup::ObjGroupManager>(
+  p_.registerComponent<objgroup::ObjGroupManager>(
     &theObjGroup, Deps<
       ctx::Context,              // Everything depends on theContext
       messaging::ActiveMessenger // Depends on active messenger to send
     >{}
   );
 
-  p.registerComponent<messaging::ActiveMessenger>(
+  p_.registerComponent<messaging::ActiveMessenger>(
     &theMsg, Deps<
 #     if backend_check_enabled(trace_enabled)
       trace::Trace,      // For trace user event registrations
@@ -1249,14 +1247,14 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.registerComponent<sched::Scheduler>(
+  p_.registerComponent<sched::Scheduler>(
     &theSched, Deps<
       ctx::Context,             // Everything depends on theContext
       util::memory::MemoryUsage // Depends on memory usage for output
     >{}
   );
 
-  p.registerComponent<term::TerminationDetector>(
+  p_.registerComponent<term::TerminationDetector>(
     &theTerm, Deps<
       ctx::Context,               // Everything depends on theContext
       messaging::ActiveMessenger, // Depends on active messenger to send term msgs
@@ -1264,14 +1262,14 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.registerComponent<collective::CollectiveAlg>(
+  p_.registerComponent<collective::CollectiveAlg>(
     &theCollective, Deps<
       ctx::Context,              // Everything depends on theContext
       messaging::ActiveMessenger // Depends on active messenger for collectives
     >{}
   );
 
-  p.registerComponent<group::GroupManager>(
+  p_.registerComponent<group::GroupManager>(
     &theGroup, Deps<
       ctx::Context,               // Everything depends on theContext
       messaging::ActiveMessenger, // Depends on active messenger for setting up
@@ -1279,7 +1277,7 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.registerComponent<pipe::PipeManager>(
+  p_.registerComponent<pipe::PipeManager>(
     &theCB, Deps<
       ctx::Context,                        // Everything depends on theContext
       messaging::ActiveMessenger,          // Depends on AM for callbacks
@@ -1289,28 +1287,28 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.registerComponent<rdma::RDMAManager>(
+  p_.registerComponent<rdma::RDMAManager>(
     &theRDMA, Deps<
       ctx::Context,              // Everything depends on theContext
       messaging::ActiveMessenger // Depends on active messenger for RDMA
     >{}
   );
 
-  p.registerComponent<param::Param>(
+  p_.registerComponent<param::Param>(
     &theParam, Deps<
       ctx::Context,              // Everything depends on theContext
       messaging::ActiveMessenger // Depends on active messenger sending
     >{}
   );
 
-  p.registerComponent<seq::Sequencer>(
+  p_.registerComponent<seq::Sequencer>(
     &theSeq, Deps<
       ctx::Context,              // Everything depends on theContext
       messaging::ActiveMessenger // Depends on active messenger for sequencing
     >{}
   );
 
-  p.registerComponent<seq::SequencerVirtual>(
+  p_.registerComponent<seq::SequencerVirtual>(
     &theVirtualSeq, Deps<
       ctx::Context,               // Everything depends on theContext
       messaging::ActiveMessenger, // Depends on active messenger for sequencing
@@ -1318,14 +1316,14 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.registerComponent<location::LocationManager>(
+  p_.registerComponent<location::LocationManager>(
     &theLocMan, Deps<
       ctx::Context,               // Everything depends on theContext
       messaging::ActiveMessenger  // Depends on active messenger for sending
     >{}
   );
 
-  p.registerComponent<vrt::VirtualContextManager>(
+  p_.registerComponent<vrt::VirtualContextManager>(
     &theVirtualManager, Deps<
       ctx::Context,               // Everything depends on theContext
       messaging::ActiveMessenger, // Depends on active messenger for messaging
@@ -1333,7 +1331,7 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.registerComponent<vrt::collection::CollectionManager>(
+  p_.registerComponent<vrt::collection::CollectionManager>(
     &theCollection, Deps<
       ctx::Context,               // Everything depends on theContext
       messaging::ActiveMessenger, // Depends on active messenger for messaging
@@ -1342,7 +1340,7 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.registerComponent<rdma::Manager>(
+  p_.registerComponent<rdma::Manager>(
     &theHandleRDMA, Deps<
       ctx::Context,                       // Everything depends on theContext
       messaging::ActiveMessenger,         // Depends on active messenger for messaging
@@ -1351,34 +1349,34 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p.add<ctx::Context>();
-  p.add<util::memory::MemoryUsage>();
-  p.add<registry::Registry>();
-  p.add<event::AsyncEvent>();
-  p.add<pool::Pool>();
+  p_.add<ctx::Context>();
+  p_.add<util::memory::MemoryUsage>();
+  p_.add<registry::Registry>();
+  p_.add<event::AsyncEvent>();
+  p_.add<pool::Pool>();
 # if backend_check_enabled(trace_enabled)
-  p.add<trace::Trace>();
+  p_.add<trace::Trace>();
 # endif
-  p.add<objgroup::ObjGroupManager>();
-  p.add<messaging::ActiveMessenger>();
-  p.add<sched::Scheduler>();
-  p.add<term::TerminationDetector>();
-  p.add<collective::CollectiveAlg>();
-  p.add<group::GroupManager>();
-  p.add<pipe::PipeManager>();
-  p.add<rdma::RDMAManager>();
-  p.add<param::Param>();
-  p.add<seq::Sequencer>();
-  p.add<seq::SequencerVirtual>();
-  p.add<location::LocationManager>();
-  p.add<vrt::VirtualContextManager>();
-  p.add<vrt::collection::CollectionManager>();
-  p.add<rdma::Manager>();
-  p.add<registry::Registry>();
-  p.add<event::AsyncEvent>();
-  p.add<pool::Pool>();
+  p_.add<objgroup::ObjGroupManager>();
+  p_.add<messaging::ActiveMessenger>();
+  p_.add<sched::Scheduler>();
+  p_.add<term::TerminationDetector>();
+  p_.add<collective::CollectiveAlg>();
+  p_.add<group::GroupManager>();
+  p_.add<pipe::PipeManager>();
+  p_.add<rdma::RDMAManager>();
+  p_.add<param::Param>();
+  p_.add<seq::Sequencer>();
+  p_.add<seq::SequencerVirtual>();
+  p_.add<location::LocationManager>();
+  p_.add<vrt::VirtualContextManager>();
+  p_.add<vrt::collection::CollectionManager>();
+  p_.add<rdma::Manager>();
+  p_.add<registry::Registry>();
+  p_.add<event::AsyncEvent>();
+  p_.add<pool::Pool>();
 
-  p.construct();
+  p_.construct();
 
   // #if backend_check_enabled(trace_enabled)
   //   theTrace->initialize();

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -81,6 +81,7 @@ struct Runtime {
 
   virtual ~Runtime();
 
+  bool live() const { return p_ and p_->live(); }
   bool isTerminated() const { return not runtime_active_; }
   bool isFinializeble() const { return initialized_ and not finalized_; }
   bool isInitialized() const { return initialized_; }

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -180,7 +180,7 @@ protected:
   bool runtime_active_ = false;
   bool is_interop_ = false;
   WorkerCountType num_workers_ = no_workers;
-  std::unique_ptr<MPI_Comm> communicator_ = nullptr;
+  MPI_Comm communicator_ = MPI_COMM_NULL;
   int user_argc_ = 0;
   char** user_argv_ = nullptr;
   std::unique_ptr<component::ComponentPack> p_;

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -82,6 +82,7 @@ struct Runtime {
   virtual ~Runtime();
 
   bool live() const { return p_ and p_->live(); }
+  int progress() { if (p_) return p_->progress(); else return 0; }
   bool isTerminated() const { return not runtime_active_; }
   bool isFinializeble() const { return initialized_ and not finalized_; }
   bool isInitialized() const { return initialized_; }

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -121,7 +121,7 @@ protected:
   void initializeWorkers(WorkerCountType const num_workers);
   void initializeLB();
 
-  void finalizeContext();
+  void finalizeMPI();
 
   void sync();
   void setup();

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -124,9 +124,6 @@ protected:
   void initializeLB();
 
   void finalizeContext();
-  void finalizeTrace();
-  void finalizeComponents();
-  void finalizeOptionalComponents();
 
   void sync();
   void setup();
@@ -186,7 +183,7 @@ protected:
   MPI_Comm* communicator_ = nullptr;
   int user_argc_ = 0;
   char** user_argv_ = nullptr;
-  component::ComponentPack p_;
+  std::unique_ptr<component::ComponentPack> p_;
 };
 
 }} /* end namespace vt::runtime */

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -180,7 +180,7 @@ protected:
   bool runtime_active_ = false;
   bool is_interop_ = false;
   WorkerCountType num_workers_ = no_workers;
-  MPI_Comm* communicator_ = nullptr;
+  std::unique_ptr<MPI_Comm> communicator_ = nullptr;
   int user_argc_ = 0;
   char** user_argv_ = nullptr;
   std::unique_ptr<component::ComponentPack> p_;

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -81,7 +81,7 @@ struct Runtime {
 
   virtual ~Runtime();
 
-  bool live() const { return p_ and p_->live(); }
+  bool isLive() const { return p_ and p_->isLive(); }
   int progress() { if (p_) return p_->progress(); else return 0; }
   bool isTerminated() const { return not runtime_active_; }
   bool isFinializeble() const { return initialized_ and not finalized_; }

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -115,8 +115,6 @@ protected:
   bool tryInitialize();
   bool tryFinalize();
 
-  void initializeContext(int argc, char** argv, MPI_Comm* comm);
-  void initializeTrace();
   void initializeErrorHandlers();
   void initializeComponents();
   void initializeOptionalComponents();

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -65,9 +65,7 @@ namespace vt { namespace runtime {
 
 struct Runtime {
   template <typename ComponentT>
-  using ComponentPtrType = std::unique_ptr<ComponentT>;
-  template <typename ComponentT>
-  using ObjGroupPtrType = ComponentT*;
+  using ComponentPtrType = ComponentT*;
   using ArgType = vt::arguments::ArgConfig;
 
   Runtime(
@@ -166,7 +164,8 @@ public:
   ComponentPtrType<group::GroupManager> theGroup;
   ComponentPtrType<pipe::PipeManager> theCB;
   ComponentPtrType<objgroup::ObjGroupManager> theObjGroup;
-  ObjGroupPtrType<rdma::Manager> theHandleRDMA;
+  ComponentPtrType<util::memory::MemoryUsage> theMemUsage;
+  ComponentPtrType<rdma::Manager> theHandleRDMA;
 
   // Node-level worker-based components for vt (these are optional)
   ComponentPtrType<worker::WorkerGroupType> theWorkerGrp;

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -186,6 +186,7 @@ protected:
   MPI_Comm* communicator_ = nullptr;
   int user_argc_ = 0;
   char** user_argv_ = nullptr;
+  component::ComponentPack p_;
 };
 
 }} /* end namespace vt::runtime */

--- a/src/vt/runtime/runtime_component_fwd.h
+++ b/src/vt/runtime/runtime_component_fwd.h
@@ -97,6 +97,9 @@ struct PipeManager;
 namespace objgroup {
 struct ObjGroupManager;
 }
+namespace util { namespace memory {
+struct MemoryUsage;
+}}
 
 #if backend_check_enabled(trace_enabled)
 namespace trace {

--- a/src/vt/runtime/runtime_get.cc
+++ b/src/vt/runtime/runtime_get.cc
@@ -88,7 +88,7 @@ namespace vt {
 
 static runtime::Runtime* no_rt = nullptr;
 
-#define IS_COMM_THREAD curRT->theContext.get()->getWorker() == worker_id_comm_thread
+#define IS_COMM_THREAD curRT->theContext->getWorker() == worker_id_comm_thread
 #define CUR_RT_SAFE (IS_COMM_THREAD ? curRT : no_rt)
 #define CUR_RT_TS curRT
 #define CUR_RT CUR_RT_SAFE
@@ -104,31 +104,32 @@ static runtime::Runtime* no_rt = nullptr;
 using CollectionManagerType = vrt::collection::CollectionManager;
 
 // Thread-safe runtime components
-ctx::Context*               theContext()        { return CUR_RT_TS->theContext.get();        }
-pool::Pool*                 thePool()           { return CUR_RT_TS->thePool.get();           }
-vrt::VirtualContextManager* theVirtualManager() { return CUR_RT_TS->theVirtualManager.get(); }
-worker::WorkerGroupType*    theWorkerGrp()      { return CUR_RT_TS->theWorkerGrp.get();      }
+ctx::Context*               theContext()        { return CUR_RT_TS->theContext;        }
+pool::Pool*                 thePool()           { return CUR_RT_TS->thePool;           }
+vrt::VirtualContextManager* theVirtualManager() { return CUR_RT_TS->theVirtualManager; }
+worker::WorkerGroupType*    theWorkerGrp()      { return CUR_RT_TS->theWorkerGrp;      }
 
 // Non thread-safe runtime components
-collective::CollectiveAlg*  theCollective()     { return CUR_RT->theCollective.get();     }
-event::AsyncEvent*          theEvent()          { return CUR_RT->theEvent.get();          }
-messaging::ActiveMessenger* theMsg()            { return CUR_RT->theMsg.get();            }
-param::Param*               theParam()          { return CUR_RT->theParam.get();          }
-rdma::RDMAManager*          theRDMA()           { return CUR_RT->theRDMA.get();           }
-registry::Registry*         theRegistry()       { return CUR_RT->theRegistry.get();       }
-sched::Scheduler*           theSched()          { return CUR_RT->theSched.get();          }
-seq::Sequencer*             theSeq()            { return CUR_RT->theSeq.get();            }
-seq::SequencerVirtual*      theVirtualSeq()     { return CUR_RT->theVirtualSeq.get();     }
-term::TerminationDetector*  theTerm()           { return CUR_RT->theTerm.get();           }
-location::LocationManager*  theLocMan()         { return CUR_RT->theLocMan.get();         }
-CollectionManagerType*      theCollection()     { return CUR_RT->theCollection.get();     }
-group::GroupManager*        theGroup()          { return CUR_RT->theGroup.get();          }
-pipe::PipeManager*          theCB()             { return CUR_RT->theCB.get();             }
-objgroup::ObjGroupManager*  theObjGroup()       { return CUR_RT->theObjGroup.get();       }
-rdma::Manager*              theHandleRDMA()     { return CUR_RT->theHandleRDMA;           }
+collective::CollectiveAlg*  theCollective()     { return CUR_RT->theCollective;     }
+event::AsyncEvent*          theEvent()          { return CUR_RT->theEvent;          }
+messaging::ActiveMessenger* theMsg()            { return CUR_RT->theMsg;            }
+param::Param*               theParam()          { return CUR_RT->theParam;          }
+rdma::RDMAManager*          theRDMA()           { return CUR_RT->theRDMA;           }
+registry::Registry*         theRegistry()       { return CUR_RT->theRegistry;       }
+sched::Scheduler*           theSched()          { return CUR_RT->theSched;          }
+seq::Sequencer*             theSeq()            { return CUR_RT->theSeq;            }
+seq::SequencerVirtual*      theVirtualSeq()     { return CUR_RT->theVirtualSeq;     }
+term::TerminationDetector*  theTerm()           { return CUR_RT->theTerm;           }
+location::LocationManager*  theLocMan()         { return CUR_RT->theLocMan;         }
+CollectionManagerType*      theCollection()     { return CUR_RT->theCollection;     }
+group::GroupManager*        theGroup()          { return CUR_RT->theGroup;          }
+pipe::PipeManager*          theCB()             { return CUR_RT->theCB;             }
+objgroup::ObjGroupManager*  theObjGroup()       { return CUR_RT->theObjGroup;       }
+rdma::Manager*              theHandleRDMA()     { return CUR_RT->theHandleRDMA;     }
+util::memory::MemoryUsage*  theMemUsage()       { return CUR_RT->theMemUsage;       }
 
 #if backend_check_enabled(trace_enabled)
-trace::Trace*               theTrace()          { return CUR_RT->theTrace.get();          }
+trace::Trace*               theTrace()          { return CUR_RT->theTrace;          }
 #endif
 
 #undef CUR_RT

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -153,7 +153,7 @@ void Scheduler::printMemoryUsage() {
     last_memory_usage_poll_ >=
     static_cast<std::size_t>(arguments::ArgConfig::vt_print_memory_sched_poll)
   ) {
-    auto usage = vt::util::memory::MemoryUsage::get();
+    auto usage = theMemUsage();
 
     if (usage != nullptr) {
       if (threshold_memory_usage_ == 0) {

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -54,6 +54,7 @@
 #include "vt/objgroup/manager.fwd.h"
 #include "vt/configs/arguments/args.h"
 #include "vt/utils/memory/memory_usage.h"
+#include "vt/runtime/runtime.h"
 
 namespace vt { namespace sched {
 
@@ -103,25 +104,11 @@ bool Scheduler::runNextUnit() {
 }
 
 bool Scheduler::progressImpl() {
-  bool const msg_sch = theMsg()->progress();
-  bool const evt_sch = theEvent()->progress();
-  bool const seq_sch = theSeq()->progress();
-  bool const vrt_sch = theVirtualSeq()->progress();
-  bool const col_sch = theCollection()->progress();
-  bool const obj_sch = theObjGroup()->progress();
-
-  bool const worker_sch =
-    theContext()->hasWorkers() ? theWorkerGrp()->progress(),false : false;
-  bool const worker_comm_sch =
-    theContext()->hasWorkers() ? theWorkerGrp()->commScheduler() : false;
+  int const total = curRT->progress();
 
   checkTermSingleNode();
 
-  bool scheduled_work =
-    msg_sch or evt_sch or seq_sch or vrt_sch or
-    col_sch or obj_sch or worker_sch or worker_comm_sch;
-
-  return scheduled_work;
+  return total != 0;
 }
 
 bool Scheduler::progressMsgOnlyImpl() {

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -84,6 +84,8 @@ struct Scheduler : runtime::component::Component<Scheduler> {
 
   Scheduler();
 
+  std::string name() override { return "Scheduler"; }
+
   static void checkTermSingleNode();
 
   bool shouldCallProgress(

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -52,6 +52,7 @@
 #include "vt/scheduler/work_unit.h"
 #include "vt/messaging/message/smart_ptr.h"
 #include "vt/timing/timing.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <cassert>
 #include <vector>
@@ -69,7 +70,7 @@ enum SchedulerEvent {
   SchedulerEventSize = 4
 };
 
-struct Scheduler {
+struct Scheduler : runtime::component::Component<Scheduler> {
   using SchedulerEventType   = SchedulerEvent;
   using TriggerType          = std::function<void()>;
   using TriggerContainerType = std::list<TriggerType>;

--- a/src/vt/sequence/sequencer.h
+++ b/src/vt/sequence/sequencer.h
@@ -200,7 +200,9 @@ bool executeSeqExpandContext(SeqType const& id, SeqNodePtrType node, Fn&& fn);
 struct Sequencer
   : runtime::component::Component<Sequencer>,
     TaggedSequencer<SeqType, SeqMigratableTriggerType>
-{ };
+{
+  std::string name() override { return "Sequencer"; }
+};
 
 #define SEQUENCE_REGISTER_HANDLER(message, handler)                     \
   static void handler(message* m) {                                     \

--- a/src/vt/sequence/sequencer.h
+++ b/src/vt/sequence/sequencer.h
@@ -198,7 +198,7 @@ template <typename Fn>
 bool executeSeqExpandContext(SeqType const& id, SeqNodePtrType node, Fn&& fn);
 
 struct Sequencer
-  : runtime::component::PollableComponent<Sequencer>,
+  : runtime::component::Component<Sequencer>,
     TaggedSequencer<SeqType, SeqMigratableTriggerType>
 { };
 

--- a/src/vt/sequence/sequencer.h
+++ b/src/vt/sequence/sequencer.h
@@ -59,6 +59,7 @@
 #include "vt/sequence/seq_matcher.h"
 #include "vt/sequence/seq_action.h"
 #include "vt/sequence/seq_parallel.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <unordered_map>
 #include <list>
@@ -69,7 +70,9 @@
 namespace vt { namespace seq {
 
 template <typename SeqTag, template <typename> class SeqTrigger>
-struct TaggedSequencer {
+struct TaggedSequencer
+  : runtime::component::PollableComponent<TaggedSequencer<SeqTag, SeqTrigger>>
+{
   using SeqType = SeqTag;
   using SeqListType = SeqList;
   using SeqContextType = SeqContext;
@@ -140,7 +143,7 @@ struct TaggedSequencer {
 
   void enqueueSeqList(SeqType const& seq_id);
   SeqType getCurrentSeq() const;
-  bool progress();
+  int progress() override;
   bool isLocalTerm();
 
   SeqNodePtrType getNode(SeqType const& id) const;

--- a/src/vt/sequence/sequencer.h
+++ b/src/vt/sequence/sequencer.h
@@ -70,9 +70,7 @@
 namespace vt { namespace seq {
 
 template <typename SeqTag, template <typename> class SeqTrigger>
-struct TaggedSequencer
-  : runtime::component::PollableComponent<TaggedSequencer<SeqTag, SeqTrigger>>
-{
+struct TaggedSequencer {
   using SeqType = SeqTag;
   using SeqListType = SeqList;
   using SeqContextType = SeqContext;
@@ -143,7 +141,6 @@ struct TaggedSequencer
 
   void enqueueSeqList(SeqType const& seq_id);
   SeqType getCurrentSeq() const;
-  int progress() override;
   bool isLocalTerm();
 
   SeqNodePtrType getNode(SeqType const& id) const;
@@ -200,7 +197,10 @@ private:
 template <typename Fn>
 bool executeSeqExpandContext(SeqType const& id, SeqNodePtrType node, Fn&& fn);
 
-using Sequencer = TaggedSequencer<SeqType, SeqMigratableTriggerType>;
+struct Sequencer
+  : runtime::component::PollableComponent<Sequencer>,
+    TaggedSequencer<SeqType, SeqMigratableTriggerType>
+{ };
 
 #define SEQUENCE_REGISTER_HANDLER(message, handler)                     \
   static void handler(message* m) {                                     \

--- a/src/vt/sequence/sequencer.impl.h
+++ b/src/vt/sequence/sequencer.impl.h
@@ -264,11 +264,6 @@ TaggedSequencer<SeqTag, SeqTrigger>::getCurrentSeq() const {
 }
 
 template <typename SeqTag, template <typename> class SeqTrigger>
-int TaggedSequencer<SeqTag, SeqTrigger>::progress() {
-  return 0;
-}
-
-template <typename SeqTag, template <typename> class SeqTrigger>
 bool TaggedSequencer<SeqTag, SeqTrigger>::isLocalTerm() {
   for (auto&& live_seq : seq_lookup_) {
     if (live_seq.second.lst.size() > 0) {

--- a/src/vt/sequence/sequencer.impl.h
+++ b/src/vt/sequence/sequencer.impl.h
@@ -264,8 +264,8 @@ TaggedSequencer<SeqTag, SeqTrigger>::getCurrentSeq() const {
 }
 
 template <typename SeqTag, template <typename> class SeqTrigger>
-bool TaggedSequencer<SeqTag, SeqTrigger>::progress() {
-  return false;
+int TaggedSequencer<SeqTag, SeqTrigger>::progress() {
+  return 0;
 }
 
 template <typename SeqTag, template <typename> class SeqTrigger>

--- a/src/vt/sequence/sequencer_fwd.h
+++ b/src/vt/sequence/sequencer_fwd.h
@@ -52,11 +52,7 @@ namespace vt { namespace seq {
 
 struct Sequencer;
 
-//using Sequencer = TaggedSequencer<SeqType, SeqMigratableTriggerType>;
-
 struct SequencerVirtual;
-
-//using SequencerVirtual = TaggedSequencerVrt<SeqType, SeqMigratableTriggerType>;
 
 }} // end namespace vt::seq
 

--- a/src/vt/sequence/sequencer_fwd.h
+++ b/src/vt/sequence/sequencer_fwd.h
@@ -50,15 +50,13 @@
 
 namespace vt { namespace seq {
 
-template <typename SeqTag, template <typename> class SeqTrigger>
-struct TaggedSequencer;
+struct Sequencer;
 
-using Sequencer = TaggedSequencer<SeqType, SeqMigratableTriggerType>;
+//using Sequencer = TaggedSequencer<SeqType, SeqMigratableTriggerType>;
 
-template <typename SeqTag, template <typename> class SeqTrigger>
-struct TaggedSequencerVrt;
+struct SequencerVirtual;
 
-using SequencerVirtual = TaggedSequencerVrt<SeqType, SeqMigratableTriggerType>;
+//using SequencerVirtual = TaggedSequencerVrt<SeqType, SeqMigratableTriggerType>;
 
 }} // end namespace vt::seq
 

--- a/src/vt/sequence/sequencer_virtual.h
+++ b/src/vt/sequence/sequencer_virtual.h
@@ -97,7 +97,7 @@ private:
   }
 
 struct SequencerVirtual
-  : runtime::component::PollableComponent<SequencerVirtual>,
+  : runtime::component::Component<SequencerVirtual>,
     TaggedSequencerVrt<SeqType, SeqMigratableTriggerType>
 { };
 

--- a/src/vt/sequence/sequencer_virtual.h
+++ b/src/vt/sequence/sequencer_virtual.h
@@ -96,7 +96,10 @@ private:
     theVirtualSeq()->sequenceVrtMsg<vrtcontext, message, handler>(m, vc); \
   }
 
-using SequencerVirtual = TaggedSequencerVrt<SeqType, SeqMigratableTriggerType>;
+struct SequencerVirtual
+  : runtime::component::PollableComponent<SequencerVirtual>,
+    TaggedSequencerVrt<SeqType, SeqMigratableTriggerType>
+{ };
 
 }} //end namespace vt::seq
 

--- a/src/vt/sequence/sequencer_virtual.h
+++ b/src/vt/sequence/sequencer_virtual.h
@@ -99,7 +99,9 @@ private:
 struct SequencerVirtual
   : runtime::component::Component<SequencerVirtual>,
     TaggedSequencerVrt<SeqType, SeqMigratableTriggerType>
-{ };
+{
+  std::string name() override { return "VirtualSequencer"; }
+};
 
 }} //end namespace vt::seq
 

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -91,6 +91,8 @@ struct TerminationDetector :
   TerminationDetector();
   virtual ~TerminationDetector() {}
 
+  std::string name() override { return "TerminationDetector"; }
+
   /****************************************************************************
    *
    * Termination interface: produce(..)/consume(..) for 4-counter wave-based

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -61,6 +61,7 @@
 #include "vt/configs/arguments/args.h"
 #include "vt/termination/graph/epoch_graph_reduce.h"
 #include "vt/termination/epoch_tags.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <cstdint>
 #include <unordered_map>
@@ -74,6 +75,7 @@ namespace vt { namespace term {
 using DijkstraScholtenTerm = term::ds::StateDS;
 
 struct TerminationDetector :
+  runtime::component::Component<TerminationDetector>,
   TermAction, collective::tree::Tree, DijkstraScholtenTerm, TermInterface
 {
   template <typename T>

--- a/src/vt/topos/location/manager.h
+++ b/src/vt/topos/location/manager.h
@@ -52,13 +52,14 @@
 #include "vt/topos/location/utility/coord.h"
 #include "vt/vrt/vrt_common.h"
 #include "vt/vrt/collection/proxy.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <unordered_map>
 #include <functional>
 
 namespace vt { namespace location {
 
-struct LocationManager {
+struct LocationManager : runtime::component::Component<LocationManager> {
   template <typename LocType>
   using PtrType = std::unique_ptr<LocType>;
   using LocCoordPtrType = LocationCoord*;

--- a/src/vt/topos/location/manager.h
+++ b/src/vt/topos/location/manager.h
@@ -90,6 +90,8 @@ struct LocationManager : runtime::component::Component<LocationManager> {
 
   virtual ~LocationManager();
 
+  std::string name() override { return "LocationManager"; }
+
   static LocInstType cur_loc_inst;
 
   PtrType<VrtLocType> virtual_loc = std::make_unique<VrtLocType>();

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -98,6 +98,8 @@ struct Trace : runtime::component::Component<Trace> {
 
   virtual ~Trace();
 
+  std::string name() override { return "Trace"; }
+
   friend struct Log;
 
   std::string getTraceName() const { return full_trace_name_; }

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -50,6 +50,7 @@
 #include "vt/trace/trace_log.h"
 #include "vt/trace/trace_registry.h"
 #include "vt/trace/trace_user_event.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include "vt/timing/timing.h"
 
@@ -86,15 +87,14 @@ private:
   TraceEventIDType event_ = trace::no_trace_event;
 };
 
-struct Trace {
+struct Trace : runtime::component::Component<Trace> {
   using LogType             = Log;
   using TraceConstantsType  = eTraceConstants;
   using TimeIntegerType     = int64_t;
   using TraceContainerType  = std::queue<LogType>;
   using TraceStackType      = std::stack<LogType>;
 
-  Trace();
-  Trace(std::string const& in_prog_name, std::string const& in_trace_name);
+  Trace(std::string const& in_prog_name);
 
   virtual ~Trace();
 
@@ -104,11 +104,8 @@ struct Trace {
   std::string getSTSName()   const { return full_sts_name_;   }
   std::string getDirectory() const { return full_dir_name_;   }
 
-  void initialize();
-  void setupNames(
-    std::string const& in_prog_name, std::string const& in_trace_name,
-    std::string const& in_dir_name = ""
-  );
+  void initialize() override;
+  void setupNames(std::string const& in_prog_name);
 
   /// Initiate a paired event.
   /// Currently endProcessing MUST be called in the opposite

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -441,18 +441,4 @@ bool MemoryUsage::hasWorkingReporter() const {
   return first_valid_reporter_ != -1;
 }
 
-/*static*/ void MemoryUsage::initialize() {
-  impl_ = std::make_unique<MemoryUsage>();
-}
-
-/*static*/ void MemoryUsage::finalize() {
-  impl_ = nullptr;
-}
-
-/*static*/ MemoryUsage* MemoryUsage::get() {
-  return impl_.get();
-}
-
-/*static*/ std::unique_ptr<MemoryUsage> MemoryUsage::impl_ = nullptr;
-
 }}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -123,8 +123,11 @@ std::size_t PS::getUsage() {
       FILE* p = popen(cmd.c_str(), "r");
       std::size_t vsz = 0;
       if (p) {
-        fscanf(p, "%zu", &vsz);
+        int ret = fscanf(p, "%zu", &vsz);
         pclose(p);
+        if (ret not_eq 1) {
+          return 0;
+        }
       }
       return vsz * 1024;
     } else {
@@ -207,12 +210,20 @@ std::size_t Stat::getUsage() {
     return 0;
   }
   for (int i = 0; i < 22; i++) {
-    fscanf(f, "%*s");
+    int ret = fscanf(f, "%*s");
+    if (ret == 0) {
+      failed_ = true;
+      break;
+    }
   }
-  fscanf(f, "%zu", &vsz);
+
+  int ret_vsz = 0;
+  if (not failed_) {
+    ret_vsz = fscanf(f, "%zu", &vsz);
+  }
   fclose(f);
 
-  if (!vsz) {
+  if (!vsz or ret_vsz == 0) {
     failed_ = true;
   }
   return vsz;

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -113,6 +113,8 @@ struct Mimalloc final : Reporter {
 struct MemoryUsage : runtime::component::Component<MemoryUsage> {
   MemoryUsage();
 
+  std::string name() override { return "MemoryUsage"; }
+
   std::size_t getAverageUsage();
 
   std::size_t getFirstUsage();

--- a/src/vt/utils/memory/memory_usage.h
+++ b/src/vt/utils/memory/memory_usage.h
@@ -46,6 +46,7 @@
 #define INCLUDED_VT_UTILS_MEMORY_MEMORY_USAGE_H
 
 #include "vt/config.h"
+#include "vt/runtime/component/component_pack.h"
 #include "vt/utils/memory/memory_units.h"
 #include "vt/utils/memory/memory_reporter.h"
 
@@ -109,7 +110,7 @@ struct Mimalloc final : Reporter {
   std::string getName() override;
 };
 
-struct MemoryUsage {
+struct MemoryUsage : runtime::component::Component<MemoryUsage> {
   MemoryUsage();
 
   std::size_t getAverageUsage();
@@ -128,19 +129,17 @@ struct MemoryUsage {
 
   std::size_t convertBytesFromString(std::string const& in);
 
-  static MemoryUsage* get();
-
-  static void initialize();
-
-  static void finalize();
-
 private:
-  static std::unique_ptr<MemoryUsage> impl_;
-
   std::vector<std::unique_ptr<Reporter>> reporters_;
   int first_valid_reporter_ = -1;
 };
 
 }}} /* end namespace vt::util::memory */
+
+namespace vt {
+
+util::memory::MemoryUsage* theMemUsage();
+
+} /* end namespace vt */
 
 #endif /*INCLUDED_VT_UTILS_MEMORY_MEMORY_USAGE_H*/

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -283,10 +283,9 @@ void LBManager::printMemoryUsage(PhaseType phase) {
       "all" == arguments::ArgConfig::vt_print_memory_node or
       std::to_string(this_node) == arguments::ArgConfig::vt_print_memory_node
     ) {
-      auto usage = util::memory::MemoryUsage::get();
-      if (usage->hasWorkingReporter()) {
+      if (theMemUsage()->hasWorkingReporter()) {
         auto memory_usage_str = fmt::format(
-          "Memory Usage: phase={}: {}\n", phase, usage->getUsageAll()
+          "Memory Usage: phase={}: {}\n", phase, theMemUsage()->getUsageAll()
         );
         vt_print(gen, memory_usage_str);
       }

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -143,8 +143,8 @@ void CollectionManager::schedule(ActionType action) {
   theSched()->enqueue(action);
 }
 
-bool CollectionManager::progress() {
-  return false;
+int CollectionManager::progress() {
+  return 0;
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -143,8 +143,4 @@ void CollectionManager::schedule(ActionType action) {
   theSched()->enqueue(action);
 }
 
-int CollectionManager::progress() {
-  return 0;
-}
-
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -76,6 +76,7 @@
 #include "vt/configs/arguments/args.h"
 #include "vt/vrt/collection/balance/proc_stats.h"
 #include "vt/vrt/collection/balance/lb_common.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <memory>
 #include <vector>
@@ -90,7 +91,9 @@
 
 namespace vt { namespace vrt { namespace collection {
 
-struct CollectionManager {
+struct CollectionManager
+  : runtime::component::PollableComponent<CollectionManager>
+{
   template <typename ColT, typename IndexT>
   using CollectionType = typename Holder<ColT, IndexT>::Collection;
   template <typename ColT, typename IndexT = typename ColT::IndexType>
@@ -728,7 +731,7 @@ private:
   void schedule(ActionType action);
 
 public:
-  bool progress();
+  int progress() override;
 
 public:
   template <typename ColT, typename IndexT>

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -143,6 +143,8 @@ struct CollectionManager
 
   virtual ~CollectionManager();
 
+  std::string name() override { return "CollectionManager"; }
+
   template <typename=void>
   void cleanupAll();
 

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -92,7 +92,7 @@
 namespace vt { namespace vrt { namespace collection {
 
 struct CollectionManager
-  : runtime::component::PollableComponent<CollectionManager>
+  : runtime::component::Component<CollectionManager>
 {
   template <typename ColT, typename IndexT>
   using CollectionType = typename Holder<ColT, IndexT>::Collection;
@@ -731,9 +731,6 @@ protected:
 
 private:
   void schedule(ActionType action);
-
-public:
-  int progress() override;
 
 public:
   template <typename ColT, typename IndexT>

--- a/src/vt/vrt/context/context_vrtmanager.h
+++ b/src/vt/vrt/context/context_vrtmanager.h
@@ -57,6 +57,7 @@
 #include "vt/vrt/context/context_vrtinfo.h"
 #include "vt/vrt/proxy/proxy_bits.h"
 #include "vt/vrt/context/context_vrt_internal_msgs.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include "vt/utils/bits/bits_common.h"
 #include "vt/activefn/activefn.h"
@@ -78,7 +79,9 @@ struct PendingRequest {
   { }
 };
 
-struct VirtualContextManager {
+struct VirtualContextManager
+  : runtime::component::Component<VirtualContextManager>
+ {
   using VirtualPtrType = std::unique_ptr<VirtualContext>;
   using PendingRequestType = PendingRequest;
   using VirtualInfoType = VirtualInfo;

--- a/src/vt/vrt/context/context_vrtmanager.h
+++ b/src/vt/vrt/context/context_vrtmanager.h
@@ -92,6 +92,8 @@ struct VirtualContextManager
 
   VirtualContextManager();
 
+  std::string name() override { return "VirtualContextManager"; }
+
   template <typename VrtContextT, typename... Args>
   VirtualProxyType makeVirtual(Args&& ... args);
 

--- a/src/vt/worker/worker_group.h
+++ b/src/vt/worker/worker_group.h
@@ -80,7 +80,7 @@ struct WorkerGroupAny
 
   virtual ~WorkerGroupAny();
 
-  void initialize();
+  void initialize() override;
   void spawnWorkers();
   void spawnWorkersBlock(WorkerCommFnType fn);
   void joinWorkers();

--- a/src/vt/worker/worker_group.h
+++ b/src/vt/worker/worker_group.h
@@ -51,6 +51,7 @@
 #include "vt/worker/worker_group_counter.h"
 #include "vt/worker/worker_group_comm.h"
 #include "vt/utils/atomic/atomic.h"
+#include "vt/runtime/component/component_pack.h"
 
 #if backend_check_enabled(stdthread)
   #include "vt/worker/worker_stdthread.h"
@@ -66,7 +67,10 @@ namespace vt { namespace worker {
 using ::vt::util::atomic::AtomicType;
 
 template <typename WorkerT>
-struct WorkerGroupAny : WorkerGroupCounter, WorkerGroupComm {
+struct WorkerGroupAny
+  : runtime::component::PollableComponent<WorkerGroupAny<WorkerT>>,
+  WorkerGroupCounter, WorkerGroupComm
+{
   using WorkerType = WorkerT;
   using WorkerPtrType = std::unique_ptr<WorkerT>;
   using WorkerContainerType = std::vector<WorkerPtrType>;
@@ -80,7 +84,7 @@ struct WorkerGroupAny : WorkerGroupCounter, WorkerGroupComm {
   void spawnWorkers();
   void spawnWorkersBlock(WorkerCommFnType fn);
   void joinWorkers();
-  void progress();
+  int progress() override;
 
   bool commScheduler();
   void enqueueCommThread(WorkUnitType const& work_unit);

--- a/src/vt/worker/worker_group.h
+++ b/src/vt/worker/worker_group.h
@@ -94,6 +94,8 @@ struct WorkerGroupAny
   );
   void enqueueAllWorkers(WorkUnitType const& work_unit);
 
+  std::string name() override { return "WorkerGroup"; }
+
 private:
   WorkerFinishedFnType finished_fn_ = nullptr;
   bool initialized_ = false;

--- a/src/vt/worker/worker_group.impl.h
+++ b/src/vt/worker/worker_group.impl.h
@@ -131,12 +131,14 @@ void WorkerGroupAny<WorkerT>::enqueueAllWorkers(WorkUnitType const& work_unit) {
 }
 
 template <typename WorkerT>
-void WorkerGroupAny<WorkerT>::progress() {
+int WorkerGroupAny<WorkerT>::progress() {
   for (auto&& elm : workers_) {
     elm->progress();
   }
 
   WorkerGroupCounter::progress();
+
+  return 0;
 }
 
 template <typename WorkerT>

--- a/src/vt/worker/worker_group_omp.cc
+++ b/src/vt/worker/worker_group_omp.cc
@@ -81,8 +81,9 @@ bool WorkerGroupOMP::commScheduler() {
   return WorkerGroupComm::schedulerComm(finished_fn_);
 }
 
-void WorkerGroupOMP::progress() {
+int WorkerGroupOMP::progress() {
   WorkerGroupCounter::progress();
+  return 0;
 }
 
 /*virtual*/ WorkerGroupOMP::~WorkerGroupOMP() {

--- a/src/vt/worker/worker_group_omp.h
+++ b/src/vt/worker/worker_group_omp.h
@@ -80,6 +80,8 @@ struct WorkerGroupOMP
 
   virtual ~WorkerGroupOMP();
 
+  std::string name() override { return "WorkerGroupOMP"; }
+
   void initialize() override;
   void spawnWorkers();
   void spawnWorkersBlock(WorkerCommFnType fn);

--- a/src/vt/worker/worker_group_omp.h
+++ b/src/vt/worker/worker_group_omp.h
@@ -55,6 +55,7 @@
 #include "vt/worker/worker_group_counter.h"
 #include "vt/worker/worker_group_comm.h"
 #include "vt/utils/mutex/mutex.h"
+#include "vt/runtime/component/component_pack.h"
 
 #include <vector>
 #include <memory>
@@ -62,7 +63,10 @@
 
 namespace vt { namespace worker {
 
-struct WorkerGroupOMP : WorkerGroupCounter, WorkerGroupComm {
+struct WorkerGroupOMP
+  : runtime::component::PollableComponent<WorkerGroupOMP>,
+    WorkerGroupCounter, WorkerGroupComm
+{
   using WorkerType = OMPWorker;
   using WorkerStateType = WorkerType;
   using WorkerStatePtrType = std::unique_ptr<WorkerStateType>;
@@ -76,11 +80,11 @@ struct WorkerGroupOMP : WorkerGroupCounter, WorkerGroupComm {
 
   virtual ~WorkerGroupOMP();
 
-  void initialize();
+  void initialize() override;
   void spawnWorkers();
   void spawnWorkersBlock(WorkerCommFnType fn);
   void joinWorkers();
-  void progress();
+  int progress() override;
   bool commScheduler();
 
   // non-thread-safe comm and worker thread enqueue

--- a/tests/perf/memory_checker.cc
+++ b/tests/perf/memory_checker.cc
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
   auto this_node = vt::theContext()->getNode();
 
   if (this_node == 0) {
-    auto usage = vt::util::memory::MemoryUsage::get();
+    auto usage = vt::theMemUsage();
     fmt::print("Initial: {}\n", usage->getUsageAll());
 
     for (int i = 0; i < 32; i++) {

--- a/tests/unit/memory/test_memory_active.cc
+++ b/tests/unit/memory/test_memory_active.cc
@@ -99,7 +99,7 @@ TYPED_TEST_P(TestMemoryActive, test_memory_remote_send) {
      *  thus the memory gets freed (or dereferenced)---the corresponding
      *  messages we are checking for a correct reference count go to 1
      */
-    theEvent()->cleanup();
+    theEvent()->finalize();
     for (auto&& msg : msgs) {
       // We expect 1 reference due to the messageRef above
       EXPECT_EQ(envelopeGetRef(msg->env), 1);
@@ -130,7 +130,7 @@ TYPED_TEST_P(TestMemoryActive, test_memory_remote_broadcast) {
      *  thus the memory gets freed (or dereferenced)---the corresponding
      *  messages we are checking for a correct reference count go to 1
      */
-    theEvent()->cleanup();
+    theEvent()->finalize();
     for (auto&& msg : msgs) {
       // We expect 1 reference due to the messageRef above
       EXPECT_EQ(envelopeGetRef(msg->env), 1);

--- a/tests/unit/memory/test_memory_lifetime.cc
+++ b/tests/unit/memory/test_memory_lifetime.cc
@@ -177,7 +177,7 @@ TEST_F(TestMemoryLifetime, test_active_send_normal_lifetime_1) {
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
-        theEvent()->cleanup();
+        theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
         envelopeDeref(msg->env);
       });
@@ -204,7 +204,7 @@ TEST_F(TestMemoryLifetime, test_active_send_normal_lifetime_2) {
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
-        theEvent()->cleanup();
+        theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
       });
     }
@@ -229,7 +229,7 @@ TEST_F(TestMemoryLifetime, test_active_bcast_normal_lifetime_1) {
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
-        theEvent()->cleanup();
+        theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
         envelopeDeref(msg->env);
       });
@@ -254,7 +254,7 @@ TEST_F(TestMemoryLifetime, test_active_bcast_normal_lifetime_2) {
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
-        theEvent()->cleanup();
+        theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
       });
     }
@@ -275,7 +275,7 @@ static void callbackHan(CallbackMsg<NormalTestMsg>* msg) {
 
   theTerm()->addAction([send_msg]{
     // Call event cleanup all pending MPI requests to clear
-    theEvent()->cleanup();
+    theEvent()->finalize();
     EXPECT_EQ(envelopeGetRef(send_msg->env), 1);
   });
 }
@@ -292,7 +292,7 @@ TEST_F(TestMemoryLifetime, test_active_send_callback_lifetime_1) {
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
-        theEvent()->cleanup();
+        theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
       });
     }
@@ -308,7 +308,7 @@ static void callbackHan(CallbackMsg<SerialTestMsg>* msg) {
 
   theTerm()->addAction([send_msg]{
     // Call event cleanup all pending MPI requests to clear
-    theEvent()->cleanup();
+    theEvent()->finalize();
     EXPECT_EQ(envelopeGetRef(send_msg->env), 1);
   });
 }
@@ -325,7 +325,7 @@ TEST_F(TestMemoryLifetime, test_active_serial_callback_lifetime_1) {
 
       theTerm()->addAction([msg]{
         // Call event cleanup all pending MPI requests to clear
-        theEvent()->cleanup();
+        theEvent()->finalize();
         EXPECT_EQ(envelopeGetRef(msg->env), 1);
       });
     }


### PR DESCRIPTION
Fixes #764

- Create a new abstract interface for VT components, universalizing `initialize` and `finalize`.
- Add new type-level dependency management between components to ensure valid startup/finalization order
  - Use topological sort to determine valid order
  - Note: the order is not necessary deterministic across platforms/compilers, but is always the same across all nodes for a given binary and always respects declared dependences
- Create abstraction for `PollableComponent<T>` inheriting from `Progressable` so scheduler knows which components to poll automatically
- Stub abstraction for diagnostics (eventually with have a universal interface for dumping state and calculating diagnostics values at shutdown, e.g., largest or average message size)
  - **Diagnostics will arrive in another PR**
- Stub abstraction for universal buffering for VT components
  - **Universal buffering will arrive in another PR**
- Add base component overload for revealing a name `std::string` for each component for use in debugging and later diagnostics

TODO:
  - [x] Add doxygen
  - [x] Cleanup runtime
  - [x] Hookup `Progressable` to scheduler component
