### PR TITLE
793 Safe MPI collectives

### DIFF
--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -144,7 +144,8 @@ CollectiveAlg::CollectiveAlg()
 
 
 TagType CollectiveAlg::mpiCollectiveAsync(ActionType action) {
-  auto tag = next_tag_;
+  auto tag = next_tag_++;
+
   CollectiveInfo info(tag, action);
 
   planned_collective_.emplace(
@@ -171,7 +172,6 @@ TagType CollectiveAlg::mpiCollectiveAsync(ActionType action) {
     collective_root, msg.get(), cb, tag, no_seq_id, 1, ident
   );
 
-  next_tag_++;
   return tag;
 }
 

--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -147,6 +147,7 @@ CollectiveAlg::CollectiveAlg()
 TagType CollectiveAlg::mpiCollectiveAsync(ActionType action) {
   auto tag = next_tag_++;
 
+  // Create a new collective action with the next tag
   CollectiveInfo info(tag, action);
 
   planned_collective_.emplace(
@@ -161,6 +162,11 @@ TagType CollectiveAlg::mpiCollectiveAsync(ActionType action) {
     tag
   );
 
+  // Do a reduction followed by a broadcast to trigger a collective
+  // operation. Note that in VT reductions and broadcasts can be executed out of
+  // order. This implies that runCollective might be called with different tags
+  // on different nodes. Thus, in runCollective, we will use a consensus
+  // protocol to agree on a consistent tag across all the nodes.
   NodeType collective_root = 0;
 
   auto cb = theCB()->makeBcast<CollectiveMsg,&runCollective>();

--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -143,7 +143,7 @@ CollectiveAlg::CollectiveAlg()
 }
 
 
-TagType CollectiveAlg::mpiCollective(ActionType action) {
+TagType CollectiveAlg::mpiCollectiveAsync(ActionType action) {
   auto tag = next_tag_;
   CollectiveInfo info(tag, action);
 
@@ -155,7 +155,7 @@ TagType CollectiveAlg::mpiCollective(ActionType action) {
 
   debug_print(
     gen, node,
-    "mpiCollective: new MPI collective with tag={}\n",
+    "mpiCollectiveAsync: new MPI collective with tag={}\n",
     tag
   );
 
@@ -186,7 +186,7 @@ void CollectiveAlg::waitCollective(TagType tag) {
 }
 
 void CollectiveAlg::mpiCollectiveWait(ActionType action) {
-  waitCollective(mpiCollective(action));
+  waitCollective(mpiCollectiveAsync(action));
 }
 
 }}  // end namespace vt::collective

--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -66,9 +66,7 @@ CollectiveScope CollectiveAlg::makeCollectiveScope(TagType in_scope_tag) {
   auto iter = scopes.find(scope_tag);
   vtAssert(iter == scopes.end(), "Scope must not already exist");
   // Must construct in call to make_unique, since constructor is private
-  auto ptr = std::make_unique<detail::ScopeImpl>(
-    detail::ScopeImpl{is_user_tag, scope_tag}
-  );
+  auto ptr = std::make_unique<detail::ScopeImpl>(detail::ScopeImpl{});
   scopes[scope_tag] = std::move(ptr);
 
   return CollectiveScope(is_user_tag, scope_tag);

--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -57,88 +57,89 @@ CollectiveAlg::CollectiveAlg()
   // stack once!
   static int reenter_counter_ = 0;
 
-  if (reenter_counter_ == 0) {
-    reenter_counter_++;
-
-    auto const this_node = theContext()->getNode();
-    TagType consensus_tag = no_tag;
-    ActionType action = no_action;
-
-    auto& planned = theCollective()->planned_collective_;
-
-    // The root decides the next tag and tells the remaining nodes
-    if (msg->root_ == this_node) {
-      debug_print(
-        gen, node,
-        "mpiCollective: running collective associated with tag={}\n",
-        msg->tag_
-      );
-
-      auto iter = planned.find(msg->tag_);
-      vtAssert(iter != planned.end(), "Planned collective does not exist");
-      consensus_tag = msg->tag_;
-      action = iter->second.action_;
-    }
-
-    // We can not use a VT broadcast here because it involves the scheduler and
-    // MPI progress and there's no safe way to guarantee that the message has been
-    // received and processed and doesn't require progress from another node
-
-    int const root = msg->root_;
-    auto comm = theContext()->getComm();
-    MPI_Request req;
-
-    // Do a async broadcast of the tag we intend to execute collectively
-    MPI_Ibcast(&consensus_tag, 1, MPI_INT32_T, root, comm, &req);
-
-    int flag = 0;
-    while (not flag) {
-      MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
-      runScheduler();
-    }
-
-    // We need a barrier here so the root doesn't finish the broadcast first and
-    // then enter the collective. We could replace the Ibcast/Ibarrier with a
-    // Iallreduce, but I think this is cheaper
-    MPI_Ibarrier(comm, &req);
-
-    flag = 0;
-    while (not flag) {
-      MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
-      runScheduler();
-    }
-
-    debug_print(
-      gen, node,
-      "mpiCollective: consensus_tag={}, msg->tag_={}\n",
-      consensus_tag, msg->tag_
-    );
-
-    // The root had a different collective in mind... let's do that one
-    if (msg->root_ != this_node) {
-      auto iter = planned.find(consensus_tag);
-      vtAssert(iter != planned.end(), "Planned collective does not exist");
-      action = iter->second.action_;
-    }
-
-    // Run the collective safely
-    action();
-
-    // Erase the tag that was actually executed
-    planned.erase(planned.find(consensus_tag));
-
-    reenter_counter_--;
-
-    // Recurse, running a postponed collective
-    auto& postponed = theCollective()->postponed_collectives_;
-    if (postponed.size() > 0) {
-      auto next_msg = postponed.back();
-      postponed.pop_back();
-      runCollective(next_msg.get());
-    }
-  } else {
+  if (reenter_counter_ != 0) {
     // Postpone any collective while the current one resolves
     theCollective()->postponed_collectives_.emplace_back(promoteMsg(msg));
+    return;
+  }
+
+  reenter_counter_++;
+
+  auto const this_node = theContext()->getNode();
+  TagType consensus_tag = no_tag;
+  ActionType action = no_action;
+
+  auto& planned = theCollective()->planned_collective_;
+
+  // The root decides the next tag and tells the remaining nodes
+  if (msg->root_ == this_node) {
+    debug_print(
+      gen, node,
+      "mpiCollective: running collective associated with tag={}\n",
+      msg->tag_
+    );
+
+    auto iter = planned.find(msg->tag_);
+    vtAssert(iter != planned.end(), "Planned collective does not exist");
+    consensus_tag = msg->tag_;
+    action = iter->second.action_;
+  }
+
+  // We can not use a VT broadcast here because it involves the scheduler and
+  // MPI progress and there's no safe way to guarantee that the message has been
+  // received and processed and doesn't require progress from another node
+
+  int const root = msg->root_;
+  auto comm = theContext()->getComm();
+  MPI_Request req;
+
+  // Do a async broadcast of the tag we intend to execute collectively
+  MPI_Ibcast(&consensus_tag, 1, MPI_INT32_T, root, comm, &req);
+
+  int flag = 0;
+  while (not flag) {
+    MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
+    runScheduler();
+  }
+
+  // We need a barrier here so the root doesn't finish the broadcast first and
+  // then enter the collective. We could replace the Ibcast/Ibarrier with a
+  // Iallreduce, but I think this is cheaper
+  MPI_Ibarrier(comm, &req);
+
+  flag = 0;
+  while (not flag) {
+    MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
+    runScheduler();
+  }
+
+  debug_print(
+    gen, node,
+    "mpiCollective: consensus_tag={}, msg->tag_={}\n",
+    consensus_tag, msg->tag_
+  );
+
+  // The root had a different collective in mind... let's do that one
+  if (msg->root_ != this_node) {
+    auto iter = planned.find(consensus_tag);
+    vtAssert(iter != planned.end(), "Planned collective does not exist");
+    action = iter->second.action_;
+  }
+
+  // Run the collective safely
+  action();
+
+  // Erase the tag that was actually executed
+  planned.erase(planned.find(consensus_tag));
+
+  reenter_counter_--;
+
+  // Recurse, running a postponed collective
+  auto& postponed = theCollective()->postponed_collectives_;
+  if (postponed.size() > 0) {
+    auto next_msg = postponed.back();
+    postponed.pop_back();
+    runCollective(next_msg.get());
   }
 }
 

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -90,36 +90,44 @@ struct CollectiveAlg :
 
 public:
   /**
-   * \brief Enqueue a lambda with an embedded MPI collective invocation to
-   * execute in the future. Returns immediately, enqueuing the action for the
-   * future.
+   * \brief Enqueue a lambda with an embedded closed set of MPI collectives
+   * invocations to execute in the future. Returns immediately, enqueuing the
+   * action for the future.
    *
-   * \param[in] action the action containing an MPI collective
+   * The set of operations specified in the lambda must be closed, meaning that
+   * MPI requests must not escape the lambda. After the lambda finishes, the set
+   * of MPI collective calls should be complete.
+   *
+   * Any buffers captured in the lambda to use with MPI collective operations
+   * need to exist until \c isCollectiveDone returns \c true or \c
+   * waitCollective returns on the returned \c TagType
+   *
+   * \param[in] action the action containing a closed set of MPI collectives
    *
    * \return tag representing the collective
    */
   TagType mpiCollectiveAsync(ActionType action);
 
   /**
-   * \brief Query whether an enqueued MPI collective is complete
+   * \brief Query whether an enqueued MPI collective set is complete
    *
-   * \param[in] tag MPI collective identifier
+   * \param[in] tag MPI collective set identifier
    *
    * \return whether it has finished or not
    */
   bool isCollectiveDone(TagType tag);
 
   /**
-   * \brief Wait on an MPI collective to complete
+   * \brief Wait on an MPI collective set to complete
    *
-   * \param[in] tag MPI collective identifier
+   * \param[in] tag MPI collective set identifier
    */
   void waitCollective(TagType tag);
 
   /**
-   * \brief Enqueue a lambda with an embedded MPI collective. Spin in the VT
-   * scheduler until it completes. Ensure that all other nodes do not depend on
-   * this node to enqueue the same collective.
+   * \brief Enqueue a lambda with an embedded closed set of MPI
+   * collectives. Spin in the VT scheduler until it terminates. All other nodes
+   * must not depend on this node to enqueue a matching collective.
    *
    * \param[in] action the action containing an MPI collective
    */

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -90,45 +90,45 @@ struct CollectiveAlg :
 
 public:
   /**
-   * \brief Enqueue a lambda with an embedded closed set of MPI collectives
-   * invocations to execute in the future. Returns immediately, enqueuing the
-   * action for the future.
+   * \brief Enqueue a lambda with an embedded closed set of MPI operations
+   * (including collectives) to execute in the future. Returns
+   * immediately, enqueuing the action for the future.
    *
    * The set of operations specified in the lambda must be closed, meaning that
    * MPI requests must not escape the lambda. After the lambda finishes, the set
    * of MPI collective calls should be complete.
    *
-   * Any buffers captured in the lambda to use with MPI collective operations
-   * need to exist until \c isCollectiveDone returns \c true or \c
+   * Any buffers captured in the lambda to use with the MPI operations
+   * are in use until \c isCollectiveDone returns \c true or \c
    * waitCollective returns on the returned \c TagType
    *
-   * \param[in] action the action containing a closed set of MPI collectives
+   * \param[in] action the action containing a closed set of MPI operations
    *
-   * \return tag representing the collective
+   * \return tag representing the operation set
    */
   TagType mpiCollectiveAsync(ActionType action);
 
   /**
-   * \brief Query whether an enqueued MPI collective set is complete
+   * \brief Query whether an enqueued MPI operation set is complete
    *
-   * \param[in] tag MPI collective set identifier
+   * \param[in] tag MPI operation set identifier
    *
    * \return whether it has finished or not
    */
   bool isCollectiveDone(TagType tag);
 
   /**
-   * \brief Wait on an MPI collective set to complete
+   * \brief Wait on an MPI operation set to complete
    *
    * \param[in] tag MPI collective set identifier
    */
   void waitCollective(TagType tag);
 
   /**
-   * \brief Enqueue a lambda with an embedded closed set of MPI
-   * collectives. Spin in the VT scheduler until it terminates.
+   * \brief Enqueue a lambda with an embedded closed set of MPI operations
+   * (including collectives). Spin in the VT scheduler until it terminates.
    *
-   * \param[in] action the action containing an MPI collective
+   * \param[in] action the action containing a set of MPI operations
    */
   void mpiCollectiveWait(ActionType action);
 

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -126,8 +126,7 @@ public:
 
   /**
    * \brief Enqueue a lambda with an embedded closed set of MPI
-   * collectives. Spin in the VT scheduler until it terminates. All other nodes
-   * must not depend on this node to enqueue a matching collective.
+   * collectives. Spin in the VT scheduler until it terminates.
    *
    * \param[in] action the action containing an MPI collective
    */

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -98,7 +98,7 @@ public:
    *
    * \return tag representing the collective
    */
-  TagType mpiCollective(ActionType action);
+  TagType mpiCollectiveAsync(ActionType action);
 
   /**
    * \brief Query whether an enqueued MPI collective is complete

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -83,11 +83,11 @@ TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
   // Put this in a separate namespace
   // @todo: broader issue: need to implement a better way to scope reductions
   auto ident = 0xEFFFFFFFFFFFFFFF;
-  auto msg = makeMessage<CollectiveMsg>(is_user_tag_, impl->scope_, tag, collective_root);
+  auto msg = makeMessage<CollectiveMsg>(is_user_tag_, scope_, tag, collective_root);
 
   // The tag for the reduce is a combination of the scope and seq tag.
   theCollective()->reduce<collective::None>(
-    collective_root, msg.get(), cb, impl->scope_, no_seq_id, 1, ident, tag
+    collective_root, msg.get(), cb, scope_, no_seq_id, 1, ident, tag
   );
 
   return tag;

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -1,0 +1,128 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                             collective_scope.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_COLLECTIVE_COLLECTIVE_SCOPE_CC
+#define INCLUDED_VT_COLLECTIVE_COLLECTIVE_SCOPE_CC
+
+#include "vt/config.h"
+#include "vt/collective/collective_scope.h"
+#include "vt/collective/collective_alg.h"
+
+namespace vt { namespace collective {
+
+TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
+  auto impl = getScope();
+  auto tag = impl->next_seq_++;
+
+  // Create a new collective action with the next tag
+  detail::ScopeImpl::CollectiveInfo info(tag, action);
+
+  impl->planned_collective_.emplace(
+    std::piecewise_construct,
+    std::forward_as_tuple(tag),
+    std::forward_as_tuple(info)
+  );
+
+  debug_print(
+    gen, node,
+    "mpiCollectiveAsync: scope={}: new MPI collective with tag={}\n",
+    scope_, tag
+  );
+
+  // Do a reduction followed by a broadcast to trigger a collective
+  // operation. Note that in VT reductions and broadcasts can be executed out of
+  // order. This implies that runCollective might be called with different tags
+  // on different nodes. Thus, in runCollective, we will use a consensus
+  // protocol to agree on a consistent tag across all the nodes.
+  NodeType collective_root = 0;
+
+  using CollectiveMsg = CollectiveAlg::CollectiveMsg;
+  auto cb = theCB()->makeBcast<CollectiveMsg,&CollectiveAlg::runCollective>();
+
+  // Put this in a separate namespace
+  // @todo: broader issue: need to implement a better way to scope reductions
+  auto ident = 0xEFFFFFFFFFFFFFFF;
+  auto msg = makeMessage<CollectiveMsg>(is_user_tag_, impl->scope_, tag, collective_root);
+
+  // The tag for the reduce is a combination of the scope and seq tag.
+  theCollective()->reduce<collective::None>(
+    collective_root, msg.get(), cb, impl->scope_, no_seq_id, 1, ident, tag
+  );
+
+  return tag;
+}
+
+bool CollectiveScope::isCollectiveDone(TagType tag) {
+  auto impl = getScope();
+  return impl->planned_collective_.find(tag) == impl->planned_collective_.end();
+}
+
+void CollectiveScope::waitCollective(TagType tag) {
+  while (not isCollectiveDone(tag)) {
+    runScheduler();
+  }
+}
+
+void CollectiveScope::mpiCollectiveWait(ActionType action) {
+  waitCollective(mpiCollectiveAsync(action));
+}
+
+detail::ScopeImpl* CollectiveScope::getScope() {
+  auto& scopes = is_user_tag_ ?
+    theCollective()->user_scope_ :
+    theCollective()->system_scope_;
+
+  auto scope_iter = scopes.find(scope_);
+  vtAssert(scope_iter != scopes.end(), "Scope must exist");
+  return scope_iter->second.get();
+}
+
+CollectiveScope::~CollectiveScope() {
+  auto impl = getScope();
+  impl->live_ = false;
+}
+
+}} /* end namespace vt::collective */
+
+#endif /*INCLUDED_VT_COLLECTIVE_COLLECTIVE_SCOPE_CC*/

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -66,8 +66,8 @@ TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
 
   debug_print(
     gen, node,
-    "mpiCollectiveAsync: scope={}: new MPI collective with tag={}\n",
-    scope_, tag
+    "mpiCollectiveAsync: is_user_tag_={}, scope={}: new MPI collective with seq tag={}\n",
+    is_user_tag_, scope_, tag
   );
 
   // Do a reduction followed by a broadcast to trigger a collective

--- a/src/vt/collective/collective_scope.h
+++ b/src/vt/collective/collective_scope.h
@@ -1,0 +1,174 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                              collective_scope.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_COLLECTIVE_COLLECTIVE_SCOPE_H
+#define INCLUDED_VT_COLLECTIVE_COLLECTIVE_SCOPE_H
+
+#include "vt/config.h"
+
+#include <unordered_map>
+
+namespace vt { namespace collective {
+
+struct CollectiveScope;
+struct CollectiveAlg;
+
+namespace detail {
+
+struct ScopeImpl {
+
+private:
+  ScopeImpl(bool in_is_user_tag, TagType in_scope)
+    : is_user_tag_(in_is_user_tag),
+      scope_(in_scope)
+  { }
+
+  friend collective::CollectiveScope;
+  friend collective::CollectiveAlg;
+
+private:
+  struct CollectiveInfo {
+    CollectiveInfo(TagType in_seq, ActionType in_action)
+      : seq_(in_seq), action_(in_action)
+    { }
+
+    TagType seq_ = no_tag;
+    ActionType action_ = no_action;
+  };
+
+private:
+  bool live_ = true;            /**< Whether the \c CollectiveScope is live */
+  bool is_user_tag_ = false;    /**< Whether the scope is user or system tagged */
+  TagType scope_ = no_tag;      /**< The scope for this collective sequence */
+  TagType next_seq_ = 1;        /**< The next sequence tag for this scope */
+  std::unordered_map<TagType, CollectiveInfo> planned_collective_;
+};
+
+} /* end namespace detail */
+
+struct CollectiveScope {
+
+private:
+  /**
+   * \internal \brief Construct a collective scope for MPI operations.
+   *
+   * \param[in] in_scope the scope tag
+   * \param[in] in_is_user_tag whether the scope tag is a user or system tag
+   */
+  explicit CollectiveScope(bool in_is_user_tag, TagType in_scope)
+    : is_user_tag_(in_is_user_tag),
+      scope_(in_scope)
+  { }
+
+  friend struct CollectiveAlg;
+
+public:
+  CollectiveScope(CollectiveScope&&) = default;
+  CollectiveScope(CollectiveScope const&) = delete;
+  CollectiveScope& operator=(CollectiveScope&&) = delete;
+  CollectiveScope& operator=(CollectiveScope const&) = delete;
+
+  ~CollectiveScope();
+
+public:
+  /**
+   * \brief Enqueue a lambda with an embedded closed set of MPI operations
+   * (including collectives) to execute in the future. Returns
+   * immediately, enqueuing the action for the future.
+   *
+   * The set of operations specified in the lambda must be closed, meaning that
+   * MPI requests must not escape the lambda. After the lambda finishes, the set
+   * of MPI collective calls should be complete.
+   *
+   * Any buffers captured in the lambda to use with the MPI operations
+   * are in use until \c isCollectiveDone returns \c true or \c
+   * waitCollective returns on the returned \c TagType
+   *
+   * \param[in] action the action containing a closed set of MPI operations
+   *
+   * \return tag representing the operation set
+   */
+  TagType mpiCollectiveAsync(ActionType action);
+
+  /**
+   * \brief Query whether an enqueued MPI operation set is complete
+   *
+   * \param[in] tag MPI operation set identifier
+   *
+   * \return whether it has finished or not
+   */
+  bool isCollectiveDone(TagType tag);
+
+  /**
+   * \brief Wait on an MPI operation set to complete
+   *
+   * \param[in] tag MPI collective set identifier
+   */
+  void waitCollective(TagType tag);
+
+  /**
+   * \brief Enqueue a lambda with an embedded closed set of MPI operations
+   * (including collectives). Spin in the VT scheduler until it terminates.
+   *
+   * \param[in] action the action containing a set of MPI operations
+   */
+  void mpiCollectiveWait(ActionType action);
+
+private:
+
+  /**
+   * \internal \brief Get the scope state
+   *
+   * \return the scope state
+   */
+  detail::ScopeImpl* getScope();
+
+private:
+  bool is_user_tag_ = false;
+  TagType scope_ = no_tag;
+};
+
+}} /* end namespace vt::collective */
+
+#endif /*INCLUDED_VT_COLLECTIVE_COLLECTIVE_SCOPE_H*/

--- a/src/vt/collective/collective_scope.h
+++ b/src/vt/collective/collective_scope.h
@@ -59,10 +59,7 @@ namespace detail {
 struct ScopeImpl {
 
 private:
-  ScopeImpl(bool in_is_user_tag, TagType in_scope)
-    : is_user_tag_(in_is_user_tag),
-      scope_(in_scope)
-  { }
+  ScopeImpl() = default;
 
   friend collective::CollectiveScope;
   friend collective::CollectiveAlg;
@@ -79,8 +76,6 @@ private:
 
 private:
   bool live_ = true;            /**< Whether the \c CollectiveScope is live */
-  bool is_user_tag_ = false;    /**< Whether the scope is user or system tagged */
-  TagType scope_ = no_tag;      /**< The scope for this collective sequence */
   TagType next_seq_ = 1;        /**< The next sequence tag for this scope */
   std::unordered_map<TagType, CollectiveInfo> planned_collective_;
 };

--- a/src/vt/collective/reduce/reduce.h
+++ b/src/vt/collective/reduce/reduce.h
@@ -95,7 +95,8 @@ struct Reduce : virtual collective::tree::Tree {
     NodeType const& root, MsgT* msg, Callback<MsgT> cb,
     TagType const& tag = no_tag, SequentialIDType const& seq = no_seq_id,
     ReduceNumType const& num_contrib = 1,
-    VirtualProxyType const& proxy = no_vrt_proxy
+    VirtualProxyType const& proxy = no_vrt_proxy,
+    ObjGroupProxyType objgroup = no_obj_group
   );
 
   template <

--- a/src/vt/collective/reduce/reduce.impl.h
+++ b/src/vt/collective/reduce/reduce.impl.h
@@ -87,10 +87,10 @@ template <typename OpT, typename MsgT, ActiveTypedFnType<MsgT> *f>
 SequentialIDType Reduce::reduce(
   NodeType const& root, MsgT* msg, Callback<MsgT> cb, TagType const& tag,
   SequentialIDType const& seq, ReduceNumType const& num_contrib,
-  VirtualProxyType const& proxy
+  VirtualProxyType const& proxy, ObjGroupProxyType objgroup
 ) {
   msg->setCallback(cb);
-  return reduce<MsgT,f>(root,msg,tag,seq,num_contrib,proxy);
+  return reduce<MsgT,f>(root,msg,tag,seq,num_contrib,proxy,objgroup);
 }
 
 template <

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1157,11 +1157,12 @@ void Runtime::setup() {
   auto action = std::bind(&Runtime::terminationHandler, this);
   theTerm->addDefaultAction(action);
 
+  // wait for all nodes to start up to initialize the runtime
+  theCollective->barrier();
+
 # if backend_check_enabled(trace_enabled)
   theTrace->loadAndBroadcastSpec();
 # endif
-
-  sync();
 
   if (ArgType::vt_pause) {
     pauseForDebugger();

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -1157,16 +1157,11 @@ void Runtime::setup() {
   auto action = std::bind(&Runtime::terminationHandler, this);
   theTerm->addDefaultAction(action);
 
-  MPI_Barrier(theContext->getComm());
-
-  // wait for all nodes to start up to initialize the runtime
-  theCollective->barrierThen([this]{
-    MPI_Barrier(theContext->getComm());
-  });
-
 # if backend_check_enabled(trace_enabled)
   theTrace->loadAndBroadcastSpec();
 # endif
+
+  sync();
 
   if (ArgType::vt_pause) {
     pauseForDebugger();

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -174,7 +174,7 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
   };
 
   auto op2 = [&]{
-    scope2.mpiCollectiveWait([&done,&reduce_val_out]{
+    scope2.mpiCollectiveAsync([&done,&reduce_val_out]{
       auto comm = theContext()->getComm();
       int val_in = 1;
       vt_print(barrier, "run MPI_Allreduce\n");

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -188,7 +188,7 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
   };
 
   auto op3 = [&]{
-    scope3.mpiCollectiveAsync([&done,&reduce_val_out]{
+    scope3.mpiCollectiveAsync([&done]{
       auto comm = theContext()->getComm();
       vt_print(barrier, "run MPI_barrier\n");
       MPI_Barrier(comm);

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -54,7 +54,7 @@ using TestMPICollective = TestParallelHarness;
 TEST_F(TestMPICollective, test_mpi_collective_1) {
   bool done = false;
 
-  theCollective()->mpiCollective([&done]{
+  theCollective()->mpiCollectiveAsync([&done]{
     auto comm = theContext()->getComm();
     MPI_Barrier(comm);
     done = true;
@@ -74,7 +74,7 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
 
   // These three collective can execute in any order, but it will always be
   // consistent across all the nodes
-  theCollective()->mpiCollective([&done]{
+  theCollective()->mpiCollectiveAsync([&done]{
     auto comm = theContext()->getComm();
     vt_print(barrier, "run MPI_Barrier\n");
     MPI_Barrier(comm);
@@ -85,7 +85,7 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
 
-  theCollective()->mpiCollective([&done,&bcast_val,root]{
+  theCollective()->mpiCollectiveAsync([&done,&bcast_val,root]{
     auto comm = theContext()->getComm();
     vt_print(barrier, "run MPI_Bcast\n");
     MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
@@ -94,7 +94,7 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
 
   int reduce_val_out = 0;
 
-  theCollective()->mpiCollective([&done,&reduce_val_out]{
+  theCollective()->mpiCollectiveAsync([&done,&reduce_val_out]{
     auto comm = theContext()->getComm();
     int val_in = 1;
     vt_print(barrier, "run MPI_Allreduce\n");
@@ -121,7 +121,7 @@ TEST_F(TestMPICollective, test_mpi_collective_3) {
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
 
-  auto tag = theCollective()->mpiCollective([&done,&bcast_val,root]{
+  auto tag = theCollective()->mpiCollectiveAsync([&done,&bcast_val,root]{
     auto comm = theContext()->getComm();
     vt_print(barrier, "run MPI_Bcast\n");
     MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -72,7 +72,7 @@ TEST_F(TestMPICollective, test_mpi_collective_1) {
 TEST_F(TestMPICollective, test_mpi_collective_2) {
   int done = 0;
 
-  auto scope = theCollective()->makeCollectiveScope();
+  vt::collective::CollectiveScope scope = theCollective()->makeCollectiveScope();
 
   // These three collective can execute in any order, but it will always be
   // consistent across all the nodes
@@ -123,7 +123,7 @@ TEST_F(TestMPICollective, test_mpi_collective_3) {
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
 
-  auto scope = theCollective()->makeCollectiveScope();
+  vt::collective::CollectiveScope scope = theCollective()->makeCollectiveScope();
 
   auto tag = scope.mpiCollectiveAsync([&done,&bcast_val,root]{
     auto comm = theContext()->getComm();
@@ -158,11 +158,11 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
   bool is_even = this_node % 2 == 0;
 
   // System scope (will have generated tag=1)
-  auto scope1 = theCollective()->makeCollectiveScope();
+  vt::collective::CollectiveScope scope1 = theCollective()->makeCollectiveScope();
   // System scope (will have generated tag=2)
-  auto scope2 = theCollective()->makeCollectiveScope();
+  vt::collective::CollectiveScope scope2 = theCollective()->makeCollectiveScope();
   // User scope with tag=1
-  auto scope3 = theCollective()->makeCollectiveScope(1);
+  vt::collective::CollectiveScope scope3 = theCollective()->makeCollectiveScope(1);
 
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -97,7 +97,7 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
   theCollective()->mpiCollective([&done,&reduce_val_out]{
     auto comm = theContext()->getComm();
     int val_in = 1;
-    vt_print(barrier, "run MPI_Reduce\n");
+    vt_print(barrier, "run MPI_Allreduce\n");
     MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
     done++;
   });
@@ -138,7 +138,7 @@ TEST_F(TestMPICollective, test_mpi_collective_3) {
   theCollective()->mpiCollectiveWait([&done,&reduce_val_out]{
     auto comm = theContext()->getComm();
     int val_in = 1;
-    vt_print(barrier, "run MPI_Reduce\n");
+    vt_print(barrier, "run MPI_Allreduce\n");
     MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
     done++;
   });

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -1,0 +1,140 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                           test_mpi_collective.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.go
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+#include <vt/transport.h>
+
+#include "test_parallel_harness.h"
+
+namespace vt { namespace tests { namespace unit {
+
+using TestMPICollective = TestParallelHarness;
+
+TEST_F(TestMPICollective, test_mpi_collective_1) {
+  bool done = false;
+
+  theCollective()->mpiCollective([&done]{
+    auto comm = theContext()->getComm();
+    MPI_Barrier(comm);
+    done = true;
+  });
+
+  theTerm()->addAction([&done]{
+    EXPECT_TRUE(done);
+  });
+
+  while (not vt::rt->isTerminated()) {
+    runScheduler();
+  }
+}
+
+TEST_F(TestMPICollective, test_mpi_collective_2) {
+  int done = 0;
+
+  // These three collective can execute in any order, but it will always be
+  // consistent across all the nodes
+  theCollective()->mpiCollective([&done]{
+    auto comm = theContext()->getComm();
+    vt_print(barrier, "run MPI_Barrier\n");
+    MPI_Barrier(comm);
+    done++;
+  });
+
+  theCollective()->mpiCollective([&done]{
+    auto comm = theContext()->getComm();
+    int val = 0;
+    vt_print(barrier, "run MPI_Bcast\n");
+    MPI_Bcast(&val, 1, MPI_INT, 0, comm);
+    done++;
+  });
+
+  theCollective()->mpiCollective([&done]{
+    auto comm = theContext()->getComm();
+    int val_in = 1;
+    int val_out = 0;
+    vt_print(barrier, "run MPI_Reduce\n");
+    MPI_Reduce(&val_in, &val_out, 1, MPI_INT, MPI_SUM, 0, comm);
+    done++;
+  });
+
+  theTerm()->addAction([&done]{
+    EXPECT_EQ(done, 3);
+  });
+
+  while (not vt::rt->isTerminated()) {
+    runScheduler();
+  }
+}
+
+TEST_F(TestMPICollective, test_mpi_collective_3) {
+  int done = 0;
+
+  // These three collective can execute in any order, but it will always be
+  // consistent across all the nodes
+  auto tag = theCollective()->mpiCollective([&done]{
+    auto comm = theContext()->getComm();
+    int val = 0;
+    vt_print(barrier, "run MPI_Bcast\n");
+    MPI_Bcast(&val, 1, MPI_INT, 0, comm);
+    done++;
+  });
+
+  theCollective()->waitCollective(tag);
+
+  EXPECT_EQ(done, 1);
+
+  theCollective()->mpiCollectiveWait([&done]{
+    auto comm = theContext()->getComm();
+    int val_in = 1;
+    int val_out = 0;
+    vt_print(barrier, "run MPI_Reduce\n");
+    MPI_Reduce(&val_in, &val_out, 1, MPI_INT, MPI_SUM, 0, comm);
+    done++;
+  });
+
+  EXPECT_EQ(done, 2);
+}
+
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -85,10 +85,10 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
 
-  theCollective()->mpiCollective([&done,&bcast_val]{
+  theCollective()->mpiCollective([&done,&bcast_val,root]{
     auto comm = theContext()->getComm();
     vt_print(barrier, "run MPI_Bcast\n");
-    MPI_Bcast(&bcast_val, 1, MPI_INT, 0, comm);
+    MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
     done++;
   });
 

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -110,8 +110,6 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
 TEST_F(TestMPICollective, test_mpi_collective_3) {
   int done = 0;
 
-  // These three collective can execute in any order, but it will always be
-  // consistent across all the nodes
   auto tag = theCollective()->mpiCollective([&done]{
     auto comm = theContext()->getComm();
     int val = 0;


### PR DESCRIPTION
Fixes #793 

Implement a new call to enqueue an MPI collective and run it safely **while** VT is running.

```C++
auto tag = vt::theCollective()->mpiCollective([]{
   MPI_Barrier(MPI_COMM_WORLD);
});

vt::theCollective()->waitCollective(tag);
```