### PR TITLE
794 Fix signal holder cleanup bug

### DIFF
--- a/src/vt/pipe/pipe_manager_base.cc
+++ b/src/vt/pipe/pipe_manager_base.cc
@@ -63,6 +63,13 @@
 
 namespace vt { namespace pipe {
 
+/*virtual*/ PipeManagerBase::~PipeManagerBase() {
+  // Run all the cleanup lambdas to clear signal holders
+  for (auto&& elm : signal_cleanup_fns_) {
+    elm.second();
+  }
+}
+
 void PipeManagerBase::newPipeState(
   PipeType const& pipe, bool persist, bool typeless, RefType num_signals,
   RefType num_listeners, RefType num_reg_listeners, DispatchFuncType fn

--- a/src/vt/pipe/pipe_manager_base.h
+++ b/src/vt/pipe/pipe_manager_base.h
@@ -79,6 +79,8 @@ struct PipeManagerBase {
 
   PipeManagerBase() = default;
 
+  virtual ~PipeManagerBase();
+
   template <typename SignalT>
   friend struct pipe::callback::CallbackAnon;
   template <typename SignalT>
@@ -161,6 +163,8 @@ private:
   PipeIDType cur_pipe_id_ = initial_pipe_id;
   // the pipe state for pipes that have a send back
   std::unordered_map<PipeType,PipeStateType> pipe_state_;
+  // ID -> type-erased SignalHolder<T> cleanup lambda
+  std::unordered_map<int, std::function<void()>> signal_cleanup_fns_;
 };
 
 }} /* end namespace vt::pipe */

--- a/src/vt/pipe/pipe_manager_base.h
+++ b/src/vt/pipe/pipe_manager_base.h
@@ -164,7 +164,7 @@ private:
   // the pipe state for pipes that have a send back
   std::unordered_map<PipeType,PipeStateType> pipe_state_;
   // ID -> type-erased SignalHolder<T> cleanup lambda
-  std::unordered_map<int, std::function<void()>> signal_cleanup_fns_;
+  std::unordered_map<unsigned, std::function<void()>> signal_cleanup_fns_;
 };
 
 }} /* end namespace vt::pipe */

