### PR TITLE
819 Collective insertable collections

### DIFF
--- a/docs/md/collection.md
+++ b/docs/md/collection.md
@@ -15,6 +15,11 @@ nodes that do not have collection elements. The \ref proc-stats component
 stores the statistics for live collections that then passes the instrumented
 data to the \ref lb-manager component to apply load balancing strategies.
 
+\section insertable Insertable Collections
+
+The \vt runtime supports collections that are dynamically insertable at
+runtime. Learn about \subpage insertable-collections
+
 \section rooted-hello-world-collection Hello World 1D Dense Collection (Rooted)
 \snippet  examples/hello_world/hello_world_collection.cc Hello world collection
 

--- a/docs/md/insertable-collections.md
+++ b/docs/md/insertable-collections.md
@@ -1,0 +1,14 @@
+\page insertable-collections Insertable Collections
+\brief Dynamically inserted collections
+
+The virtual context collection component
+`vt::vrt::collection::CollectionManager` supports sparse collections that can be
+dynamically inserted at runtime. To declare an insertable collection, inherit
+from `vt::InsertableCollection` instead of the dense collection
+`vt::Collection`. After the collection is constructed, elements will not be
+created automatically for the index range passed to `theCollection()->construct`
+or `theCollection()->constructCollective()`. Instead, the user is responsible
+for inserting the indices that exist after the collection is constructed.
+
+\section insertable-example-program Insertable Collection Example
+\snippet examples/collection/collective_insertable.cc Collective insertable example

--- a/examples/collection/CMakeLists.txt
+++ b/examples/collection/CMakeLists.txt
@@ -6,6 +6,7 @@ set(
   jacobi2d_vt
   migrate_collection
   insertable_collection
+  collective_insertable
   reduce_integral
   transpose
 )

--- a/examples/collection/collective_insertable.cc
+++ b/examples/collection/collective_insertable.cc
@@ -42,6 +42,8 @@
 //@HEADER
 */
 
+/// [Collective insertable example]
+
 #include <vt/transport.h>
 
 static constexpr int32_t const default_num_elms = 64;
@@ -109,3 +111,5 @@ int main(int argc, char** argv) {
 
   return 0;
 }
+
+/// [Collective insertable example]

--- a/examples/collection/collective_insertable.cc
+++ b/examples/collection/collective_insertable.cc
@@ -1,0 +1,109 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                          collective_insertable.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+
+static constexpr int32_t const default_num_elms = 64;
+
+struct InsertCol : vt::InsertableCollection<InsertCol, vt::Index1D> {
+  InsertCol() {
+    vt::NodeType this_node = vt::theContext()->getNode();
+    ::fmt::print("{}: constructing: idx={}\n", this_node, getIndex().x());
+  }
+
+  ~InsertCol() {
+    vtAssert(reduce_done_, "Reduce must hit all live element");
+  }
+
+  using Msg = vt::CollectionMessage<InsertCol>;
+  using ReduceMsg = vt::collective::ReduceNoneMsg;
+
+  void done(ReduceMsg* msg) {
+    //fmt::print("{}: done\n", this->getIndex());
+    reduce_done_ = true;
+  }
+
+  void doWork(Msg* msg) {
+    auto proxy = getCollectionProxy();
+    auto red_msg = vt::makeMessage<ReduceMsg>();
+    auto cb = vt::theCB()->makeBcast<InsertCol,ReduceMsg,&InsertCol::done>(proxy);
+    proxy.reduce(red_msg.get(),cb);
+  }
+
+private:
+  bool reduce_done_ = false;
+};
+
+int main(int argc, char** argv) {
+  vt::initialize(argc, argv);
+
+  vt::NodeType this_node = vt::theContext()->getNode();
+  vt::NodeType num_nodes = vt::theContext()->getNumNodes();
+
+  int32_t num_elms = default_num_elms;
+  if (argc > 1) {
+    num_elms = atoi(argv[1]);
+  }
+
+  auto range = vt::Index1D(num_elms);
+  auto proxy = vt::theCollection()->constructCollective<InsertCol>(range);
+
+  proxy.startInsertCollective();
+
+  for (int i = 0; i < 32; i++) {
+    if (i < range.x() and i % num_nodes == this_node) {
+      proxy(i).insert();
+    }
+  }
+
+  proxy.finishInsertCollective();
+
+  if (this_node == 0) {
+    proxy.broadcast<InsertCol::Msg,&InsertCol::doWork>();
+  }
+
+  vt::finalize();
+
+  return 0;
+}

