### PR TITLE
Fix nvcc warning about sign mismatch

### DIFF
--- a/src/vt/trace/trace_common.h
+++ b/src/vt/trace/trace_common.h
@@ -56,7 +56,7 @@ using TraceEntryIDType    = size_t; // uint32_t, maybe..
 using TraceEntrySeqType   = uint32_t;
 
 static constexpr TraceEntryIDType const no_trace_entry_id = 0;
-static constexpr TraceEntrySeqType const no_trace_entry_seq = -1;
+static constexpr TraceEntrySeqType const no_trace_entry_seq = ~0;
 
 // user traces
 using TraceEventIDType    = uint32_t;


### PR DESCRIPTION
> EMPIRE/TPL/vt/src/vt/trace/trace_common.h(59): warning: integer conversion resulted in a change of sign