### PR TITLE
#955 clear out uses of addAction in tests

### DIFF
--- a/.github/workflows/dockerimage-gcc-5-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-5-ubuntu-mpich.yml
@@ -51,7 +51,7 @@ jobs:
         message("::set-output name=timestamp::${current_date}")
     - uses: actions/cache@v1
       env:
-        cache-name: ubuntu-gcc-5-cache
+        cache-name: ubuntu-gcc-5-cache-new
       with:
         path: ${{ env.BUILD_ROOT }}/ccache
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.cache_ts.outputs.timestamp }}

--- a/scripts/workflows.ini
+++ b/scripts/workflows.ini
@@ -103,6 +103,7 @@ test_configuration = "gcc-5, ubuntu, mpich"
 compiler_type = gnu
 compiler = gcc-5
 output_name = .github/workflows/dockerimage-gcc-5-ubuntu-mpich.yml
+cache_name = "[% linux %]-[% compiler %]-cache-new"
 
 [PR-tests-gcc-6]
 test_configuration = "gcc-6, ubuntu, mpich"

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -132,19 +132,19 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send) {
     fmt::print("test_type_safe_active_fn_send: node={}\n", my_node);
   #endif
 
-  if (my_node == from_node) {
-    for (int i = 0; i < num_msg_sent; i++) {
-      #if DEBUG_TEST_HARNESS_PRINT
-        fmt::print("{}: sendMsg: i={}\n", my_node, i);
-      #endif
-      auto msg = makeMessage<TestMsg>();
-      theMsg()->sendMsg<TestMsg, test_handler>(to_node, msg);
-    }
-  } else if (my_node == to_node) {
-    theTerm()->addAction([=]{
+  runInEpochCollective([=]{
+    if (my_node == from_node) {
+      for (int i = 0; i < num_msg_sent; i++) {
+        #if DEBUG_TEST_HARNESS_PRINT
+          fmt::print("{}: sendMsg: i={}\n", my_node, i);
+        #endif
+        auto msg = makeMessage<TestMsg>();
+        theMsg()->sendMsg<TestMsg, test_handler>(1, msg);
+      }
+    } else if (my_node == to_node) {
       EXPECT_EQ(handler_count, num_msg_sent);
-    });
-  }
+    }
+  });
 
   // Spin here so test_vec does not go out of scope before the send completes
   while (not vt::rt->isTerminated()) {

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -132,7 +132,7 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send) {
     fmt::print("test_type_safe_active_fn_send: node={}\n", my_node);
   #endif
 
-  runInEpochCollective([=]{
+  vt::runInEpochCollective([=]{
     if (my_node == from_node) {
       for (int i = 0; i < num_msg_sent; i++) {
         #if DEBUG_TEST_HARNESS_PRINT

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -132,7 +132,7 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send) {
     fmt::print("test_type_safe_active_fn_send: node={}\n", my_node);
   #endif
 
-  vt::runInEpochCollective([=]{
+  vt::runInEpochCollective([&]{
     if (my_node == from_node) {
       for (int i = 0; i < num_msg_sent; i++) {
         #if DEBUG_TEST_HARNESS_PRINT
@@ -141,10 +141,12 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send) {
         auto msg = makeMessage<TestMsg>();
         theMsg()->sendMsg<TestMsg, test_handler>(1, msg);
       }
-    } else if (my_node == to_node) {
-      EXPECT_EQ(handler_count, num_msg_sent);
     }
   });
+
+  if (my_node == to_node) {
+    EXPECT_EQ(handler_count, num_msg_sent);
+  }
 
   // Spin here so test_vec does not go out of scope before the send completes
   while (not vt::rt->isTerminated()) {

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -76,7 +76,6 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   delivered = false;
 
   std::vector<messaging::PendingSend> pending;
-  bool done = false;
   auto ep = theTerm()->makeEpochCollective();
   theMsg()->pushEpoch(ep);
 

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -87,18 +87,18 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   pending.emplace_back(
     theMsg()->sendMsg<TestMsg, handlerPing>(next, msg)
   );
-
+  
   // Must be stamped with the current epoch
   EXPECT_EQ(envelopeGetEpoch(msg_hold->env), ep);
 
   theMsg()->popEpoch(ep);
-  theTerm()->addAction([&done] { done = true; });
+  // theTerm->addAction([&done] { done = true; });
   theTerm()->finishedEpoch(ep);
 
   // It should not break out of this loop because of `done`, thus `k` is used to
   // break out
   int k = 0;
-  while (not done) {
+  while (!theTerm()->isEpochTerminated(ep)) {
     k++;
     vt::runScheduler();
     if (k > 10) {
@@ -107,15 +107,16 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   }
 
   // Epoch should not end with a valid pending send created in an live epoch
-  EXPECT_EQ(done, false);
+  EXPECT_EQ(theTerm()->isEpochTerminated(ep), false);
   EXPECT_EQ(delivered, false);
 
   // Now we send the message off!
   pending.clear();
 
-  do vt::runScheduler(); while (not done);
+  // do vt::runScheduler(); while (not done);
+  vt::runSchedulerThrough(ep);
 
-  EXPECT_EQ(done, true);
+  EXPECT_EQ(theTerm()->isEpochTerminated(ep), true);
   EXPECT_EQ(delivered, true);
 }
 

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -87,15 +87,15 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   pending.emplace_back(
     theMsg()->sendMsg<TestMsg, handlerPing>(next, msg)
   );
-  
+
   // Must be stamped with the current epoch
   EXPECT_EQ(envelopeGetEpoch(msg_hold->env), ep);
 
   theMsg()->popEpoch(ep);
-  // theTerm->addAction([&done] { done = true; });
   theTerm()->finishedEpoch(ep);
 
-  // It should not break out of this loop because of `done`, thus `k` is used to
+  // It should not break out of this loop because of
+  // !theTerm()->isEpochTermianted(ep), thus `k` is used to
   // break out
   int k = 0;
   while (!theTerm()->isEpochTerminated(ep)) {
@@ -113,7 +113,6 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   // Now we send the message off!
   pending.clear();
 
-  // do vt::runScheduler(); while (not done);
   vt::runSchedulerThrough(ep);
 
   EXPECT_EQ(theTerm()->isEpochTerminated(ep), true);

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -92,7 +92,7 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   EXPECT_EQ(envelopeGetEpoch(msg_hold->env), ep);
 
   theMsg()->popEpoch(ep);
-  vt::runInEpochCollective([&done] { done = true; });
+  theTerm()->addAction([&done] { done = true; });
   theTerm()->finishedEpoch(ep);
 
   // It should not break out of this loop because of `done`, thus `k` is used to

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -92,7 +92,7 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   EXPECT_EQ(envelopeGetEpoch(msg_hold->env), ep);
 
   theMsg()->popEpoch(ep);
-  runInEpochCollective(ep, [&done] { done = true; });
+  vt::runInEpochCollective([&done] { done = true; });
   theTerm()->finishedEpoch(ep);
 
   // It should not break out of this loop because of `done`, thus `k` is used to

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -92,7 +92,7 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   EXPECT_EQ(envelopeGetEpoch(msg_hold->env), ep);
 
   theMsg()->popEpoch(ep);
-  theTerm()->addAction(ep, [&done] { done = true; });
+  runInEpochCollective(ep, [&done] { done = true; });
   theTerm()->finishedEpoch(ep);
 
   // It should not break out of this loop because of `done`, thus `k` is used to

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -173,12 +173,12 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
       }
     });
 
-		vt::runInEpochCollective([&]{
-			for (int i = 0; i < 5; i++) {
-				if (this_node == 0) {
-					proxy.template broadcast<TestCol::NullMsg,&TestCol::doIter>();
-				}
-			}
+    vt::runInEpochCollective([&]{
+      for (int i = 0; i < 5; i++) {
+        if (this_node == 0) {
+          proxy.template broadcast<TestCol::NullMsg,&TestCol::doIter>();
+        }
+      }
     });
 
     vt::theCollection()->checkpointToFile(proxy, checkpoint_name);
@@ -201,7 +201,9 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
     });
 
     vt::theCollective()->barrier();
+  }
 
+  {
     auto proxy = vt::theCollection()->restoreFromFile<TestCol>(
       range, checkpoint_name
     );

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -173,13 +173,13 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
       }
     });
 
-    vt::runInEpochCollective([&]{
-      for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 5; i++) {
+      vt::runInEpochCollective([&]{
         if (this_node == 0) {
           proxy.template broadcast<TestCol::NullMsg,&TestCol::doIter>();
         }
-      }
-    });
+      });
+    }
 
     vt::theCollection()->checkpointToFile(proxy, checkpoint_name);
 

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -149,6 +149,17 @@ struct TestCol : vt::Collection<TestCol,vt::Index3D> {
   std::shared_ptr<int> token;
 };
 
+static void runInEpoch(std::function<void()> fn) {
+  vt::EpochType ep = vt::theTerm()->makeEpochCollective();
+  vt::theMsg()->pushEpoch(ep);
+  fn();
+  vt::theMsg()->popEpoch(ep);
+  vt::theTerm()->finishedEpoch(ep);
+  bool done = false;
+  vt::runInEpochCollective([&]{ done = true; });
+  vt::theSched()->runSchedulerWhile([&] { return not done; });
+}
+
 using TestCheckpoint = TestParallelHarness;
 
 static constexpr int32_t const num_elms = 8;
@@ -174,7 +185,7 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
     });
 
     for (int i = 0; i < 5; i++) {
-      vt::runInEpochCollective([&]{
+      runInEpoch([&]{
         if (this_node == 0) {
           proxy.template broadcast<TestCol::NullMsg,&TestCol::doIter>();
         }

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -156,7 +156,7 @@ static void runInEpoch(std::function<void()> fn) {
   vt::theMsg()->popEpoch(ep);
   vt::theTerm()->finishedEpoch(ep);
   bool done = false;
-  vt::theTerm()->addAction(ep, [&]{ done = true; });
+  runInEpochCollective(ep, [&]{ done = true; });
   vt::theSched()->runSchedulerWhile([&] { return not done; });
 }
 

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -156,7 +156,7 @@ static void runInEpoch(std::function<void()> fn) {
   vt::theMsg()->popEpoch(ep);
   vt::theTerm()->finishedEpoch(ep);
   bool done = false;
-  runInEpochCollective(ep, [&]{ done = true; });
+  vt::runInEpochCollective([&]{ done = true; });
   vt::theSched()->runSchedulerWhile([&] { return not done; });
 }
 

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -149,17 +149,6 @@ struct TestCol : vt::Collection<TestCol,vt::Index3D> {
   std::shared_ptr<int> token;
 };
 
-static void runInEpoch(std::function<void()> fn) {
-  vt::EpochType ep = vt::theTerm()->makeEpochCollective();
-  vt::theMsg()->pushEpoch(ep);
-  fn();
-  vt::theMsg()->popEpoch(ep);
-  vt::theTerm()->finishedEpoch(ep);
-  bool done = false;
-  vt::runInEpochCollective([&]{ done = true; });
-  vt::theSched()->runSchedulerWhile([&] { return not done; });
-}
-
 using TestCheckpoint = TestParallelHarness;
 
 static constexpr int32_t const num_elms = 8;
@@ -184,13 +173,13 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
       }
     });
 
-    for (int i = 0; i < 5; i++) {
-      runInEpoch([&]{
-        if (this_node == 0) {
-          proxy.template broadcast<TestCol::NullMsg,&TestCol::doIter>();
-        }
-      });
-    }
+		vt::runInEpochCollective([&]{
+			for (int i = 0; i < 5; i++) {
+				if (this_node == 0) {
+					proxy.template broadcast<TestCol::NullMsg,&TestCol::doIter>();
+				}
+			}
+    });
 
     vt::theCollection()->checkpointToFile(proxy, checkpoint_name);
 

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -116,7 +116,7 @@ TEST_F(TestDestroy, test_destroy_1) {
     // ::fmt::print("broadcasting proxy={:x}\n", proxy.getProxy());
     proxy.broadcast<WorkMsg,DestroyTest::work>(msg.get());
   }
-  theTerm()->addAction([]{
+  runInEpochCollective([]{
     // ::fmt::print("num destroyed={}\n", num_destroyed);
     // Relies on default mapping equally distributing
     EXPECT_EQ(num_destroyed, num_elms_per_node);

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -109,7 +109,7 @@ static constexpr int32_t const num_elms_per_node = 8;
 TEST_F(TestDestroy, test_destroy_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  
+
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node);

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -116,7 +116,7 @@ TEST_F(TestDestroy, test_destroy_1) {
     // ::fmt::print("broadcasting proxy={:x}\n", proxy.getProxy());
     proxy.broadcast<WorkMsg,DestroyTest::work>(msg.get());
   }
-  runInEpochCollective([]{
+  vt::runInEpochCollective([]{
     // ::fmt::print("num destroyed={}\n", num_destroyed);
     // Relies on default mapping equally distributing
     EXPECT_EQ(num_destroyed, num_elms_per_node);

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -109,18 +109,19 @@ static constexpr int32_t const num_elms_per_node = 8;
 TEST_F(TestDestroy, test_destroy_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  if (this_node == 0) {
-    auto const& range = Index1D(num_nodes * num_elms_per_node);
-    auto proxy = theCollection()->construct<DestroyTest>(range);
-    auto msg = makeMessage<WorkMsg>();
-    // ::fmt::print("broadcasting proxy={:x}\n", proxy.getProxy());
-    proxy.broadcast<WorkMsg,DestroyTest::work>(msg.get());
-  }
-  vt::runInEpochCollective([]{
+  
+  vt::runInEpochCollective([&]{
+    if (this_node == 0) {
+      auto const& range = Index1D(num_nodes * num_elms_per_node);
+      auto proxy = theCollection()->construct<DestroyTest>(range);
+      auto msg = makeMessage<WorkMsg>();
+      // ::fmt::print("broadcasting proxy={:x}\n", proxy.getProxy());
+      proxy.broadcast<WorkMsg,DestroyTest::work>(msg.get());
+    }
+  });
     // ::fmt::print("num destroyed={}\n", num_destroyed);
     // Relies on default mapping equally distributing
-    EXPECT_EQ(num_destroyed, num_elms_per_node);
-  });
+  EXPECT_EQ(num_destroyed, num_elms_per_node);
 }
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -99,8 +99,6 @@ TEST_F(TestInsert, test_insert_dense_1) {
       }
     }
   });
-  /// ::fmt::print("num inserted={}\n", num_inserted);
-  // Relies on default mapping equally distributing
   EXPECT_EQ(num_inserted, num_elms_per_node);
   num_inserted = 0;
 }

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -96,7 +96,7 @@ TEST_F(TestInsert, test_insert_dense_1) {
       proxy[i].insert();
     }
   }
-  theTerm()->addAction([]{
+  vt::runInEpochCollective([]{
     /// ::fmt::print("num inserted={}\n", num_inserted);
     // Relies on default mapping equally distributing
     EXPECT_EQ(num_inserted, num_elms_per_node);
@@ -114,7 +114,7 @@ TEST_F(TestInsert, test_insert_sparse_1) {
       proxy[i].insert();
     }
   }
-  runInEpochCollective([]{
+  vt::runInEpochCollective([]{
     /// ::fmt::print("num inserted={}\n", num_inserted);
     // Relies on default mapping equally distributing
     EXPECT_EQ(num_inserted, num_elms_per_node);
@@ -132,7 +132,7 @@ TEST_F(TestInsert, test_insert_dense_node_1) {
       proxy[i].insert(this_node);
     }
   }
-  theTerm()->addAction([=]{
+  vt::runInEpochCollective([=]{
     /// ::fmt::print("num inserted={}\n", num_inserted);
     // Relies on default mapping equally distributing
     if (this_node == 0) {
@@ -152,7 +152,7 @@ TEST_F(TestInsert, test_insert_sparse_node_1) {
       proxy[i].insert(this_node);
     }
   }
-  theTerm()->addAction([=]{
+  vt::runInEpochCollective([=]{
     /// ::fmt::print("num inserted={}\n", num_inserted);
     // Relies on default mapping equally distributing
     if (this_node == 0) {
@@ -175,7 +175,7 @@ TEST_F(TestInsert, test_insert_send_dense_node_1) {
       // ::fmt::print("sending to {}\n", i);
     }
   }
-  theTerm()->addAction([=]{
+  vt::runInEpochCollective([=]{
     /// ::fmt::print("num inserted={}\n", num_inserted);
     // Relies on default mapping equally distributing
     if (this_node == 1 || (this_node == 0 && num_nodes == 1)) {
@@ -199,7 +199,7 @@ TEST_F(TestInsert, test_insert_send_sparse_node_1) {
       proxy[i].send<WorkMsg,&InsertTest::work>(msg.get());
     }
   }
-  theTerm()->addAction([=]{
+  vt::runInEpochCollective([=]{
     /// ::fmt::print("num inserted={}\n", num_inserted);
     // Relies on default mapping equally distributing
     if (this_node == 1 || (this_node == 0 && num_nodes == 1)) {

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -75,7 +75,7 @@ struct InsertTest : InsertableCollection<InsertTest,Index1D> {
 };
 
 void InsertTest::work(WorkMsg* msg) {
-  // ::fmt::print("node={}: num_work={}\n", theContext()->getNode(), num_work);
+  //::fmt::print("node={}: num_work={}\n", theContext()->getNode(), num_work);
   num_work++;
 }
 
@@ -89,7 +89,7 @@ static constexpr int32_t const num_elms_per_node = 8;
 TEST_F(TestInsert, test_insert_dense_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  
+
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node);
@@ -108,7 +108,7 @@ TEST_F(TestInsert, test_insert_dense_1) {
 TEST_F(TestInsert, test_insert_sparse_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  
+
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node * 16);
@@ -127,7 +127,7 @@ TEST_F(TestInsert, test_insert_sparse_1) {
 TEST_F(TestInsert, test_insert_dense_node_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  
+
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node);
@@ -148,7 +148,7 @@ TEST_F(TestInsert, test_insert_dense_node_1) {
 TEST_F(TestInsert, test_insert_sparse_node_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  
+
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node * 16);
@@ -169,7 +169,7 @@ TEST_F(TestInsert, test_insert_sparse_node_1) {
 TEST_F(TestInsert, test_insert_send_dense_node_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  
+
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node);
@@ -195,7 +195,7 @@ TEST_F(TestInsert, test_insert_send_dense_node_1) {
 TEST_F(TestInsert, test_insert_send_sparse_node_1) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
-  
+
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node * 16);

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -114,7 +114,7 @@ TEST_F(TestInsert, test_insert_sparse_1) {
       proxy[i].insert();
     }
   }
-  theTerm()->addAction([]{
+  runInEpochCollective([]{
     /// ::fmt::print("num inserted={}\n", num_inserted);
     // Relies on default mapping equally distributing
     EXPECT_EQ(num_inserted, num_elms_per_node);

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -118,10 +118,10 @@ TEST_F(TestInsert, test_insert_sparse_1) {
       }
     }
   });
-    /// ::fmt::print("num inserted={}\n", num_inserted);
-    // Relies on default mapping equally distributing
-    EXPECT_EQ(num_inserted, num_elms_per_node);
-    num_inserted = 0;
+  /// ::fmt::print("num inserted={}\n", num_inserted);
+  // Relies on default mapping equally distributing
+  EXPECT_EQ(num_inserted, num_elms_per_node);
+  num_inserted = 0;
 }
 
 TEST_F(TestInsert, test_insert_dense_node_1) {

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -194,20 +194,20 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
 
   auto op2 = [&]{
     scope2.mpiCollectiveAsync([&done,&reduce_val_out]{
-			auto comm = theContext()->getComm();
-			int val_in = 1;
-			vt_print(barrier, "run MPI_Allreduce\n");
-			MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
-			run_order[done++] = 2;
+      auto comm = theContext()->getComm();
+      int val_in = 1;
+      vt_print(barrier, "run MPI_Allreduce\n");
+      MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
+      run_order[done++] = 2;
     });
   };
 
   auto op3 = [&]{
     scope3.mpiCollectiveAsync([&done]{
-			auto comm = theContext()->getComm();
-			vt_print(barrier, "run MPI_barrier\n");
-			MPI_Barrier(comm);
-			run_order[done++] = 3;
+      auto comm = theContext()->getComm();
+      vt_print(barrier, "run MPI_barrier\n");
+      MPI_Barrier(comm);
+      run_order[done++] = 3;
     });
   };
 

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -218,7 +218,7 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
     } else {
       op2(); op3(); op1();
     }
-	runScheduler();
+	  runScheduler();
   });
 
   auto num_nodes = theContext()->getNumNodes();

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -194,11 +194,11 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
 
   auto op2 = [&]{
     scope2.mpiCollectiveAsync([&done,&reduce_val_out]{
-    auto comm = theContext()->getComm();
-      int val_in = 1;
-    vt_print(barrier, "run MPI_Allreduce\n");
-    MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
-    run_order[done++] = 2;
+			auto comm = theContext()->getComm();
+			int val_in = 1;
+			vt_print(barrier, "run MPI_Allreduce\n");
+			MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
+			run_order[done++] = 2;
     });
   };
 

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -60,7 +60,7 @@ TEST_F(TestMPICollective, test_mpi_collective_1) {
     done = true;
   });
 
-  theTerm()->addAction([&done]{
+  runInEpochCollective([&done]{
     EXPECT_TRUE(done);
   });
 
@@ -104,7 +104,7 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
     done++;
   });
 
-  theTerm()->addAction([&done,&bcast_val,&reduce_val_out]{
+  runInEpochCollective([&done,&bcast_val,&reduce_val_out]{
     auto num_nodes = theContext()->getNumNodes();
     EXPECT_EQ(done, 3);
     EXPECT_EQ(bcast_val, 29);
@@ -234,7 +234,7 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
 
   bool finished_spin = false;
 
-  theTerm()->addAction(epoch, [&done,&bcast_val,&reduce_val_out,&finished_spin]{
+  runInEpochCollective(epoch, [&done,&bcast_val,&reduce_val_out,&finished_spin]{
     auto num_nodes = theContext()->getNumNodes();
     EXPECT_EQ(done, 3);
     EXPECT_EQ(bcast_val, 29);

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -60,7 +60,7 @@ TEST_F(TestMPICollective, test_mpi_collective_1) {
     done = true;
   });
 
-  runInEpochCollective([&done]{
+  vt::runInEpochCollective([&done]{
     EXPECT_TRUE(done);
   });
 
@@ -104,7 +104,7 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
     done++;
   });
 
-  runInEpochCollective([&done,&bcast_val,&reduce_val_out]{
+  vt::runInEpochCollective([&done,&bcast_val,&reduce_val_out]{
     auto num_nodes = theContext()->getNumNodes();
     EXPECT_EQ(done, 3);
     EXPECT_EQ(bcast_val, 29);
@@ -234,7 +234,7 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
 
   bool finished_spin = false;
 
-  runInEpochCollective(epoch, [&done,&bcast_val,&reduce_val_out,&finished_spin]{
+  vt::runInEpochCollective([&done,&bcast_val,&reduce_val_out,&finished_spin]{
     auto num_nodes = theContext()->getNumNodes();
     EXPECT_EQ(done, 3);
     EXPECT_EQ(bcast_val, 29);

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -187,8 +187,8 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
     scope1.mpiCollectiveAsync([&done,&bcast_val,root]{
       auto comm = theContext()->getComm();
       vt_print(barrier, "run MPI_Bcast\n");
-    MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
-    run_order[done++] = 1;
+      MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
+      run_order[done++] = 1;
     });
   };
 

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -204,10 +204,10 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
 
   auto op3 = [&]{
     scope3.mpiCollectiveAsync([&done]{
-      auto comm = theContext()->getComm();
-	  vt_print(barrier, "run MPI_barrier\n");
-	  MPI_Barrier(comm);
-	  run_order[done++] = 3;
+			auto comm = theContext()->getComm();
+			vt_print(barrier, "run MPI_barrier\n");
+			MPI_Barrier(comm);
+			run_order[done++] = 3;
     });
   };
 
@@ -218,7 +218,6 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
     } else {
       op2(); op3(); op1();
     }
-	  runScheduler();
   });
 
   auto num_nodes = theContext()->getNumNodes();

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -75,8 +75,8 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
 
-  int reduce_val_out = 0;  
-  
+  int reduce_val_out = 0;
+
   vt::runInEpochCollective([&]{
     scope.mpiCollectiveAsync([&done]{
       auto comm = theContext()->getComm();
@@ -100,9 +100,9 @@ TEST_F(TestMPICollective, test_mpi_collective_2) {
       done++;
     });
   });
-  
+
   auto num_nodes = theContext()->getNumNodes();
-  
+
   EXPECT_EQ(done, 3);
   EXPECT_EQ(bcast_val, 29);
   EXPECT_EQ(reduce_val_out, num_nodes);
@@ -185,20 +185,20 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
 
   auto op1 = [&]{
     scope1.mpiCollectiveAsync([&done,&bcast_val,root]{
-  	  auto comm = theContext()->getComm();
-  	  vt_print(barrier, "run MPI_Bcast\n");
-	  MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
-	  run_order[done++] = 1;
+      auto comm = theContext()->getComm();
+      vt_print(barrier, "run MPI_Bcast\n");
+    MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
+    run_order[done++] = 1;
     });
   };
 
   auto op2 = [&]{
     scope2.mpiCollectiveAsync([&done,&reduce_val_out]{
-	  auto comm = theContext()->getComm();
+    auto comm = theContext()->getComm();
       int val_in = 1;
-	  vt_print(barrier, "run MPI_Allreduce\n");
-	  MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
-	  run_order[done++] = 2;
+    vt_print(barrier, "run MPI_Allreduce\n");
+    MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
+    run_order[done++] = 2;
     });
   };
 
@@ -220,7 +220,7 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
     }
 	runScheduler();
   });
-  
+
   auto num_nodes = theContext()->getNumNodes();
   EXPECT_EQ(done, 3);
   EXPECT_EQ(bcast_val, 29);


### PR DESCRIPTION
@PhilMiller @lifflander 
There should be some discussion about the test case test_pending_send.cc. That is a special case and was not amenable to the typical case of removing add action and placing runInEpochCollective. Jonathan and I had a call on Sunday to discuss the implementation in this request. The issue is that the runInEpochCollective has no support for actions that are emplaced for execution later. Instead it just runs a unit of work and moves on. That does not work in the test_pending_send case as it is a sort of prepare and wait sort of send instead of send at the immediate moment.