### PR TITLE
878 Cleanup group manager interfaces

### DIFF
--- a/examples/group/group_collective.cc
+++ b/examples/group/group_collective.cc
@@ -78,7 +78,7 @@ int main(int argc, char** argv) {
       auto const& root = 0;
       auto const& in_group = vt::theGroup()->inGroup(group);
       auto const& root_node = vt::theGroup()->groupRoot(group);
-      auto const& is_default_group = vt::theGroup()->groupDefault(group);
+      auto const& is_default_group = vt::theGroup()->isGroupDefault(group);
       fmt::print(
         "{}: Group is created: group={:x}, in_group={}, root={}, "
         "is_default_group={}\n",

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -147,7 +147,7 @@ NodeType GroupManager::groupRoot(GroupType const& group) const {
   return root;
 }
 
-bool GroupManager::groupDefault(GroupType const& group) const {
+bool GroupManager::isGroupDefault(GroupType const& group) const {
   auto iter = local_collective_group_info_.find(group);
   vtAssert(iter != local_collective_group_info_.end(), "Must exist");
   auto const& def = iter->second->isGroupDefault();

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -518,7 +518,7 @@ void GroupManager::addCleanupAction(ActionType action) {
   cleanup_actions_.push_back(action);
 }
 
-RemoteOperationIDType GroupManager::getNextID(){
+RemoteOperationIDType GroupManager::getNextOpID(){
   return cur_id_++;
 }
 

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -59,7 +59,7 @@
 namespace vt { namespace group {
 
 GroupType GroupManager::newGroup(
-  RegionPtrType in_region, bool const& is_static, ActionGroupType action
+  RegionPtrType in_region, bool const is_static, ActionGroupType action
 ) {
   return newLocalGroup(std::move(in_region), is_static, action);
 }
@@ -86,7 +86,7 @@ GroupType GroupManager::newGroupCollectiveLabel(GroupCollectiveLabelTagType) {
 }
 
 GroupType GroupManager::newCollectiveGroup(
-  bool const& is_in_group, bool const& is_static, ActionGroupType action,
+  bool const is_in_group, bool const is_static, ActionGroupType action,
   bool make_mpi_group
 ) {
   auto const& this_node = theContext()->getNode();
@@ -103,7 +103,7 @@ GroupType GroupManager::newCollectiveGroup(
 }
 
 GroupType GroupManager::newLocalGroup(
-  RegionPtrType in_region, bool const& is_static, ActionGroupType action
+  RegionPtrType in_region, bool const is_static, ActionGroupType action
 ) {
   auto const& this_node = theContext()->getNode();
   auto new_id = next_group_id_++;
@@ -118,13 +118,13 @@ GroupType GroupManager::newLocalGroup(
   return group;
 }
 
-bool GroupManager::inGroup(GroupType const& group) {
+bool GroupManager::inGroup(GroupType const group) {
   auto iter = local_collective_group_info_.find(group);
   vtAssert(iter != local_collective_group_info_.end(), "Must exist");
   return iter->second->inGroup();
 }
 
-GroupManager::ReducePtrType GroupManager::groupReducer(GroupType const& group) {
+GroupManager::ReducePtrType GroupManager::groupReducer(GroupType const group) {
   auto iter = local_collective_group_info_.find(group);
   vtAssert(iter != local_collective_group_info_.end(), "Must exist");
   auto const& is_default_group = iter->second->isGroupDefault();
@@ -135,7 +135,7 @@ GroupManager::ReducePtrType GroupManager::groupReducer(GroupType const& group) {
   }
 }
 
-NodeType GroupManager::groupRoot(GroupType const& group) const {
+NodeType GroupManager::groupRoot(GroupType const group) const {
   auto iter = local_collective_group_info_.find(group);
   vtAssert(iter != local_collective_group_info_.end(), "Must exist");
   auto const& root = iter->second->getRoot();
@@ -143,7 +143,7 @@ NodeType GroupManager::groupRoot(GroupType const& group) const {
   return root;
 }
 
-bool GroupManager::isGroupDefault(GroupType const& group) const {
+bool GroupManager::isGroupDefault(GroupType const group) const {
   auto iter = local_collective_group_info_.find(group);
   vtAssert(iter != local_collective_group_info_.end(), "Must exist");
   auto const& def = iter->second->isGroupDefault();
@@ -161,12 +161,12 @@ RemoteOperationIDType GroupManager::registerContinuation(ActionType action) {
 }
 
 void GroupManager::registerContinuation(
-  RemoteOperationIDType const& op, ActionType action
+  RemoteOperationIDType const op, ActionType action
 ) {
   continuation_actions_[op].push_back(action);
 }
 
-void GroupManager::triggerContinuation(RemoteOperationIDType const& op) {
+void GroupManager::triggerContinuation(RemoteOperationIDType const op) {
   auto iter = continuation_actions_.find(op);
   if (iter != continuation_actions_.end()) {
     for (auto&& elm : iter->second) {
@@ -177,8 +177,8 @@ void GroupManager::triggerContinuation(RemoteOperationIDType const& op) {
 }
 
 void GroupManager::initializeRemoteGroup(
-  GroupType const& group, RegionPtrType in_region, bool const& is_static,
-  RegionType::SizeType const& group_size
+  GroupType const group, RegionPtrType in_region, bool const is_static,
+  RegionType::SizeType const group_size
 ) {
   auto group_info = std::make_unique<GroupInfoType>(
     info_rooted_remote_cons, std::move(in_region), group, group_size
@@ -192,7 +192,7 @@ void GroupManager::initializeRemoteGroup(
   group_ptr->setup();
 }
 
-MPI_Comm GroupManager::getGroupComm(GroupType const& group_id) {
+MPI_Comm GroupManager::getGroupComm(GroupType const group_id) {
   auto iter = local_collective_group_info_.find(group_id);
   vtAssert(
     iter != local_collective_group_info_.end(),
@@ -211,7 +211,7 @@ MPI_Comm GroupManager::getGroupComm(GroupType const& group_id) {
 }
 
 void GroupManager::initializeLocalGroupCollective(
-  GroupType const& group, bool const& is_static, ActionType action,
+  GroupType const group, bool const is_static, ActionType action,
   bool const in_group, bool make_mpi_group
 ) {
   auto group_info = std::make_unique<GroupInfoType>(
@@ -227,10 +227,10 @@ void GroupManager::initializeLocalGroupCollective(
 }
 
 void GroupManager::initializeLocalGroup(
-  GroupType const& group, RegionPtrType in_region, bool const& is_static, ActionType action
+  GroupType const group, RegionPtrType in_region, bool const is_static, ActionType action
 ) {
 
-  auto const& group_size = in_region->getSize();
+  auto const group_size = in_region->getSize();
   auto group_info = std::make_unique<GroupInfoType>(
     info_rooted_local_cons, std::move(in_region), action, group, group_size
   );
@@ -244,8 +244,8 @@ void GroupManager::initializeLocalGroup(
 }
 
 /*static*/ EventType GroupManager::groupHandler(
-  MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-  MsgSizeType const& size, bool const root, bool* const deliver
+  MsgSharedPtr<BaseMsgType> const& base, NodeType const from,
+  MsgSizeType const size, bool const root, bool* const deliver
 ) {
   auto const& msg = reinterpret_cast<ShortMessage*>(base.get());
   auto const& is_pipe = envelopeIsPipe(msg->env);
@@ -291,8 +291,8 @@ void GroupManager::initializeLocalGroup(
 }
 
 EventType GroupManager::sendGroupCollective(
-  MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-  MsgSizeType const& size, bool const is_root,
+  MsgSharedPtr<BaseMsgType> const& base, NodeType const from,
+  MsgSizeType const size, bool const is_root,
   bool* const deliver
 ) {
   auto const& send_tag = static_cast<messaging::MPI_TagType>(
@@ -402,8 +402,8 @@ EventType GroupManager::sendGroupCollective(
 }
 
 EventType GroupManager::sendGroup(
-  MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-  MsgSizeType const& size, bool const is_root,
+  MsgSharedPtr<BaseMsgType> const& base, NodeType const from,
+  MsgSizeType const size, bool const is_root,
   bool* const deliver
 ) {
   auto const& this_node = theContext()->getNode();

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -59,10 +59,8 @@
 namespace vt { namespace group {
 
 GroupType GroupManager::newGroup(
-  RegionPtrType in_region, bool const& is_collective, bool const& is_static,
-  ActionGroupType action
+  RegionPtrType in_region, bool const& is_static, ActionGroupType action
 ) {
-  vtAssert(!is_collective, "Must not be collective");
   return newLocalGroup(std::move(in_region), is_static, action);
 }
 
@@ -70,8 +68,7 @@ GroupType GroupManager::newGroup(
   RegionPtrType in_region, ActionGroupType action
 ) {
   bool const is_static = true;
-  bool const is_collective = false;
-  return newGroup(std::move(in_region), is_collective, is_static, action);
+  return newGroup(std::move(in_region), is_static, action);
 }
 
 GroupType GroupManager::newGroupCollective(

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -111,10 +111,9 @@ GroupType GroupManager::newLocalGroup(
   auto const& group = GroupIDBuilder::createGroupID(
     new_id, this_node, is_collective, is_static
   );
-  auto const& size = in_region->getSize();
   auto group_action = std::bind(action, group);
   initializeLocalGroup(
-    group, std::move(in_region), is_static, group_action, size
+    group, std::move(in_region), is_static, group_action
   );
   return group;
 }
@@ -228,9 +227,10 @@ void GroupManager::initializeLocalGroupCollective(
 }
 
 void GroupManager::initializeLocalGroup(
-  GroupType const& group, RegionPtrType in_region, bool const& is_static,
-  ActionType action, RegionType::SizeType const& group_size
+  GroupType const& group, RegionPtrType in_region, bool const& is_static, ActionType action
 ) {
+
+  auto const& group_size = in_region->getSize();
   auto group_info = std::make_unique<GroupInfoType>(
     info_rooted_local_cons, std::move(in_region), action, group, group_size
   );

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -243,11 +243,9 @@ private:
    * \param[in] in_region list of nodes in group
    * \param[in] is_static whether the group is static after creation
    * \param[in] action action to execute when group is finished construction
-   * \param[in] group_size the number of nodes in the group
    */
   void initializeLocalGroup(
-    GroupType const& group, RegionPtrType in_region, bool const& is_static,
-    ActionType action, RegionType::SizeType const& group_size
+    GroupType const& group, RegionPtrType in_region, bool const& is_static, ActionType action
   );
 
   /**

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -359,7 +359,7 @@ public:
    *
    * \return whether it is the default group
    */
-  bool groupDefault(GroupType const& group) const;
+  bool isGroupDefault(GroupType const& group) const;
 
   /**
    * \internal \brief Add a cleanup action

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -373,7 +373,7 @@ public:
    *
    * \return the operation ID
    */
-  RemoteOperationIDType getNextID();
+  RemoteOperationIDType getNextOpID();
 
 private:
   /**

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -130,7 +130,7 @@ struct GroupManager : runtime::component::Component<GroupManager> {
    * \return the group ID
    */
   GroupType newGroup(
-    RegionPtrType in_region, bool const& is_static, ActionGroupType action
+    RegionPtrType in_region, bool const is_static, ActionGroupType action
   );
 
   /**
@@ -172,7 +172,7 @@ struct GroupManager : runtime::component::Component<GroupManager> {
    *
    * \return whether this node is included
    */
-  bool inGroup(GroupType const& group);
+  bool inGroup(GroupType const group);
 
   /**
    * \brief Get MPI_Comm from VT group
@@ -182,10 +182,10 @@ struct GroupManager : runtime::component::Component<GroupManager> {
    * \return the MPI_Comm associated with the group; returns \c MPI_COMM_WORLD
    * if group was created without a communicator
    */
-  MPI_Comm getGroupComm(GroupType const& group_id);
+  MPI_Comm getGroupComm(GroupType const group_id);
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
-  void sendMsg(GroupType const& group, MsgT* msg);
+  void sendMsg(GroupType const group, MsgT* msg);
 
   friend struct Info;
   friend struct InfoColl;
@@ -205,7 +205,7 @@ private:
    * \return the group ID
    */
   GroupType newCollectiveGroup(
-    bool const& in_group, bool const& is_static, ActionGroupType action,
+    bool const in_group, bool const is_static, ActionGroupType action,
     bool make_mpi_group = false
   );
 
@@ -219,7 +219,7 @@ private:
    * \return the group ID
    */
   GroupType newLocalGroup(
-    RegionPtrType in_region, bool const& is_static, ActionGroupType action
+    RegionPtrType in_region, bool const is_static, ActionGroupType action
   );
 
   /**
@@ -232,7 +232,7 @@ private:
    * \param[in] make_mpi_group whether VT should create an underlying MPI group
    */
   void initializeLocalGroupCollective(
-    GroupType const& group, bool const& is_static, ActionType action,
+    GroupType const group, bool const is_static, ActionType action,
     bool const in_group, bool make_mpi_group
   );
 
@@ -245,7 +245,7 @@ private:
    * \param[in] action action to execute when group is finished construction
    */
   void initializeLocalGroup(
-    GroupType const& group, RegionPtrType in_region, bool const& is_static, ActionType action
+    GroupType const group, RegionPtrType in_region, bool const is_static, ActionType action
   );
 
   /**
@@ -257,8 +257,8 @@ private:
    * \param[in] group_size the number of nodes in the group
    */
   void initializeRemoteGroup(
-    GroupType const& group, RegionPtrType in_region, bool const& is_static,
-    RegionType::SizeType const& group_size
+    GroupType const group, RegionPtrType in_region, bool const is_static,
+    RegionType::SizeType const group_size
   );
 
   /**
@@ -284,7 +284,7 @@ private:
    * \param[in] action the continuation
    */
   void registerContinuation(
-    RemoteOperationIDType const& op, ActionType action
+    RemoteOperationIDType const op, ActionType action
   );
 
   /**
@@ -292,7 +292,7 @@ private:
    *
    * \param[in] op the operation ID
    */
-  void triggerContinuation(RemoteOperationIDType const& op);
+  void triggerContinuation(RemoteOperationIDType const op);
 
   /**
    * \internal \brief Send message to a rooted group
@@ -306,8 +306,8 @@ private:
    * \return the event ID for any generated events (like MPI_Requests)
    */
   EventType sendGroup(
-    MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-    MsgSizeType const& size, bool const is_root,
+    MsgSharedPtr<BaseMsgType> const& base, NodeType const from,
+    MsgSizeType const size, bool const is_root,
     bool* const deliver
   );
 
@@ -323,8 +323,8 @@ private:
    * \return the event ID for any generated events (like MPI_Requests)
    */
   EventType sendGroupCollective(
-    MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-    MsgSizeType const& size, bool const is_root,
+    MsgSharedPtr<BaseMsgType> const& base, NodeType const from,
+    MsgSizeType const size, bool const is_root,
     bool* const deliver
   );
 
@@ -336,7 +336,7 @@ public:
    *
    * \return pointer to the reducer
    */
-  ReducePtrType groupReducer(GroupType const& group);
+  ReducePtrType groupReducer(GroupType const group);
 
   /**
    * \brief Get the root node for a group
@@ -345,7 +345,7 @@ public:
    *
    * \return the root node
    */
-  NodeType groupRoot(GroupType const& group) const;
+  NodeType groupRoot(GroupType const group) const;
 
   /**
    * \brief Check if a group is the default group (all nodes, default spanning
@@ -355,7 +355,7 @@ public:
    *
    * \return whether it is the default group
    */
-  bool isGroupDefault(GroupType const& group) const;
+  bool isGroupDefault(GroupType const group) const;
 
   /**
    * \internal \brief Add a cleanup action
@@ -385,8 +385,8 @@ private:
    * \return the event ID for any generated events (like MPI_Requests)
    */
   static EventType groupHandler(
-    MsgSharedPtr<BaseMsgType> const& msg, NodeType const& from,
-    MsgSizeType const& msg_size, bool const is_root,
+    MsgSharedPtr<BaseMsgType> const& msg, NodeType const from,
+    MsgSizeType const msg_size, bool const is_root,
     bool* const deliver
   );
 
@@ -426,8 +426,8 @@ struct GroupManagerT : public GroupManager
 
   static void pushCleanupAction();
   static RemoteOperationIDType registerContinuationT(ActionTType action);
-  static void registerContinuationT(RemoteOperationIDType const& op, ActionTType a);
-  static void triggerContinuationT(RemoteOperationIDType const& op, T t);
+  static void registerContinuationT(RemoteOperationIDType const op, ActionTType a);
+  static void triggerContinuationT(RemoteOperationIDType const op, T t);
 
 private:
   static ActionContainerTType continuation_actions_t_;

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -124,15 +124,13 @@ struct GroupManager : runtime::component::Component<GroupManager> {
    * \brief Create a new rooted group.
    *
    * \param[in] in_region list of nodes to include
-   * \param[in] is_collective whether it's collective, which must be false
    * \param[in] is_static whether the group is static after creation
    * \param[in] action action to execute when group is finished construction
    *
    * \return the group ID
    */
   GroupType newGroup(
-    RegionPtrType in_region, bool const& is_collective,
-    bool const& is_static, ActionGroupType action
+    RegionPtrType in_region, bool const& is_static, ActionGroupType action
   );
 
   /**

--- a/src/vt/group/group_manager.impl.h
+++ b/src/vt/group/group_manager.impl.h
@@ -100,7 +100,7 @@ RemoteOperationIDType GroupManagerT<T>::registerContinuationT(ActionTType act) {
 
 template <typename T>
 void GroupManagerT<T>::registerContinuationT(
-  RemoteOperationIDType const& op, ActionTType action
+  RemoteOperationIDType const op, ActionTType action
 ) {
   vt_debug_print_verbose(
     group, node,
@@ -121,7 +121,7 @@ void GroupManagerT<T>::registerContinuationT(
 
 template <typename T>
 void GroupManagerT<T>::triggerContinuationT(
-  RemoteOperationIDType const& op, T t
+  RemoteOperationIDType const op, T t
 ) {
   auto iter = continuation_actions_t_.find(op);
   auto const& found = iter != continuation_actions_t_.end();

--- a/src/vt/group/group_manager.impl.h
+++ b/src/vt/group/group_manager.impl.h
@@ -82,7 +82,7 @@ template <typename T>
 RemoteOperationIDType GroupManagerT<T>::registerContinuationT(ActionTType act) {
   pushCleanupAction();
 
-  RemoteOperationIDType next_id = theGroup()->getNextID();
+  RemoteOperationIDType next_id = theGroup()->getNextOpID();
   continuation_actions_t_.emplace(
     std::piecewise_construct,
     std::forward_as_tuple(next_id),

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -295,7 +295,7 @@ GroupType CollectionManager::createGroupCollection(
   auto const group_id = theGroup()->newGroupCollective(
     in_group, [proxy](GroupType new_group){
       auto const& group_root = theGroup()->groupRoot(new_group);
-      auto const& is_group_default = theGroup()->groupDefault(new_group);
+      auto const& is_group_default = theGroup()->isGroupDefault(new_group);
       auto const& my_in_group = theGroup()->inGroup(new_group);
       auto elm_holder = theCollection()->findElmHolder<ColT,IndexT>(proxy);
       elm_holder->setGroup(new_group);

--- a/tests/unit/group/test_group.cc
+++ b/tests/unit/group/test_group.cc
@@ -136,7 +136,7 @@ TEST_F(TestGroup, test_group_collective_construct_1) {
     theGroup()->newGroupCollective(
       node_filter, [=](GroupType group) {
         auto const& in_group = theGroup()->inGroup(group);
-        auto const& is_default_group = theGroup()->groupDefault(group);
+        auto const& is_default_group = theGroup()->isGroupDefault(group);
         EXPECT_EQ(in_group, node_filter);
         EXPECT_EQ(is_default_group, false);
         auto msg = makeMessage<TestMsg>();


### PR DESCRIPTION
- [x] Remove is_collective where it's not needed or must be true
- [x] Remove group_size from interface where it's not needed
- [x] Rename groupDefault to isGroupDefault (boolean)
- [x] Rename getNextID to getNextOpID
- [x] Remove redundant `const refs`
- [x] Do any other cleanup that you notice along the way

Fixes #878 