### PR TITLE
 #870: Change name of component ProcStats to NodeStats for consistency

### DIFF
--- a/docs/md/node-stats.md
+++ b/docs/md/node-stats.md
@@ -1,14 +1,14 @@
-\page proc-stats Processor Statistics
+\page node-stats Node Statistics
 \brief Manager object profiling data
 
-The processor statistics manager component
-`vt::vrt::collection::balance::ProcStats`, accessed via `vt::theProcStats()`
+The node statistics manager component
+`vt::vrt::collection::balance::NodeStats`, accessed via `vt::theNodeStats()`
 manages instrumentation data from objects in a collection. It holds data per
 node on the timing of these objects and communication between them demarcated by
 phase and subphase.
 
-When LB is invoked in \vt, the \ref lb-manager passes the processor
-statistics to the various LB strategies to run the load balancer. The processor
+When LB is invoked in \vt, the \ref lb-manager passes the node
+statistics to the various LB strategies to run the load balancer. The node
 statistics component can also dump the statistic data it holds to files, which
 can be read externally. The LBAF (Load Balancing Analysis Framework) can also
 then read this data to analyze the quality of the load distribution at any phase
@@ -16,7 +16,7 @@ in the file.
 
 \section export-lb-stats-file Exporting LB Statistic Files (VOM)
 
-The `ProcStats` component, after collecting statistics from the running program,
+The `NodeStats` component, after collecting statistics from the running program,
 can dump these to files in a VOM file (Virtual Object Map). As indicated by the
 name, the VOM file specifies the mapping of object to node for each phase along
 with statistics for each object (computation time and communication load).

--- a/docs/md/vt.md
+++ b/docs/md/vt.md
@@ -52,7 +52,7 @@ management.
 | \subpage objgroup           | `vt::theObjGroup()`    | \copybrief objgroup         | @m_class{m-label m-success} **Core**           |
 | \subpage param              | `vt::theParam()`       | \copybrief param            | @m_class{m-label m-danger} **Experimental**    |
 | \subpage pipe               | `vt::theCB()`          | \copybrief pipe             | @m_class{m-label m-success} **Core**           |
-| \subpage proc-stats         | `vt::theProcStats()`   | \copybrief proc-stats       | @m_class{m-label m-warning} **Optional**       |
+| \subpage node-stats         | `vt::theNodeStats()`   | \copybrief node-stats       | @m_class{m-label m-warning} **Optional**       |
 | \subpage pool               | `vt::thePool()`        | \copybrief pool             | @m_class{m-label m-success} **Core**           |
 | \subpage rdma               | `vt::theRDMA()`        | \copybrief rdma             | @m_class{m-label m-danger} **Experimental**    |
 | \subpage rdmahandle         | `vt::theHandleRDMA()`  | \copybrief rdmahandle       | @m_class{m-label m-warning} **Optional**       |

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -721,7 +721,7 @@ void Runtime::initializeComponents() {
       group::GroupManager,                 // For broadcasts
       sched::Scheduler,                    // For scheduling work
       location::LocationManager,           // For element location
-      vrt::collection::balance::ProcStats, // For stat collection
+      vrt::collection::balance::NodeStats, // For stat collection
       vrt::collection::balance::LBManager  // For load balancing
     >{}
   );
@@ -736,8 +736,8 @@ void Runtime::initializeComponents() {
     >{}
   );
 
