### PR TITLE
908 - fix NVCC issues (mostly around serialization)

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -5,6 +5,10 @@ set -ex
 source_dir=${1}
 build_dir=${2}
 
+# Dependency versions, when fetched via git.
+detector_rev=master
+checkpoint_rev=develop
+
 if test "${VT_DOXYGEN_ENABLED:-0}" -eq 1
 then
     token=${3}
@@ -32,7 +36,7 @@ if test -d "${source_dir}/lib/detector"
 then
     echo "Detector already in lib... not downloading, building, and installing"
 else
-    git clone -b master --depth 1 https://github.com/DARMA-tasking/detector.git
+    git clone -b "${detector_rev}" --depth 1 https://github.com/DARMA-tasking/detector.git
     export DETECTOR=$PWD/detector
     export DETECTOR_BUILD=${build_dir}/detector
     mkdir -p "$DETECTOR_BUILD"
@@ -49,7 +53,7 @@ if test -d "${source_dir}/lib/checkpoint"
 then
     echo "Checkpoint already in lib... not downloading, building, and installing"
 else
-    git clone -b develop --depth 1 https://github.com/DARMA-tasking/checkpoint.git
+    git clone -b "${checkpoint_rev}" --depth 1 https://github.com/DARMA-tasking/checkpoint.git
     export CHECKPOINT=$PWD/checkpoint
     export CHECKPOINT_BUILD=${build_dir}/checkpoint
     mkdir -p "$CHECKPOINT_BUILD"

--- a/cmake/turn_on_warnings.cmake
+++ b/cmake/turn_on_warnings.cmake
@@ -18,4 +18,6 @@ if(NOT hasParent)
   enable_cxx_compiler_flag_if_supported("-Wshadow")
   enable_cxx_compiler_flag_if_supported("-Wno-unknown-pragmas")
   enable_cxx_compiler_flag_if_supported("-Wsign-compare")
+  # Not really a warning, is still diagnostic related..
+  enable_cxx_compiler_flag_if_supported("-ftemplate-backtrace-limit=100")
 endif()

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -55,7 +55,7 @@
 
 namespace vt { namespace messaging {
 
-constexpr ByteType msgsize_not_specified = -1;
+constexpr ByteType msgsize_not_specified = static_cast<ByteType>(-1);
 constexpr NodeType broadcast_dest = uninitialized_destination;
 
 template <typename MsgPtrT>

--- a/src/vt/rdmahandle/manager.impl.h
+++ b/src/vt/rdmahandle/manager.impl.h
@@ -53,6 +53,9 @@ namespace vt { namespace rdma {
 namespace impl {
 
 struct HandleData {
+  // #949. NVCC shim: Ensure type is compatible with serialization.
+  using isByteCopyable = std::true_type;
+
   HandleData();
   HandleData(HandleKey in_key, std::size_t in_size, int in_count)
     : key_(in_key),

--- a/tests/perf/ping_pong.cc
+++ b/tests/perf/ping_pong.cc
@@ -105,7 +105,7 @@ static void finishedPing(FinishedPingMsg<num_bytes>* msg) {
 
   if (num_bytes != max_bytes) {
     auto pmsg = makeMessage<PingMsg<num_bytes * 2>>();
-    theMsg()->sendMsg<PingMsg<num_bytes * 2>, pingPong>(
+    theMsg()->sendMsg<PingMsg<num_bytes * 2>, pingPong<num_bytes * 2>>(
       pong_node, pmsg.get()
     );
   }
@@ -133,7 +133,7 @@ static void pingPong(PingMsg<num_bytes>* in_msg) {
 
   if (cnt >= num_pings) {
     auto msg = makeMessage<FinishedPingMsg<num_bytes>>(num_bytes);
-    theMsg()->sendMsg<FinishedPingMsg<num_bytes>, finishedPing>(
+    theMsg()->sendMsg<FinishedPingMsg<num_bytes>, finishedPing<num_bytes>>(
       0, msg.get()
     );
   } else {
@@ -141,12 +141,12 @@ static void pingPong(PingMsg<num_bytes>* in_msg) {
       theContext()->getNode() == ping_node ? pong_node : ping_node;
     #if REUSE_MESSAGE_PING_PONG
       // @todo: fix this memory allocation problem
-      theMsg()->sendMsg<PingMsg<num_bytes>, pingPong>(
+      theMsg()->sendMsg<PingMsg<num_bytes>, pingPong<num_bytes>>(
         next, in_msg, [=]{ /*delete in_msg;*/ }
       );
     #else
       auto m = makeMessage<PingMsg<num_bytes>>(cnt + 1);
-      theMsg()->sendMsg<PingMsg<num_bytes>, pingPong>(next, m.get());
+      theMsg()->sendMsg<PingMsg<num_bytes>, pingPong<num_bytes>>(next, m.get());
     #endif
   }
 }
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
 
   if (my_node == 0) {
     auto m = makeMessage<PingMsg<min_bytes>>();
-    theMsg()->sendMsg<PingMsg<min_bytes>, pingPong>(pong_node, m.get());
+    theMsg()->sendMsg<PingMsg<min_bytes>, pingPong<min_bytes>>(pong_node, m.get());
   }
 
   while (!rt->isTerminated()) {

--- a/tests/unit/pool/test_pool_message_sizes.cc
+++ b/tests/unit/pool/test_pool_message_sizes.cc
@@ -102,12 +102,12 @@ void TestPoolMessageSizes::testPoolFun(TestMsg<num_bytes>* prev_msg) {
 
   if (count < max_test_count) {
     auto msg = makeMessage<TestMsg<num_bytes>>();
-    theMsg()->sendMsg<TestMsg<num_bytes>, testPoolFun>(
+    theMsg()->sendMsg<TestMsg<num_bytes>, testPoolFun<num_bytes>>(
       next, msg.get()
     );
   } else {
     auto msg = makeMessage<TestMsg<num_bytes * 2>>();
-    theMsg()->sendMsg<TestMsg<num_bytes * 2>, testPoolFun>(
+    theMsg()->sendMsg<TestMsg<num_bytes * 2>, testPoolFun<num_bytes * 2>>(
       next, msg.get()
     );
     count = 0;


### PR DESCRIPTION
Something broke with https://github.com/DARMA-tasking/vt/pull/911 and it stopped tracking new commits. This might have been related to the subsequent GitHub outage.. created a new PR in any case.

---

Fixes several NVCC issues to get compilation to work in 10.1 and 11 NVCC/Cuda compilers.

Build has outstanding issue of supplying both "-std=C++1y" and "std=C++14" options at the same time. This raises warnings in NVCC, although it should be operating in C++14 mode.

Fixes: #908