### PR TITLE
854 - Outside Scheduler Loop Events

### DIFF
--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -74,21 +74,6 @@ Scheduler::Scheduler() {
   progress_time_enabled_ = arguments::ArgConfig::vt_sched_progress_sec != 0.0;
 }
 
-/*virtual*/ void Scheduler::startup() /*override*/ {
-#if backend_check_enabled(trace_enabled)
-  between_sched_event_type_ = trace::TraceRegistry::registerEventHashed(
-    "Scheduler", "Between_Schedulers"
-  );
-#else
-  between_sched_event_type_ = trace::no_trace_entry_id;
-#endif
-}
-
-/*virtual*/ void Scheduler::finalize() /*override*/ {
-  // Complete any event between last runSchedulerWhile and vt::finalize.
-  endBetweenLoopEvent();
-}
-
 void Scheduler::enqueue(ActionType action) {
   bool const is_term = false;
 # if backend_check_enabled(priorities)
@@ -367,9 +352,5 @@ namespace vt {
 void runScheduler() {
   theSched()->scheduler();
 }
-
-  theSched()->triggerEvent(sched::SchedulerEvent::PendingSchedulerLoop);
-
-  theSched()->triggerEvent(sched::SchedulerEvent::PendingSchedulerLoop);
 
 } //end namespace vt

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -279,10 +279,6 @@ void Scheduler::scheduler(bool msg_only) {
       is_idle = true;
       triggerEvent(SchedulerEventType::BeginIdle);
     }
-
-  } else {
-    // n.b. Work queue is empty - however, if a trace event was written WITHOUT
-    // new work being queued then the trace state may be in a non-idle state.
   }
 
   if (not msg_only) {
@@ -308,13 +304,21 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
 
   triggerEvent(SchedulerEventType::BeginSchedulerLoop);
 
+  // When resuming a top-level scheduler, ensure to immediately enter
+  // an idle state if such applies.
+  if (not is_idle and work_queue_.empty()) {
+    is_idle = true;
+    triggerEvent(SchedulerEventType::BeginIdle);
+  }
+
   while (cond()) {
     scheduler();
   }
 
-  // At the end of a nested scheduler context, always ensure to enter into
-  // a non-idle state as the outer work resumes.
-  if (action_depth_ > 0 and is_idle) {
+  // After running the scheduler ensure to exit idle state.
+  // For nested schedulers the outside scheduler has work to do.
+  // Between top-level schedulers, non-idle indicates lack of scheduling.
+  if (is_idle) {
     is_idle = false;
     triggerEvent(SchedulerEventType::EndIdle);
   }

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -304,9 +304,7 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
     "Nested schedulers never expected from idle context"
   );
 
-  if (action_depth_ == 0) {
-    between_sched_event_ = nullptr;
-  }
+  between_sched_event_ = nullptr;
 
   triggerEvent(SchedulerEventType::BeginSchedulerLoop);
 
@@ -371,5 +369,9 @@ namespace vt {
 void runScheduler() {
   theSched()->scheduler();
 }
+
+  theSched()->between_sched_event_ = nullptr; // loop will be entered
+
+  theSched()->between_sched_event_ = nullptr; // loop will be entered
 
 } //end namespace vt

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -303,8 +303,6 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
     "Nested schedulers never expected from idle context"
   );
 
-  endBetweenLoopEvent();
-
   triggerEvent(SchedulerEventType::BeginSchedulerLoop);
 
   // When resuming a top-level scheduler, ensure to immediately enter
@@ -327,22 +325,6 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
   }
 
   triggerEvent(SchedulerEventType::EndSchedulerLoop);
