### PR TITLE
#986: Run MPI collectives as part of active epoch at initial call

### DIFF
--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -195,14 +195,18 @@ static void broadcastConsensus(
     "Planned collective does not exist within scope"
   );
   auto action = iter_seq->second.action_;
+  auto epoch = iter_seq->second.epoch_;
 
   // Run the collective safely.
   // The action is expected to use MPI calls; not VT calls.
   {
     VT_ALLOW_MPI_CALLS;
+    theMsg()->pushEpoch(epoch);
     action();
+    theMsg()->popEpoch(epoch);
   }
 
+  theTerm()->consume(epoch);
   // Erase the tag that was actually executed
   impl->planned_collective_.erase(iter_seq);
 

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -56,9 +56,11 @@ namespace vt { namespace collective {
 TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
   auto impl = getScope();
   auto tag = impl->next_seq_++;
+  auto epoch = theMsg()->getEpoch();
 
   // Create a new collective action with the next tag
-  detail::ScopeImpl::CollectiveInfo info(tag, action);
+  detail::ScopeImpl::CollectiveInfo info(tag, action, epoch);
+  theTerm()->produce(epoch);
 
   impl->planned_collective_.emplace(
     std::piecewise_construct,

--- a/src/vt/collective/collective_scope.h
+++ b/src/vt/collective/collective_scope.h
@@ -66,12 +66,13 @@ private:
 
 private:
   struct CollectiveInfo {
-    CollectiveInfo(TagType in_seq, ActionType in_action)
-      : seq_(in_seq), action_(in_action)
+    CollectiveInfo(TagType in_seq, ActionType in_action, EpochType in_epoch)
+      : seq_(in_seq), action_(in_action), epoch_(in_epoch)
     { }
 
     TagType seq_ = no_tag;
     ActionType action_ = no_action;
+    EpochType epoch_ = no_epoch;
   };
 
 private:
@@ -132,6 +133,9 @@ public:
    * Any buffers captured in the lambda to use with the MPI operations
    * are in use until \c isCollectiveDone returns \c true or \c
    * waitCollective returns on the returned \c TagType
+   *
+   * The operation is counted as activity in the active termination
+   * detection epoch
    *
    * \param[in] action the action containing a closed set of MPI operations
    *


### PR DESCRIPTION
Fixes: #986