### PR TITLE
856 Args: CLI I/O config files

### DIFF
--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -577,7 +577,6 @@ void addConfigFileArgs(CLI::App& app) {
   a2->group(configGroup);
 }
 
-
 class VtFormatter : public CLI::Formatter {
 public:
   std::string make_usage(const CLI::App *, std::string name) const override {

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -195,7 +195,10 @@ void addColorArgs(CLI::App& app) {
   a->group(outputGroup);
   b->group(outputGroup);
   a1->group(outputGroup);
-  b->excludes(a);
+  // Do not exclude 'a' from 'b' here because when inputting/outputting a
+  // config, both will be written out causing an error when reading a written
+  // input file with defaults
+  // b->excludes(a);
 }
 
 void addSignalArgs(CLI::App& app) {

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -687,6 +687,14 @@ std::tuple<int, std::string> parseArguments(CLI::App& app, int& argc, char**& ar
     args_to_parse.push_back(*it);
   }
 
+  // Allow a input config file
+  app.set_config(
+    "--vt_input_config",
+    "", // no default file name
+    "Read in an ini config file for VT",
+    false // not required
+  );
+
   try {
     app.parse(args_to_parse);
   } catch (CLI::Error &ex) {

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -712,7 +712,7 @@ std::tuple<int, std::string> parseArguments(CLI::App& app, int& argc, char**& ar
   // If the user specified to output the full configuration, save it in a string
   // so node 0 can output in the runtime once MPI is init'ed
   if (ArgConfig::vt_output_config) {
-    ArgConfig::vt_output_config_str = app.config_to_str(true,true);
+    ArgConfig::vt_output_config_str = app.config_to_str(true, true);
   }
 
   // Get the clean prog name; don't allow path bleed in usages.

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -179,6 +179,10 @@ public:
   static std::string vt_user_str_2;
   static std::string vt_user_str_3;
 
+  static bool vt_output_config;
+  static std::string vt_output_config_file;
+  static std::string vt_output_config_str;
+
   /// Name of the program launched (excluding any path!)
   static std::string prog_name;
 

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -80,6 +80,7 @@
 #include <string>
 #include <vector>
 #include <tuple>
+#include <fstream>
 
 #include <cstdio>
 #include <cstdint>
@@ -350,6 +351,14 @@ bool Runtime::initialize(bool const force_now) {
       theSched->enqueue([this]{
         this->checkForArgumentErrors();
       });
+
+      // If the user specified to output a configuration file, write it to the
+      // specified file on rank 0
+      if (ArgType::vt_output_config) {
+        std::ofstream out(ArgType::vt_output_config_file);
+        out << ArgType::vt_output_config_str;
+        out.close();
+      }
     }
     setup();
     sync();

--- a/src/vt/runtime/runtime_banner.cc
+++ b/src/vt/runtime/runtime_banner.cc
@@ -622,6 +622,20 @@ void Runtime::printStartupBanner() {
     fmt::print("{}\t{}{}", vt_pre, f12, reset);
   }
 
+  if (ArgType::vt_output_config) {
+    auto f11 = fmt::format("Enabled configuration output");
+    auto f12 = opt_on("--vt_output_config", f11);
+    fmt::print("{}\t{}{}", vt_pre, f12, reset);
+
+    if (ArgType::vt_output_config_file != "") {
+      auto f13 = fmt::format(
+        "Config file name \"{}\"", ArgType::vt_output_config_file
+      );
+      auto f14 = opt_on("--vt_output_config_file", f13);
+      fmt::print("{}\t{}{}", vt_pre, f14, reset);
+    }
+  }
+
   if (ArgType::vt_memory_reporters != "") {
     auto f11 = fmt::format(
       "Memory usage checker precedence: {}",


### PR DESCRIPTION
Fixes #856 

Allows inputting/outputting config files for easier reproducibility and debugging. Exports the entire config with `--vt_output_config`. Config can be imported with `--vt_input_config`.