### PR TITLE
884 rename getNumTotalChildren to getNumDescendants

### DIFF
--- a/src/vt/collective/scatter/scatter.cc
+++ b/src/vt/collective/scatter/scatter.cc
@@ -78,7 +78,7 @@ char* Scatter::applyScatterRecur(
 }
 
 void Scatter::scatterIn(ScatterMsg* msg) {
-  auto const& total_children = getNumTotalChildren();
+  auto const& total_children = getNumDescendants();
   auto const& elm_size = msg->elm_bytes_;
   auto const& total_size = msg->total_bytes_;
   auto in_base_ptr = reinterpret_cast<char*>(msg) + sizeof(ScatterMsg);
@@ -91,7 +91,7 @@ void Scatter::scatterIn(ScatterMsg* msg) {
     user_handler, total_size, elm_size, in_ptr - in_base_ptr, total_children
   );
   Tree::foreachChild([&](NodeType child) {
-    auto const& num_children = getNumTotalChildren(child) + 1;
+    auto const& num_children = getNumDescendants(child) + 1;
     auto const& child_bytes_size = num_children * elm_size;
     auto child_msg = makeMessageSz<ScatterMsg>(
       child_bytes_size, child_bytes_size, elm_size

--- a/src/vt/collective/tree/tree.cc
+++ b/src/vt/collective/tree/tree.cc
@@ -95,19 +95,19 @@ Tree::NodeListType Tree::getChildren(NodeType node) const {
   return children;
 }
 
-std::size_t Tree::getNumTotalChildren(NodeType child) const {
+std::size_t Tree::getNumDescendants(NodeType child) const {
   std::size_t total = 0;
   auto children = getChildren(child);
   for (auto&& elm : children) {
-    total += getNumTotalChildren(elm);
+    total += getNumDescendants(elm);
   }
   return total + children.size();
 }
 
-std::size_t Tree::getNumTotalChildren() const {
+std::size_t Tree::getNumDescendants() const {
   auto total_size = 0;
   foreachChild([this,&total_size](NodeType child){
-    total_size += getNumTotalChildren(child);
+    total_size += getNumDescendants(child);
   });
   return total_size;
 }

--- a/src/vt/collective/tree/tree.h
+++ b/src/vt/collective/tree/tree.h
@@ -177,14 +177,14 @@ struct Tree {
    *
    * \return number of descendants
    */
-  std::size_t getNumTotalChildren(NodeType child) const;
+  std::size_t getNumDescendants(NodeType child) const;
 
   /**
-   * \internal \brief Get total children in tree
+   * \internal \brief Get total number of descendants in the tree.
    *
-   * \return number of children
+   * \return number of descendants
    */
-  std::size_t getNumTotalChildren() const;
+  std::size_t getNumDescendants() const;
 
 private:
   bool set_up_tree_ = false;


### PR DESCRIPTION
rename the method and update the docs

Fixes #884 