### PR TITLE
1007 Add missing cleanup for restoreFromFile

### DIFF
--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -304,6 +304,20 @@ private:
     VirtualProxyType proxy, typename ColT::IndexType idx, Args&&... args
   );
 
+  /**
+   * \internal \brief Insert into a collection on this node with a pointer to
+   * the collection element to insert
+   *
+   * \param[in] proxy the collection proxy
+   * \param[in] idx the index to insert
+   * \param[in] ptr unique ptr to insert for the collection
+   */
+  template <typename ColT>
+  void staticInsertColPtr(
+    VirtualProxyType proxy, typename ColT::IndexType idx,
+    std::unique_ptr<ColT> ptr
+  );
+
 public:
   /**
    * \brief Collectively construct a virtual context collection with a staged

--- a/src/vt/vrt/collection/staged_token/token.h
+++ b/src/vt/vrt/collection/staged_token/token.h
@@ -62,6 +62,8 @@ struct InsertTokenRval {
   template <typename... Args>
   void insert(Args&&... args);
 
+  void insertPtr(std::unique_ptr<ColT> ptr);
+
   friend CollectionManager;
 
 private:

--- a/src/vt/vrt/collection/staged_token/token.impl.h
+++ b/src/vt/vrt/collection/staged_token/token.impl.h
@@ -59,6 +59,11 @@ void InsertTokenRval<ColT,IndexT>::insert(Args&&... args) {
   return theCollection()->staticInsert<ColT>(proxy_,idx_,args...);
 }
 
+template <typename ColT, typename IndexT>
+void InsertTokenRval<ColT,IndexT>::insertPtr(std::unique_ptr<ColT> ptr) {
+  return theCollection()->staticInsertColPtr<ColT>(proxy_,idx_,std::move(ptr));
+}
+
 // /*virtual*/ InsertToken::~InsertToken() {
 //   theCollection()->finishedStaticInsert<ColT>(proxy_);
 // }

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -234,8 +234,6 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
       }
     });
 
-    vt::theCollective()->barrier();
-
     // Ensure that all elements were properly destroyed
     EXPECT_EQ(counter, 0);
   }

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -54,9 +54,37 @@ namespace vt { namespace tests { namespace unit {
 static constexpr std::size_t data1_len = 1024;
 static constexpr std::size_t data2_len = 64;
 
+static std::size_t counter = 0;
+
 struct TestCol : vt::Collection<TestCol,vt::Index3D> {
 
-  TestCol() = default;
+  TestCol() {
+    // fmt::print("{} ctor\n", theContext()->getNode());
+    counter++;
+  }
+  TestCol(TestCol&& other)
+    : iter(other.iter),
+      data1(std::move(other.data1)),
+      data2(std::move(other.data2)),
+      token(other.token)
+  {
+    // fmt::print("{} move ctor\n", theContext()->getNode());
+    counter++;
+  }
+  TestCol(TestCol const& other)
+    : iter(other.iter),
+      data1(other.data1),
+      data2(other.data2),
+      token(other.token)
+  {
+    // fmt::print("{} copy ctor\n", theContext()->getNode());
+    counter++;
+  }
+
+  virtual ~TestCol() {
+    // fmt::print("{} destroying\n", theContext()->getNode());
+    counter--;
+  }
 
   struct NullMsg : vt::CollectionMessage<TestCol> {};
 
@@ -194,11 +222,22 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
     // Restoration should be done now
     vt::theCollective()->barrier();
 
-    runInEpoch([&]{
+    runInEpochCollective([&]{
       if (this_node == 0) {
         proxy.broadcast<TestCol::NullMsg,&TestCol::verify>();
       }
     });
+
+    runInEpochCollective([&]{
+      if (this_node == 0) {
+        proxy.destroy();
+      }
+    });
+
+    vt::theCollective()->barrier();
+
+    // Ensure that all elements were properly destroyed
+    EXPECT_EQ(counter, 0);
   }
 
 }


### PR DESCRIPTION
Fixes #1007

- Write a test that triggers the destruction bug
- Add missing cleanup functions (destroy not working) for token-based collection insertion
- Refactor to avoid calling both copy constructor and move constructor when restoring from file
- Create a helper for doing the insertion once the unique pointer is available