### PR TITLE
955 Clear out uses of addAction in tests

### DIFF
--- a/tests/unit/pipe/test_callback_func.cc
+++ b/tests/unit/pipe/test_callback_func.cc
@@ -88,9 +88,9 @@ TEST_F(TestCallbackFunc, test_callback_func_2) {
 
   called = 0;
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node]{
     if (this_node == 0) {
-      auto cb = theCB()->makeFunc([] { called = 400; });
+      auto cb = theCB()->makeFunc([]{ called = 400; });
       auto msg = makeMessage<CallbackMsg>(cb);
       theMsg()->sendMsg<CallbackMsg, test_handler>(1, msg.get());
     }

--- a/tests/unit/pipe/test_callback_func.cc
+++ b/tests/unit/pipe/test_callback_func.cc
@@ -88,14 +88,16 @@ TEST_F(TestCallbackFunc, test_callback_func_2) {
 
   called = 0;
 
-  if (this_node == 0) {
-    auto cb = theCB()->makeFunc([]{ called = 400; });
-    auto msg = makeMessage<CallbackMsg>(cb);
-    theMsg()->sendMsg<CallbackMsg, test_handler>(1, msg.get());
+  runInEpochCollective([=] {
+    if (this_node == 0) {
+      auto cb = theCB()->makeFunc([] { called = 400; });
+      auto msg = makeMessage<CallbackMsg>(cb);
+      theMsg()->sendMsg<CallbackMsg, test_handler>(1, msg.get());
+    }
+  });
 
-    theTerm()->addAction([=]{
-      EXPECT_EQ(called, 400);
-    });
+  if (this_node == 0) {
+    EXPECT_EQ(called, 400);
   }
 }
 

--- a/tests/unit/pipe/test_callback_func_ctx.cc
+++ b/tests/unit/pipe/test_callback_func_ctx.cc
@@ -115,28 +115,27 @@ TEST_F(TestCallbackFuncCtx, test_callback_func_ctx_2) {
     return;
   }
 
-  ctx = std::make_unique<Context>();
-  ctx->val = this_node;
+  runInEpochCollective([=] {
+    ctx = std::make_unique<Context>();
+    ctx->val = this_node;
 
-  auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
-  auto cb = theCB()->makeFunc<DataMsg,Context>(
-    ctx.get(), [next](DataMsg* msg, Context* my_ctx){
-      called = 500;
-      EXPECT_EQ(my_ctx->val, theContext()->getNode());
-      //fmt::print("{}: a={},b={},c={}\n",n,msg->a,msg->b,msg->c);
-      EXPECT_EQ(msg->a, next+1);
-      EXPECT_EQ(msg->b, next+2);
-      EXPECT_EQ(msg->c, next+3);
-    }
-  );
-  //fmt::print("{}: next={}\n", this_node, next);
-  auto msg = makeMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, test_handler>(next, msg.get());
-
-  theTerm()->addAction([=]{
-    //fmt::print("{}: called={}\n", this_node, called);
-    EXPECT_EQ(called, 500);
+    auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeFunc<DataMsg, Context>(
+      ctx.get(), [next](DataMsg* msg, Context* my_ctx) {
+        called = 500;
+        EXPECT_EQ(my_ctx->val, theContext()->getNode());
+        // fmt::print("{}: a={},b={},c={}\n",n,msg->a,msg->b,msg->c);
+        EXPECT_EQ(msg->a, next + 1);
+        EXPECT_EQ(msg->b, next + 2);
+        EXPECT_EQ(msg->c, next + 3);
+      });
+    // fmt::print("{}: next={}\n", this_node, next);
+    auto msg = makeMessage<CallbackDataMsg>(cb);
+    theMsg()->sendMsg<CallbackDataMsg, test_handler>(next, msg.get());
   });
+
+  // fmt::print("{}: called={}\n", this_node, called);
+  EXPECT_EQ(called, 500);
 }
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/pipe/test_callback_func_ctx.cc
+++ b/tests/unit/pipe/test_callback_func_ctx.cc
@@ -115,7 +115,7 @@ TEST_F(TestCallbackFuncCtx, test_callback_func_ctx_2) {
     return;
   }
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node, num_nodes]{
     ctx = std::make_unique<Context>();
     ctx->val = this_node;
 

--- a/tests/unit/pipe/test_callback_send.cc
+++ b/tests/unit/pipe/test_callback_send.cc
@@ -114,36 +114,39 @@ TEST_F(TestCallbackSend, test_callback_send_1) {
   auto const& this_node = theContext()->getNode();
 
   called = 0;
-  auto cb = theCB()->makeSend<DataMsg,callbackFn>(this_node);
-  auto nmsg = makeMessage<DataMsg>(1,2,3);
-  cb.send(nmsg.get());
 
-  theTerm()->addAction([=]{
-    EXPECT_EQ(called, 100);
+  runInEpochCollective([=] {
+    auto cb = theCB()->makeSend<DataMsg, callbackFn>(this_node);
+    auto nmsg = makeMessage<DataMsg>(1, 2, 3);
+    cb.send(nmsg.get());
   });
+
+  EXPECT_EQ(called, 100);
 }
 
 TEST_F(TestCallbackSend, test_callback_send_2) {
   auto const& this_node = theContext()->getNode();
   called = 0;
-  auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
-  auto nmsg = makeMessage<DataMsg>(1,2,3);
-  cb.send(nmsg.get());
 
-  theTerm()->addAction([=]{
-    EXPECT_EQ(called, 200);
+  runInEpochCollective([=] {
+    auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
+    auto nmsg = makeMessage<DataMsg>(1, 2, 3);
+    cb.send(nmsg.get());
   });
+
+  EXPECT_EQ(called, 200);
 }
 
 TEST_F(TestCallbackSend, test_callback_send_3) {
   auto const& this_node = theContext()->getNode();
   called = 0;
-  auto cb = theCB()->makeSend<CallbackFunctorEmpty>(this_node);
-  cb.send();
 
-  theTerm()->addAction([=]{
-    EXPECT_EQ(called, 300);
+  runInEpochCollective([=] {
+    auto cb = theCB()->makeSend<CallbackFunctorEmpty>(this_node);
+    cb.send();
   });
+
+  EXPECT_EQ(called, 300);
 }
 
 TEST_F(TestCallbackSend, test_callback_send_remote_1) {
@@ -151,14 +154,15 @@ TEST_F(TestCallbackSend, test_callback_send_remote_1) {
   auto const& num_nodes = theContext()->getNumNodes();
 
   called = 0;
-  auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
-  auto cb = theCB()->makeSend<DataMsg,callbackFn>(this_node);
-  auto msg = makeMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
-  theTerm()->addAction([=]{
-    EXPECT_EQ(called, 100);
+  runInEpochCollective([=] {
+    auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeSend<DataMsg, callbackFn>(this_node);
+    auto msg = makeMessage<CallbackDataMsg>(cb);
+    theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
   });
+
+  EXPECT_EQ(called, 100);
 }
 
 TEST_F(TestCallbackSend, test_callback_send_remote_2) {
@@ -166,14 +170,15 @@ TEST_F(TestCallbackSend, test_callback_send_remote_2) {
   auto const& num_nodes = theContext()->getNumNodes();
 
   called = 0;
-  auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
-  auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
-  auto msg = makeMessage<CallbackDataMsg>(cb);
-  theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
 
-  theTerm()->addAction([=]{
-    EXPECT_EQ(called, 200);
+  runInEpochCollective([=] {
+    auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
+    auto msg = makeMessage<CallbackDataMsg>(cb);
+    theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
   });
+
+  EXPECT_EQ(called, 200);
 }
 
 TEST_F(TestCallbackSend, test_callback_send_remote_3) {
@@ -181,14 +186,15 @@ TEST_F(TestCallbackSend, test_callback_send_remote_3) {
   auto const& num_nodes = theContext()->getNumNodes();
 
   called = 0;
-  auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
-  auto cb = theCB()->makeSend<CallbackFunctorEmpty>(this_node);
-  auto msg = makeMessage<CallbackMsg>(cb);
-  theMsg()->sendMsg<CallbackMsg, testHandlerEmpty>(next, msg.get());
 
-  theTerm()->addAction([=]{
-    EXPECT_EQ(called, 300);
+  runInEpochCollective([=] {
+    auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeSend<CallbackFunctorEmpty>(this_node);
+    auto msg = makeMessage<CallbackMsg>(cb);
+    theMsg()->sendMsg<CallbackMsg, testHandlerEmpty>(next, msg.get());
   });
+
+  EXPECT_EQ(called, 300);
 }
 
 

--- a/tests/unit/pipe/test_callback_send.cc
+++ b/tests/unit/pipe/test_callback_send.cc
@@ -115,7 +115,7 @@ TEST_F(TestCallbackSend, test_callback_send_1) {
 
   called = 0;
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node]{
     auto cb = theCB()->makeSend<DataMsg, callbackFn>(this_node);
     auto nmsg = makeMessage<DataMsg>(1, 2, 3);
     cb.send(nmsg.get());
@@ -128,7 +128,7 @@ TEST_F(TestCallbackSend, test_callback_send_2) {
   auto const& this_node = theContext()->getNode();
   called = 0;
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node]{
     auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
     auto nmsg = makeMessage<DataMsg>(1, 2, 3);
     cb.send(nmsg.get());
@@ -141,7 +141,7 @@ TEST_F(TestCallbackSend, test_callback_send_3) {
   auto const& this_node = theContext()->getNode();
   called = 0;
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node]{
     auto cb = theCB()->makeSend<CallbackFunctorEmpty>(this_node);
     cb.send();
   });
@@ -155,7 +155,7 @@ TEST_F(TestCallbackSend, test_callback_send_remote_1) {
 
   called = 0;
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node, num_nodes]{
     auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeSend<DataMsg, callbackFn>(this_node);
     auto msg = makeMessage<CallbackDataMsg>(cb);
@@ -171,7 +171,7 @@ TEST_F(TestCallbackSend, test_callback_send_remote_2) {
 
   called = 0;
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node, num_nodes]{
     auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeSend<CallbackFunctor>(this_node);
     auto msg = makeMessage<CallbackDataMsg>(cb);
@@ -187,7 +187,7 @@ TEST_F(TestCallbackSend, test_callback_send_remote_3) {
 
   called = 0;
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node, num_nodes]{
     auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeSend<CallbackFunctorEmpty>(this_node);
     auto msg = makeMessage<CallbackMsg>(cb);

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -128,25 +128,29 @@ static void cb3(DataMsg* msg, TestCol* col) {
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
   auto const& this_node = theContext()->getNode();
 
-  if (this_node == 0) {
-    auto const& range = Index1D(32);
-    auto proxy = theCollection()->construct<TestCol>(range);
+  runInEpochCollective([=] {
+    if (this_node == 0) {
+      auto const& range = Index1D(32);
+      auto proxy = theCollection()->construct<TestCol>(range);
 
-    for (auto i = 0; i < 32; i++) {
-      if (i % 2 == 0) {
-        auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb1>(proxy(i));
-        auto nmsg = makeMessage<DataMsg>(8,9,10);
-        cb.send(nmsg.get());
-      } else {
-        auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb2>(proxy(i));
-        auto nmsg = makeMessage<DataMsg>(8,9,10);
-        cb.send(nmsg.get());
+      for (auto i = 0; i < 32; i++) {
+        if (i % 2 == 0) {
+          auto cb =
+            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb1>(proxy(i));
+          auto nmsg = makeMessage<DataMsg>(8, 9, 10);
+          cb.send(nmsg.get());
+        } else {
+          auto cb =
+            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb2>(proxy(i));
+          auto nmsg = makeMessage<DataMsg>(8, 9, 10);
+          cb.send(nmsg.get());
+        }
       }
     }
+  });
 
-    theTerm()->addAction([=]{
-      proxy.destroy();
-    });
+  if (this_node == 0) {
+    theCollection()->destroyCollections();
   }
 }
 
@@ -158,52 +162,58 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
     return;
   }
 
-  if (this_node == 0) {
-    auto const& range = Index1D(32);
-    auto proxy = theCollection()->construct<TestCol>(range);
+  runInEpochCollective([=] {
+    if (this_node == 0) {
+      auto const& range = Index1D(32);
+      auto proxy = theCollection()->construct<TestCol>(range);
 
-    for (auto i = 0; i < 32; i++) {
-      auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
-      if (i % 2 == 0) {
-        auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb1>(proxy(i));
-        auto msg = makeMessage<CallbackDataMsg>(cb);
-        theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
-      } else {
-        auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb2>(proxy(i));
-        auto msg = makeMessage<CallbackDataMsg>(cb);
-        theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
+      for (auto i = 0; i < 32; i++) {
+        auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+        if (i % 2 == 0) {
+          auto cb =
+            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb1>(proxy(i));
+          auto msg = makeMessage<CallbackDataMsg>(cb);
+          theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
+        } else {
+          auto cb =
+            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb2>(proxy(i));
+          auto msg = makeMessage<CallbackDataMsg>(cb);
+          theMsg()->sendMsg<CallbackDataMsg, testHandler>(next, msg.get());
+        }
       }
     }
+  });
 
-    theTerm()->addAction([=]{
-      proxy.destroy();
-    });
+  if (this_node == 0) {
+    theCollection()->destroyCollections();
   }
-
 }
 
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
   auto const& this_node = theContext()->getNode();
 
-  if (this_node == 0) {
-    auto const& range = Index1D(32);
-    auto proxy = theCollection()->construct<TestCol>(range);
+  runInEpochCollective([=] {
+    if (this_node == 0) {
+      auto const& range = Index1D(32);
+      auto proxy = theCollection()->construct<TestCol>(range);
 
-    for (auto i = 0; i < 32; i++) {
-      if (i % 2 == 0) {
-        auto cb = theCB()->makeSend<TestCol,DataMsg,&TestCol::cb1>(proxy(i));
-        auto nmsg = makeMessage<DataMsg>(8,9,10);
-        cb.send(nmsg.get());
-      } else {
-        auto cb = theCB()->makeSend<TestCol,DataMsg,cb3>(proxy(i));
-        auto nmsg = makeMessage<DataMsg>(8,9,10);
-        cb.send(nmsg.get());
+      for (auto i = 0; i < 32; i++) {
+        if (i % 2 == 0) {
+          auto cb =
+            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb1>(proxy(i));
+          auto nmsg = makeMessage<DataMsg>(8, 9, 10);
+          cb.send(nmsg.get());
+        } else {
+          auto cb = theCB()->makeSend<TestCol, DataMsg, cb3>(proxy(i));
+          auto nmsg = makeMessage<DataMsg>(8, 9, 10);
+          cb.send(nmsg.get());
+        }
       }
     }
+  });
 
-    theTerm()->addAction([=]{
-      proxy.destroy();
-    });
+  if (this_node == 0) {
+    theCollection()->destroyCollections();
   }
 }
 

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -56,6 +56,8 @@ namespace vt { namespace tests { namespace unit {
 using namespace vt;
 using namespace vt::tests::unit;
 
+struct TestColMsg;
+
 struct CallbackMsg : vt::Message {
   CallbackMsg() = default;
   explicit CallbackMsg(Callback<> in_cb) : cb_(in_cb) { }
@@ -90,7 +92,7 @@ struct TestCol : vt::Collection<TestCol, vt::Index1D> {
   TestCol() = default;
   virtual ~TestCol() = default;
 
-  void check(DataMsg* msg) {
+  void check(TestColMsg* msg) {
     if (this->getIndex().x() % 2 == 0) {
       EXPECT_EQ(val, 29);
     } else {
@@ -123,6 +125,8 @@ static void cb3(DataMsg* msg, TestCol* col) {
   col->val = 13;
 }
 
+struct TestColMsg : ::vt::CollectionMessage<TestCol> {};
+
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
   auto const& this_node = theContext()->getNode();
   auto const& range = Index1D(32);
@@ -146,14 +150,10 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
     }
   });
 
-  runInEpochCollective([this_node, proxy] {
+  runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
-      for (auto i = 0; i < 32; i++) {
-        auto cb =
-          theCB()->makeSend<TestCol, DataMsg, &TestCol::check>(proxy(i));
-        auto nmsg = makeMessage<DataMsg>();
-        cb.send(nmsg.get());
-      }
+      auto msg = makeMessage<TestColMsg>();
+      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }
@@ -190,12 +190,8 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
 
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
-      for (auto i = 0; i < 32; i++) {
-        auto cb =
-          theCB()->makeSend<TestCol, DataMsg, &TestCol::check>(proxy(i));
-        auto nmsg = makeMessage<DataMsg>();
-        cb.send(nmsg.get());
-      }
+      auto msg = makeMessage<TestColMsg>();
+      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }
@@ -224,12 +220,8 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
 
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
-      for (auto i = 0; i < 32; i++) {
-        auto cb =
-          theCB()->makeSend<TestCol, DataMsg, &TestCol::check>(proxy(i));
-        auto nmsg = makeMessage<DataMsg>();
-        cb.send(nmsg.get());
-      }
+      auto msg = makeMessage<TestColMsg>();
+      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -128,7 +128,7 @@ static void cb3(DataMsg* msg, TestCol* col) {
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
   auto const& this_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node]{
     if (this_node == 0) {
       auto const& range = Index1D(32);
       auto proxy = theCollection()->construct<TestCol>(range);
@@ -162,7 +162,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
     return;
   }
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node, num_nodes]{
     if (this_node == 0) {
       auto const& range = Index1D(32);
       auto proxy = theCollection()->construct<TestCol>(range);
@@ -192,7 +192,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
   auto const& this_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([this_node]{
     if (this_node == 0) {
       auto const& range = Index1D(32);
       auto proxy = theCollection()->construct<TestCol>(range);

--- a/tests/unit/rdma/test_rdma_collection_handle.extended.cc
+++ b/tests/unit/rdma/test_rdma_collection_handle.extended.cc
@@ -202,14 +202,14 @@ TYPED_TEST_P(TestRDMAHandleCollection, test_rdma_handle_collection_1) {
     }
   );
 
-  runInEpochCollective([=] {
+  runInEpochCollective([proxy]{
     if (theContext()->getNode() == 0) {
       proxy.template broadcast<
         typename TestCol<T>::TestMsg, &TestCol<T>::initialize>();
     }
   });
 
-  runInEpochCollective([=] {
+  runInEpochCollective([proxy]{
     if (theContext()->getNode() == 0) {
       proxy.template broadcast<
         typename TestCol<T>::TestMsg, &TestCol<T>::afterMigrate>();

--- a/tests/unit/rdma/test_rdma_collection_handle.extended.cc
+++ b/tests/unit/rdma/test_rdma_collection_handle.extended.cc
@@ -202,21 +202,19 @@ TYPED_TEST_P(TestRDMAHandleCollection, test_rdma_handle_collection_1) {
     }
   );
 
-  auto migrate_epoch = theTerm()->makeEpochCollective();
-  if (theContext()->getNode() == 0) {
-    theTerm()->produce(migrate_epoch);
-    proxy.template broadcast<
-      typename TestCol<T>::TestMsg, &TestCol<T>::initialize
-    >(migrate_epoch);
-    theTerm()->addAction(migrate_epoch,[=]{
+  runInEpochCollective([=] {
+    if (theContext()->getNode() == 0) {
       proxy.template broadcast<
-        typename TestCol<T>::TestMsg, &TestCol<T>::afterMigrate
-      >();
-    });
-  }
-  theTerm()->finishedEpoch(migrate_epoch);
+        typename TestCol<T>::TestMsg, &TestCol<T>::initialize>();
+    }
+  });
 
-  do vt::runScheduler(); while (not vt::rt->isTerminated());
+  runInEpochCollective([=] {
+    if (theContext()->getNode() == 0) {
+      proxy.template broadcast<
+        typename TestCol<T>::TestMsg, &TestCol<T>::afterMigrate>();
+    }
+  });
 }
 
 using RDMACollectionTestTypes = testing::Types<

--- a/tests/unit/sequencer/test_sequencer.extended.cc
+++ b/tests/unit/sequencer/test_sequencer.extended.cc
@@ -162,7 +162,7 @@ TEST_F(TestSequencer, test_single_wait) {
   fmt::print("test_seq_handler: node={}\n", my_node);
 #endif
 
-  runInEpochCollective([=] {
+  runInEpochCollective([my_node]{
     if (my_node == 1) {
       auto msg = makeMessage<TestMsg>();
       theMsg()->sendMsg<TestMsg, testSeqHan>(0, msg.get());
@@ -183,7 +183,7 @@ TEST_F(TestSequencer, test_single_wait) {
 TEST_F(TestSequencer, test_single_wait_tagged) {
   auto const& my_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([my_node]{
     if (my_node == 0) {
       SeqType const& seq_id = theSeq()->nextSeq();
       theSeq()->sequenced(seq_id, testSingleTaggedWaitFn);
@@ -202,7 +202,7 @@ TEST_F(TestSequencer, test_single_wait_tagged) {
 TEST_F(TestSequencer, test_multi_wait) {
   auto const& my_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([my_node]{
     if (my_node == 0) {
       SeqType const& seq_id = theSeq()->nextSeq();
       theSeq()->sequenced(seq_id, testMultiWaitFn);
@@ -224,7 +224,7 @@ TEST_F(TestSequencer, test_multi_wait) {
 TEST_F(TestSequencer, test_multi_wait_tagged) {
   auto const& my_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([my_node]{
     if (my_node == 0) {
       SeqType const& seq_id = theSeq()->nextSeq();
       theSeq()->sequenced(seq_id, testMultiTaggedWaitFn);

--- a/tests/unit/sequencer/test_sequencer_for.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_for.extended.cc
@@ -99,21 +99,21 @@ TEST_F(TestSequencerFor, test_for) {
 
   SeqType const& seq_id = theSeq()->nextSeq();
 
-  if (my_node == 0) {
-    theSeq()->sequenced(seq_id, testSeqForFn);
-  }
-
-  for (int i = 0; i < end_range; i++) {
-    if (my_node == 1) {
-      auto msg = makeMessage<TestMsg>();
-      theMsg()->sendMsg<TestMsg, testSeqForHan>(0, msg.get());
+  runInEpochCollective([=] {
+    if (my_node == 0) {
+      theSeq()->sequenced(seq_id, testSeqForFn);
     }
-  }
+
+    for (int i = 0; i < end_range; i++) {
+      if (my_node == 1) {
+        auto msg = makeMessage<TestMsg>();
+        theMsg()->sendMsg<TestMsg, testSeqForHan>(0, msg.get());
+      }
+    }
+  });
 
   if (my_node == 0) {
-    theTerm()->addAction([=]{
-      testSeqForFn(-1);
-    });
+    testSeqForFn(-1);
   }
 }
 

--- a/tests/unit/sequencer/test_sequencer_for.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_for.extended.cc
@@ -99,7 +99,7 @@ TEST_F(TestSequencerFor, test_for) {
 
   SeqType const& seq_id = theSeq()->nextSeq();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([seq_id, my_node]{
     if (my_node == 0) {
       theSeq()->sequenced(seq_id, testSeqForFn);
     }

--- a/tests/unit/sequencer/test_sequencer_nested.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_nested.extended.cc
@@ -264,22 +264,23 @@ struct TestSequencerNested : TestParallelHarness {
 #define SEQ_EXPAND(SEQ_HAN, SEQ_FN, NODE, MSG_TYPE, NUM_MSGS, IS_TAG)   \
   do {                                                                  \
     SeqType const& seq_id = theSeq()->nextSeq();                        \
-    if ((NODE) == 0) {                                                  \
-      theSeq()->sequenced(seq_id, (SEQ_FN));                            \
-    }                                                                   \
-    for (int i = 0; i < (NUM_MSGS); i++) {                              \
-      TagType const tag = (IS_TAG) ? i+1 : no_tag;                      \
-      if ((NODE) == 1) {                                                \
-        auto msg = makeMessage<MSG_TYPE>();                             \
-        theMsg()->sendMsg<MSG_TYPE, SEQ_HAN>(                           \
-          0, msg.get(), tag                                             \
-        );                                                              \
+                                                                        \
+    runInEpochCollective([=]{                                           \
+      if ((NODE) == 0) {                                                \
+        theSeq()->sequenced(seq_id, (SEQ_FN));                          \
       }                                                                 \
-    }                                                                   \
+      for (int i = 0; i < (NUM_MSGS); i++) {                            \
+        TagType const tag = (IS_TAG) ? i+1 : no_tag;                    \
+        if ((NODE) == 1) {                                              \
+          auto msg = makeMessage<MSG_TYPE>();                           \
+          theMsg()->sendMsg<MSG_TYPE, SEQ_HAN>(                         \
+            0, msg.get(), tag                                           \
+          );                                                            \
+        }                                                               \
+      }                                                                 \
+    });                                                                 \
     if ((NODE) == 0) {                                                  \
-      theTerm()->addAction([=]{                                         \
         SEQ_FN(-1);                                                     \
-      });                                                               \
     }                                                                   \
   } while (false);
 

--- a/tests/unit/sequencer/test_sequencer_parallel.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_parallel.extended.cc
@@ -149,7 +149,7 @@ TEST_P(TestSequencerParallelParam, test_seq_parallel_param) {
   SeqType const& seq_id = theSeq()->nextSeq();
   auto seq_par_cnt_fn = std::bind(seqParFnN, _1, par_count);
 
-  runInEpochCollective([=] {
+  runInEpochCollective([=]{
     if (node == 0) {
       seq_par_cnt_fn(SeqParResetAtomicValue);
       theSeq()->sequenced(seq_id, seq_par_cnt_fn);

--- a/tests/unit/sequencer/test_sequencer_parallel.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_parallel.extended.cc
@@ -149,24 +149,23 @@ TEST_P(TestSequencerParallelParam, test_seq_parallel_param) {
   SeqType const& seq_id = theSeq()->nextSeq();
   auto seq_par_cnt_fn = std::bind(seqParFnN, _1, par_count);
 
-  if (node == 0) {
-    seq_par_cnt_fn(SeqParResetAtomicValue);
-    theSeq()->sequenced(seq_id, seq_par_cnt_fn);
-  }
-
-  for (CountType i = 0; i < par_count; i++) {
-    if (node == 1) {
-      auto msg = makeMessage<TestMsg>();
-      theMsg()->sendMsg<TestMsg, seqParHanN>(0, msg.get());
+  runInEpochCollective([=] {
+    if (node == 0) {
+      seq_par_cnt_fn(SeqParResetAtomicValue);
+      theSeq()->sequenced(seq_id, seq_par_cnt_fn);
     }
-  }
+
+    for (CountType i = 0; i < par_count; i++) {
+      if (node == 1) {
+        auto msg = makeMessage<TestMsg>();
+        theMsg()->sendMsg<TestMsg, seqParHanN>(0, msg.get());
+      }
+    }
+  });
 
   if (node == 0) {
-    theTerm()->addAction([=]{
-      seq_par_cnt_fn(SeqParFinalizeAtomicValue);
-    });
+    seq_par_cnt_fn(SeqParFinalizeAtomicValue);
   }
-
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -317,22 +316,22 @@ struct TestSequencerParallel : TestParallelHarness {
 #define PAR_EXPAND(SEQ_HAN, SEQ_FN, NODE, MSG_TYPE, NUM_MSGS, IS_TAG) \
   do {                                                                \
     SeqType const& seq_id = theSeq()->nextSeq();                      \
-    if ((NODE) == 0) {                                                \
-      theSeq()->sequenced(seq_id, (SEQ_FN));                          \
-    }                                                                 \
-    for (int i = 0; i < (NUM_MSGS); i++) {                            \
-      TagType const tag = (IS_TAG) ? i+1 : no_tag;                    \
-      if ((NODE) == 1) {                                              \
-      auto msg = makeMessage<MSG_TYPE>();                             \
-        theMsg()->sendMsg<MSG_TYPE, SEQ_HAN>(                         \
-          0, msg.get(), tag                                           \
-        );                                                            \
+    runInEpochCollective([=]{                                         \
+      if ((NODE) == 0) {                                              \
+        theSeq()->sequenced(seq_id, (SEQ_FN));                        \
       }                                                               \
-    }                                                                 \
+      for (int i = 0; i < (NUM_MSGS); i++) {                          \
+        TagType const tag = (IS_TAG) ? i+1 : no_tag;                  \
+        if ((NODE) == 1) {                                            \
+          auto msg = makeMessage<MSG_TYPE>();                         \
+          theMsg()->sendMsg<MSG_TYPE, SEQ_HAN>(                       \
+            0, msg.get(), tag                                         \
+          );                                                          \
+        }                                                             \
+      }                                                               \
+    });                                                               \
     if ((NODE) == 0) {                                                \
-      theTerm()->addAction([=]{                                       \
         SEQ_FN(-1);                                                   \
-      });                                                             \
     }                                                                 \
   } while (false);
 

--- a/tests/unit/sequencer/test_sequencer_vrt.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_vrt.extended.cc
@@ -182,7 +182,7 @@ struct TestSequencerVirtual : TestParallelHarness {
 TEST_F(TestSequencerVirtual, test_seq_vc_1) {
   auto const& my_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([my_node]{
     if (my_node == 0) {
       auto proxy = theVirtualManager()->makeVirtual<VirtualType>(29);
       SeqType const& seq_id = theVirtualSeq()->createVirtualSeq(proxy);
@@ -207,7 +207,7 @@ TEST_F(TestSequencerVirtual, test_seq_vc_1) {
 TEST_F(TestSequencerVirtual, test_seq_vc_2) {
   auto const& my_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([my_node]{
     if (my_node == 0) {
       auto proxy = theVirtualManager()->makeVirtual<VirtualType>(85);
       SeqType const& seq_id = theVirtualSeq()->createVirtualSeq(proxy);
@@ -233,7 +233,7 @@ TEST_F(TestSequencerVirtual, test_seq_vc_2) {
 TEST_F(TestSequencerVirtual, test_seq_vc_distinct_inst_3) {
   auto const& my_node = theContext()->getNode();
 
-  runInEpochCollective([=] {
+  runInEpochCollective([my_node]{
     if (my_node == 0) {
       auto proxy_a = theVirtualManager()->makeVirtual<VirtualType>(85);
       SeqType const& seq_id_a = theVirtualSeq()->createVirtualSeq(proxy_a);


### PR DESCRIPTION
- [x] tests/unit/pipe/test_callback_func.cc:1
- [x] tests/unit/pipe/test_callback_func_ctx.cc:1
- [x] tests/unit/pipe/test_callback_send.cc:6
- [x] tests/unit/pipe/test_callback_send_collection.extended.cc:3
- [x] tests/unit/rdma/test_rdma_collection_handle.extended.cc:1
- [x] tests/unit/sequencer/test_sequencer.extended.cc:4
- [x] tests/unit/sequencer/test_sequencer_extensive.extended.cc:1
- [x] tests/unit/sequencer/test_sequencer_for.extended.cc:1
- [x] tests/unit/sequencer/test_sequencer_nested.extended.cc:1
- [x] tests/unit/sequencer/test_sequencer_parallel.extended.cc:2
- [x] tests/unit/sequencer/test_sequencer_vrt.extended.cc:3

Following tests are left unchanged (addAction() is a part of termination namespace so i thought its usage here makes sense)
-  tests/unit/termination/test_termination_action_callable.extended.cc:2
-  tests/unit/termination/test_termination_action_common.impl.h:2
-  tests/unit/termination/test_termination_reset.cc:2