--- a/src/vt/pipe/pipe_manager_base.impl.h
+++ b/src/vt/pipe/pipe_manager_base.impl.h
@@ -125,7 +125,7 @@ void PipeManagerBase::registerCallback(
    *  Save the new listener in the typed signal holder container for delivery
    *  when a signal arrives
    */
-  holder.addListener(pipe,std::move(listener));
+  holder.addListener(pipe, std::move(listener));
   /*
    *  Update the number of registered listeners in the pipe state
    */

--- a/src/vt/pipe/pipe_manager_base.impl.h
+++ b/src/vt/pipe/pipe_manager_base.impl.h
@@ -111,6 +111,16 @@ template <typename SignalT, typename ListenerT>
 void PipeManagerBase::registerCallback(
   PipeType const& pipe, ListenerT&& listener, bool update_state
 ) {
+  auto& holder = signal_holder_<SignalT>;
+  auto const holder_id = holder.getID();
+
+  auto cleanup_iter = signal_cleanup_fns_.find(holder_id);
+  if (cleanup_iter == signal_cleanup_fns_.end()) {
+    signal_cleanup_fns_[holder_id] = []{
+      signal_holder_<SignalT>.clearAll();
+    };
+  }
+
   /*
    *  Save the new listener in the typed signal holder container for delivery
    *  when a signal arrives

--- a/src/vt/pipe/pipe_manager_base.impl.h
+++ b/src/vt/pipe/pipe_manager_base.impl.h
@@ -125,7 +125,7 @@ void PipeManagerBase::registerCallback(
    *  Save the new listener in the typed signal holder container for delivery
    *  when a signal arrives
    */
-  signal_holder_<SignalT>.addListener(pipe,std::move(listener));
+  holder.addListener(pipe,std::move(listener));
   /*
    *  Update the number of registered listeners in the pipe state
    */

--- a/src/vt/pipe/signal/signal_holder.cc
+++ b/src/vt/pipe/signal/signal_holder.cc
@@ -44,6 +44,6 @@
 
 namespace vt { namespace pipe { namespace signal {
 
-/*static*/ int signal_holder_next_id_ = 1;
+/*static*/ unsigned signal_holder_next_id_ = 1;
 
 }}} /* end namespace vt::pipe::signal */

--- a/src/vt/pipe/signal/signal_holder.cc
+++ b/src/vt/pipe/signal/signal_holder.cc
@@ -1,0 +1,49 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               signal_holder.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+namespace vt { namespace pipe { namespace signal {
+
+/*static*/ int signal_holder_next_id_ = 1;
+
+}}} /* end namespace vt::pipe::signal */

--- a/src/vt/pipe/signal/signal_holder.h
+++ b/src/vt/pipe/signal/signal_holder.h
@@ -58,6 +58,10 @@
 
 namespace vt { namespace pipe { namespace signal {
 
+/// Used to assign a ID to each signal holder instance to generate unique
+/// cleanup lambdas
+static int signal_holder_next_id_ = 1;
+
 template <typename SignalT>
 struct SignalHolder {
   using DataType             = typename SignalT::DataType;
@@ -73,6 +77,10 @@ struct SignalHolder {
   using SignalMapType        = std::unordered_map<PipeType,SignalListType>;
   using CountMapType         = std::unordered_map<PipeType,SigCountType>;
   using ListenerMapIterType  = typename ListenerMapType::iterator;
+
+  SignalHolder()
+    : id_(signal_holder_next_id_++)
+  { }
 
   void addSignal(PipeType const& pid, DataPtrType in_data);
   void removeListener(PipeType const& pid, ListenerPtrType listener);
@@ -91,11 +99,14 @@ struct SignalHolder {
   );
   bool finished(ListenerPtrType listener) const;
   bool exists(PipeType const& pipe) const;
+  int getID() const { return id_; }
+  void clearAll();
 
 private:
   SignalMapType pending_holder_;
   CountMapType listener_count_;
   ListenerMapType listeners_;
+  int id_ = -1;
 };
 
 }}} /* end namespace vt::pipe::signal */

--- a/src/vt/pipe/signal/signal_holder.h
+++ b/src/vt/pipe/signal/signal_holder.h
@@ -60,7 +60,7 @@ namespace vt { namespace pipe { namespace signal {
 
 /// Used to assign a ID to each signal holder instance to generate unique
 /// cleanup lambdas
-static int signal_holder_next_id_ = 1;
+static unsigned signal_holder_next_id_ = 1;
 
 template <typename SignalT>
 struct SignalHolder {
@@ -99,14 +99,14 @@ struct SignalHolder {
   );
   bool finished(ListenerPtrType listener) const;
   bool exists(PipeType const& pipe) const;
-  int getID() const { return id_; }
+  unsigned getID() const { return id_; }
   void clearAll();
 
 private:
   SignalMapType pending_holder_;
   CountMapType listener_count_;
   ListenerMapType listeners_;
-  int id_ = -1;
+  unsigned id_ = 0;
 };
 
 }}} /* end namespace vt::pipe::signal */

--- a/src/vt/pipe/signal/signal_holder.impl.h
+++ b/src/vt/pipe/signal/signal_holder.impl.h
@@ -90,6 +90,13 @@ void SignalHolder<SignalT>::removeListener(
 }
 
 template <typename SignalT>
+void SignalHolder<SignalT>::clearAll() {
+  listeners_.clear();
+  listener_count_.clear();
+  listeners_.clear();
+}
+
+template <typename SignalT>
 void SignalHolder<SignalT>::clearAllListeners(PipeType const& pid) {
   auto iter = listeners_.find(pid);
   if (iter != listeners_.end()) {

--- a/src/vt/pipe/signal/signal_holder.impl.h
+++ b/src/vt/pipe/signal/signal_holder.impl.h
@@ -93,7 +93,7 @@ template <typename SignalT>
 void SignalHolder<SignalT>::clearAll() {
   listeners_.clear();
   listener_count_.clear();
-  listeners_.clear();
+  pending_holder_.clear();
 }
 
 template <typename SignalT>

--- a/tests/unit/pipe/test_signal_cleanup.cc
+++ b/tests/unit/pipe/test_signal_cleanup.cc
@@ -1,0 +1,125 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                           test_signal_cleanup.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "data_message.h"
+
+#include "vt/transport.h"
+
+#include <memory>
+
+namespace vt { namespace tests { namespace unit {
+
+using namespace vt;
+using namespace vt::tests::unit;
+
+using DataMsg = vt::Message;
+
+struct CallbackMsg : vt::Message {
+  CallbackMsg() = default;
+  explicit CallbackMsg(vt::Callback<DataMsg> in_cb) : cb_(in_cb) { }
+
+  vt::Callback<DataMsg> cb_;
+};
+
+using TestSignalCleanup = TestParallelHarness;
+
+void bounce(CallbackMsg* msg) {
+  auto mm = makeMessage<DataMsg>();
+  msg->cb_.send(mm.get());
+}
+
+TEST_F(TestSignalCleanup, test_signal_cleanup_3) {
+  auto const this_node = theContext()->getNode();
+
+  int c1 = 0, c2 = 0;
+
+  if (this_node == 0) {
+    auto cb = theCB()->makeFunc<DataMsg>([&c1](DataMsg* msg){
+      c1++;
+      fmt::print("called A");
+    });
+    auto msg = makeMessage<CallbackMsg>(cb);
+    theMsg()->sendMsg<CallbackMsg, bounce>(1, msg.get());
+  }
+
+  // run until termination
+  do vt::runScheduler(); while (not vt::rt->isTerminated());
+
+  // explicitly finalize runtime to destroy and reset components---and force it
+  // now!
+  vt::rt->finalize(true);
+
+  // re-init runtime, fresh state---force it now!
+  vt::rt->initialize(true);
+
+  // Create another callback with the same template signature, meaning it will
+  // target the same signal holder. The old callback from the previous init
+  // should *not* trigger again.
+  //
+  // Since the RT has been finalized, the pipe ID for the new callback will be
+  // the same as the one before.
+  //
+  if (this_node == 0) {
+    auto cb = theCB()->makeFunc<DataMsg>([&c2](DataMsg* msg){
+      c2++;
+      fmt::print("called B");
+    });
+    auto msg = makeMessage<CallbackMsg>(cb);
+    theMsg()->sendMsg<CallbackMsg, bounce>(1, msg.get());
+  }
+
+  // run until termination
+  do vt::runScheduler(); while (not vt::rt->isTerminated());
+
+  // now, check if we only fired the callbacks exactly once!
+  if (this_node == 0) {
+    EXPECT_EQ(c1, 1);
+    EXPECT_EQ(c2, 1);
+  }
+}
+
+}}} // end namespace vt::tests::unit


### PR DESCRIPTION
Fixes #794 

Fixes a bug discovered when writing safe MPI collective code. If the VT runtime is finalized, the pipe IDs are reset (used to identify a callback instance). But, the signal holder, which is a templated static container are not reset. Thus, the old registered listeners get triggered causing all sort of havoc. This was especially disturbing with testing, but many gtest tests run multiple tests in the same harness instance in one execution finalizing the VT runtime in between tests.

This also indicates that we probably need to audit all static (especially templated) data that is used in the runtime. There may be other static/global instances that would cause problems across finalizations or if VT is initialized twice (only halfway supported).