### PR TITLE
831 Implement RandomLB

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ set(
         vrt/collection/balance/gossiplb
         vrt/collection/balance/statsmaplb
         vrt/collection/balance/zoltanlb
+        vrt/collection/balance/randomlb
         vrt/collection/balance/lb_invoke
         vrt/collection/balance/proxy
     lb/instrumentation

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -55,6 +55,7 @@
 #include "vt/vrt/collection/balance/statsmaplb/statsmaplb.h"
 #include "vt/vrt/collection/balance/stats_restart_reader.h"
 #include "vt/vrt/collection/balance/zoltanlb/zoltanlb.h"
+#include "vt/vrt/collection/balance/randomlb/randomlb.h"
 #include "vt/vrt/collection/messages/system_create.h"
 #include "vt/vrt/collection/manager.fwd.h"
 #include "vt/utils/memory/memory_usage.h"
@@ -164,6 +165,7 @@ void LBManager::collectiveImpl(
     case LBType::RotateLB:       makeLB<lb::RotateLB>(msg);       break;
     case LBType::GossipLB:       makeLB<lb::GossipLB>(msg);       break;
     case LBType::StatsMapLB:     makeLB<lb::StatsMapLB>(msg);     break;
+    case LBType::RandomLB:       makeLB<lb::RandomLB>(msg);       break;
 #   if backend_check_enabled(zoltan)
     case LBType::ZoltanLB:       makeLB<lb::ZoltanLB>(msg);       break;
 #   endif

--- a/src/vt/vrt/collection/balance/lb_type.h
+++ b/src/vt/vrt/collection/balance/lb_type.h
@@ -63,6 +63,7 @@ enum struct LBType : int8_t {
 # if backend_check_enabled(zoltan)
   , ZoltanLB         = 6
 # endif
+  , RandomLB         = 7
 };
 
 template <typename SerializerT>

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.cc
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.cc
@@ -45,6 +45,7 @@
 #include "vt/vrt/collection/balance/randomlb/randomlb.h"
 
 #include <random>
+#include <set>
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.cc
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                  lb_type.cc
+//                                 randomlb.cc
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,42 +42,67 @@
 //@HEADER
 */
 
-#include "vt/config.h"
-#include "vt/vrt/collection/balance/lb_common.h"
-#include "vt/vrt/collection/balance/lb_type.h"
+#include "vt/vrt/collection/balance/randomlb/randomlb.h"
 
-namespace vt { namespace vrt { namespace collection {
+#include <random>
 
-namespace balance {
+namespace vt { namespace vrt { namespace collection { namespace lb {
 
-std::unordered_map<LBType,std::string> lb_names_ = {
-  {LBType::NoLB,           std::string{"NoLB"          }},
-# if backend_check_enabled(zoltan)
-  {LBType::ZoltanLB,       std::string{"ZoltanLB"      }},
-# endif
-  {LBType::GreedyLB,       std::string{"GreedyLB"      }},
-  {LBType::HierarchicalLB, std::string{"HierarchicalLB"}},
-  {LBType::RotateLB,       std::string{"RotateLB"      }},
-  {LBType::GossipLB,       std::string{"GossipLB"      }},
-  {LBType::StatsMapLB,     std::string{"StatsMapLB"    }},
-  {LBType::RandomLB,       std::string{"RandomLB"      }},
-};
+void RandomLB::init(objgroup::proxy::Proxy<RandomLB> in_proxy) {
+  proxy = in_proxy;
+}
 
-} /* end namespace balance */
+void RandomLB::inputParams(balance::SpecEntry* spec) {
+  std::vector<std::string> allowed{"seed", "randomize_seed"};
+  spec->checkAllowedKeys(allowed);
+  seed_ = spec->getOrDefault<int32_t>("seed", seed_);
+  randomize_seed_ = spec->getOrDefault<bool>("randomize_seed", randomize_seed_);
+}
 
-namespace lb {
+void RandomLB::runLB() {
+  auto const this_node = theContext()->getNode();
+  auto const num_nodes = static_cast<int32_t>(theContext()->getNumNodes());
 
-std::unordered_map<Statistic,std::string> lb_stat_name_ = {
-  {Statistic::P_l,         std::string{"P_l"}},
-  {Statistic::P_c,         std::string{"P_c"}},
-  {Statistic::P_t,         std::string{"P_t"}},
-  {Statistic::O_l,         std::string{"O_l"}},
-  {Statistic::O_c,         std::string{"O_c"}},
-  {Statistic::O_t,         std::string{"O_t"}},
-  {Statistic::ObjectRatio, std::string{"ObjectRatio"}},
-  {Statistic::EdgeRatio,   std::string{"EdgeRatio"}}
-};
+  if (this_node == 0) {
+    vt_print(
+      lb, "RandomLB: runLB: randomize_seed={}, seed={}\n",
+      randomize_seed_, seed_
+    );
+    fflush(stdout);
+  }
 
-} /* end namespace lb */
+  std::mt19937 gen;
+  if (randomize_seed_) {
+    std::random_device rd;
+    gen = std::mt19937{rd()};
+  } else {
+    int32_t const node_seed = seed_ + static_cast<int32_t>(this_node);
+    gen = std::mt19937{node_seed};
+  }
+  std::uniform_int_distribution<> dist(0, num_nodes-1);
 
-}}} /* end namespace vt::vrt::collection::balance */
+  startMigrationCollective();
+
+  // Sort the object so we have a deterministic order over them
+  std::set<ObjIDType> objs;
+  for (auto&& stat : *load_data) {
+    objs.insert(stat.first);
+  }
+
+  for (auto&& obj : objs) {
+    auto const to_node = dist(gen);
+    if (to_node != this_node) {
+      debug_print(
+        lb, node,
+        "RandomLB: migrating obj={:x} from={} to={}\n",
+        obj, this_node, to_node
+      );
+      migrateObjectTo(obj, to_node);
+    }
+  }
+
+  finishMigrationCollective();
+}
+
+}}}} /* end namespace vt::vrt::collection::balance::lb */
+

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.cc
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.cc
@@ -77,7 +77,8 @@ void RandomLB::runLB() {
     std::random_device rd;
     gen = std::mt19937{rd()};
   } else {
-    int32_t const node_seed = seed_ + static_cast<int32_t>(this_node);
+    using ResultType = std::mt19937::result_type;
+    auto const node_seed = seed_ + static_cast<ResultType>(this_node);
     gen = std::mt19937{node_seed};
   }
   std::uniform_int_distribution<> dist(0, num_nodes-1);

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.cc
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.cc
@@ -83,7 +83,7 @@ void RandomLB::runLB() {
 
   startMigrationCollective();
 
-  // Sort the object so we have a deterministic order over them
+  // Sort the objects so we have a deterministic order over them
   std::set<ObjIDType> objs;
   for (auto&& stat : *load_data) {
     objs.insert(stat.first);

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.h
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.h
@@ -62,7 +62,6 @@ struct RandomLB : BaseLB {
 private:
   int seed_ = 123456789;
   bool randomize_seed_ = false;
-  std::random_device device_;
   objgroup::proxy::Proxy<RandomLB> proxy = {};
 };
 

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.h
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                  lb_type.cc
+//                                  randomlb.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,42 +42,30 @@
 //@HEADER
 */
 
-#include "vt/config.h"
-#include "vt/vrt/collection/balance/lb_common.h"
-#include "vt/vrt/collection/balance/lb_type.h"
+#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_RANDOMLB_RANDOMLB_H
+#define INCLUDED_VT_VRT_COLLECTION_BALANCE_RANDOMLB_RANDOMLB_H
 
-namespace vt { namespace vrt { namespace collection {
+#include "vt/vrt/collection/balance/baselb/baselb.h"
 
-namespace balance {
+#include <random>
 
-std::unordered_map<LBType,std::string> lb_names_ = {
-  {LBType::NoLB,           std::string{"NoLB"          }},
-# if backend_check_enabled(zoltan)
-  {LBType::ZoltanLB,       std::string{"ZoltanLB"      }},
-# endif
-  {LBType::GreedyLB,       std::string{"GreedyLB"      }},
-  {LBType::HierarchicalLB, std::string{"HierarchicalLB"}},
-  {LBType::RotateLB,       std::string{"RotateLB"      }},
-  {LBType::GossipLB,       std::string{"GossipLB"      }},
-  {LBType::StatsMapLB,     std::string{"StatsMapLB"    }},
-  {LBType::RandomLB,       std::string{"RandomLB"      }},
+namespace vt { namespace vrt { namespace collection { namespace lb {
+
+struct RandomLB : BaseLB {
+
+  RandomLB() = default;
+
+  void init(objgroup::proxy::Proxy<RandomLB> in_proxy);
+  void runLB() override;
+  void inputParams(balance::SpecEntry* spec) override;
+
+private:
+  int seed_ = 123456789;
+  bool randomize_seed_ = false;
+  std::random_device device_;
+  objgroup::proxy::Proxy<RandomLB> proxy = {};
 };
 
-} /* end namespace balance */
+}}}} /* end namespace vt::vrt::collection::balance::lb */
 
-namespace lb {
-
-std::unordered_map<Statistic,std::string> lb_stat_name_ = {
-  {Statistic::P_l,         std::string{"P_l"}},
-  {Statistic::P_c,         std::string{"P_c"}},
-  {Statistic::P_t,         std::string{"P_t"}},
-  {Statistic::O_l,         std::string{"O_l"}},
-  {Statistic::O_c,         std::string{"O_c"}},
-  {Statistic::O_t,         std::string{"O_t"}},
-  {Statistic::ObjectRatio, std::string{"ObjectRatio"}},
-  {Statistic::EdgeRatio,   std::string{"EdgeRatio"}}
-};
-
-} /* end namespace lb */
-
-}}} /* end namespace vt::vrt::collection::balance */
+#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_RANDOMLB_RANDOMLB_H*/


### PR DESCRIPTION
Fixes #831 

New load balancer for testing---RandomLB. It can be explicitly seeded or randomized using C++'s `std::random_device`:

- Seeding: `--vt_lb --vt_lb_name="RandomLB" --vt_lb_args="seed=1024"`
- Randomizing:  `--vt_lb --vt_lb_name="RandomLB" --vt_lb_args="randomize_seed=true"`