-
-#if backend_check_enabled(trace_enabled)
-  if (action_depth_ == 0) {
-    // Start an event representing time outside of top-level scheduler.
-    between_sched_event_ = theTrace()->beginProcessing(
-      between_sched_event_type_, 0, trace::no_trace_event, 0
-    );
-  }
-#endif
-}
-
-void Scheduler::endBetweenLoopEvent() {
-#if backend_check_enabled(trace_enabled)
-  theTrace()->endProcessing(between_sched_event_);
-  between_sched_event_ = trace::TraceProcessingTag{};
-#endif
 }
 
 void Scheduler::triggerEvent(SchedulerEventType const& event) {
@@ -386,8 +368,8 @@ void runScheduler() {
   theSched()->scheduler();
 }
 
-  theSched()->endBetweenLoopEvent(); // loop will be entered
+  theSched()->triggerEvent(sched::SchedulerEvent::PendingSchedulerLoop);
 
-  theSched()->endBetweenLoopEvent(); // loop will be entered
+  theSched()->triggerEvent(sched::SchedulerEvent::PendingSchedulerLoop);
 
 } //end namespace vt

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -159,7 +159,7 @@ private:
   Queue<UnitType> work_queue_;
 # endif
 
-  trace::UserEventIDType between_sched_event_type_ = trace::no_user_event_id;
+  trace::TraceEntryIDType between_sched_event_type_ = trace::no_trace_entry_id;
 
   bool has_executed_      = false;
   bool is_idle            = true;
@@ -167,8 +167,8 @@ private:
   // The depth of work action currently executing.
   unsigned int action_depth_ = 0;
 
-  // User event for tracking between top-level VT scheduler loops.
-  std::unique_ptr<trace::TraceScopedEvent> between_sched_event_ = nullptr;
+  // Event to track time between top-level VT scheduler loops.
+  trace::TraceProcessingTag between_sched_event_;
 
   // The number of termination messages currently in the queue---they weakly
   // imply idleness for the stake of termination
@@ -185,7 +185,7 @@ private:
   std::size_t threshold_memory_usage_ = 0;
   std::size_t last_memory_usage_poll_ = 0;
 
-  // Access to between_sched_event_
+  // Access to endBetweenLoopEvent()
   friend void vt::runInEpochRooted(ActionType&& fn);
   friend void vt::runInEpochCollective(ActionType&& fn);
 };

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -52,6 +52,8 @@
 #include "vt/scheduler/work_unit.h"
 #include "vt/messaging/message/smart_ptr.h"
 #include "vt/timing/timing.h"
+#include "vt/trace/trace.h"
+#include "vt/trace/trace_user.h"
 
 #include <cassert>
 #include <vector>
