### PR TITLE
#845 Log events 'between' top-level schedulers; can cover when VT is not running.

### DIFF
--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -589,9 +589,10 @@ void Runtime::initializeComponents() {
   >{});
 
 # if backend_check_enabled(trace_enabled)
+  // The Trace and Scheduler components have a co-dependency. However,
+  // the lifetime of theTrace should be longer than that of theSched.
   p_->registerComponent<trace::Trace>(&theTrace, Deps<
-      ctx::Context,    // Everything depends on theContext
-      sched::Scheduler // Depends on scheduler for triggers
+      ctx::Context  // Everything depends on theContext
     >{},
     ArgType::prog_name
   );
@@ -618,6 +619,9 @@ void Runtime::initializeComponents() {
 
   p_->registerComponent<sched::Scheduler>(
     &theSched, Deps<
+#     if backend_check_enabled(trace_enabled)
+      trace::Trace,             // For scheduler-related trace events
+#     endif
       ctx::Context,             // Everything depends on theContext
       util::memory::MemoryUsage // Depends on memory usage for output
     >{}

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -290,9 +290,7 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
     "Nested schedulers never expected from idle context"
   );
 
-  if (action_depth_ == 0) {
-    between_sched_event_ = nullptr;
-  }
+  between_sched_event_ = nullptr;
 
   triggerEvent(SchedulerEventType::BeginSchedulerLoop);
 
@@ -369,6 +367,8 @@ void runSchedulerThrough(EpochType epoch) {
 }
 
 void runInEpochRooted(ActionType&& fn) {
+  theSched()->between_sched_event_ = nullptr; // loop will be entered
+
   auto ep = theTerm()->makeEpochRooted();
   theMsg()->pushEpoch(ep);
   fn();
@@ -378,6 +378,8 @@ void runInEpochRooted(ActionType&& fn) {
 }
 
 void runInEpochCollective(ActionType&& fn) {
+  theSched()->between_sched_event_ = nullptr; // loop will be entered
+
   auto ep = theTerm()->makeEpochCollective();
   theMsg()->pushEpoch(ep);
   fn();

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -75,15 +75,18 @@ Scheduler::Scheduler() {
 }
 
 void Scheduler::startup() /*override*/ {
-  // Depends on theTrace
-  between_sched_event_type_ = trace::registerEventHashed(
-    "Between VT schedulers"
+#if backend_check_enabled(trace_enabled)
+  between_sched_event_type_ = trace::TraceRegistry::registerEventHashed(
+    "Scheduler", "Between_Schedulers"
   );
+#else
+  between_sched_event_type_ = trace::no_trace_entry_id;
+#endif
 }
 
 void Scheduler::finalize() /*override*/ {
   // Complete any event between last runSchedulerWhile and vt::finalize.
-  between_sched_event_ = nullptr;
+  endBetweenLoopEvent();
 }
 
 void Scheduler::enqueue(ActionType action) {
@@ -286,7 +289,7 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
     "Nested schedulers never expected from idle context"
   );
 
-  between_sched_event_ = nullptr;
+  endBetweenLoopEvent();
 
   triggerEvent(SchedulerEventType::BeginSchedulerLoop);
 
@@ -311,12 +314,21 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
 
   triggerEvent(SchedulerEventType::EndSchedulerLoop);
 
+#if backend_check_enabled(trace_enabled)
   if (action_depth_ == 0) {
     // Start an event representing time outside of top-level scheduler.
-    between_sched_event_ = std::make_unique<trace::TraceScopedEvent>(
-      between_sched_event_type_
+    between_sched_event_ = theTrace()->beginProcessing(
+      between_sched_event_type_, 0, trace::no_trace_event, 0
     );
   }
+#endif
+}
+
+void Scheduler::endBetweenLoopEvent() {
+#if backend_check_enabled(trace_enabled)
+  theTrace()->endProcessing(between_sched_event_);
+  between_sched_event_ = trace::TraceProcessingTag{};
+#endif
 }
 
 void Scheduler::triggerEvent(SchedulerEventType const& event) {
@@ -371,7 +383,7 @@ void runSchedulerThrough(EpochType epoch) {
 }
 
 void runInEpochRooted(ActionType&& fn) {
-  theSched()->between_sched_event_ = nullptr; // loop will be entered
+  theSched()->endBetweenLoopEvent(); // loop will be entered
 
   auto ep = theTerm()->makeEpochRooted();
   theMsg()->pushEpoch(ep);
@@ -382,7 +394,7 @@ void runInEpochRooted(ActionType&& fn) {
 }
 
 void runInEpochCollective(ActionType&& fn) {
-  theSched()->between_sched_event_ = nullptr; // loop will be entered
+  theSched()->endBetweenLoopEvent(); // loop will be entered
 
   auto ep = theTerm()->makeEpochCollective();
   theMsg()->pushEpoch(ep);

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -74,14 +74,14 @@ Scheduler::Scheduler() {
   progress_time_enabled_ = arguments::ArgConfig::vt_sched_progress_sec != 0.0;
 }
 
-/*virtual*/ void Scheduler::startup() /*override*/ {
+void Scheduler::startup() /*override*/ {
   // Depends on theTrace
   between_sched_event_type_ = trace::registerEventHashed(
     "Between VT schedulers"
   );
 }
 
-/*virtual*/ void Scheduler::finalize() /*override*/ {
+void Scheduler::finalize() /*override*/ {
   // Complete any event between last runSchedulerWhile and vt::finalize.
   between_sched_event_ = nullptr;
 }

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -74,6 +74,18 @@ Scheduler::Scheduler() {
   progress_time_enabled_ = arguments::ArgConfig::vt_sched_progress_sec != 0.0;
 }
 
+/*virtual*/ void Scheduler::startup() /*override*/ {
+  // Depends on theTrace
+  between_sched_event_type_ = trace::registerEventHashed(
+    "Between VT schedulers"
+  );
+}
+
+/*virtual*/ void Scheduler::finalize() /*override*/ {
+  // Complete any event between last runSchedulerWhile and vt::finalize.
+  between_sched_event_ = nullptr;
+}
+
 void Scheduler::enqueue(ActionType action) {
   bool const is_term = false;
 # if backend_check_enabled(priorities)
@@ -265,28 +277,44 @@ void Scheduler::scheduler(bool msg_only) {
 }
 
 void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
+  // This loop construct can run either in a top-level or nested context.
+  // 1. In a top-level context the idle time will encompass the time not
+  //    processing any actions when the work queue is empty. Leaving starts
+  //    a 'between scheduler' event which will only complete on the next call.
+  // 2. In a nested context, idle is always exited at the end
+  //    as the parent context is "not idle". Likewise, no 'between scheduler'
+  //    event is started.
+
   vtAssert(
     action_depth_ == 0 or not is_idle,
     "Nested schedulers never expected from idle context"
   );
 
+  if (action_depth_ == 0) {
+    between_sched_event_ = nullptr;
+  }
+
   triggerEvent(SchedulerEventType::BeginSchedulerLoop);
 
   while (cond()) {
-    runScheduler();
+    scheduler();
   }
 
   // At the end of a nested scheduler context, always ensure to enter into
-  // a non-idle state as the outer work resumes, even if the scheduler
-  // work queue is itself empty. That is, a nested scheduler should
-  // ONLY trigger an idle state during the duration of the scheduling loop.
-  // The opposite does not hold: idle is only entered when there is no work.
+  // a non-idle state as the outer work resumes.
   if (action_depth_ > 0 and is_idle) {
     is_idle = false;
     triggerEvent(SchedulerEventType::EndIdle);
   }
 
   triggerEvent(SchedulerEventType::EndSchedulerLoop);
+
+  if (action_depth_ == 0) {
+    // Start an event representing time outside of top-level scheduler.
+    between_sched_event_ = std::make_unique<trace::TraceScopedEvent>(
+      between_sched_event_type_
+    );
+  }
 }
 
 void Scheduler::triggerEvent(SchedulerEventType const& event) {

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -99,8 +99,8 @@ struct Scheduler : runtime::component::Component<Scheduler> {
 
   std::string name() override { return "Scheduler"; }
 
-  virtual void startup() override;
-  virtual void finalize() override;
+  void startup() override;
+  void finalize() override;
 
   static void checkTermSingleNode();
 

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -53,8 +53,6 @@
 #include "vt/messaging/message/smart_ptr.h"
 #include "vt/timing/timing.h"
 #include "vt/runtime/component/component_pack.h"
-#include "vt/trace/trace.h"
-#include "vt/trace/trace_user.h"
 
 #include <cassert>
 #include <vector>
@@ -73,14 +71,15 @@ namespace vt {
 namespace vt { namespace sched {
 
 enum SchedulerEvent {
-  BeginIdle          = 0,
-  EndIdle            = 1,
-  BeginIdleMinusTerm = 2,
-  EndIdleMinusTerm   = 3,
-  BeginSchedulerLoop = 4,
-  EndSchedulerLoop   = 5,
+  BeginIdle            = 0,
+  EndIdle              = 1,
+  BeginIdleMinusTerm   = 2,
+  EndIdleMinusTerm     = 3,
+  BeginSchedulerLoop   = 4,
+  EndSchedulerLoop     = 5,
+  PendingSchedulerLoop = 6,
 
-  LastSchedulerEvent = 5,
+  LastSchedulerEvent   = 6,
 };
 
 struct Scheduler : runtime::component::Component<Scheduler> {
@@ -98,9 +97,6 @@ struct Scheduler : runtime::component::Component<Scheduler> {
   Scheduler();
 
   std::string name() override { return "Scheduler"; }
-
-  void startup() override;
-  void finalize() override;
 
   static void checkTermSingleNode();
 
@@ -162,16 +158,11 @@ private:
   Queue<UnitType> work_queue_;
 # endif
 
-  trace::TraceEntryIDType between_sched_event_type_ = trace::no_trace_entry_id;
-
   bool has_executed_      = false;
   bool is_idle            = true;
   bool is_idle_minus_term = true;
   // The depth of work action currently executing.
   unsigned int action_depth_ = 0;
-
-  // Event to track time between top-level VT scheduler loops.
-  trace::TraceProcessingTag between_sched_event_;
 
   // The number of termination messages currently in the queue---they weakly
   // imply idleness for the stake of termination
@@ -188,7 +179,7 @@ private:
   std::size_t threshold_memory_usage_ = 0;
   std::size_t last_memory_usage_poll_ = 0;
 
-  // Access to endBetweenLoopEvent()
+  // Access to triggerEvent.
   friend void vt::runInEpochRooted(ActionType&& fn);
   friend void vt::runInEpochCollective(ActionType&& fn);
 };

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -53,6 +53,8 @@
 #include "vt/messaging/message/smart_ptr.h"
 #include "vt/timing/timing.h"
 #include "vt/runtime/component/component_pack.h"
+#include "vt/trace/trace.h"
+#include "vt/trace/trace_user.h"
 
 #include <cassert>
 #include <vector>
@@ -88,6 +90,9 @@ struct Scheduler : runtime::component::Component<Scheduler> {
   Scheduler();
 
   std::string name() override { return "Scheduler"; }
+
+  virtual void startup() override;
+  virtual void finalize() override;
 
   static void checkTermSingleNode();
 
@@ -149,11 +154,16 @@ private:
   Queue<UnitType> work_queue_;
 # endif
 
+  trace::UserEventIDType between_sched_event_type_ = trace::no_user_event_id;
+
   bool has_executed_      = false;
   bool is_idle            = true;
   bool is_idle_minus_term = true;
   // The depth of work action currently executing.
   unsigned int action_depth_ = 0;
+
+  // User event for tracking between top-level VT scheduler loops.
+  std::unique_ptr<trace::TraceScopedEvent> between_sched_event_ = nullptr;
 
   // The number of termination messages currently in the queue---they weakly
   // imply idleness for the stake of termination

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -62,6 +62,14 @@
 #include <functional>
 #include <memory>
 
+namespace vt {
+  void runScheduler();
+  void runSchedulerThrough(EpochType epoch);
+
+  void runInEpochRooted(ActionType&& fn);
+  void runInEpochCollective(ActionType&& fn);
+}
+
 namespace vt { namespace sched {
 
 enum SchedulerEvent {
@@ -179,6 +187,10 @@ private:
   std::size_t last_threshold_memory_usage_ = 0;
   std::size_t threshold_memory_usage_ = 0;
   std::size_t last_memory_usage_poll_ = 0;
+
+  // Access to between_sched_event_
+  friend void vt::runInEpochRooted(ActionType&& fn);
+  friend void vt::runInEpochCollective(ActionType&& fn);
 };
 
 }} //end namespace vt::sched
@@ -186,12 +198,6 @@ private:
 #include "vt/scheduler/scheduler.impl.h"
 
 namespace vt {
-
-void runScheduler();
-void runSchedulerThrough(EpochType epoch);
-
-void runInEpochRooted(ActionType&& fn);
-void runInEpochCollective(ActionType&& fn);
 
 extern sched::Scheduler* theSched();
 

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -162,7 +162,7 @@ private:
   Queue<UnitType> work_queue_;
 # endif
 
-  trace::UserEventIDType between_sched_event_type_ = trace::no_user_event_id;
+  trace::TraceEntryIDType between_sched_event_type_ = trace::no_trace_entry_id;
 
   bool has_executed_      = false;
   bool is_idle            = true;
@@ -170,8 +170,8 @@ private:
   // The depth of work action currently executing.
   unsigned int action_depth_ = 0;
 
-  // User event for tracking between top-level VT scheduler loops.
-  std::unique_ptr<trace::TraceScopedEvent> between_sched_event_ = nullptr;
+  // Event to track time between top-level VT scheduler loops.
+  trace::TraceProcessingTag between_sched_event_;
 
   // The number of termination messages currently in the queue---they weakly
   // imply idleness for the stake of termination
@@ -188,7 +188,7 @@ private:
   std::size_t threshold_memory_usage_ = 0;
   std::size_t last_memory_usage_poll_ = 0;
 
-  // Access to between_sched_event_
+  // Access to endBetweenLoopEvent()
   friend void vt::runInEpochRooted(ActionType&& fn);
   friend void vt::runInEpochCollective(ActionType&& fn);
 };

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -120,10 +120,18 @@ Trace::Trace(std::string const& in_prog_name)
   event_holds_.push_back(0);
 }
 
-void Trace::initialize() {
+void Trace::initialize() /*override*/ {
 #if backend_check_enabled(trace_enabled)
   setupNames(prog_name_);
 
+  // Register a trace user event to demarcate flushes that occur
+  flush_event_ = vt::trace::registerEventCollective("trace_flush");
+#endif
+}
+
+void Trace::startup() /*override*/ {
+#if backend_check_enabled(trace_enabled)
+  // Trace is a dependency of the Scheduler (co-dependency).
   theSched()->registerTrigger(
     sched::SchedulerEvent::BeginSchedulerLoop, [this]{ beginSchedulerLoop(); }
   );
@@ -136,9 +144,6 @@ void Trace::initialize() {
   theSched()->registerTrigger(
     sched::SchedulerEvent::EndIdle, [this]{ endIdle(); }
   );
-
-  // Register a trace user event to demarcate flushes that occur
-  flush_event_ = vt::trace::registerEventCollective("trace_flush");
 #endif
 }
 

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -487,7 +487,9 @@ void Trace::endProcessing(
   TraceProcessingTag const& processing_tag,
   double const time
 ) {
-  if (not checkDynamicRuntimeEnabled()) {
+  // End event honored even if tracing is disabled in this phase.
+  // This ensures proper stack unwinding in all contexts.
+  if (not checkDynamicRuntimeEnabled(true)) {
     return;
   }
 
@@ -642,7 +644,7 @@ TraceEventIDType Trace::messageRecv(
   );
 }
 
-bool Trace::checkDynamicRuntimeEnabled() {
+bool Trace::checkDynamicRuntimeEnabled(bool is_end_event) {
   /*
    * enabled_ -> this is the dynamic check that can be disabled at any point via
    * the application
@@ -657,7 +659,7 @@ bool Trace::checkDynamicRuntimeEnabled() {
   return
     enabled_ and
     traceWritingEnabled(theContext()->getNode()) and
-    trace_enabled_cur_phase_;
+    (trace_enabled_cur_phase_ or is_end_event);
 }
 
 void Trace::setTraceEnabledCurrentPhase(PhaseType cur_phase) {
@@ -668,15 +670,9 @@ void Trace::setTraceEnabledCurrentPhase(PhaseType cur_phase) {
     bool ret = proxy.get()->checkTraceEnabled(spec_index);
 
     if (trace_enabled_cur_phase_ != ret) {
-      auto time = getCurrentTime();
-      // Close and pop everything, we are disabling traces at this point
-      std::size_t hold_at = event_holds_.back();
-      while (open_events_.size() > hold_at) {
-        traces_.push(
-          LogType{open_events_.back(), time, TraceConstantsType::EndProcessing}
-        );
-        open_events_.pop_back();
-      }
+      // N.B. Future endProcessing calls are required to close the current
+      // open event stack, even after the tracing is disabled for the phase.
+      // This ensures valid stack unwinding in all cases.
 
       // Go ahead and perform a trace flush when tracing is disabled (and was
       // previously enabled) to reduce memory footprint.
@@ -720,24 +716,7 @@ TraceEventIDType Trace::logEvent(LogType&& log) {
     open_events_.push_back(log /* copy, not forwarding rv-ref */);
     break;
   }
-  case TraceConstantsType::EndProcessing: {
-    // Ideal route is to call endProcessing(tag) directly as all
-    // data should be on the beginProcessing event and not changed after.
-    // This case remains for compatibility.
-
-    vtAssert(
-      open_events_.back().ep == log.ep and
-      open_events_.back().type == TraceConstantsType::BeginProcessing,
-      "Top event should be correct type and event"
-    );
-
-    // Steal top event information
-    LogType const& top = open_events_.back();
-    TraceProcessingTag processing_tag{top.ep, top.event};
-    endProcessing(processing_tag);
-
-    return trace::no_trace_event; // n.b. pushed eagerly
-  }
+  // TraceConstantsType::EndProcessing must be through endProcessing(tag).
   case TraceConstantsType::Creation:
   case TraceConstantsType::CreationBcast:
   case TraceConstantsType::MessageRecv:

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -110,6 +110,8 @@ struct Trace : runtime::component::Component<Trace> {
   std::string getDirectory() const { return full_dir_name_;   }
 
   void initialize() override;
+  void startup() override;
+
   void setupNames(std::string const& in_prog_name);
 
   /// Initiate a paired event.

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -185,7 +185,7 @@ struct Trace : runtime::component::Component<Trace> {
   /// Events already logged may still be written to the trace log.
   void disableTracing();
 
-  bool checkDynamicRuntimeEnabled();
+  bool checkDynamicRuntimeEnabled(bool is_end_event = false);
 
   void loadAndBroadcastSpec();
   void setTraceEnabledCurrentPhase(PhaseType cur_phase);

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -111,6 +111,7 @@ struct Trace : runtime::component::Component<Trace> {
 
   void initialize() override;
   void startup() override;
+  void finalize() override;
 
   void setupNames(std::string const& in_prog_name);
 
@@ -132,6 +133,7 @@ struct Trace : runtime::component::Component<Trace> {
     double const time = getCurrentTime()
   );
 
+  void pendingSchedulerLoop();
   void beginSchedulerLoop();
   void endSchedulerLoop();
 
@@ -272,6 +274,10 @@ private:
   ObjGroupProxyType spec_proxy_ = vt::no_obj_group;
   bool trace_enabled_cur_phase_ = true;
   UserEventIDType flush_event_  = no_user_event_id;
+
+  // Processing event between top-level loops.
+  TraceEntryIDType between_sched_event_type_ = no_trace_entry_id;
+  TraceProcessingTag between_sched_event_;
 };
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace_user.h
+++ b/src/vt/trace/trace_user.h
@@ -78,22 +78,23 @@ struct TraceScopedEventHash final {
     event_ = registerEventHashed(str_);
   }
 
+  TraceScopedEventHash& operator=(TraceScopedEventHash const&) = delete;
+
   ~TraceScopedEventHash() { end(); }
 
   void end() {
-    if (not ended_ and event_ != no_user_event_id) {
-      end_ = Trace::getCurrentTime();
-      ended_ = true;
-      theTrace()->addUserEventBracketed(event_, begin_, end_);
+    if (event_ != no_user_event_id) {
+      double end = Trace::getCurrentTime();
+      theTrace()->addUserEventBracketed(event_, begin_, end);
+
+      event_ = no_user_event_id;
     }
   }
 
 private:
   double begin_          = 0.0;
-  double end_            = 0.0;
   std::string str_       = "";
   UserEventIDType event_ = no_user_event_id;
-  bool ended_            = false;
 };
 
 struct TraceScopedEvent final {
@@ -102,21 +103,22 @@ struct TraceScopedEvent final {
       event_(event)
   { }
 
+  TraceScopedEvent& operator=(TraceScopedEvent const&) = delete;
+
   ~TraceScopedEvent() { end(); }
 
   void end() {
-    if (not ended_ and event_ != no_user_event_id) {
-      end_ = Trace::getCurrentTime();
-      ended_ = true;
-      theTrace()->addUserEventBracketed(event_, begin_, end_);
+    if (event_ != no_user_event_id) {
+      double end = Trace::getCurrentTime();
+      theTrace()->addUserEventBracketed(event_, begin_, end);
+
+      event_ = no_user_event_id;
     }
   }
 
 private:
   double begin_          = 0.0;
-  double end_            = 0.0;
   UserEventIDType event_ = no_user_event_id;
-  bool ended_            = false;
 };
 
 struct TraceScopedNote final {
@@ -127,15 +129,17 @@ struct TraceScopedNote final {
       note_(in_note)
   { }
 
-  ~TraceScopedNote() {
-    if (event_ != no_user_event_id) {
-      end_ = Trace::getCurrentTime();
-      theTrace()->addUserBracketedNote(begin_, end_, note_, event_);
-    }
-  }
+  TraceScopedNote& operator=(TraceScopedNote const&) = delete;
+
+  ~TraceScopedNote() { end(); }
 
   void end() {
-    end_ = Trace::getCurrentTime();
+    if (event_ != no_user_event_id) {
+      double end = Trace::getCurrentTime();
+      theTrace()->addUserBracketedNote(begin_, end, note_, event_);
+
+      event_ = no_user_event_id;
+    }
   }
 
   void setEvent(TraceEventIDType const in_event) {
@@ -144,7 +148,6 @@ struct TraceScopedNote final {
 
 private:
   double begin_           = 0.0;
-  double end_             = 0.0;
   TraceEventIDType event_ = no_trace_event;
   std::string note_       = "";
 };


### PR DESCRIPTION
All code that (consistently) uses `runSchedulerWhile` will emit events "between" such top-level loops. This also includes time between the last `runSchedulerWhile` and when the scheduler is finalized.

The red processing events on node 0 are time spent between the calls to `runSchedulerWhile` which is called via `runInEpoch*` (an artificial delay has been added). Node 1 jumps directly to vt::finalize and thus does not have (much) time "between" top-level schedulers.

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/1430176/84611877-de2a2f00-ae73-11ea-9379-08b350aaf324.png">

These changes should be matched in all client usages to never call `runScheduler` directly. This is because a 'between' event may remain on the open event stack until the next call to `runSchedulerWhile` or VT finalization.

--

Using user events (older commits):

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/1430176/84605018-dc9a4000-ae4e-11ea-9df7-bcd072cb5dec.png">

Fixes #845