-  p_->registerComponent<vrt::collection::balance::ProcStats>(
-    &theProcStats, Deps<
+  p_->registerComponent<vrt::collection::balance::NodeStats>(
+    &theNodeStats, Deps<
       ctx::Context                        // Everything depends on theContext
     >{}
   );
@@ -745,7 +745,7 @@ void Runtime::initializeComponents() {
   p_->registerComponent<vrt::collection::balance::StatsRestartReader>(
     &theStatsReader, Deps<
       ctx::Context,                        // Everything depends on theContext
-      vrt::collection::balance::ProcStats  // Depends on proc stats for input
+      vrt::collection::balance::NodeStats  // Depends on node stats for input
     >{}
   );
 
@@ -753,7 +753,7 @@ void Runtime::initializeComponents() {
     &theLBManager, Deps<
       ctx::Context,                        // Everything depends on theContext
       util::memory::MemoryUsage,           // Output mem usage on phase change
-      vrt::collection::balance::ProcStats  // For stat collection
+      vrt::collection::balance::NodeStats  // For stat collection
     >{}
   );
 
@@ -783,7 +783,7 @@ void Runtime::initializeComponents() {
   p_->add<registry::Registry>();
   p_->add<event::AsyncEvent>();
   p_->add<pool::Pool>();
-  p_->add<vrt::collection::balance::ProcStats>();
+  p_->add<vrt::collection::balance::NodeStats>();
   p_->add<vrt::collection::balance::LBManager>();
 
   if (needStatsRestartReader()) {

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -215,7 +215,7 @@ struct Runtime {
    *
    * \warning Do not call this. It does an unsafe \c MPI_Barrier
    *
-   * \todo Remove this and fix the single one callsite in \c ProcStats
+   * \todo Remove this and fix the single one callsite in \c NodeStats
    */
   void systemSync() { sync(); }
 
@@ -389,7 +389,7 @@ public:
   ComponentPtrType<objgroup::ObjGroupManager> theObjGroup;
   ComponentPtrType<util::memory::MemoryUsage> theMemUsage;
   ComponentPtrType<rdma::Manager> theHandleRDMA;
-  ComponentPtrType<vrt::collection::balance::ProcStats> theProcStats;
+  ComponentPtrType<vrt::collection::balance::NodeStats> theNodeStats;
   ComponentPtrType<vrt::collection::balance::StatsRestartReader> theStatsReader;
   ComponentPtrType<vrt::collection::balance::LBManager> theLBManager;
 

--- a/src/vt/runtime/runtime_component_fwd.h
+++ b/src/vt/runtime/runtime_component_fwd.h
@@ -89,7 +89,7 @@ namespace vrt { namespace collection {
 struct CollectionManager;
 }}
 namespace vrt { namespace collection { namespace balance {
-struct ProcStats;
+struct NodeStats;
 struct StatsRestartReader;
 struct LBManager;
 }}}

--- a/src/vt/runtime/runtime_get.cc
+++ b/src/vt/runtime/runtime_get.cc
@@ -127,7 +127,7 @@ pipe::PipeManager*          theCB()                 { return CUR_RT->theCB;     
 objgroup::ObjGroupManager*  theObjGroup()           { return CUR_RT->theObjGroup;       }
 rdma::Manager*              theHandleRDMA()         { return CUR_RT->theHandleRDMA;     }
 util::memory::MemoryUsage*  theMemUsage()           { return CUR_RT->theMemUsage;       }
-vrt::collection::balance::ProcStats* theProcStats() { return CUR_RT->theProcStats;      }
+vrt::collection::balance::NodeStats* theNodeStats() { return CUR_RT->theNodeStats;      }
 vrt::collection::balance::StatsRestartReader* theStatsReader() { return CUR_RT->theStatsReader;      }
 vrt::collection::balance::LBManager* theLBManager() { return CUR_RT->theLBManager;      }
 

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -51,7 +51,7 @@
 #include "vt/vrt/collection/balance/lb_invoke/start_lb_msg.h"
 #include "vt/vrt/collection/balance/read_lb.h"
 #include "vt/vrt/collection/balance/lb_invoke/lb_manager.h"
-#include "vt/vrt/collection/balance/proc_stats.h"
+#include "vt/vrt/collection/balance/node_stats.h"
 #include "vt/timing/timing.h"
 #include "vt/collective/reduce/reduce.h"
 #include "vt/collective/collective_alg.h"
@@ -189,7 +189,7 @@ void BaseLB::applyMigrations(TransferVecType const &transfers) {
     auto from = objGetNode(obj_id);
 
     if (from != to) {
-      bool has_object = theProcStats()->hasObjectToMigrate(obj_id);
+      bool has_object = theNodeStats()->hasObjectToMigrate(obj_id);
 
       vt_debug_print(
         lb, node,
@@ -199,7 +199,7 @@ void BaseLB::applyMigrations(TransferVecType const &transfers) {
 
       if (has_object) {
         local_migration_count_++;
-        theProcStats()->migrateObjTo(obj_id, to);
+        theNodeStats()->migrateObjTo(obj_id, to);
       } else {
         off_node_migrate[from].push_back(std::make_tuple(obj_id,to));
       }
@@ -227,8 +227,8 @@ void BaseLB::transferMigrations(TransferMsg<TransferVecType>* msg) {
   for (auto&& elm : migrate_list) {
     auto obj_id  = std::get<0>(elm);
     auto to_node = std::get<1>(elm);
-    vtAssert(theProcStats()->hasObjectToMigrate(obj_id), "Must have object");
-    theProcStats()->migrateObjTo(obj_id, to_node);
+    vtAssert(theNodeStats()->hasObjectToMigrate(obj_id), "Must have object");
+    theNodeStats()->migrateObjTo(obj_id, to_node);
   }
 }
 

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -71,7 +71,7 @@ struct BaseLB {
   using ObjSampleType    = std::map<ObjBinType, ObjBinListType>;
   using ElementLoadType  = std::unordered_map<ObjIDType,TimeType>;
   using ElementCommType  = balance::CommMapType;
-  using StatsMsgType     = balance::ProcStatsMsg;
+  using StatsMsgType     = balance::NodeStatsMsg;
   using TransferDestType = std::tuple<ObjIDType,NodeType>;
   using TransferVecType  = std::vector<TransferDestType>;
   using TransferType     = std::map<NodeType, TransferVecType>;

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -93,7 +93,7 @@ template <typename ColT>
   auto const& idx = col->getIndex();
   auto const& elm_proxy = proxy[idx];
 
-  theProcStats()->addProcStats(col, cur_phase, total_load, subphase_loads, comm);
+  theNodeStats()->addNodeStats(col, cur_phase, total_load, subphase_loads, comm);
 
   auto const before_ready = theCollection()->numReadyCollections();
   theCollection()->makeCollectionReady(untyped_proxy);

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -48,7 +48,7 @@
 #include "vt/vrt/collection/balance/lb_invoke/start_lb_msg.h"
 #include "vt/vrt/collection/balance/read_lb.h"
 #include "vt/vrt/collection/balance/lb_type.h"
-#include "vt/vrt/collection/balance/proc_stats.h"
+#include "vt/vrt/collection/balance/node_stats.h"
 #include "vt/vrt/collection/balance/hierarchicallb/hierlb.h"
 #include "vt/vrt/collection/balance/greedylb/greedylb.h"
 #include "vt/vrt/collection/balance/rotatelb/rotatelb.h"
@@ -134,10 +134,10 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
 
 void LBManager::setLoadModel(std::shared_ptr<LoadModel> model) {
   model_ = model;
-  auto stats = theProcStats();
-  model_->setLoads(stats->getProcLoad(),
-                   stats->getProcSubphaseLoad(),
-                   stats->getProcComm());
+  auto stats = theNodeStats();
+  model_->setLoads(stats->getNodeLoad(),
+                   stats->getNodeSubphaseLoad(),
+                   stats->getNodeComm());
 }
 
 template <typename LB>
@@ -160,7 +160,7 @@ LBManager::makeLB(MsgSharedPtr<StartLBMsg> msg) {
       lb, node,
       "LBManager: running strategy\n"
     );
-    strat->startLB(phase, base_proxy, model_.get(), theProcStats()->getProcComm()->back());
+    strat->startLB(phase, base_proxy, model_.get(), theNodeStats()->getNodeComm()->back());
   });
 
   runInEpochCollective([=] {
@@ -176,7 +176,7 @@ LBManager::makeLB(MsgSharedPtr<StartLBMsg> msg) {
       lb, node,
       "LBManager: finished migrations\n"
     );
-    theProcStats()->startIterCleanup();
+    theNodeStats()->startIterCleanup();
     this->finishedRunningLB(phase);
   });
 }

--- a/src/vt/vrt/collection/balance/model/load_model.h
+++ b/src/vt/vrt/collection/balance/model/load_model.h
@@ -128,7 +128,7 @@ public:
    */
   virtual TimeType getWork(ElementIDType object, PhaseOffset when) = 0;
 
-  // Object enumeration, to abstract away access to the underlying structures from ProcStats
+  // Object enumeration, to abstract away access to the underlying structures from NodeStats
   virtual ObjectIterator begin() = 0;
   virtual ObjectIterator end() = 0;
 

--- a/src/vt/vrt/collection/balance/model/per_collection.cc
+++ b/src/vt/vrt/collection/balance/model/per_collection.cc
@@ -43,7 +43,7 @@
 */
 
 #include "vt/vrt/collection/balance/model/per_collection.h"
-#include "vt/vrt/collection/balance/proc_stats.h"
+#include "vt/vrt/collection/balance/node_stats.h"
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
@@ -72,7 +72,7 @@ void PerCollection::updateLoads(PhaseType last_completed_phase) {
 
 TimeType PerCollection::getWork(ElementIDType object, PhaseOffset when) {
   // See if some specific model has been given for the object in question
-  auto mi = models_.find(theProcStats()->getCollectionProxyForElement(object));
+  auto mi = models_.find(theNodeStats()->getCollectionProxyForElement(object));
   if (mi != models_.end())
     return mi->second->getWork(object, when);
 

--- a/src/vt/vrt/collection/balance/model/raw_data.h
+++ b/src/vt/vrt/collection/balance/model/raw_data.h
@@ -73,7 +73,7 @@ struct RawData : public LoadModel {
   int getNumCompletedPhases() override { return proc_load_->size(); }
   int getNumSubphases() override;
 
-  // Observer pointers to the underlying data. In operation, these would be owned by ProcStats
+  // Observer pointers to the underlying data. In operation, these would be owned by NodeStats
   std::vector<LoadMapType>         const* proc_load_;
   std::vector<SubphaseLoadMapType> const* proc_subphase_load_;
   std::vector<CommMapType>         const* proc_comm_;

--- a/src/vt/vrt/collection/balance/node_stats.h
+++ b/src/vt/vrt/collection/balance/node_stats.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                 proc_stats.h
+//                                 node_stats.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,8 +42,8 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VRT_COLLECTION_BALANCE_PROC_STATS_H
-#define INCLUDED_VRT_COLLECTION_BALANCE_PROC_STATS_H
+#if !defined INCLUDED_VRT_COLLECTION_BALANCE_NODE_STATS_H
+#define INCLUDED_VRT_COLLECTION_BALANCE_NODE_STATS_H
 
 #include "vt/config.h"
 #include "vt/vrt/collection/balance/lb_common.h"
@@ -62,7 +62,7 @@
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
 /**
- * \struct ProcStats
+ * \struct NodeStats
  *
  * \brief A VT component that backs the instrumentation of virtualized entities
  * on each node, such as the objects that the collection manager orchestrates,
@@ -75,34 +75,34 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
  * it to the load balancing framework, specifically the
  * \c * vt::vrt::collection::balance::LBManager
  */
-struct ProcStats : runtime::component::Component<ProcStats> {
+struct NodeStats : runtime::component::Component<NodeStats> {
   using MigrateFnType       = std::function<void(NodeType)>;
 
   /**
-   * \internal \brief System call to construct \c ProcStats
+   * \internal \brief System call to construct \c NodeStats
    */
-  ProcStats() = default;
+  NodeStats() = default;
 
-  std::string name() override { return "ProcStats"; }
+  std::string name() override { return "NodeStats"; }
 
 private:
   /**
-   * \internal \brief Setup the proxy for \c ProcStats
+   * \internal \brief Setup the proxy for \c NodeStats
    *
    * \param[in] in_proxy the objgroup proxy
    */
-  void setProxy(objgroup::proxy::Proxy<ProcStats> in_proxy);
+  void setProxy(objgroup::proxy::Proxy<NodeStats> in_proxy);
 
 public:
   /**
-   * \internal \brief Construct the ProcStats component
+   * \internal \brief Construct the NodeStats component
    *
    * \return pointer to the component
    */
-  static std::unique_ptr<ProcStats> construct();
+  static std::unique_ptr<NodeStats> construct();
 
   /**
-   * \internal \brief Add processor statistics for local object
+   * \internal \brief Add node statistics for local object
    *
    * \param[in] col_elm the collection element pointer
    * \param[in] phase the current phase
@@ -111,14 +111,14 @@ public:
    *
    * \return the temporary ID for the object assigned for this phase
    */
-  ElementIDType addProcStats(
+  ElementIDType addNodeStats(
     Migratable* col_elm,
     PhaseType const& phase, TimeType const& time,
     std::vector<TimeType> const& subphase_time, CommMapType const& comm
   );
 
   /**
-   * \internal \brief Clear/reset all statistics and IDs on this processor
+   * \internal \brief Clear/reset all statistics and IDs on this node
    */
   void clearStats();
 
@@ -173,28 +173,28 @@ public:
    *
    * \return an observer pointer to the load map
    */
-  std::vector<LoadMapType> const* getProcLoad() const;
+  std::vector<LoadMapType> const* getNodeLoad() const;
 
   /**
    * \internal \brief Get stored object loads for individual subphases
    *
    * \return an observer pointer to the subphase load map
    */
-  std::vector<SubphaseLoadMapType> const* getProcSubphaseLoad() const;
+  std::vector<SubphaseLoadMapType> const* getNodeSubphaseLoad() const;
 
   /**
    * \internal \brief Get stored object comm graph
    *
    * \return an observer pointer to the comm graph
    */
-  std::vector<CommMapType> const* getProcComm() const;
+  std::vector<CommMapType> const* getNodeComm() const;
 
   /**
-   * \internal \brief Test if this processor has an object to migrate
+   * \internal \brief Test if this node has an object to migrate
    *
    * \param[in] obj_id the object temporary ID
    *
-   * \return whether this processor has the object
+   * \return whether this node has the object
    */
   bool hasObjectToMigrate(ElementIDType obj_id) const;
 
@@ -204,7 +204,7 @@ public:
    * \param[in] obj_id the object temporary ID
    * \param[in] to_node the node to migrate to
    *
-   * \return whether this processor has the object
+   * \return whether this node has the object
    */
   bool migrateObjTo(ElementIDType obj_id, NodeType to_node);
 
@@ -250,21 +250,21 @@ private:
 
 private:
   /// Local proxy to objgroup
-  objgroup::proxy::Proxy<ProcStats> proxy_;
-  /// Processor timings for each local object
-  std::vector<LoadMapType> proc_data_;
-  /// Processor subphase timings for each local object
-  std::vector<SubphaseLoadMapType> proc_subphase_data_;
+  objgroup::proxy::Proxy<NodeStats> proxy_;
+  /// Node timings for each local object
+  std::vector<LoadMapType> node_data_;
+  /// Node subphase timings for each local object
+  std::vector<SubphaseLoadMapType> node_subphase_data_;
   /// Local migration type-free lambdas for each object
-  std::unordered_map<ElementIDType,MigrateFnType> proc_migrate_;
+  std::unordered_map<ElementIDType,MigrateFnType> node_migrate_;
   /// Map of temporary ID to permanent ID
-  std::unordered_map<ElementIDType,ElementIDType> proc_temp_to_perm_;
+  std::unordered_map<ElementIDType,ElementIDType> node_temp_to_perm_;
   /// Map of permanent ID to temporary ID
-  std::unordered_map<ElementIDType,ElementIDType> proc_perm_to_temp_;
+  std::unordered_map<ElementIDType,ElementIDType> node_perm_to_temp_;
   /// Map from element temporary ID to the collection's virtual proxy (untyped)
-  std::unordered_map<ElementIDType,VirtualProxyType> proc_collection_lookup_;
-  /// Processor communication graph for each local object
-  std::vector<CommMapType> proc_comm_;
+  std::unordered_map<ElementIDType,VirtualProxyType> node_collection_lookup_;
+  /// Node communication graph for each local object
+  std::vector<CommMapType> node_comm_;
   /// The current element ID
   ElementIDType next_elm_;
   /// The stats file name for outputting instrumentation
@@ -277,8 +277,8 @@ private:
 
 namespace vt {
 
-extern vrt::collection::balance::ProcStats* theProcStats();
+extern vrt::collection::balance::NodeStats* theNodeStats();
 
 } /* end namespace vt */
 
-#endif /*INCLUDED_VRT_COLLECTION_BALANCE_PROC_STATS_H*/
+#endif /*INCLUDED_VRT_COLLECTION_BALANCE_NODE_STATS_H*/

--- a/src/vt/vrt/collection/balance/stats_msg.h
+++ b/src/vt/vrt/collection/balance/stats_msg.h
@@ -159,22 +159,22 @@ static_assert(
   "Must be trivially copyable to avoid serialization."
 );
 
-struct ProcStatsMsg : NonSerialized<
+struct NodeStatsMsg : NonSerialized<
   collective::ReduceTMsg<LoadData>,
-  ProcStatsMsg
+  NodeStatsMsg
 >
 {
   using MessageParentType = NonSerialized<
     collective::ReduceTMsg<LoadData>,
-    ProcStatsMsg
+    NodeStatsMsg
   >;
 
-  ProcStatsMsg() = default;
-  ProcStatsMsg(lb::Statistic in_stat, TimeType const in_total_load)
+  NodeStatsMsg() = default;
+  NodeStatsMsg(lb::Statistic in_stat, TimeType const in_total_load)
     : MessageParentType(LoadData(in_total_load)),
       stat_(in_stat)
   { }
-  ProcStatsMsg(lb::Statistic in_stat, LoadData&& ld)
+  NodeStatsMsg(lb::Statistic in_stat, LoadData&& ld)
     : MessageParentType(std::move(ld)),
       stat_(in_stat)
   { }

--- a/src/vt/vrt/collection/balance/statsmaplb/statsmaplb.cc
+++ b/src/vt/vrt/collection/balance/statsmaplb/statsmaplb.cc
@@ -44,7 +44,7 @@
 
 #include "vt/config.h"
 #include "vt/vrt/collection/balance/baselb/baselb.h"
-#include "vt/vrt/collection/balance/proc_stats.h"
+#include "vt/vrt/collection/balance/node_stats.h"
 #include "vt/vrt/collection/balance/statsmaplb/statsmaplb.h"
 #include "vt/vrt/collection/balance/stats_restart_reader.h"
 #include "vt/context/context.h"
@@ -58,7 +58,7 @@ void StatsMapLB::init(objgroup::proxy::Proxy<StatsMapLB> in_proxy) {
 void StatsMapLB::runLB() {
   auto const& myNewList = theStatsReader()->getMoveList(phase_);
   for (size_t in = 0; in < myNewList.size(); in += 2) {
-    auto temp_id = theProcStats()->permToTemp(myNewList[in]);
+    auto temp_id = theNodeStats()->permToTemp(myNewList[in]);
 
     vtAssert(temp_id != balance::no_element_id, "Must have valid ID here");
 

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -59,8 +59,8 @@ void CollectionManager::finalize() {
   // Statistics output when LB is enabled and appropriate flag is enabled
 #if vt_check_enabled(lblite)
   if (ArgType::vt_lb_stats) {
-    theProcStats()->outputStatsFile();
-    theProcStats()->clearStats();
+    theNodeStats()->outputStatsFile();
+    theNodeStats()->clearStats();
   }
 #endif
 }

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -69,7 +69,7 @@
 #include "vt/vrt/collection/dispatch/registry.h"
 #include "vt/vrt/collection/holders/insert_context_holder.h"
 #include "vt/vrt/collection/collection_directory.h"
-#include "vt/vrt/collection/balance/proc_stats.h"
+#include "vt/vrt/collection/balance/node_stats.h"
 #include "vt/vrt/proxy/collection_proxy.h"
 #include "vt/registry/auto/map/auto_registry_map.h"
 #include "vt/registry/auto/collection/auto_registry_collection.h"
@@ -2620,7 +2620,7 @@ MigrateStatus CollectionManager::migrateIn(
   CollectionProxy<ColT, IndexT>(proxy).operator()(idx);
 
   // Always assign a new temp element ID for LB statistic tracking
-  vrt_elm_ptr->temp_elm_id_ = theProcStats()->getNextElm();
+  vrt_elm_ptr->temp_elm_id_ = theNodeStats()->getNextElm();
 
   bool const is_static = ColT::isStaticSized();
 

--- a/src/vt/vrt/collection/types/migratable.cc
+++ b/src/vt/vrt/collection/types/migratable.cc
@@ -50,8 +50,8 @@
 namespace vt { namespace vrt { namespace collection {
 
 Migratable::Migratable()
-  : stats_elm_id_(theProcStats()->getNextElm()),
-    temp_elm_id_(theProcStats()->getNextElm())
+  : stats_elm_id_(theNodeStats()->getNextElm()),
+    temp_elm_id_(theNodeStats()->getNextElm())
 { }
 
 /*virtual*/ void Migratable::destroy() {

--- a/src/vt/vrt/collection/types/migratable.h
+++ b/src/vt/vrt/collection/types/migratable.h
@@ -57,7 +57,7 @@ namespace vt { namespace vrt { namespace collection {
 
 // Forward declaration for friend declaration below
 namespace balance {
-  struct ProcStats;
+  struct NodeStats;
 }
 
 struct Migratable : MigrateHookBase {
@@ -108,7 +108,7 @@ protected:
 
 protected:
   friend struct balance::ElementStats;
-  friend struct balance::ProcStats;
+  friend struct balance::NodeStats;
   balance::ElementStats stats_;
 public:
   balance::ElementStats& getStats() { return stats_; }

--- a/tests/unit/lb/test_lb_stats_reader.cc
+++ b/tests/unit/lb/test_lb_stats_reader.cc
@@ -48,7 +48,7 @@
 #include <vector>
 
 #include <vt/transport.h>
-#include <vt/vrt/collection/balance/proc_stats.h>
+#include <vt/vrt/collection/balance/node_stats.h>
 #include <vt/vrt/collection/balance/stats_restart_reader.h>
 
 #include "test_parallel_harness.h"


### PR DESCRIPTION
Changes: 
- Rename ProcStats structure to NodeStats (file name changed as well)
- **Rename ProcStatsMsg to NodeStatsMsg ( I assumed by the name of structure that it's related to ProcStats, so i changed it for consistency )**
- Rename all member functions/variables so that they refer to 'node' instead of 'process'
- Update docs 