--- a/src/vt/vrt/collection/insert/insert_finished.h
+++ b/src/vt/vrt/collection/insert/insert_finished.h
@@ -61,6 +61,10 @@ struct InsertFinished : BaseProxyT {
   InsertFinished& operator=(InsertFinished const&) = default;
 
   void finishedInserting(ActionType action = nullptr) const;
+
+  void startInsertCollective() const;
+
+  void finishInsertCollective() const;
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/insert/insert_finished.impl.h
+++ b/src/vt/vrt/collection/insert/insert_finished.impl.h
@@ -63,19 +63,19 @@ void InsertFinished<ColT,IndexT,BaseProxyT>::finishedInserting(
   ActionType action
 ) const {
   auto const col_proxy = this->getProxy();
-  theCollection()->finishedInserting<ColT,IndexT>(col_proxy,action);
+  theCollection()->finishedInserting<ColT>(col_proxy,action);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 void InsertFinished<ColT,IndexT,BaseProxyT>::startInsertCollective() const {
   auto const col_proxy = this->getProxy();
-  theCollection()->startInsertCollective<ColT,IndexT>(col_proxy);
+  theCollection()->startInsertCollective<ColT>(col_proxy);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 void InsertFinished<ColT,IndexT,BaseProxyT>::finishInsertCollective() const {
   auto const col_proxy = this->getProxy();
-  theCollection()->finishInsertCollective<ColT,IndexT>(col_proxy);
+  theCollection()->finishInsertCollective<ColT>(col_proxy);
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/insert/insert_finished.impl.h
+++ b/src/vt/vrt/collection/insert/insert_finished.impl.h
@@ -66,6 +66,18 @@ void InsertFinished<ColT,IndexT,BaseProxyT>::finishedInserting(
   theCollection()->finishedInserting<ColT,IndexT>(col_proxy,action);
 }
 
+template <typename ColT, typename IndexT, typename BaseProxyT>
+void InsertFinished<ColT,IndexT,BaseProxyT>::startInsertCollective() const {
+  auto const col_proxy = this->getProxy();
+  theCollection()->startInsertCollective<ColT,IndexT>(col_proxy);
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+void InsertFinished<ColT,IndexT,BaseProxyT>::finishInsertCollective() const {
+  auto const col_proxy = this->getProxy();
+  theCollection()->finishInsertCollective<ColT,IndexT>(col_proxy);
+}
+
 }}} /* end namespace vt::vrt::collection */
 
 #endif /*INCLUDED_VRT_COLLECTION_INSERT_INSERT_FINISHED_IMPL_H*/

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -244,6 +244,14 @@ struct CollectionManager
   template <
     typename ColT,  mapping::ActiveMapTypedFnType<typename ColT::IndexType> fn
   >
+  CollectionProxyWrapType<ColT> constructCollective(typename ColT::IndexType range);
+
+  template <typename ColT>
+  CollectionProxyWrapType<ColT> constructCollective(typename ColT::IndexType range);
+
+  template <
+    typename ColT,  mapping::ActiveMapTypedFnType<typename ColT::IndexType> fn
+  >
   CollectionProxyWrapType<ColT> constructCollective(
     typename ColT::IndexType range, DistribConstructFn<ColT> cons_fn,
     TagType const& tag = no_tag

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -1600,11 +1600,13 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] idx the index to insert
    * \param[in] node the node to insert on
+   * \param[in] msg_insert_epoch the insert epoch on the message
    */
   template <typename ColT, typename IndexT = typename ColT::IndexType>
   void insert(
     CollectionProxyWrapType<ColT,IndexT> const& proxy, IndexT idx,
-    NodeType const& node = uninitialized_destination
+    NodeType const& node = uninitialized_destination,
+    EpochType msg_insert_epoch = no_epoch
   );
 
   /**

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -1662,9 +1662,9 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] insert_action action to execute after insertions complete
    */
-  template <typename ColT, typename IndexT = typename ColT::IndexType>
+  template <typename ColT>
   void finishedInserting(
-    CollectionProxyWrapType<ColT,IndexT> const& proxy,
+    CollectionProxyWrapType<ColT> const& proxy,
     ActionType insert_action = nullptr
   );
 
@@ -1673,9 +1673,9 @@ public:
    *
    * \param[in] proxy the proxy for the collection
    */
-  template <typename ColT, typename IndexT = typename ColT::IndexType>
+  template <typename ColT>
   void startInsertCollective(
-    CollectionProxyWrapType<ColT,IndexT> const& proxy
+    CollectionProxyWrapType<ColT> const& proxy
   );
 
   /**
@@ -1683,9 +1683,9 @@ public:
    *
    * \param[in] proxy the proxy for the collection
    */
-  template <typename ColT, typename IndexT = typename ColT::IndexType>
+  template <typename ColT>
   void finishInsertCollective(
-    CollectionProxyWrapType<ColT,IndexT> const& proxy
+    CollectionProxyWrapType<ColT> const& proxy
   );
 
   /**
@@ -1697,15 +1697,16 @@ public:
   void addCleanupFn(VirtualProxyType proxy);
 
 private:
+
   /**
    * \internal \brief Finish insertion epoch
    *
    * \param[in] proxy the collection proxy
    * \param[in] insert_epoch insert epoch
    */
-  template <typename ColT, typename IndexT = typename ColT::IndexType>
+  template <typename ColT>
   void finishedInsertEpoch(
-    CollectionProxyWrapType<ColT,IndexT> const& proxy,
+    CollectionProxyWrapType<ColT> const& proxy,
     EpochType const& insert_epoch
   );
 

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -1669,6 +1669,26 @@ public:
   );
 
   /**
+   * \brief Starting inserting elements in a collection collectively
+   *
+   * \param[in] proxy the proxy for the collection
+   */
+  template <typename ColT, typename IndexT = typename ColT::IndexType>
+  void startInsertCollective(
+    CollectionProxyWrapType<ColT,IndexT> const& proxy
+  );
+
+  /**
+   * \brief Finished inserting elements in a collection collectively
+   *
+   * \param[in] proxy the proxy for the collection
+   */
+  template <typename ColT, typename IndexT = typename ColT::IndexType>
+  void finishInsertCollective(
+    CollectionProxyWrapType<ColT,IndexT> const& proxy
+  );
+
+  /**
    * \internal \brief Add a cleanup function for a collection after destruction
    *
    * \param[in] proxy the collection proxy bits

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -303,6 +303,25 @@ struct CollectionManager
   );
 
 private:
+
+  /**
+   * \internal \brief Construct an element on this node
+   *
+   * \param[in] proxy the collection proxy
+   * \param[in] cur_idx the index to construct
+   * \param[in] range the range for the collection
+   * \param[in] map_han the map handler
+   * \param[in] map_fn the map function
+   * \param[in] user_construct_fn the construct function
+   */
+  template <typename ColT>
+  void constructElement(
+    VirtualProxyType proxy, typename ColT::IndexType cur_idx,
+    typename ColT::IndexType range, HandlerType map_han,
+    auto_registry::AutoActiveMapType map_fn,
+    DistribConstructFn<ColT> user_construct_fn
+  );
+
   /**
    * \internal \brief Insert into a collection on this node
    *

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -311,15 +311,14 @@ private:
    * \param[in] cur_idx the index to construct
    * \param[in] range the range for the collection
    * \param[in] map_han the map handler
-   * \param[in] map_fn the map function
    * \param[in] user_construct_fn the construct function
+   * \param[in] mapped_node mapped node for the element
    */
   template <typename ColT>
   void constructElement(
     VirtualProxyType proxy, typename ColT::IndexType cur_idx,
     typename ColT::IndexType range, HandlerType map_han,
-    auto_registry::AutoActiveMapType map_fn,
-    DistribConstructFn<ColT> user_construct_fn
+    DistribConstructFn<ColT> user_construct_fn, NodeType mapped_node
   );
 
   /**

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1528,7 +1528,7 @@ CollectionManager::constructCollectiveMap(
   // collection
   theLocMan()->getCollectionLM<ColT, IndexT>(proxy);
 
-  auto const is_static = ColT::isStaticSized();
+  bool const is_static = ColT::isStaticSized();
 
   vt_debug_print(
     vrt_coll, node,

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1460,7 +1460,8 @@ bool CollectionManager::insertCollectionElement(
  */
 
 template <
-  typename ColT,  mapping::ActiveMapTypedFnType<typename ColT::IndexType> fn
+  typename ColT,
+  mapping::ActiveMapTypedFnType<typename ColT::IndexType> fn
 >
 CollectionManager::CollectionProxyWrapType<ColT>
 CollectionManager::constructCollective(typename ColT::IndexType range) {

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2310,10 +2310,8 @@ void CollectionManager::finishInsertCollective(
   vtAssert(insert_epoch != no_epoch, "Epoch should be valid");
 
   // Wait on the insert epoch, ensuring that insertions are complete
-  bool done = false;
-  theTerm()->addAction(insert_epoch, [&done] { done = true; });
   theTerm()->finishedEpoch(insert_epoch);
-  theSched()->runSchedulerWhile([&done] { return not done; });
+  vt::runSchedulerThrough(insert_epoch);
 
   // Reset the insert epoch to none so no insertions can be completed until \c
   // startInsertCollective in invoked

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2482,6 +2482,12 @@ void CollectionManager::insert(
       auto const this_node = theContext()->getNode();
       auto cur_idx = idx;
 
+      vt_debug_print(
+        vrt_coll, node,
+        "insert: proxy={:x}, insert_node={}\n",
+        untyped_proxy, insert_node
+      );
+
       if (insert_node == this_node) {
         auto const& num_elms = max_idx.getSize();
         std::tuple<> tup;
@@ -2514,6 +2520,12 @@ void CollectionManager::insert(
         // Clear the current index context
         IdxContextHolder::clear();
       } else {
+        vtAssertInfo(
+          insert_node >= 0 and insert_node < theContext()->getNumNodes(),
+          "Invalid insert node",
+          insert_node
+        );
+
         auto msg = makeMessage<InsertMsg<ColT,IndexT>>(
           proxy,max_idx,idx,insert_node,mapped_node,insert_epoch,cur_epoch
         );

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2115,7 +2115,7 @@ void CollectionManager::setupNextInsertTrigger(
       "insert finished insert trigger: epoch={}\n",
       insert_epoch
     );
-    theCollection()->finishedInsertEpoch<ColT,IndexT>(proxy,insert_epoch);
+    theCollection()->finishedInsertEpoch<ColT>(proxy,insert_epoch);
   };
   auto start_detect = [insert_epoch,finished_insert_trigger]{
     vt_debug_print(
@@ -2137,10 +2137,12 @@ void CollectionManager::setupNextInsertTrigger(
   }
 }
 
-template <typename ColT, typename IndexT>
+template <typename ColT>
 void CollectionManager::finishedInsertEpoch(
-  CollectionProxyWrapType<ColT,IndexT> const& proxy, EpochType const& epoch
+  CollectionProxyWrapType<ColT> const& proxy, EpochType const& epoch
 ) {
+  using IndexT = typename ColT::IndexType;
+
   auto const& untyped_proxy = proxy.getProxy();
 
   vt_debug_print(
@@ -2274,24 +2276,24 @@ template <typename ColT, typename IndexT>
         ActInsertMsg<ColT,IndexT>,actInsertHandler<ColT,IndexT>
       >(node,smsg.get());
     };
-    return theCollection()->finishedInserting<ColT,IndexT>(msg->proxy_, send);
+    return theCollection()->finishedInserting<ColT>(msg->proxy_, send);
   } else {
-    return theCollection()->finishedInserting<ColT,IndexT>(msg->proxy_);
+    return theCollection()->finishedInserting<ColT>(msg->proxy_);
   }
 }
 
-template <typename ColT, typename IndexT>
+template <typename ColT>
 void CollectionManager::startInsertCollective(
-  CollectionProxyWrapType<ColT,IndexT> const& proxy
+  CollectionProxyWrapType<ColT> const& proxy
 ) {
   auto const untyped_proxy = proxy.getProxy();
   auto insert_ep = theTerm()->makeEpochCollective("startInsertCollective");
   UniversalIndexHolder<>::insertSetEpoch(untyped_proxy, insert_ep);
 }
 
-template <typename ColT, typename IndexT>
+template <typename ColT>
 void CollectionManager::finishInsertCollective(
-  CollectionProxyWrapType<ColT,IndexT> const& proxy
+  CollectionProxyWrapType<ColT> const& proxy
 ) {
   auto const untyped_proxy = proxy.getProxy();
 
@@ -2326,11 +2328,13 @@ void CollectionManager::finishInsertCollective(
   });
 }
 
-template <typename ColT, typename IndexT>
+template <typename ColT>
 void CollectionManager::finishedInserting(
-  CollectionProxyWrapType<ColT,IndexT> const& proxy,
+  CollectionProxyWrapType<ColT> const& proxy,
   ActionType insert_action
 ) {
+  using IndexT = typename ColT::IndexType;
+
   auto const& this_node = theContext()->getNode();
   auto const& untyped_proxy = proxy.getProxy();
   /*

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1459,9 +1459,28 @@ bool CollectionManager::insertCollectionElement(
  * user supplying the pointers to the elements.
  */
 
+template <
+  typename ColT,  mapping::ActiveMapTypedFnType<typename ColT::IndexType> fn
+>
+CollectionManager::CollectionProxyWrapType<ColT>
+CollectionManager::constructCollective(typename ColT::IndexType range) {
+  using IndexT = typename ColT::IndexType;
+  auto const& map_han = auto_registry::makeAutoHandlerMap<IndexT, fn>();
+  auto cons_fn = [](typename ColT::IndexType) { return std::make_unique<ColT>(); };
+  return constructCollectiveMap<ColT>(range,cons_fn,map_han,no_tag);
+}
+
 template <typename ColT>
 CollectionManager::CollectionProxyWrapType<ColT>
- CollectionManager::constructCollective(
+CollectionManager::constructCollective(typename ColT::IndexType range) {
+  auto const map_han = getDefaultMap<ColT>();
+  auto cons_fn = [](typename ColT::IndexType) { return std::make_unique<ColT>(); };
+  return constructCollectiveMap<ColT>(range,cons_fn,map_han,no_tag);
+}
+
+template <typename ColT>
+CollectionManager::CollectionProxyWrapType<ColT>
+CollectionManager::constructCollective(
   typename ColT::IndexType range, DistribConstructFn<ColT> cons_fn,
   TagType const& tag
 ) {

--- a/tests/unit/collection/test_collective_insertable.extended.cc
+++ b/tests/unit/collection/test_collective_insertable.extended.cc
@@ -80,8 +80,11 @@ TEST_F(TestCollectiveInsertable, test_collective_insertable_1) {
     proxy = vt::theCollection()->constructCollective<MyCol, &myMap>(range);
   });
 
-  // No elements should be created at this point
-  EXPECT_EQ(inserted_indices.size(), 0);
+  // No elements should be created at this point; this must be in a collective
+  // epoch so it doesn't race with future insert messages
+  vt::runInEpochCollective([&]{
+    EXPECT_EQ(inserted_indices.size(), 0);
+  });
 
   auto num_nodes = vt::theContext()->getNumNodes();
   auto this_node = vt::theContext()->getNode();

--- a/tests/unit/collection/test_collective_insertable.extended.cc
+++ b/tests/unit/collection/test_collective_insertable.extended.cc
@@ -1,0 +1,134 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                    test_collective_insertable.extended.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+
+#include <set>
+#include <cmath>
+
+namespace vt { namespace tests { namespace unit {
+
+std::set<vt::Index1D> inserted_indices;
+
+struct MyCol : vt::InsertableCollection<MyCol,Index1D> {
+  MyCol() { inserted_indices.insert(getIndex()); }
+};
+
+using TestCollectiveInsertable = TestParallelHarness;
+
+static constexpr int32_t const num_elms = 64;
+
+vt::NodeType myMap(vt::Index1D* idx, vt::Index1D* range, vt::NodeType) {
+  // block-like map
+  auto num_nodes = vt::theContext()->getNumNodes();
+  auto per_node = (NodeType)std::round((double)range->x() / num_nodes);
+  return (idx->x() / per_node) % num_nodes;
+}
+
+TEST_F(TestCollectiveInsertable, test_collective_insertable_1) {
+
+  vt::CollectionProxy<MyCol, vt::Index1D> proxy;
+
+  auto range = vt::Index1D(num_elms);
+
+  // Create the collection
+  vt::runInEpochCollective([&]{
+    proxy = vt::theCollection()->constructCollective<MyCol, &myMap>(range);
+  });
+
+  // No elements should be created at this point
+  EXPECT_EQ(inserted_indices.size(), 0);
+
+  auto num_nodes = vt::theContext()->getNumNodes();
+  auto this_node = vt::theContext()->getNode();
+
+  vt::runInEpochCollective([&]{
+    proxy.startInsertCollective();
+
+    // insert even elements
+    for (int i = 0; i < num_elms; i++) {
+      // round-robin dispatch, some inserts will occur off-node due to block map
+      if (i % 2 == 0 and i % num_nodes == this_node) {
+        proxy[i].insert();
+      }
+    }
+
+    proxy.finishInsertCollective();
+  });
+
+  // check that even elements, mapped here, exist!
+  for (int i = 0; i < num_elms; i++) {
+    vt::Index1D idx{i};
+    if (i % 2 == 0 and myMap(&idx, &range, 0) == this_node) {
+      EXPECT_NE(inserted_indices.find(idx), inserted_indices.end());
+    }
+  }
+
+  vt::runInEpochCollective([&]{
+    proxy.startInsertCollective();
+
+    // insert odd elements
+    for (int i = 0; i < num_elms; i++) {
+      if (i % 2 != 0 and i % num_nodes == this_node) {
+        proxy[i].insert();
+      }
+    }
+
+    proxy.finishInsertCollective();
+  });
+
+
+  // check that all elements exist!
+  for (int i = 0; i < num_elms; i++) {
+    vt::Index1D idx{i};
+    if (myMap(&idx, &range, 0) == this_node) {
+      EXPECT_NE(inserted_indices.find(idx), inserted_indices.end());
+    }
+  }
+}
+
+}}} // end namespace vt::tests::unit


### PR DESCRIPTION
Fixes #819

- Allow insertable collections to be created with 
  `theCollection()->constructCollective<ColT>`.
- Add new functionality for collective insertion epochs instead of the rooted ones currently implemented which are not as suitable for NimbleSM's use case.

- [x] Write tests for new functionality