### PR TITLE
1004 Create collection on single node in TestCallbackSendCollection and TestCallbackBcastCollection

### DIFF
--- a/tests/unit/pipe/test_callback_bcast_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_bcast_collection.extended.cc
@@ -133,7 +133,12 @@ struct TestColMsg : ::vt::CollectionMessage<TestCol> {};
 TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_1) {
   auto const& this_node = theContext()->getNode();
   auto const& range = Index1D(32);
-  auto proxy = theCollection()->construct<TestCol>(range);
+
+  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
+
+  if (this_node == 0) {
+    proxy = theCollection()->construct<TestCol>(range);
+  }
 
   runInEpochCollective([&]{
     if (this_node == 0) {
@@ -160,7 +165,12 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_2) {
   }
 
   auto const& range = Index1D(32);
-  auto proxy = theCollection()->construct<TestCol>(range);
+
+  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
+
+  if (this_node == 0) {
+    proxy = theCollection()->construct<TestCol>(range);
+  }
 
   runInEpochCollective([&]{
     if (this_node == 0) {
@@ -188,7 +198,12 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_3) {
   }
 
   auto const& range = Index1D(32);
-  auto proxy = theCollection()->construct<TestCol>(range);
+
+  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
+
+  if (this_node == 0) {
+    proxy = theCollection()->construct<TestCol>(range);
+  }
 
   runInEpochCollective([&]{
     if (this_node == 0) {

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -130,7 +130,12 @@ struct TestColMsg : ::vt::CollectionMessage<TestCol> {};
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
   auto const& this_node = theContext()->getNode();
   auto const& range = Index1D(32);
-  auto proxy = theCollection()->construct<TestCol>(range);
+
+  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
+
+  if (this_node == 0) {
+    proxy = theCollection()->construct<TestCol>(range);
+  }
 
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
@@ -167,7 +172,12 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
   }
 
   auto const& range = Index1D(32);
-  auto proxy = theCollection()->construct<TestCol>(range);
+
+  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
+
+  if (this_node == 0) {
+    proxy = theCollection()->construct<TestCol>(range);
+  }
 
   runInEpochCollective([this_node, num_nodes, proxy]{
     if (this_node == 0) {
@@ -199,7 +209,12 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
   auto const& this_node = theContext()->getNode();
   auto const& range = Index1D(32);
-  auto proxy = theCollection()->construct<TestCol>(range);
+
+  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
+
+  if (this_node == 0) {
+    proxy = theCollection()->construct<TestCol>(range);
+  }
 
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {


### PR DESCRIPTION
Fixes #1004 
Create collection on single node in TestCallbackSendCollection and TestCallbackBcastCollection in order to prevent CI failing on some build configs.