@@ -85,6 +87,9 @@ struct Scheduler {
 # endif
 
   Scheduler();
+
+  virtual void startup() override;
+  virtual void finalize() override;
 
   static void checkTermSingleNode();
 
@@ -146,11 +151,16 @@ private:
   Queue<UnitType> work_queue_;
 # endif
 
+  trace::UserEventIDType between_sched_event_type_ = trace::no_user_event_id;
+
   bool has_executed_      = false;
   bool is_idle            = true;
   bool is_idle_minus_term = true;
   // The depth of work action currently executing.
   unsigned int action_depth_ = 0;
+
+  // User event for tracking between top-level VT scheduler loops.
+  std::unique_ptr<trace::TraceScopedEvent> between_sched_event_ = nullptr;
 
   // The number of termination messages currently in the queue---they weakly
   // imply idleness for the stake of termination

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -61,6 +61,14 @@
 #include <functional>
 #include <memory>
 
+namespace vt {
+  void runScheduler();
+  void runSchedulerThrough(EpochType epoch);
+
+  void runInEpochRooted(ActionType&& fn);
+  void runInEpochCollective(ActionType&& fn);
+}
+
 namespace vt { namespace sched {
 
 enum SchedulerEvent {
@@ -176,6 +184,10 @@ private:
   std::size_t last_threshold_memory_usage_ = 0;
   std::size_t threshold_memory_usage_ = 0;
   std::size_t last_memory_usage_poll_ = 0;
+
+  // Access to between_sched_event_
+  friend void vt::runInEpochRooted(ActionType&& fn);
+  friend void vt::runInEpochCollective(ActionType&& fn);
 };
 
 }} //end namespace vt::sched
@@ -183,8 +195,6 @@ private:
 #include "vt/scheduler/scheduler.impl.h"
 
 namespace vt {
-
-void runScheduler();
 
 extern sched::Scheduler* theSched();
 

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -95,8 +95,6 @@ struct Scheduler {
 
   Scheduler();
 
-  virtual void startup() override;
-  virtual void finalize() override;
   static void checkTermSingleNode();
 
   bool shouldCallProgress(

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -52,8 +52,6 @@
 #include "vt/scheduler/work_unit.h"
 #include "vt/messaging/message/smart_ptr.h"
 #include "vt/timing/timing.h"
-#include "vt/trace/trace.h"
-#include "vt/trace/trace_user.h"
 
 #include <cassert>
 #include <vector>
@@ -72,14 +70,15 @@ namespace vt {
 namespace vt { namespace sched {
 
 enum SchedulerEvent {
-  BeginIdle          = 0,
-  EndIdle            = 1,
-  BeginIdleMinusTerm = 2,
-  EndIdleMinusTerm   = 3,
-  BeginSchedulerLoop = 4,
-  EndSchedulerLoop   = 5,
+  BeginIdle            = 0,
+  EndIdle              = 1,
+  BeginIdleMinusTerm   = 2,
+  EndIdleMinusTerm     = 3,
+  BeginSchedulerLoop   = 4,
+  EndSchedulerLoop     = 5,
+  PendingSchedulerLoop = 6,
 
-  LastSchedulerEvent = 5,
+  LastSchedulerEvent   = 6,
 };
 
 struct Scheduler {
@@ -98,7 +97,6 @@ struct Scheduler {
 
   virtual void startup() override;
   virtual void finalize() override;
-
   static void checkTermSingleNode();
 
   bool shouldCallProgress(
@@ -159,16 +157,11 @@ private:
   Queue<UnitType> work_queue_;
 # endif
 
-  trace::TraceEntryIDType between_sched_event_type_ = trace::no_trace_entry_id;
-
   bool has_executed_      = false;
   bool is_idle            = true;
   bool is_idle_minus_term = true;
   // The depth of work action currently executing.
   unsigned int action_depth_ = 0;
-
-  // Event to track time between top-level VT scheduler loops.
-  trace::TraceProcessingTag between_sched_event_;
 
   // The number of termination messages currently in the queue---they weakly
   // imply idleness for the stake of termination
@@ -185,7 +178,7 @@ private:
   std::size_t threshold_memory_usage_ = 0;
   std::size_t last_memory_usage_poll_ = 0;
 
-  // Access to endBetweenLoopEvent()
+  // Access to triggerEvent.
   friend void vt::runInEpochRooted(ActionType&& fn);
   friend void vt::runInEpochCollective(ActionType&& fn);
 };

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -116,41 +116,48 @@ Trace::Trace(std::string const& in_prog_name, std::string const& in_trace_name)
    */
 
   incremental_flush_mode = Z_SYNC_FLUSH;
-}
 
-Trace::Trace() { }
-
-/*static*/ void Trace::traceBeginIdleTrigger() {
-  #if backend_check_enabled(trace_enabled)
-    if (not theTrace()->inIdleEvent()) {
-      theTrace()->beginIdle();
-    }
-  #endif
-}
-
-void Trace::initialize() {
-#if backend_check_enabled(trace_enabled)
   // The first (implied) scheduler always starts with an empty event stack.
   event_holds_.push_back(0);
+}
 
+void Trace::initialize() /*override*/ {
+#if backend_check_enabled(trace_enabled)
+  setupNames(prog_name_);
+
+  between_sched_event_type_ = trace::TraceRegistry::registerEventHashed(
+    "Scheduler", "Between_Schedulers"
+  );
+
+  // Register a trace user event to demarcate flushes that occur
+  flush_event_ = trace::registerEventCollective("trace_flush");
+#endif
+}
+
+void Trace::startup() /*override*/ {
+#if backend_check_enabled(trace_enabled)
+  theSched()->registerTrigger(
+    sched::SchedulerEvent::PendingSchedulerLoop, [this]{ pendingSchedulerLoop(); }
+  );
   theSched()->registerTrigger(
     sched::SchedulerEvent::BeginSchedulerLoop, [this]{ beginSchedulerLoop(); }
   );
   theSched()->registerTrigger(
     sched::SchedulerEvent::EndSchedulerLoop, [this]{ endSchedulerLoop(); }
   );
-
   theSched()->registerTrigger(
     sched::SchedulerEvent::BeginIdle, [this]{ beginIdle(); }
   );
   theSched()->registerTrigger(
     sched::SchedulerEvent::EndIdle, [this]{ endIdle(); }
   );
-
-
-  // Register a trace user event to demarcate flushes that occur
-  flush_event_ = vt::trace::registerEventCollective("trace_flush");
 #endif
+}
+
+void Trace::finalize() /*override*/ {
+  // Always end any between-loop event left open.
+  endProcessing(between_sched_event_);
+  between_sched_event_ = TraceProcessingTag{};
 }
 
 void Trace::loadAndBroadcastSpec() {
@@ -545,7 +552,17 @@ void Trace::endProcessing(
   // Unlike logEvent there is currently no flush here.
 }
 
+void Trace::pendingSchedulerLoop() {
+  // Always end between-loop event.
+  endProcessing(between_sched_event_);
+  between_sched_event_ = TraceProcessingTag{};
+}
+
 void Trace::beginSchedulerLoop() {
+  // Always end between-loop event. The pending case is not always triggered.
+  endProcessing(between_sched_event_);
+  between_sched_event_ = TraceProcessingTag{};
+
   // Capture the current open event depth.
   event_holds_.push_back(open_events_.size());
 }
@@ -562,6 +579,13 @@ void Trace::endSchedulerLoop() {
   );
 
   event_holds_.pop_back();
+
+  // Start an event representing time outside of top-level scheduler.
+  if (event_holds_.size() == 1) {
+    between_sched_event_ = beginProcessing(
+      between_sched_event_type_, 0, trace::no_trace_event, 0
+    );
+  }
 }
 
 void Trace::beginIdle(double const time) {

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -690,9 +690,9 @@ bool Trace::checkDynamicRuntimeEnabled(bool is_end_event) {
    * specification file
    */
   return
-    enabled_ and
-    traceWritingEnabled(theContext()->getNode()) and
-    (trace_enabled_cur_phase_ or is_end_event);
+    traceWritingEnabled(theContext()->getNode())
+    and (is_end_event
+         or (enabled_ and trace_enabled_cur_phase_));
 }
 
 void Trace::setTraceEnabledCurrentPhase(PhaseType cur_phase) {

--- a/src/vt/trace/trace.cc
+++ b/src/vt/trace/trace.cc
@@ -496,7 +496,9 @@ void Trace::endProcessing(
   TraceProcessingTag const& processing_tag,
   double const time
 ) {
-  if (not checkDynamicRuntimeEnabled()) {
+  // End event honored even if tracing is disabled in this phase.
+  // This ensures proper stack unwinding in all contexts.
+  if (not checkDynamicRuntimeEnabled(true)) {
     return;
   }
 
@@ -652,7 +654,7 @@ TraceEventIDType Trace::messageRecv(
   );
 }
 
-bool Trace::checkDynamicRuntimeEnabled() {
+bool Trace::checkDynamicRuntimeEnabled(bool is_end_event) {
   /*
    * enabled_ -> this is the dynamic check that can be disabled at any point via
    * the application
@@ -667,7 +669,7 @@ bool Trace::checkDynamicRuntimeEnabled() {
   return
     enabled_ and
     traceWritingEnabled(theContext()->getNode()) and
-    trace_enabled_cur_phase_;
+    (trace_enabled_cur_phase_ or is_end_event);
 }
 
 void Trace::setTraceEnabledCurrentPhase(PhaseType cur_phase) {
@@ -678,15 +680,9 @@ void Trace::setTraceEnabledCurrentPhase(PhaseType cur_phase) {
     bool ret = proxy.get()->checkTraceEnabled(spec_index);
 
     if (trace_enabled_cur_phase_ != ret) {
-      auto time = getCurrentTime();
-      // Close and pop everything, we are disabling traces at this point
-      std::size_t hold_at = event_holds_.back();
-      while (open_events_.size() > hold_at) {
-        traces_.push(
-          LogType{open_events_.back(), time, TraceConstantsType::EndProcessing}
-        );
-        open_events_.pop_back();
-      }
+      // N.B. Future endProcessing calls are required to close the current
+      // open event stack, even after the tracing is disabled for the phase.
+      // This ensures valid stack unwinding in all cases.
 
       // Go ahead and perform a trace flush when tracing is disabled (and was
       // previously enabled) to reduce memory footprint.
@@ -730,24 +726,7 @@ TraceEventIDType Trace::logEvent(LogType&& log) {
     open_events_.push_back(log /* copy, not forwarding rv-ref */);
     break;
   }
-  case TraceConstantsType::EndProcessing: {
-    // Ideal route is to call endProcessing(tag) directly as all
-    // data should be on the beginProcessing event and not changed after.
-    // This case remains for compatibility.
-
-    vtAssert(
-      open_events_.back().ep == log.ep and
-      open_events_.back().type == TraceConstantsType::BeginProcessing,
-      "Top event should be correct type and event"
-    );
-
-    // Steal top event information
-    LogType const& top = open_events_.back();
-    TraceProcessingTag processing_tag{top.ep, top.event};
-    endProcessing(processing_tag);
-
-    return trace::no_trace_event; // n.b. pushed eagerly
-  }
+  // TraceConstantsType::EndProcessing must be through endProcessing(tag).
   case TraceConstantsType::Creation:
   case TraceConstantsType::CreationBcast:
   case TraceConstantsType::MessageRecv:

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -107,8 +107,8 @@ struct Trace {
   std::string getSTSName()   const { return full_sts_name_;   }
   std::string getDirectory() const { return full_dir_name_;   }
 
-  void initialize() override;
-  void startup() override;
+  virtual void initialize(); // override in 1.1 with Component deps.
+  virtual void startup();    // override in 1.1 with Component deps.
 
   void setupNames(
     std::string const& in_prog_name, std::string const& in_trace_name,

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -107,7 +107,9 @@ struct Trace {
   std::string getSTSName()   const { return full_sts_name_;   }
   std::string getDirectory() const { return full_dir_name_;   }
 
-  void initialize();
+  void initialize() override;
+  void startup() override;
+
   void setupNames(
     std::string const& in_prog_name, std::string const& in_trace_name,
     std::string const& in_dir_name = ""
@@ -131,6 +133,7 @@ struct Trace {
     double const time = getCurrentTime()
   );
 
+  void pendingSchedulerLoop();
   void beginSchedulerLoop();
   void endSchedulerLoop();
 
@@ -273,6 +276,10 @@ private:
   ObjGroupProxyType spec_proxy_ = vt::no_obj_group;
   bool trace_enabled_cur_phase_ = true;
   UserEventIDType flush_event_  = no_user_event_id;
+
+  // Processing event between top-level loops.
+  TraceEntryIDType between_sched_event_type_ = no_trace_entry_id;
+  TraceProcessingTag between_sched_event_;
 };
 
 }} //end namespace vt::trace

--- a/src/vt/trace/trace.h
+++ b/src/vt/trace/trace.h
@@ -184,7 +184,7 @@ struct Trace {
   /// Events already logged may still be written to the trace log.
   void disableTracing();
 
-  bool checkDynamicRuntimeEnabled();
+  bool checkDynamicRuntimeEnabled(bool is_end_event = false);
 
   void loadAndBroadcastSpec();
   void setTraceEnabledCurrentPhase(PhaseType cur_phase);

--- a/src/vt/trace/trace_user.h
+++ b/src/vt/trace/trace_user.h
@@ -78,22 +78,23 @@ struct TraceScopedEventHash final {
     event_ = registerEventHashed(str_);
   }
 
+  TraceScopedEventHash& operator=(TraceScopedEventHash const&) = delete;
+
   ~TraceScopedEventHash() { end(); }
 
   void end() {
-    if (not ended_ and event_ != no_user_event_id) {
-      end_ = Trace::getCurrentTime();
-      ended_ = true;
-      theTrace()->addUserEventBracketed(event_, begin_, end_);
+    if (event_ != no_user_event_id) {
+      double end = Trace::getCurrentTime();
+      theTrace()->addUserEventBracketed(event_, begin_, end);
+
+      event_ = no_user_event_id;
     }
   }
 
 private:
   double begin_          = 0.0;
-  double end_            = 0.0;
   std::string str_       = "";
   UserEventIDType event_ = no_user_event_id;
-  bool ended_            = false;
 };
 
 struct TraceScopedEvent final {
@@ -102,21 +103,22 @@ struct TraceScopedEvent final {
       event_(event)
   { }
 
+  TraceScopedEvent& operator=(TraceScopedEvent const&) = delete;
+
   ~TraceScopedEvent() { end(); }
 
   void end() {
-    if (not ended_ and event_ != no_user_event_id) {
-      end_ = Trace::getCurrentTime();
-      ended_ = true;
-      theTrace()->addUserEventBracketed(event_, begin_, end_);
+    if (event_ != no_user_event_id) {
+      double end = Trace::getCurrentTime();
+      theTrace()->addUserEventBracketed(event_, begin_, end);
+
+      event_ = no_user_event_id;
     }
   }
 
 private:
   double begin_          = 0.0;
-  double end_            = 0.0;
   UserEventIDType event_ = no_user_event_id;
-  bool ended_            = false;
 };
 
 struct TraceScopedNote final {
@@ -127,15 +129,17 @@ struct TraceScopedNote final {
       note_(in_note)
   { }
 
-  ~TraceScopedNote() {
-    if (event_ != no_user_event_id) {
-      end_ = Trace::getCurrentTime();
-      theTrace()->addUserBracketedNote(begin_, end_, note_, event_);
-    }
-  }
+  TraceScopedNote& operator=(TraceScopedNote const&) = delete;
+
+  ~TraceScopedNote() { end(); }
 
   void end() {
-    end_ = Trace::getCurrentTime();
+    if (event_ != no_user_event_id) {
+      double end = Trace::getCurrentTime();
+      theTrace()->addUserBracketedNote(begin_, end, note_, event_);
+
+      event_ = no_user_event_id;
+    }
   }
 
   void setEvent(TraceEventIDType const in_event) {
@@ -144,7 +148,6 @@ struct TraceScopedNote final {
 
 private:
   double begin_           = 0.0;
-  double end_             = 0.0;
   TraceEventIDType event_ = no_trace_event;
   std::string note_       = "";
 };


### PR DESCRIPTION
Ported to beta.9 branch.

**Note**: this _may_ fail in code that uses manual scheduler loops (not using `runSchedulerWhile`) when tracing is enabled if begin/end processing events are intertwined. All client code should be updated to use `runSchedulerWhile` for 'guaranteed' pairings.

It might be useful to accept the other scheduler-loop constructs into beta9, if such makes implementation easier.