### PR TITLE
796 Reduction Scoping

### DIFF
--- a/examples/group/group_collective.cc
+++ b/examples/group/group_collective.cc
@@ -87,14 +87,14 @@ int main(int argc, char** argv) {
       auto const& root_node = vt::theGroup()->groupRoot(group);
       auto const& is_default_group = vt::theGroup()->groupDefault(group);
       fmt::print(
-        "{}: Group is created: group={}, in_group={}, root={}, "
+        "{}: Group is created: group={:x}, in_group={}, root={}, "
         "is_default_group={}\n",
         this_node, group, in_group, root_node, is_default_group
       );
       if (in_group) {
         using Op = vt::collective::PlusOp<int>;
         auto msg = vt::makeMessage<ReduceMsg>(1);
-        vt::theGroup()->groupReduce(group)->reduce<Op, Print>(root, msg.get());
+        vt::theGroup()->groupReducer(group)->reduce<Op, Print>(root, msg.get());
       }
       if (this_node == 1) {
         auto msg = vt::makeMessage<HelloGroupMsg>();

--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -49,8 +49,8 @@
 namespace vt { namespace collective {
 
 CollectiveAlg::CollectiveAlg()
-  : tree::Tree(tree::tree_cons_tag_t),
-    reduce::Reduce(),
+  : reduce::ReduceManager(),
+    tree::Tree(tree::tree_cons_tag_t),
     barrier::Barrier()
 { }
 

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -50,7 +50,8 @@
 #include "vt/activefn/activefn.h"
 #include "vt/messaging/message.h"
 #include "vt/collective/barrier/barrier.h"
-#include "vt/collective/reduce/reduce.h"
+#include "vt/collective/reduce/reduce_manager.h"
+#include "vt/collective/reduce/operators/default_msg.h"
 #include "vt/collective/scatter/scatter.h"
 #include "vt/utils/hash/hash_tuple.h"
 #include "vt/runtime/component/component_pack.h"
@@ -65,7 +66,7 @@ constexpr CollectiveAlgType const fst_collective_alg = 1;
 
 struct CollectiveAlg :
     runtime::component::Component<CollectiveAlg>,
-    virtual reduce::Reduce,
+    virtual reduce::ReduceManager,
     virtual barrier::Barrier,
     virtual scatter::Scatter
 {
@@ -141,7 +142,7 @@ extern collective::CollectiveAlg *theCollective();
 
 } //end namespace vt
 
-#include "vt/collective/reduce/reduce.impl.h"
+#include "vt/collective/reduce/reduce_manager.impl.h"
 #include "vt/collective/scatter/scatter.impl.h"
 
 #endif /*INCLUDED_COLLECTIVE_COLLECTIVE_ALG_H*/

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -80,16 +80,16 @@ TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
 
   using CollectiveMsg = CollectiveAlg::CollectiveMsg;
   auto cb = theCB()->makeBcast<CollectiveMsg,&CollectiveAlg::runCollective>();
-
-  // Put this in a separate namespace
-  // @todo: broader issue: need to implement a better way to scope reductions
-  auto ident = 0xEFFFFFFFFFFFFFFF;
   auto msg = makeMessage<CollectiveMsg>(is_user_tag_, scope_, tag, collective_root);
 
   // The tag for the reduce is a combination of the scope and seq tag.
-  theCollective()->reduce<collective::None>(
-    collective_root, msg.get(), cb, scope_, no_seq_id, 1, ident, tag
-  );
+  auto r = theCollective()->reducer();
+
+  using collective::reduce::makeStamp;
+  using collective::reduce::TagPair;
+
+  auto stamp = makeStamp<TagPair>(scope_, tag);
+  r->reduce<collective::None>(collective_root, msg.get(), cb, stamp);
 
   return tag;
 }

--- a/src/vt/collective/reduce/reduce.cc
+++ b/src/vt/collective/reduce/reduce.cc
@@ -51,8 +51,10 @@
 
 namespace vt { namespace collective { namespace reduce {
 
-Reduce::Reduce()
-  : tree::Tree(tree::tree_cons_tag_t)
+Reduce::Reduce(detail::ReduceScope const& in_scope)
+  : tree::Tree(tree::tree_cons_tag_t),
+    scope_(in_scope),
+    next_seq_(1)
 {
   debug_print(
     reduce, node,
@@ -61,14 +63,24 @@ Reduce::Reduce()
   );
 }
 
-Reduce::Reduce(GroupType const& group, collective::tree::Tree* in_tree)
-  : tree::Tree(*in_tree), group_(group)
+Reduce::Reduce(
+  detail::ReduceScope const& in_scope, collective::tree::Tree* in_tree
+) : tree::Tree(*in_tree),
+    scope_(in_scope),
+    next_seq_(1)
 {
   debug_print(
     reduce, node,
-    "Reduce constructor: children={}, parent={}, group={:x}\n",
-    getNumChildren(), getParent(), group
+    "Reduce constructor: children={}, parent={}\n",
+    getNumChildren(), getParent()
   );
+}
+
+detail::ReduceStamp Reduce::generateNextID() {
+  ++next_seq_;
+  detail::ReduceStamp stamp;
+  stamp.init<detail::StrongSeq>(next_seq_);
+  return stamp;
 }
 
 }}} /* end namespace vt::collective::reduce */

--- a/src/vt/collective/reduce/reduce_hash.h
+++ b/src/vt/collective/reduce/reduce_hash.h
@@ -45,44 +45,27 @@
 #if !defined INCLUDED_COLLECTIVE_REDUCE_REDUCE_HASH_H
 #define INCLUDED_COLLECTIVE_REDUCE_REDUCE_HASH_H
 
-#include "vt/config.h"
+#include "vt/collective/reduce/reduce_scope.h"
 
 #include <tuple>
 
 namespace vt { namespace collective { namespace reduce {
 
-using ReduceIdentifierType =
-  std::tuple<TagType,SequentialIDType,VirtualProxyType,ObjGroupProxyType>;
-using ReduceSeqLookupType =
-  std::tuple<VirtualProxyType,TagType,ObjGroupProxyType>;
+using ReduceVirtualIDType =
+  std::tuple<collective::reduce::ReduceStamp,VirtualProxyType>;
 
 }}} /* end namespace vt::collective::reduce */
 
 namespace std {
 
-using ReduceIDType = ::vt::collective::reduce::ReduceIdentifierType;
-using ReduceLookupType = ::vt::collective::reduce::ReduceSeqLookupType;
-
 template <>
-struct hash<ReduceIDType> {
-  size_t operator()(ReduceIDType const& in) const {
-    auto const& combined =
-      std::hash<vt::TagType>()(std::get<0>(in)) ^
-      std::hash<vt::SequentialIDType>()(std::get<1>(in)) ^
-      std::hash<vt::VirtualProxyType>()(std::get<2>(in)) ^
-      std::hash<vt::ObjGroupProxyType>()(std::get<3>(in));
-    return combined;
-  }
-};
-
-template <>
-struct hash<ReduceLookupType> {
-  size_t operator()(ReduceLookupType const& in) const {
-    auto const& combined =
-      std::hash<vt::VirtualProxyType>()(std::get<0>(in)) ^
-      std::hash<vt::TagType>()(std::get<1>(in)) ^
-      std::hash<vt::ObjGroupProxyType>()(std::get<2>(in));
-    return combined;
+struct hash<vt::collective::reduce::ReduceVirtualIDType> {
+  size_t operator()(
+    vt::collective::reduce::ReduceVirtualIDType const& in
+  ) const {
+    return
+      std::hash<vt::collective::reduce::ReduceStamp>()(std::get<0>(in)) ^
+      std::hash<vt::VirtualProxyType>()(std::get<1>(in));
   }
 };
 

--- a/src/vt/collective/reduce/reduce_msg.h
+++ b/src/vt/collective/reduce/reduce_msg.h
@@ -47,6 +47,7 @@
 
 #include "vt/config.h"
 #include "vt/collective/reduce/reduce.fwd.h"
+#include "vt/collective/reduce/reduce_scope.h"
 #include "vt/messaging/message.h"
 
 #include <cstdlib>
@@ -82,18 +83,17 @@ struct ReduceMsg : SerializeSupported<
     ReduceMsg
   >;
 
+  ReduceStamp const& stamp() const { return reduce_id_.stamp(); }
+  detail::ReduceScope const& scope() const { return reduce_id_.scope(); }
+
   NodeType reduce_root_ = uninitialized_destination;
-  TagType reduce_tag_ = no_tag;
-  SequentialIDType reduce_seq_ = no_seq_id;
-  VirtualProxyType reduce_proxy_ = no_vrt_proxy;
-  ObjGroupProxyType reduce_objgroup_ = no_obj_group;
+  detail::ReduceIDImpl reduce_id_;
   HandlerType combine_handler_ = uninitialized_handler;
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
     MessageParentType::serialize(s);
-    s | reduce_root_ | reduce_tag_ | reduce_seq_ | reduce_proxy_;
-    s | reduce_objgroup_;
+    s | reduce_root_ | reduce_id_;
     s | combine_handler_;
   }
 };

--- a/src/vt/collective/reduce/reduce_scope.h
+++ b/src/vt/collective/reduce/reduce_scope.h
@@ -1,0 +1,276 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                reduce_scope.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_COLLECTIVE_REDUCE_REDUCE_SCOPE_H
+#define INCLUDED_VT_COLLECTIVE_REDUCE_REDUCE_SCOPE_H
+
+#include "vt/collective/reduce/scoping/strong_types.h"
+#include "vt/utils/adt/union.h"
+
+namespace vt { namespace collective { namespace reduce { namespace detail {
+
+/**
+ * \struct ReduceScope
+ *
+ * \brief A unique scope for reduction operations, identified by the obj group
+ * proxy, virtual proxy, group ID, or component ID.
+ */
+struct ReduceScope {
+  using ValueType = vt::adt::SafeUnion<
+    StrongObjGroup, StrongVrtProxy, StrongGroup, StrongCom, StrongUserID
+  >;
+
+  ReduceScope() = default;
+
+  bool operator==(ReduceScope const& in) const {
+    return in.l0_ == l0_;
+  }
+  bool operator!=(ReduceScope const& in) const {
+    return !(this->operator==(in));
+  }
+
+  ValueType& get() { return l0_; }
+  ValueType const& get() const { return l0_; }
+
+  template <typename T, typename... Args>
+  friend ReduceScope makeScope(Args&&... args);
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | l0_;
+  }
+
+  std::string str() const {
+    if (l0_.is<StrongObjGroup>()) {
+      return fmt::format("objgroup[{:x}]", l0_.get<StrongObjGroup>().get());
+    } else if (l0_.is<StrongVrtProxy>()) {
+      return fmt::format("vrtproxy[{:x}]", l0_.get<StrongVrtProxy>().get());
+    } else if (l0_.is<StrongGroup>()) {
+      return fmt::format("group[{:x}]", l0_.get<StrongGroup>().get());
+    } else if (l0_.is<StrongCom>()) {
+      return fmt::format("component[{}]", l0_.get<StrongCom>().get());
+    } else if (l0_.is<StrongUserID>()) {
+      return fmt::format("userID[{}]", l0_.get<StrongUserID>().get());
+    } else {
+      return "<unknown-type>";
+    }
+  }
+
+private:
+  ValueType l0_;
+};
+
+/**
+ * \brief Create a new reduction scope
+ *
+ * \param[in] args constructor for reduction scope type
+ *
+ * \return the new scope
+ */
+template <typename T, typename... Args>
+inline ReduceScope makeScope(Args&&... args);
+
+/**
+ * \brief Reduction stamp bits to identify a specific instance of a reduction.
+ */
+using ReduceStamp = vt::adt::SafeUnion<
+  StrongTag, TagPair, StrongSeq, StrongUserID, StrongEpoch
+>;
+
+/**
+ * \brief Stringize a \c ReduceStamp
+ *
+ * \param[in] stamp the reduction stamp
+ *
+ * \return a string
+ */
+inline std::string stringizeStamp(ReduceStamp const& stamp);
+
+/**
+ * \internal \struct ReduceIDImpl
+ *
+ * \brief Sent in all reduction messages to identify the scope and reduction
+ * stamp so it gets merged with the right data.
+ */
+struct ReduceIDImpl {
+  ReduceIDImpl() = default;
+  ReduceIDImpl(ReduceIDImpl const&) = default;
+  ReduceIDImpl(ReduceIDImpl&&) = default;
+
+  ReduceIDImpl& operator=(ReduceIDImpl const& in) = default;
+
+  ReduceIDImpl(ReduceStamp const& in_stamp, ReduceScope const& in_scope)
+    : stamp_(in_stamp),
+      scope_(in_scope)
+  { }
+
+  bool operator==(ReduceIDImpl const& in) const {
+    return in.stamp_ == stamp_ and in.scope_ == scope_;
+  }
+  bool operator!=(ReduceIDImpl const& in) const {
+    return !(this->operator==(in));
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | stamp_ | scope_;
+  }
+
+  ReduceStamp const& stamp() const { return stamp_; }
+  ReduceScope const& scope() const { return scope_; }
+
+protected:
+  ReduceStamp stamp_;
+  ReduceScope scope_;
+};
+
+static_assert(
+  std::is_trivially_destructible<ReduceStamp>::value,
+  "Must be trivially destructible"
+);
+static_assert(
+  std::is_trivially_copyable<ReduceStamp>::value,
+  "Must be trivially copyable"
+);
+
+static_assert(
+  std::is_trivially_destructible<ReduceScope>::value,
+  "Must be trivially destructible"
+);
+static_assert(
+  std::is_trivially_copyable<ReduceScope>::value,
+  "Must be trivially copyable"
+);
+
+static_assert(
+  std::is_trivially_destructible<ReduceIDImpl>::value,
+  "Must be trivially destructible"
+);
+static_assert(
+  std::is_trivially_copyable<ReduceIDImpl>::value,
+  "Must be trivially copyable"
+);
+
+/**
+ * \internal \struct ReduceScopeHolder
+ *
+ * \brief Holds instances of reducers indexed by the reduction scope bits.
+ */
+template <typename T>
+struct ReduceScopeHolder {
+  using DefaultCreateFunction = std::function<T(detail::ReduceScope const&)>;
+
+  explicit ReduceScopeHolder(DefaultCreateFunction in_default_creator)
+    : default_creator_(in_default_creator)
+  { }
+
+  T& get(ReduceScope const& scope);
+
+  template <typename U>
+  T& getOnDemand(U&& scope);
+
+  struct ObjGroupTag { };
+  struct VrtProxyTag { };
+  struct GroupTag { };
+  struct ComponentTag { };
+  struct UserIDTag { };
+
+  T& get(ObjGroupTag, ObjGroupProxyType proxy);
+  T& get(VrtProxyTag, VirtualProxyType proxy);
+  T& get(GroupTag, GroupType group);
+  T& get(ComponentTag, ComponentIDType component_id);
+  T& get(UserIDTag, UserIDType user_id);
+
+  void make(ObjGroupTag, ObjGroupProxyType proxy);
+  void make(GroupTag, GroupType group, DefaultCreateFunction fn);
+
+private:
+  DefaultCreateFunction default_creator_ = nullptr;
+  std::unordered_map<ReduceScope, T> scopes_;
+};
+
+}}}} /* end namespace vt::collective::reduce::detail */
+
+namespace vt { namespace collective { namespace reduce {
+
+using ReduceStamp = detail::ReduceStamp;
+using UserIDType = detail::UserIDType;
+using StrongUserID = detail::StrongUserID;
+using StrongEpoch = detail::StrongEpoch;
+using TagPair = detail::TagPair;
+
+/**
+ * \brief Create a new reduction stamp
+ *
+ * \param[in] args args to the stamp type constructor
+ *
+ * \return a new reduction stamp
+ */
+template <typename T, typename... Args>
+ReduceStamp makeStamp(Args&&... args) {
+  ReduceStamp stamp;
+  stamp.init<T>(std::forward<Args>(args)...);
+  return stamp;
+}
+
+}}} /* end namespace vt::collective::reduce */
+
+namespace std {
+
+template <>
+struct hash<vt::collective::reduce::detail::ReduceScope> {
+  size_t operator()(
+    vt::collective::reduce::detail::ReduceScope const& in
+  ) const {
+    using ValueType =
+      typename vt::collective::reduce::detail::ReduceScope::ValueType;
+    return std::hash<ValueType>()(in.get());
+  }
+};
+
+} /* end namespace std */
+
+#include "vt/collective/reduce/reduce_scope.impl.h"
+
+#endif /*INCLUDED_VT_COLLECTIVE_REDUCE_REDUCE_SCOPE_H*/

--- a/src/vt/collective/reduce/reduce_scope.impl.h
+++ b/src/vt/collective/reduce/reduce_scope.impl.h
@@ -1,0 +1,159 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                             reduce_scope.impl.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_COLLECTIVE_REDUCE_REDUCE_SCOPE_IMPL_H
+#define INCLUDED_VT_COLLECTIVE_REDUCE_REDUCE_SCOPE_IMPL_H
+
+#include "vt/config.h"
+
+namespace vt { namespace collective { namespace reduce { namespace detail {
+
+template <typename T, typename... Args>
+inline ReduceScope makeScope(Args&&... args) {
+  ReduceScope scope;
+  scope.l0_.init<T>(std::forward<Args>(args)...);
+  return scope;
+}
+
+inline std::string stringizeStamp(ReduceStamp const& stamp) {
+  if (stamp.is<StrongTag>()) {
+    return fmt::format("tag[{}]", stamp.get<StrongTag>().get());
+  } else if (stamp.is<TagPair>()) {
+    return fmt::format(
+      "tagPair[{},{}]",
+      stamp.get<TagPair>().first(),
+      stamp.get<TagPair>().second()
+    );
+  } else if (stamp.is<StrongSeq>()) {
+    return fmt::format("seq[{}]", stamp.get<StrongSeq>().get());
+  } else if (stamp.is<StrongUserID>()) {
+    return fmt::format("userID[{}]", stamp.get<StrongUserID>().get());
+  } else if (stamp.is<StrongEpoch>()) {
+    return fmt::format("epoch[{:x}]", stamp.get<StrongEpoch>().get());
+  } else {
+    return "<no-stamp>";
+  }
+}
+
+template <typename T>
+T& ReduceScopeHolder<T>::get(ReduceScope const& scope) {
+  debug_print(
+    reduce, node,
+    "ReduceScopeHolder get scope={}\n",
+    scope.str()
+  );
+
+  auto iter = scopes_.find(scope);
+  vtAssert(iter != scopes_.end(), "Scope must exist");
+  return iter->second;
+}
+
+template <typename T>
+template <typename U>
+T& ReduceScopeHolder<T>::getOnDemand(U&& scope) {
+  auto iter = scopes_.find(scope);
+  if (iter == scopes_.end()) {
+    vtAssert(
+      not scope.get().template is<StrongGroup>(),
+      "Group reducers cannot be on-demand created -- needs spanning tree"
+    );
+
+    iter = scopes_.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(scope),
+      std::forward_as_tuple(default_creator_(scope))
+    ).first;
+  }
+
+  vtAssert(iter != scopes_.end(), "Scope must exist");
+
+  return iter->second;
+}
+
+template <typename T>
+T& ReduceScopeHolder<T>::get(ObjGroupTag, ObjGroupProxyType proxy) {
+  return getOnDemand(makeScope<StrongObjGroup>(proxy));
+}
+
+template <typename T>
+T& ReduceScopeHolder<T>::get(VrtProxyTag, VirtualProxyType proxy) {
+  return getOnDemand(makeScope<StrongVrtProxy>(proxy));
+}
+
+template <typename T>
+T& ReduceScopeHolder<T>::get(GroupTag, GroupType group) {
+  return get(makeScope<StrongGroup>(group));
+}
+
+template <typename T>
+T& ReduceScopeHolder<T>::get(ComponentTag, ComponentIDType component_id) {
+  return getOnDemand(makeScope<StrongCom>(component_id));
+}
+
+template <typename T>
+T& ReduceScopeHolder<T>::get(UserIDTag, UserIDType user_id) {
+  return getOnDemand(makeScope<StrongUserID>(user_id));
+}
+
+template <typename T>
+void ReduceScopeHolder<T>::make(ObjGroupTag, ObjGroupProxyType proxy) {
+  getOnDemand(makeScope<StrongObjGroup>(proxy));
+}
+
+template <typename T>
+void ReduceScopeHolder<T>::make(
+  GroupTag, GroupType group, DefaultCreateFunction fn
+) {
+  ReduceScope scope = makeScope<StrongGroup>(group);
+  scopes_.emplace(
+    std::piecewise_construct,
+    std::forward_as_tuple(scope),
+    std::forward_as_tuple(fn(scope))
+  );
+}
+
+
+}}}} /* end namespace vt::collective::reduce::detail */
+
+#endif /*INCLUDED_VT_COLLECTIVE_REDUCE_REDUCE_SCOPE_IMPL_H*/

--- a/src/vt/collective/reduce/reduce_state.h
+++ b/src/vt/collective/reduce/reduce_state.h
@@ -54,19 +54,15 @@
 
 namespace vt { namespace collective { namespace reduce {
 
-template <typename T>
 struct ReduceState {
   using ReduceNumType = int32_t;
-  using ReduceVecType = std::vector<MsgSharedPtr<T>>;
+  using ReduceVecType = std::vector<MsgSharedPtr<ReduceMsg>>;
 
-  ReduceState(
-    TagType in_tag_, SequentialIDType in_seq_id_, ReduceNumType in_num_contrib
-  ) : tag_(in_tag_), seq_id_(in_seq_id_), num_contrib_(in_num_contrib)
+  explicit ReduceState(ReduceNumType in_num_contrib)
+    : num_contrib_(in_num_contrib)
   { }
 
   ReduceVecType msgs               = {};
-  TagType tag_                     = no_tag;
-  SequentialIDType seq_id_         = no_seq_id;
   ReduceNumType num_contrib_       = 1;
   ReduceNumType num_local_contrib_ = 0;
   HandlerType combine_handler_     = uninitialized_handler;

--- a/src/vt/collective/reduce/reduce_state_holder.h
+++ b/src/vt/collective/reduce/reduce_state_holder.h
@@ -47,36 +47,29 @@
 
 #include "vt/config.h"
 #include "vt/collective/reduce/reduce_state.h"
-#include "vt/collective/reduce/reduce_hash.h"
+#include "vt/collective/reduce/reduce_scope.h"
 
 #include <unordered_map>
 
 namespace vt { namespace collective { namespace reduce {
 
-template <typename T>
 struct ReduceStateHolder {
-  using ReduceIDType    = ReduceIdentifierType;
-  using ReduceStateType = ReduceState<T>;
-  using LookupType      = std::unordered_map<ReduceIDType,ReduceStateType>;
-  using GroupLookupType = std::unordered_map<GroupType, LookupType>;
+  using ReduceIDType    = detail::ReduceStamp;
+  using ReduceStateType = ReduceState;
 
 public:
-  static bool exists(GroupType group, ReduceIDType const& id);
+  bool exists(ReduceIDType const& id);
 
-  static ReduceStateType& find(GroupType group, ReduceIDType const& id);
+  ReduceStateType& find(ReduceIDType const& id);
 
-  static void erase(GroupType group, ReduceIDType const& id);
+  void erase(ReduceIDType const& id);
 
-  static void insert(
-    GroupType group, ReduceIDType const& id, ReduceStateType&& state
-  );
+  void insert(ReduceIDType const& id, ReduceStateType&& state);
 
 private:
-  static GroupLookupType state_lookup_;
+  std::unordered_map<detail::ReduceStamp, ReduceState> state_lookup_;
 };
 
 }}} /* end namespace vt::collective::reduce */
-
-#include "vt/collective/reduce/reduce_state_holder.impl.h"
 
 #endif /*INCLUDED_VT_COLLECTIVE_REDUCE_REDUCE_STATE_HOLDER_H*/

--- a/src/vt/collective/reduce/scoping/strong_types.h
+++ b/src/vt/collective/reduce/scoping/strong_types.h
@@ -1,0 +1,127 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                strong_types.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_COLLECTIVE_REDUCE_SCOPING_STRONG_TYPES_H
+#define INCLUDED_VT_COLLECTIVE_REDUCE_SCOPING_STRONG_TYPES_H
+
+#include "vt/configs/types/types_type.h"
+#include "vt/configs/types/types_sentinels.h"
+#include "vt/collective/reduce/scoping/strong.h"
+
+namespace vt { namespace collective { namespace reduce { namespace detail {
+
+using UserIDType = uint64_t;
+
+namespace tags {
+
+struct TagTag {};
+struct SeqTag {};
+struct ObjGroupTag {};
+struct VrtProxyTag {};
+struct GroupTag {};
+struct ComponentTag {};
+struct UserIDTag {};
+struct EpochTag {};
+
+} /* end namespace tags */
+
+using StrongTag      = Strong<TagType,           no_tag,       tags::TagTag>;
+using StrongSeq      = Strong<SequentialIDType,  no_seq_id,    tags::SeqTag>;
+using StrongObjGroup = Strong<ObjGroupProxyType, no_obj_group, tags::ObjGroupTag>;
+using StrongVrtProxy = Strong<VirtualProxyType,  no_vrt_proxy, tags::VrtProxyTag>;
+using StrongGroup    = Strong<GroupType,         no_group,     tags::GroupTag>;
+using StrongCom      = Strong<ComponentIDType,   u32empty,     tags::ComponentTag>;
+using StrongUserID   = Strong<UserIDType,        u64empty,     tags::UserIDTag>;
+using StrongEpoch    = Strong<EpochType,         no_epoch,     tags::EpochTag>;
+
+/**
+ * \struct TagPair
+ *
+ * \brief Holds a pair of tags, which can be used to identify a reduction
+ * instance
+ */
+struct TagPair {
+  TagPair() = default;
+  TagPair(TagType in_t1, TagType in_t2)
+    : t1_(in_t1), t2_(in_t2)
+  { }
+
+  bool operator==(TagPair const& in) const {
+    return in.first() == first() and in.second() == second();
+  }
+
+  bool operator!=(TagPair const& in) const {
+    return !(this->operator==(in));
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | t1_ | t2_;
+  }
+
+  TagType first() const { return t1_; }
+  TagType second() const { return t2_; }
+
+private:
+  TagType t1_ = no_tag;
+  TagType t2_ = no_tag;
+};
+
+}}}} /* end namespace vt::collective::reduce::detail */
+
+namespace std {
+
+template <>
+struct hash<vt::collective::reduce::detail::TagPair> {
+  size_t operator()(
+    vt::collective::reduce::detail::TagPair const& in
+  ) const {
+    return std::hash<vt::TagType>()(in.first()) ^
+           std::hash<vt::TagType>()(in.second());
+  }
+};
+
+} /* end namespace std */
+
+#endif /*INCLUDED_VT_COLLECTIVE_REDUCE_SCOPING_STRONG_TYPES_H*/

--- a/src/vt/configs/types/types_type.h
+++ b/src/vt/configs/types/types_type.h
@@ -114,6 +114,8 @@ using ObjGroupProxyType       = uint64_t;
 using PriorityType            = uint16_t;
 /// Used for hold the level for a priority of a message
 using PriorityLevelType       = uint8_t;
+/// Used for hold a unique ID for each component
+using ComponentIDType         = uint32_t;
 
 // Action types for attaching a closure to a runtime function
 /// Used for generically store an action to perform

--- a/src/vt/group/collective/group_collective.h
+++ b/src/vt/group/collective/group_collective.h
@@ -61,7 +61,7 @@ struct GroupCollective {
   using TreePtrType = std::unique_ptr<TreeType>;
   using NodeListType = TreeType::NodeListType;
   using ReduceType = collective::reduce::Reduce;
-  using ReducePtrType = std::unique_ptr<ReduceType>;
+  using ReducePtrType = ReduceType*;
 
   explicit GroupCollective()
     : init_span_(

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -128,14 +128,14 @@ bool GroupManager::inGroup(GroupType const& group) {
   return iter->second->inGroup();
 }
 
-GroupManager::ReducePtrType GroupManager::groupReduce(GroupType const& group) {
+GroupManager::ReducePtrType GroupManager::groupReducer(GroupType const& group) {
   auto iter = local_collective_group_info_.find(group);
   vtAssert(iter != local_collective_group_info_.end(), "Must exist");
   auto const& is_default_group = iter->second->isGroupDefault();
   if (!is_default_group) {
     return iter->second->getReduce();
   } else {
-    return theCollective();
+    return theCollective()->global();
   }
 }
 

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -168,7 +168,7 @@ private:
   );
 
 public:
-  ReducePtrType groupReduce(GroupType const& group);
+  ReducePtrType groupReducer(GroupType const& group);
   NodeType groupRoot(GroupType const& group) const;
   bool groupDefault(GroupType const& group) const;
 

--- a/src/vt/lb/instrumentation/centralized/collect.cc
+++ b/src/vt/lb/instrumentation/centralized/collect.cc
@@ -148,9 +148,10 @@ namespace vt { namespace lb { namespace instrumentation {
 /*static*/ void CentralCollect::startReduce(LBPhaseType const& phase) {
   auto const& root = CentralCollect::collect_root_;
   auto msg = CentralCollect::collectStats(phase);
-  theCollective()->reduce<CollectMsg, CentralCollect::centralizedCollect>(
-    root, msg
-  );
+  theCollective()->global()->
+    reduce<CollectMsg, CentralCollect::centralizedCollect>(
+      root, msg
+    );
 }
 
 /*static*/ LBPhaseType CentralCollect::currentPhase() {

--- a/src/vt/objgroup/manager.h
+++ b/src/vt/objgroup/manager.h
@@ -143,8 +143,9 @@ struct ObjGroupManager : runtime::component::Component<ObjGroupManager> {
    */
 
   template <typename ObjT, typename MsgT, ActiveTypedFnType<MsgT> *f>
-  EpochType reduce(
-    ProxyType<ObjT> proxy, MsgSharedPtr<MsgT> msg, EpochType epoch, TagType tag
+  void reduce(
+    ProxyType<ObjT> proxy, MsgSharedPtr<MsgT> msg,
+    collective::reduce::ReduceStamp const& stamp
   );
 
   /*

--- a/src/vt/objgroup/manager.impl.h
+++ b/src/vt/objgroup/manager.impl.h
@@ -287,15 +287,15 @@ void ObjGroupManager::broadcast(MsgSharedPtr<MsgT> msg, HandlerType han) {
 }
 
 template <typename ObjT, typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType ObjGroupManager::reduce(
-  ProxyType<ObjT> proxy, MsgSharedPtr<MsgT> msg, EpochType epoch, TagType tag
+void ObjGroupManager::reduce(
+  ProxyType<ObjT> proxy, MsgSharedPtr<MsgT> msg,
+  collective::reduce::ReduceStamp const& stamp
 ) {
   auto const root = 0;
-  auto const contrib = 1;
   auto const objgroup = proxy.getProxy();
-  return theCollective()->reduce<MsgT,f>(
-    root, msg.get(), tag, epoch, contrib, no_vrt_proxy, objgroup
-  );
+
+  auto r = theCollective()->getReducerObjGroup(objgroup);
+  r->template reduce<MsgT,f>(root, msg.get(), stamp);
 }
 
 template <typename ObjT>

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -54,6 +54,7 @@
 #include "vt/pipe/pipe_callback_only.h"
 #include "vt/collective/reduce/operators/functors/none_op.h"
 #include "vt/collective/reduce/operators/callback_op.h"
+#include "vt/collective/reduce/reduce_scope.h"
 #include "vt/utils/static_checks/msg_ptr.h"
 #include "vt/rdmahandle/handle.fwd.h"
 #include "vt/rdmahandle/handle_set.fwd.h"
@@ -62,6 +63,7 @@ namespace vt { namespace objgroup { namespace proxy {
 
 template <typename ObjT>
 struct Proxy {
+  using ReduceStamp = collective::reduce::ReduceStamp;
 
   Proxy() = default;
   Proxy(Proxy const&) = default;
@@ -96,9 +98,8 @@ public:
       MsgT, OpT, collective::reduce::operators::ReduceCallback<MsgT>
     >
   >
-  EpochType reduce(
-    MsgPtrT msg, Callback<MsgT> cb, EpochType epoch = no_epoch,
-    TagType tag = no_tag
+  void reduce(
+    MsgPtrT msg, Callback<MsgT> cb, ReduceStamp stamp = ReduceStamp{}
   ) const;
 
   template <
@@ -108,18 +109,14 @@ public:
     typename MsgT = typename util::MsgPtrType<MsgPtrT>::MsgType,
     ActiveTypedFnType<MsgT> *f = MsgT::template msgHandler<MsgT, OpT, FunctorT>
   >
-  EpochType reduce(
-    MsgPtrT msg, EpochType epoch = no_epoch, TagType tag = no_tag
-  ) const;
+  void reduce(MsgPtrT msg, ReduceStamp stamp = ReduceStamp{}) const;
 
   template <
     typename MsgPtrT,
     typename MsgT = typename util::MsgPtrType<MsgPtrT>::MsgType,
     ActiveTypedFnType<MsgT> *f
   >
-  EpochType reduce(
-    MsgPtrT msg, EpochType epoch = no_epoch, TagType tag = no_tag
-  ) const;
+  void reduce(MsgPtrT msg, ReduceStamp stamp = ReduceStamp{}) const;
 
   /*
    * Get the local pointer to this object group residing in the current node

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -79,13 +79,13 @@ template <typename ObjT>
 template <
   typename OpT, typename MsgPtrT, typename MsgT, ActiveTypedFnType<MsgT> *f
 >
-EpochType Proxy<ObjT>::reduce(
-  MsgPtrT inmsg, Callback<MsgT> cb, EpochType epoch, TagType tag
+void Proxy<ObjT>::reduce(
+  MsgPtrT inmsg, Callback<MsgT> cb, ReduceStamp stamp
 ) const {
   auto proxy = Proxy<ObjT>(*this);
   auto msg = promoteMsg(inmsg);
   msg->setCallback(cb);
-  return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,epoch,tag);
+  return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,stamp);
 }
 
 template <typename ObjT>
@@ -93,22 +93,18 @@ template <
   typename OpT, typename FunctorT, typename MsgPtrT, typename MsgT,
   ActiveTypedFnType<MsgT> *f
 >
-EpochType Proxy<ObjT>::reduce(
-  MsgPtrT inmsg, EpochType epoch, TagType tag
-) const {
+void Proxy<ObjT>::reduce(MsgPtrT inmsg, ReduceStamp stamp) const {
   auto proxy = Proxy<ObjT>(*this);
   auto msg = promoteMsg(inmsg);
-  return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,epoch,tag);
+  return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,stamp);
 }
 
 template <typename ObjT>
 template <typename MsgPtrT, typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType Proxy<ObjT>::reduce(
-  MsgPtrT inmsg, EpochType epoch, TagType tag
-) const {
+void Proxy<ObjT>::reduce(MsgPtrT inmsg, ReduceStamp stamp) const {
   auto proxy = Proxy<ObjT>(*this);
   auto msg = promoteMsg(inmsg);
-  return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,epoch,tag);
+  return theObjGroup()->reduce<ObjT, MsgT, f>(proxy,msg,stamp);
 }
 
 template <typename ObjT>

--- a/src/vt/runtime/component/base.cc
+++ b/src/vt/runtime/component/base.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                reduce_tags.h
+//                                   base.cc
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,14 +42,14 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_COLLECTIVE_REDUCE_TAGS_H
-#define INCLUDED_COLLECTIVE_REDUCE_TAGS_H
+#include "vt/runtime/component/base.h"
+#include "vt/collective/reduce/reduce.h"
+#include "vt/collective/collective_alg.h"
 
-#include "vt/config.h"
+namespace vt { namespace runtime { namespace component {
 
-namespace vt { namespace collective { namespace reduce {
+collective::reduce::Reduce* BaseComponent::reducer() {
+  return theCollective()->getReducerComponent(component_id_);
+}
 
-static constexpr int32_t const create_group_tag = 0x0EEF0EEF;
-
-}}} /* end namespace vt::collective::reduce */
-#endif /*INCLUDED_COLLECTIVE_REDUCE_TAGS_H*/
+}}} /* end namespace vt::runtime::component */

--- a/src/vt/runtime/component/base.h
+++ b/src/vt/runtime/component/base.h
@@ -45,13 +45,22 @@
 #if !defined INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
 #define INCLUDED_VT_RUNTIME_COMPONENT_BASE_H
 
+#include "vt/configs/types/types_type.h"
 #include "vt/runtime/component/diagnostic.h"
 #include "vt/runtime/component/bufferable.h"
 #include "vt/runtime/component/progressable.h"
 
 #include <string>
 
+namespace vt { namespace collective { namespace reduce {
+
+struct Reduce;
+
+}}} /* end namespace vt::collective::reduce */
+
 namespace vt { namespace runtime { namespace component {
+
+struct ComponentPack;
 
 /**
  * \struct BaseComponent base.h vt/runtime/component/base.h
@@ -99,6 +108,15 @@ struct BaseComponent : Diagnostic, Bufferable, Progressable {
   virtual std::string name() = 0;
 
   virtual ~BaseComponent() { }
+
+  friend struct ComponentPack;
+
+  ComponentIDType getComponentID() const { return component_id_; }
+
+  collective::reduce::Reduce* reducer();
+
+protected:
+  ComponentIDType component_id_ = 0;
 };
 
 }}} /* end namespace vt::runtime::component */

--- a/src/vt/runtime/component/component_pack.cc
+++ b/src/vt/runtime/component/component_pack.cc
@@ -69,6 +69,7 @@ void ComponentPack::construct() {
 
   // Run the startup now that all components are live
   for (auto&& c : live_components_) {
+    c->component_id_ = cur_id_++;
     c->startup();
   }
 

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -170,6 +170,8 @@ private:
   std::vector<std::unique_ptr<BaseComponent>> live_components_;
   /// Set of non-owning pointers to pollable components for progress engine
   std::vector<Progressable*> pollable_components_;
+  /// Component ID for assigning during construction
+  ComponentIDType cur_id_ = 1;
 };
 
 template <typename... Ts>

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -650,7 +650,10 @@ void TerminationDetector::startEpochGraphBuild() {
   auto msg = makeMessage<MsgType>(graph);
   NodeType root = 0;
   auto cb = vt::theCB()->makeSend<MsgType, epochGraphBuiltHandler>(root);
-  theCollective()->reduce<ReduceOp>(root, msg.get(), cb);
+
+  auto r = theTerm()->reducer();
+  r->reduce<ReduceOp>(root, msg.get(), cb);
+
   if (theContext()->getNode() != root) {
     theTerm()->has_printed_epoch_graph = true;
   }

--- a/src/vt/utils/adt/union.h
+++ b/src/vt/utils/adt/union.h
@@ -1,0 +1,682 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                   union.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_UTILS_ADT_UNION_H
+#define INCLUDED_VT_UTILS_ADT_UNION_H
+
+#include "vt/config.h"
+
+namespace vt { namespace util { namespace adt {
+namespace detail {
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * \internal \struct Sizer
+ *
+ * \brief Union of char[sizeof(U)] all types (T, Ts...) which is never
+ * constructed but used to calculate the appropriate size of the
+ * \c AlignedCharUnion to hold any of these types.
+ */
+template <typename T, typename... Ts>
+union Sizer {
+  char _cur[sizeof(T)];
+  Sizer<Ts...> _rest;
+};
+
+template <typename T>
+union Sizer<T> {
+  char _cur[sizeof(T)];
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * \internal \struct Aligner
+ *
+ * \brief Contains all the types (T, Ts...) to determine the max alignment
+ * required for them for the alignas in the \c AlignedCharUnion
+ */
+template <typename T, typename... Ts>
+struct Aligner {
+  Aligner() = delete;
+  T _cur;
+  Aligner<Ts...> _rest;
+};
+
+template <typename T>
+struct Aligner<T> {
+  Aligner() = delete;
+  T _cur;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Used to assert that \c T is included in \c Us
+template <typename T, typename... Us>
+struct MustBe;
+
+template <typename T, typename U, typename... Us>
+struct MustBe<T, U, Us...> {
+  static constexpr bool const is_same =
+    std::is_same<T,U>::value or MustBe<T,Us...>::is_same;
+};
+
+template <typename T>
+struct MustBe<T> {
+  static constexpr bool const is_same = false;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Turn a pack into a \c char and indicates order in the pack for selection
+
+template <typename... Us>
+struct GetPlace {
+  static constexpr uint8_t const value = sizeof...(Us) + 1;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/// Find the place of a given \c T inside a pack \c U, Us...
+
+template <typename T, typename U, typename... Us>
+struct Which;
+
+template <typename T, typename U, typename Enable, typename... Us>
+struct WhichImpl;
+
+template <typename T, typename U, typename... Us>
+struct WhichImpl<T, U, typename std::enable_if_t<std::is_same<T,U>::value>, Us...> {
+  static constexpr uint8_t const value = sizeof...(Us) + 1;
+};
+
+template <typename T, typename U, typename... Us>
+struct WhichImpl<T, U, typename std::enable_if_t<not std::is_same<T,U>::value>, Us...> {
+  static constexpr uint8_t const value = Which<T, Us...>::value;
+};
+
+template <typename T, typename U, typename... Us>
+struct Which : WhichImpl<T, U, void, Us...> { };
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Automatically deallocate based on active element
+template <typename T, typename... Ts>
+struct Deallocate {
+  template <typename U>
+  static void apply(uint8_t which, U* u) {
+    if (which == GetPlace<Ts...>::value) {
+      u->template deallocateAs<T>();
+    } else {
+      Deallocate<Ts...>::apply(which, u);
+    }
+  }
+};
+
+template <typename T>
+struct Deallocate<T> {
+  template <typename U>
+  static void apply(uint8_t which, U* u) {
+    if (which == static_cast<uint8_t>(1)) {
+      u->template deallocateAs<T>();
+    } else {
+      vtAssert(false, "Invalid type; can not deallocate");
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Automatically invoke the right copy constructor
+template <typename T, typename... Ts>
+struct Copy {
+  static void apply(uint8_t which, char const* from, char* to) {
+    if (which == GetPlace<Ts...>::value) {
+      new (to) T{*reinterpret_cast<T const*>(from)};
+    } else {
+      Copy<Ts...>::apply(which, from, to);
+    }
+  }
+};
+
+template <typename T>
+struct Copy<T> {
+  static void apply(uint8_t which, char const* from, char* to) {
+    if (which == static_cast<uint8_t>(1)) {
+      new (to) T{*reinterpret_cast<T const*>(from)};
+    } else {
+      vtAssert(false, "Invalid type; can not copy");
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Automatically invoke the right move constructor
+template <typename T, typename... Ts>
+struct Move {
+  static void apply(uint8_t which, char* from, char* to) {
+    if (which == GetPlace<Ts...>::value) {
+      new (reinterpret_cast<T*>(to)) T{std::move(*reinterpret_cast<T*>(from))};
+    } else {
+      Move<Ts...>::apply(which, from, to);
+    }
+  }
+};
+
+template <typename T>
+struct Move<T> {
+  static void apply(uint8_t which, char* from, char* to) {
+    if (which == static_cast<uint8_t>(1)) {
+      new (reinterpret_cast<T*>(to)) T{std::move(*reinterpret_cast<T*>(from))};
+    } else {
+      vtAssert(false, "Invalid type; can not move");
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Automatically invoke the right serializer
+template <typename T, typename... Ts>
+struct Serialize {
+  template <typename U, typename SerializerT>
+  static void apply(uint8_t which, U* u, SerializerT& s) {
+    if (which == GetPlace<Ts...>::value) {
+      u->template serializeAs<T>(s);
+    } else {
+      Serialize<Ts...>::apply(which, u, s);
+    }
+  }
+};
+
+template <typename T>
+struct Serialize<T> {
+  template <typename U, typename SerializerT>
+  static void apply(uint8_t which, U* u, SerializerT& s) {
+    if (which == static_cast<uint8_t>(1)) {
+      u->template serializeAs<T>(s);
+    } else {
+      vtAssert(false, "Invalid type; can not serialize");
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Automatically invoke the underlying comparison
+template <typename T, typename... Ts>
+struct Compare {
+  template <typename U>
+  static bool apply(uint8_t which, U const* u1, U const* u2) {
+    if (which == GetPlace<Ts...>::value) {
+      return u1->template compareAs<T>(u2);
+    } else {
+      return Compare<Ts...>::apply(which, u1, u2);
+    }
+  }
+};
+
+template <typename T>
+struct Compare<T> {
+  template <typename U>
+  static bool apply(uint8_t which, U const* u1, U const* u2) {
+    if (which == static_cast<uint8_t>(1)) {
+      return u1->template compareAs<T>(u2);
+    } else {
+      vtAssert(false, "Invalid type; can not compare");
+      return false;
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Automatically invoke the right hash
+template <typename T, typename... Ts>
+struct Hash {
+  template <typename U>
+  static std::size_t apply(uint8_t which, U const* u1) {
+    if (which == GetPlace<Ts...>::value) {
+      return u1->template hashAs<T>();
+    } else {
+      return Hash<Ts...>::apply(which, u1);
+    }
+  }
+};
+
+template <typename T>
+struct Hash<T> {
+  template <typename U>
+  static std::size_t apply(uint8_t which, U const* u1) {
+    if (which == static_cast<uint8_t>(1)) {
+      return u1->template hashAs<T>();
+    } else {
+      vtAssert(false, "Invalid type; can not compare");
+      return false;
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename... Ts>
+struct IsTriviallyDestructible {
+  static constexpr bool const value =
+    std::is_trivially_destructible<T>::value and IsTriviallyDestructible<Ts...>::value;
+};
+
+template <typename T>
+struct IsTriviallyDestructible<T> {
+  static constexpr bool const value = std::is_trivially_destructible<T>::value;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename... Ts>
+struct IsTriviallyCopyable {
+  static constexpr bool const value =
+    std::is_trivially_copyable<T>::value and IsTriviallyCopyable<Ts...>::value;
+};
+
+template <typename T>
+struct IsTriviallyCopyable<T> {
+  static constexpr bool const value = std::is_trivially_copyable<T>::value;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename... Ts>
+struct AllUnique;
+
+template <typename U, typename T, typename... Ts>
+struct AllUnique<U, T, Ts...>
+  : AllUnique<U, T>, AllUnique<U, Ts...>, AllUnique<T, Ts...> { };
+
+template <typename U, typename T>
+struct AllUnique<U, T> {
+  static_assert(not std::is_same<U, T>::value, "Types must be unique");
+};
+
+} /* end namespace detail */
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename... Ts>
+struct UnionBase {
+
+  UnionBase() = default;
+  explicit UnionBase(uint8_t in_which)
+    : which_(in_which)
+  { }
+
+  /**
+   * \brief Get the char* to underlying bytes
+   */
+  char* getUnsafeRawBytes() { return static_cast<char*>(this->data_); }
+
+protected:
+  alignas(detail::Aligner<T,Ts...>) char data_[sizeof(detail::Sizer<T,Ts...>)];
+  uint8_t which_ = 0;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename Enable, typename... Ts>
+struct UnionDestroy;
+
+template <typename T, typename... Ts>
+struct UnionDestroy<
+  T,
+  typename std::enable_if_t<detail::IsTriviallyDestructible<T, Ts...>::value>,
+  Ts...
+> : UnionBase<T, Ts...> {
+
+  UnionDestroy() = default;
+  explicit UnionDestroy(uint8_t in_which)
+    : UnionBase<T, Ts...>(in_which)
+  { }
+
+  /**
+   * \brief Reset the union, calling the appropriate destructor if one variant
+   * is active.
+   */
+  void reset() {
+    this->which_ = 0;
+  }
+};
+
+template <typename T, typename... Ts>
+struct UnionDestroy<
+  T,
+  typename std::enable_if_t<not detail::IsTriviallyDestructible<T, Ts...>::value>,
+  Ts...
+> : UnionBase<T, Ts...> {
+
+  UnionDestroy() = default;
+  explicit UnionDestroy(uint8_t in_which)
+    : UnionBase<T, Ts...>(in_which)
+  { }
+
+  /**
+   * \brief Reset the union, calling the appropriate destructor if one variant
+   * is active.
+   */
+  void reset() {
+    if (this->which_ != 0) {
+      detail::Deallocate<T, Ts...>::apply(this->which_, this);
+      this->which_ = 0;
+    }
+  }
+
+  /**
+   * \brief Deallocate as a certain type \c U
+   */
+  template <typename U>
+  void deallocateAs() {
+    vtAssert(
+      (this->which_ == detail::Which<U, T, Ts...>::value),
+      "Deallocating as wrong type"
+    );
+    reinterpret_cast<U*>(this->getUnsafeRawBytes())->~U();
+    this->which_ = 0;
+  }
+
+  ~UnionDestroy() { reset(); }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename Enable, typename... Ts>
+struct UnionCopy;
+
+template <typename T, typename... Ts>
+struct UnionCopy<
+  T,
+  typename std::enable_if_t<detail::IsTriviallyCopyable<T, Ts...>::value>,
+  Ts...
+> : UnionDestroy<T, void, Ts...> {
+
+  UnionCopy() = default;
+
+};
+
+template <typename T, typename... Ts>
+struct UnionCopy<
+  T,
+  typename std::enable_if_t<not detail::IsTriviallyCopyable<T, Ts...>::value>,
+  Ts...
+> : UnionDestroy<T, void, Ts...> {
+
+  UnionCopy() = default;
+
+  UnionCopy(UnionCopy&& other) {
+    this->which_ = other.which_;
+    if (this->which_ != 0) {
+      detail::Move<T, Ts...>::apply(this->which_, other.data_, this->data_);
+    }
+  }
+
+  UnionCopy(UnionCopy const& other) {
+    this->which_ = other.which_;
+    if (this->which_ != 0) {
+      detail::Copy<T, Ts...>::apply(this->which_, other.data_, this->data_);
+    }
+  }
+
+  UnionCopy& operator=(UnionCopy const& other) {
+    this->reset();
+    this->which_ = other.which_;
+    if (this->which_ != 0) {
+      detail::Copy<T, Ts...>::apply(this->which_, other.data_, this->data_);
+    }
+    return *this;
+  }
+
+  UnionCopy& operator=(UnionCopy&& other) {
+    this->reset();
+    this->which_ = other.which_;
+    if (this->which_ != 0) {
+      detail::Move<T, Ts...>::apply(this->which_, other.data_, this->data_);
+    }
+    return *this;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * \struct AlignedCharUnion
+ *
+ * \brief An aligned type-safe union that remembers its last type and runtime
+ * checks to ensure correctness.
+ *
+ * Example of use:
+ *
+ *    struct Test1 {
+ *      Test1(int in_a) : a_(in_a) {}
+ *      int a_;
+ *    };
+ *
+ *    AlignedCharUnion<int, float, Test1> x;
+ *    x.init<Test1>(100);
+ *    x.get<Test1>.a_ = 10;
+ *    x.reset();
+ *    x.init<int>();
+ *    x.get<int> = 10;
+ *
+ */
+template <typename T, typename... Ts>
+struct AlignedCharUnion : UnionCopy<T, void, Ts...> {
+
+  AlignedCharUnion() = default;
+
+  std::size_t hash() const {
+    if (this->which_ != 0) {
+      return detail::Hash<T, Ts...>::apply(this->which_, this);
+    } else {
+      return 0;
+    }
+  }
+
+  bool operator==(AlignedCharUnion const& other) const {
+    if (this->which_ != other.which_) {
+      return false;
+    }
+    if (this->which_ == 0) {
+      return true;
+    }
+    return detail::Compare<T, Ts...>::apply(this->which_, this, &other);
+  }
+
+  /**
+   * \brief Initialize as \c U with arguments to constructor \c Args
+   *
+   * \param[in] args constructor arguments
+   */
+  template <typename U, typename... Args>
+  void init(Args&&... args) {
+    staticAssertCorrectness<U>();
+    vtAssert(this->which_ == 0, "Must be uninitialized");
+    this->which_ = detail::Which<U, T, Ts...>::value;
+    auto t = getUnsafe<U>();
+    new (t) U{std::forward<Args>(args)...};
+  }
+
+  /**
+   * \brief Check if union has active type \c U
+   *
+   * \return whether \c U is active
+   */
+  template <typename U>
+  bool is() const {
+    staticAssertCorrectness<U>();
+    return this->which_ == detail::Which<U, T, Ts...>::value;
+  }
+
+  /**
+   * \brief Get a reference as a certain type \c U
+   */
+  template <typename U>
+  U& get() {
+    staticAssertCorrectness<U>();
+    return *getSafe<U>();
+  }
+
+  /**
+   * \brief Get a const reference as a certain type \c U
+   */
+  template <typename U>
+  U const& get() const {
+    staticAssertCorrectness<U>();
+    return *getSafe<U>();
+  }
+
+  /**
+   * \brief View as a certain type, unsafe unless union is used across basic
+   * types
+   */
+  template <typename U>
+  U& viewAs() {
+    staticAssertCorrectness<U>();
+    return *getUnsafe<U>();
+  }
+
+  /**
+   * \brief Serialize as the right underlying type
+   *
+   * \param[in] s the serializer
+   */
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | this->which_;
+    if (this->which_ != 0) {
+      detail::Serialize<T, Ts...>::apply(this->which_, this, s);
+    }
+  }
+
+public:
+  template <typename U, typename SerializerT>
+  void serializeAs(SerializerT& s) {
+    U* t = getUnsafe<U>();
+    s | *t;
+  }
+
+  template <typename U>
+  bool compareAs(AlignedCharUnion const* other) const {
+    U const* t1 = getUnsafe<U>();
+    U const* t2 = other->getUnsafe<U>();
+    return *t1 == *t2;
+  }
+
+  template <typename U>
+  std::size_t hashAs() const {
+    U const* t1 = getUnsafe<U>();
+    return std::hash<U>()(*t1);
+  }
+
+private:
+  template <typename U>
+  U* getSafe() {
+    staticAssertCorrectness<U>();
+    vtAssert(
+      (detail::Which<U, T, Ts...>::value == this->which_),
+      "Must be initialized as U"
+    );
+    return getUnsafe<U>();
+  }
+
+  template <typename U>
+  U const* getSafe() const {
+    staticAssertCorrectness<U>();
+    vtAssert(
+      (detail::Which<U, T, Ts...>::value == this->which_),
+      "Must be initialized as U"
+    );
+    return getUnsafe<U>();
+  }
+
+  template <typename U>
+  U* getUnsafe() {
+    staticAssertCorrectness<U>();
+    return reinterpret_cast<U*>(static_cast<char*>(this->data_));
+  }
+
+  template <typename U>
+  U const* getUnsafe() const {
+    staticAssertCorrectness<U>();
+    return reinterpret_cast<U const*>(static_cast<char const*>(this->data_));
+  }
+
+  template <typename U>
+  void staticAssertCorrectness() const {
+    detail::AllUnique<T, Ts...>{};
+    static_assert(
+      detail::MustBe<U, T, Ts...>::is_same, "Must be the valid type in union"
+    );
+  }
+};
+
+}}} /* end namespace vt::util::adt */
+
+namespace std {
+
+template <typename T, typename... Ts>
+struct hash<vt::util::adt::AlignedCharUnion<T, Ts...>> {
+  size_t operator()(
+    vt::util::adt::AlignedCharUnion<T, Ts...> const& in
+  ) const {
+    return in.hash();
+  }
+};
+
+} /* end namespace std */
+
+namespace vt { namespace adt {
+
+template <typename T, typename... Ts>
+using SafeUnion = util::adt::AlignedCharUnion<T, Ts...>;
+
+}} /* end namespace vt::adt */
+
+#endif /*INCLUDED_VT_UTILS_ADT_UNION_H*/

--- a/src/vt/vrt/collection/reducable/reducable.h
+++ b/src/vt/vrt/collection/reducable/reducable.h
@@ -51,6 +51,7 @@
 #include "vt/pipe/pipe_callback_only.h"
 #include "vt/collective/reduce/operators/functors/none_op.h"
 #include "vt/collective/reduce/operators/callback_op.h"
+#include "vt/collective/reduce/reduce_scope.h"
 
 #include <functional>
 
@@ -58,6 +59,7 @@ namespace vt { namespace vrt { namespace collection {
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 struct Reducable : BaseProxyT {
+  using ReduceStamp = collective::reduce::ReduceStamp;
   using ReduceIdxFuncType = std::function<bool(IndexT const&)>;
 
   Reducable() = default;
@@ -66,7 +68,6 @@ struct Reducable : BaseProxyT {
   explicit Reducable(VirtualProxyType const in_proxy);
   Reducable& operator=(Reducable const&) = default;
 
-
   template <
     typename OpT = collective::None,
     typename MsgT,
@@ -74,9 +75,8 @@ struct Reducable : BaseProxyT {
       MsgT, OpT, collective::reduce::operators::ReduceCallback<MsgT>
     >
   >
-  EpochType reduce(
-    MsgT *const msg, Callback<MsgT> cb, EpochType const& epoch = no_epoch,
-    TagType const& tag = no_tag
+  void reduce(
+    MsgT *const msg, Callback<MsgT> cb, ReduceStamp stamp = ReduceStamp{}
   ) const;
 
   template <
@@ -85,36 +85,26 @@ struct Reducable : BaseProxyT {
     typename MsgT,
     ActiveTypedFnType<MsgT> *f = MsgT::template msgHandler<MsgT, OpT, FunctorT>
   >
-  EpochType reduce(
-    MsgT *const msg, EpochType const& epoch = no_epoch,
-    TagType const& tag = no_tag
-  ) const;
+  void reduce(MsgT *const msg, ReduceStamp stamp = ReduceStamp{}) const;
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-  EpochType reduce(
-    MsgT *const msg, EpochType const& epoch = no_epoch,
-    TagType const& tag = no_tag,
+  void reduce(
+    MsgT *const msg, ReduceStamp stamp = ReduceStamp{},
     NodeType const& node = uninitialized_destination
   ) const;
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-  EpochType reduceExpr(
-    MsgT *const msg, ReduceIdxFuncType fn, EpochType const& epoch = no_epoch,
-    TagType const& tag = no_tag,
+  void reduceExpr(
+    MsgT *const msg, ReduceIdxFuncType fn, ReduceStamp stamp = ReduceStamp{},
     NodeType const& node = uninitialized_destination
   ) const;
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-  EpochType reduce(
-    MsgT *const msg, EpochType const& epoch, TagType const& tag,
-    IndexT const& idx
-  ) const;
+  void reduce(MsgT *const msg, ReduceStamp stamp, IndexT const& idx) const;
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-  EpochType reduceExpr(
-    MsgT *const msg, ReduceIdxFuncType fn, EpochType const& epoch,
-    TagType const& tag,
-    IndexT const& idx
+  void reduceExpr(
+    MsgT *const msg, ReduceIdxFuncType fn, ReduceStamp stamp, IndexT const& idx
   ) const;
 };
 

--- a/src/vt/vrt/collection/reducable/reducable.impl.h
+++ b/src/vt/vrt/collection/reducable/reducable.impl.h
@@ -60,8 +60,8 @@ Reducable<ColT,IndexT,BaseProxyT>::Reducable(VirtualProxyType const in_proxy)
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename OpT, typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType Reducable<ColT,IndexT,BaseProxyT>::reduce(
-  MsgT *const msg, Callback<MsgT> cb, EpochType const& epoch, TagType const& tag
+void Reducable<ColT,IndexT,BaseProxyT>::reduce(
+  MsgT *const msg, Callback<MsgT> cb, ReduceStamp stamp
 ) const {
   auto const proxy = this->getProxy();
   msg->setCallback(cb);
@@ -71,60 +71,53 @@ EpochType Reducable<ColT,IndexT,BaseProxyT>::reduce(
     print_ptr(msg)
   );
   auto const root_node = 0;
-  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,epoch,tag,root_node);
+  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,stamp,root_node);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename OpT, typename FunctorT, typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType Reducable<ColT,IndexT,BaseProxyT>::reduce(
-  MsgT *const msg, EpochType const& epoch, TagType const& tag
+void Reducable<ColT,IndexT,BaseProxyT>::reduce(
+  MsgT *const msg, ReduceStamp stamp
 ) const {
   auto const proxy = this->getProxy();
   auto const root_node = 0;
-  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,epoch,tag,root_node);
+  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,stamp,root_node);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType Reducable<ColT,IndexT,BaseProxyT>::reduce(
-  MsgT *const msg, EpochType const& epoch, TagType const& tag,
-  NodeType const& node
+void Reducable<ColT,IndexT,BaseProxyT>::reduce(
+  MsgT *const msg, ReduceStamp stamp, NodeType const& node
 ) const {
   auto const proxy = this->getProxy();
-  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,epoch,tag,node);
+  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,stamp,node);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType Reducable<ColT,IndexT,BaseProxyT>::reduceExpr(
-  MsgT *const msg, ReduceIdxFuncType fn, EpochType const& epoch,
-  TagType const& tag, NodeType const& node
+void Reducable<ColT,IndexT,BaseProxyT>::reduceExpr(
+  MsgT *const msg, ReduceIdxFuncType fn, ReduceStamp stamp, NodeType const& node
 ) const {
   auto const proxy = this->getProxy();
-  return theCollection()->reduceMsgExpr<ColT,MsgT,f>(
-    proxy,msg,fn,epoch,tag,node
-  );
+  return theCollection()->reduceMsgExpr<ColT,MsgT,f>(proxy,msg,fn,stamp,node);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType Reducable<ColT,IndexT,BaseProxyT>::reduce(
-  MsgT *const msg, EpochType const& epoch, TagType const& tag, IndexT const& idx
+void Reducable<ColT,IndexT,BaseProxyT>::reduce(
+  MsgT *const msg, ReduceStamp stamp, IndexT const& idx
 ) const {
   auto const proxy = this->getProxy();
-  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,epoch,tag,idx);
+  return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,stamp,idx);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-EpochType Reducable<ColT,IndexT,BaseProxyT>::reduceExpr(
-  MsgT *const msg, ReduceIdxFuncType fn, EpochType const& epoch,
-  TagType const& tag, IndexT const& idx
+void Reducable<ColT,IndexT,BaseProxyT>::reduceExpr(
+  MsgT *const msg, ReduceIdxFuncType fn, ReduceStamp stamp, IndexT const& idx
 ) const {
   auto const proxy = this->getProxy();
-  return theCollection()->reduceMsgExpr<ColT,MsgT,f>(
-    proxy,msg,fn,epoch,tag,idx
-  );
+  return theCollection()->reduceMsgExpr<ColT,MsgT,f>(proxy,msg,fn,stamp,idx);
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/tests/unit/collectives/test_collectives_reduce.cc
+++ b/tests/unit/collectives/test_collectives_reduce.cc
@@ -154,7 +154,7 @@ TEST_F(TestReduce, test_reduce_op) {
 
   auto msg = makeMessage<MyReduceMsg>(my_node);
   debug_print(reduce, node, "msg->num={}\n", msg->num);
-  theCollective()->reduce<MyReduceMsg, reducePlus>(root, msg.get());
+  theCollective()->global()->reduce<MyReduceMsg, reducePlus>(root, msg.get());
 }
 
 TEST_F(TestReduce, test_reduce_plus_default_op) {
@@ -163,7 +163,9 @@ TEST_F(TestReduce, test_reduce_plus_default_op) {
 
   auto msg = makeMessage<SysMsg>(my_node);
   debug_print(reduce, node, "msg->num={}\n", msg->getConstVal());
-  theCollective()->reduce<PlusOp<int>, Verify<ReduceOP::Plus>>(root, msg.get());
+  theCollective()->global()->reduce<PlusOp<int>, Verify<ReduceOP::Plus>>(
+    root, msg.get()
+  );
 }
 
 TEST_F(TestReduce, test_reduce_max_default_op) {
@@ -172,7 +174,9 @@ TEST_F(TestReduce, test_reduce_max_default_op) {
 
   auto msg = makeMessage<SysMsg>(my_node);
   debug_print(reduce, node, "msg->num={}\n", msg->getConstVal());
-  theCollective()->reduce<MaxOp<int>, Verify<ReduceOP::Max>>(root, msg.get());
+  theCollective()->global()->reduce<MaxOp<int>, Verify<ReduceOP::Max>>(
+    root, msg.get()
+  );
 }
 
 TEST_F(TestReduce, test_reduce_min_default_op) {
@@ -181,7 +185,9 @@ TEST_F(TestReduce, test_reduce_min_default_op) {
 
   auto msg = makeMessage<SysMsg>(my_node);
   debug_print(reduce, node, "msg->num={}\n", msg->getConstVal());
-  theCollective()->reduce<MinOp<int>, Verify<ReduceOP::Min>>(root, msg.get());
+  theCollective()->global()->reduce<MinOp<int>, Verify<ReduceOP::Min>>(
+    root, msg.get()
+  );
 }
 
 TEST_F(TestReduce, test_reduce_vec_bool_msg) {
@@ -192,7 +198,9 @@ TEST_F(TestReduce, test_reduce_vec_bool_msg) {
 
   auto const root = 0;
   auto msg = makeMessage<ReduceVecMsg<bool>>(vecOfBool);
-  theCollective()->reduce<PlusOp<std::vector<bool>>, Verify<ReduceOP::Plus>>(root, msg.get());
+  theCollective()->global()->reduce<
+    PlusOp<std::vector<bool>>, Verify<ReduceOP::Plus>
+  >(root, msg.get());
 }
 
 TEST_F(TestReduce, test_reduce_vec_int_msg) {
@@ -205,7 +213,9 @@ TEST_F(TestReduce, test_reduce_vec_int_msg) {
 
   auto const root = 0;
   auto msg = makeMessage<ReduceVecMsg<int>>(vecOfInt);
-  theCollective()->reduce<PlusOp<std::vector<int>>, Verify<ReduceOP::Plus>>(root, msg.get());
+  theCollective()->global()->reduce<
+    PlusOp<std::vector<int>>, Verify<ReduceOP::Plus>
+  >(root, msg.get());
 }
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/utils/test_safe_union.cc
+++ b/tests/unit/utils/test_safe_union.cc
@@ -1,0 +1,230 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                             test_safe_union.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include <vt/transport.h>
+#include <vt/utils/adt/union.h>
+#include "test_harness.h"
+
+namespace vt { namespace tests { namespace unit {
+
+using TestSafeUnion = TestHarness;
+
+TEST_F(TestSafeUnion, test_safe_union_1) {
+
+  vt::adt::SafeUnion<int64_t> x1;
+  vt::adt::SafeUnion<int64_t, int64_t> x2;
+  vt::adt::SafeUnion<int64_t, int64_t, int64_t> x3;
+  vt::adt::SafeUnion<int64_t, int64_t, int64_t, int64_t> x4;
+
+  static_assert(
+    sizeof(x1) == sizeof(x2) and
+    sizeof(x2) == sizeof(x3) and
+    sizeof(x3) == sizeof(x4),
+    "As a union these must all be the same size!"
+  );
+
+  vt::adt::SafeUnion<int64_t> y1;
+  vt::adt::SafeUnion<int64_t, char> y2;
+
+  // This makes an assertion about alignment that will hold across these two
+  // types
+  static_assert(
+    sizeof(y1) == sizeof(y2),
+    "As a union these must be the same size!"
+  );
+}
+
+static int destroy_counter = 0;
+
+TEST_F(TestSafeUnion, test_safe_union_2) {
+
+  destroy_counter = 0;
+
+  struct MyTest {
+    struct Tag { };
+    explicit MyTest(Tag) { }
+    MyTest(MyTest const&) = delete;
+    MyTest(MyTest&&) = delete;
+    ~MyTest() { destroy_counter++; }
+    int v = 0;
+  };
+
+  vt::adt::SafeUnion<int, float, MyTest> x;
+
+  EXPECT_FALSE(x.is<int>());
+  EXPECT_FALSE(x.is<float>());
+  EXPECT_FALSE(x.is<MyTest>());
+
+  x.init<int>(100);
+
+  EXPECT_TRUE(x.is<int>());
+  EXPECT_FALSE(x.is<float>());
+  EXPECT_FALSE(x.is<MyTest>());
+
+  EXPECT_EQ(x.get<int>(), 100);
+
+  x.reset();
+
+  EXPECT_FALSE(x.is<int>());
+  EXPECT_FALSE(x.is<float>());
+  EXPECT_FALSE(x.is<MyTest>());
+
+  x.init<float>(29.33f);
+
+  EXPECT_FALSE(x.is<int>());
+  EXPECT_TRUE(x.is<float>());
+  EXPECT_FALSE(x.is<MyTest>());
+
+  EXPECT_EQ(x.get<float>(), 29.33f);
+
+  x.reset();
+
+  x.init<MyTest>(MyTest::Tag{});
+
+  EXPECT_EQ(x.get<MyTest>().v, 0);
+
+  x.get<MyTest>().v = 129;
+
+  EXPECT_EQ(x.get<MyTest>().v, 129);
+
+  EXPECT_EQ(destroy_counter, 0);
+
+  x.reset();
+
+  EXPECT_EQ(destroy_counter, 1);
+
+}
+
+static int copy_counter = 0;
+static int move_counter = 0;
+static int destroy_counter_2 = 0;
+
+TEST_F(TestSafeUnion, test_safe_union_3) {
+
+  destroy_counter = destroy_counter_2 = 0;
+  copy_counter = 0;
+  move_counter = 0;
+
+  struct MyTest {
+    struct Tag { };
+    explicit MyTest(Tag) { }
+    MyTest(MyTest const& other) {
+      copy_counter++;
+      v = other.v;
+    }
+    MyTest(MyTest&& other) : v(std::move(other.v)) {
+      move_counter++;
+    }
+    ~MyTest() { destroy_counter++; }
+    bool operator==(MyTest const& other) const { return v == other.v; }
+    int v = 0;
+  };
+
+  struct MyTest2 {
+    ~MyTest2() { destroy_counter_2++; }
+    bool operator==(MyTest2 const& other) const { return true; }
+  };
+
+  vt::adt::SafeUnion<float, int, MyTest, double, MyTest2> x;
+
+  x.init<MyTest>(MyTest::Tag{});
+
+  EXPECT_TRUE(x.is<MyTest>());
+
+  x.get<MyTest>().v = 234;
+
+  x.reset();
+  x.init<MyTest2>();
+  x.reset();
+  x.init<int>();
+  x.reset();
+  x.init<float>();
+  x.reset();
+  x.init<double>();
+  x.reset();
+
+  EXPECT_EQ(destroy_counter, 1);
+  EXPECT_EQ(destroy_counter_2, 1);
+  EXPECT_EQ(copy_counter, 0);
+
+  x.init<MyTest>(MyTest::Tag{});
+  x.get<MyTest>().v = 235;
+
+  EXPECT_EQ(x.get<MyTest>().v, 235);
+
+  vt::adt::SafeUnion<float, int, MyTest, double, MyTest2> y(x);
+
+  EXPECT_TRUE(y == x);
+  x.get<MyTest>().v = 236;
+  EXPECT_FALSE(y == x);
+
+  EXPECT_EQ(copy_counter, 1);
+  EXPECT_TRUE(y.is<MyTest>());
+  EXPECT_EQ(y.get<MyTest>().v, 235);
+
+  vt::adt::SafeUnion<float, int, MyTest, double, MyTest2> z;
+  z = y;
+
+  EXPECT_EQ(copy_counter, 2);
+
+  vt::adt::SafeUnion<float, int, MyTest, double, MyTest2> u;
+  u = std::move(z);
+
+  EXPECT_EQ(copy_counter, 2);
+  EXPECT_EQ(move_counter, 1);
+
+  u.reset();
+  EXPECT_EQ(destroy_counter, 2);
+  y.reset();
+  EXPECT_EQ(destroy_counter, 3);
+  x.reset();
+  EXPECT_EQ(destroy_counter, 4);
+  z.reset();
+  EXPECT_EQ(destroy_counter, 5);
+}
+
+
+}}} /* end namespace vt::tests::unit */


### PR DESCRIPTION
Fixes #796 
Fixes #821 

Rewrite machinery for scoping and stamping reductions.

This PR solves long-standing issues with collisions in asynchronous reductions. Create reducer instances with scoping for each instance and stamping reductions within a scope for identification across reductions in the same scope.

Note, this a breaking API change.

`theCollective()->reduce<>(..)` is no longer allowed.
You may access `theCollective()->global()->reduce(..)` but this not recommended.

- Every component now has its own scope with an accessor in the base component class.
- Every collection instance has its own reducer scope (accessed automatically through the proxy.reduce)
- Every group has its own scope (tied to a group's default spanning tree)
- Every obj group has its own scope (accessed automatically through proxy.reduce)

The new implementation is far more compact in bits sent with a reduction message by using SafeUnion. Probably 1/3 of the space required before.