### PR TITLE
959 Add some more tests for various load models (Part 2)

### DIFF
--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -164,7 +164,9 @@ TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
     {1, {TimeType{16.6}, TimeType{280}, TimeType{23}}}};
 
   for (; num_phases < 2; ++num_phases) {
+    test_model->updateLoads(num_phases);
     int objects_seen = 0;
+
     for (auto&& obj : *test_model) {
       EXPECT_TRUE(obj == 1 || obj == 2 || obj == 3);
       ++objects_seen;

--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -1,0 +1,182 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                      test_model_comm_overhead.nompi.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <vt/vrt/collection/balance/model/load_model.h>
+#include <vt/vrt/collection/balance/model/comm_overhead.h>
+#include <vt/vrt/collection/balance/lb_comm.h>
+
+#include <gtest/gtest.h>
+
+#include "test_harness.h"
+
+#include <memory>
+
+namespace vt { namespace tests { namespace unit {
+
+using TestModelCommOverhead = TestHarness;
+
+using vt::vrt::collection::balance::CommKeyType;
+using vt::vrt::collection::balance::CommMapType;
+using vt::vrt::collection::balance::CommOverhead;
+using vt::vrt::collection::balance::CommVolume;
+using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::LoadMapType;
+using vt::vrt::collection::balance::LoadModel;
+using vt::vrt::collection::balance::ObjectIterator;
+using vt::vrt::collection::balance::PhaseOffset;
+using vt::vrt::collection::balance::SubphaseLoadMapType;
+
+using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
+using ProcSubphaseLoadMap = std::unordered_map<PhaseType, SubphaseLoadMapType>;
+using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+
+static auto num_phases = 0;
+
+struct StubModel : LoadModel {
+
+  StubModel() = default;
+  virtual ~StubModel() = default;
+
+  void setLoads(
+    ProcLoadMap const* proc_load, ProcSubphaseLoadMap const*,
+    ProcCommMap const*) override {
+    proc_load_ = proc_load;
+  }
+
+  void updateLoads(PhaseType) override {}
+
+  TimeType getWork(ElementIDType id, PhaseOffset phase) override {
+    const auto work = proc_load_->at(0).at(id);
+
+    if (phase.subphase == PhaseOffset::WHOLE_PHASE) {
+      return work;
+    } else {
+      return work / 10;
+    }
+  }
+
+  ObjectIterator begin() override {
+    return ObjectIterator(proc_load_->at(0).begin());
+  }
+  ObjectIterator end() override {
+    return ObjectIterator(proc_load_->at(0).end());
+  }
+
+  int getNumCompletedPhases() override { return num_phases; }
+
+  // Not used in this test
+  int getNumObjects() override { return 0; }
+  int getNumSubphases() override { return 0; }
+  int getNumPastPhasesNeeded(int look_back = 0) override { return look_back; }
+
+private:
+  ProcLoadMap const* proc_load_ = nullptr;
+};
+
+TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
+  ProcLoadMap proc_load = {
+    {0,
+     LoadMapType{
+       {ElementIDType{1}, TimeType{60}},
+       {ElementIDType{2}, TimeType{150}},
+       {ElementIDType{3}, TimeType{75}}}}};
+
+  ProcCommMap proc_comm = {
+    {0,
+     CommMapType{// Node 1 -> Node 2
+                 {{CommKeyType::CollectionTag{}, ElementIDType{1},
+                   ElementIDType{1}, ElementIDType{2}, ElementIDType{2}, false},
+                  CommVolume{20.0, 2}},
+
+                 // Node 3 -> Node 2
+                 {{CommKeyType::CollectionTag{}, ElementIDType{3},
+                   ElementIDType{3}, ElementIDType{2}, ElementIDType{2}, false},
+                  CommVolume{5.0, 5}},
+
+                 // Node 1 -> Node 3
+                 {{CommKeyType::CollectionTag{}, ElementIDType{1},
+                   ElementIDType{1}, ElementIDType{3}, ElementIDType{3}, false},
+                  CommVolume{100.0, 1}}}},
+    {1,
+     CommMapType{// Node 3 -> Node 1 (current phase) -> Node 2
+                 {{CommKeyType::CollectionTag{}, ElementIDType{3},
+                   ElementIDType{3}, ElementIDType{2}, ElementIDType{1}, false},
+                  CommVolume{20.0, 2}},
+
+                 // Node 3 -> Node 2 (current phase) -> Node 1
+                 {{CommKeyType::CollectionTag{}, ElementIDType{3},
+                   ElementIDType{3}, ElementIDType{1}, ElementIDType{2}, false},
+                  CommVolume{500.0, 50}},
+
+                 // Node 1 -> Node 3 (current phase) -> Node 2
+                 {{CommKeyType::CollectionTag{}, ElementIDType{1},
+                   ElementIDType{1}, ElementIDType{2}, ElementIDType{3}, false},
+                  CommVolume{25.0, 10}}}}};
+
+  auto test_model =
+    std::make_shared<CommOverhead>(std::make_shared<StubModel>(), 3.0, 5.0);
+  test_model->setLoads(&proc_load, nullptr, &proc_comm);
+
+  std::unordered_map<PhaseType, std::vector<TimeType>> expected_work = {
+    {0, {TimeType{60}, TimeType{296}, TimeType{578}}},
+    {1, {TimeType{16.6}, TimeType{280}, TimeType{23}}}};
+
+  for (; num_phases < 2; ++num_phases) {
+    int objects_seen = 0;
+    for (auto&& obj : *test_model) {
+      EXPECT_TRUE(obj == 1 || obj == 2 || obj == 3);
+      ++objects_seen;
+
+      const auto subphase = num_phases == 0 ? PhaseOffset::WHOLE_PHASE : 1;
+      auto work_val = test_model->getWork(obj, PhaseOffset{0, subphase});
+      EXPECT_EQ(work_val, expected_work[num_phases][obj - 1])
+        << fmt::format("For element={} on phase={}\n", obj, num_phases);
+    }
+
+    EXPECT_EQ(objects_seen, 3);
+  }
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_model_norm.nompi.cc
+++ b/tests/unit/collection/test_model_norm.nompi.cc
@@ -123,6 +123,7 @@ TEST_F(TestModelNorm, test_model_norm_1) {
 
   auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
   test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+  test_model->updateLoads(0);
 
   for (unsigned int iter = 0; iter < num_subphases; ++iter) {
     int objects_seen = 0;
@@ -155,6 +156,7 @@ TEST_F(TestModelNorm, test_model_norm_2) {
   // finite 'power' value
   auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
   test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+  test_model->updateLoads(0);
 
   std::array<TimeType, 2> expected_norms = {
     TimeType{33.019}, TimeType{73.986}};
@@ -188,6 +190,7 @@ TEST_F(TestModelNorm, test_model_norm_3) {
   auto test_model = std::make_shared<Norm>(
     std::make_shared<StubModel>(), std::numeric_limits<double>::infinity());
   test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+  test_model->updateLoads(0);
 
   std::array<TimeType, 2> expected_norms = {TimeType{30}, TimeType{60}};
 

--- a/tests/unit/collection/test_model_norm.nompi.cc
+++ b/tests/unit/collection/test_model_norm.nompi.cc
@@ -50,7 +50,7 @@
 
 #include "test_harness.h"
 
-#include <cmath>
+#include <limits>
 #include <memory>
 
 namespace vt { namespace tests { namespace unit {
@@ -185,8 +185,8 @@ TEST_F(TestModelNorm, test_model_norm_3) {
        {ElementIDType{2}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}};
 
   // infinite 'power' value
-  auto test_model =
-    std::make_shared<Norm>(std::make_shared<StubModel>(), std::exp(800));
+  auto test_model = std::make_shared<Norm>(
+    std::make_shared<StubModel>(), std::numeric_limits<double>::infinity());
   test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
 
   std::array<TimeType, 2> expected_norms = {TimeType{30}, TimeType{60}};

--- a/tests/unit/collection/test_model_norm.nompi.cc
+++ b/tests/unit/collection/test_model_norm.nompi.cc
@@ -1,0 +1,207 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                          test_model_norm.nompi.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <vt/vrt/collection/balance/model/load_model.h>
+#include <vt/vrt/collection/balance/model/norm.h>
+
+#include <gtest/gtest.h>
+
+#include "test_harness.h"
+
+#include <cmath>
+#include <memory>
+
+namespace vt { namespace tests { namespace unit {
+
+using TestModelNorm = TestHarness;
+
+using vt::vrt::collection::balance::CommMapType;
+using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::LoadMapType;
+using vt::vrt::collection::balance::LoadModel;
+using vt::vrt::collection::balance::Norm;
+using vt::vrt::collection::balance::ObjectIterator;
+using vt::vrt::collection::balance::PhaseOffset;
+using vt::vrt::collection::balance::SubphaseLoadMapType;
+
+using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
+using ProcSubphaseLoadMap = std::unordered_map<PhaseType, SubphaseLoadMapType>;
+using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+
+constexpr auto num_subphases = 3;
+
+struct StubModel : LoadModel {
+
+  StubModel() = default;
+  virtual ~StubModel() = default;
+
+  void setLoads(
+    ProcLoadMap const* proc_load, ProcSubphaseLoadMap const* proc_subphase_load,
+    ProcCommMap const*) override {
+    proc_load_ = proc_load;
+    proc_subphase_load_ = proc_subphase_load;
+  }
+
+  void updateLoads(PhaseType) override {}
+
+  TimeType getWork(ElementIDType id, PhaseOffset phase) override {
+    return proc_subphase_load_->at(0).at(id).at(phase.subphase);
+  }
+
+  ObjectIterator begin() override {
+    return ObjectIterator(proc_load_->at(0).begin());
+  }
+  ObjectIterator end() override {
+    return ObjectIterator(proc_load_->at(0).end());
+  }
+
+  int getNumSubphases() override { return num_subphases; }
+
+  // Not used in this test
+  int getNumObjects() override { return 0; }
+  int getNumCompletedPhases() override { return 0; }
+  int getNumPastPhasesNeeded(int look_back = 0) override { return look_back; }
+
+private:
+  ProcLoadMap const* proc_load_ = nullptr;
+  ProcSubphaseLoadMap const* proc_subphase_load_ = nullptr;
+};
+
+TEST_F(TestModelNorm, test_model_norm_1) {
+  ProcLoadMap proc_load = {
+    {0,
+     LoadMapType{
+       {ElementIDType{1}, TimeType{60}}, {ElementIDType{2}, TimeType{150}}}}};
+
+  ProcSubphaseLoadMap proc_subphase_load = {
+    {0,
+     SubphaseLoadMapType{
+       {ElementIDType{1}, {TimeType{10}, TimeType{20}, TimeType{30}}},
+       {ElementIDType{2}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}};
+
+  auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
+  test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+
+  for (unsigned int iter = 0; iter < num_subphases; ++iter) {
+    int objects_seen = 0;
+    for (auto&& obj : *test_model) {
+      EXPECT_TRUE(obj == 1 || obj == 2);
+      ++objects_seen;
+
+      // offset.subphase != PhaseOffset::WHOLE_PHASE
+      // expect work load value for given subphase
+      auto work_val = test_model->getWork(obj, PhaseOffset{0, iter});
+      EXPECT_EQ(work_val, proc_subphase_load[0][obj][iter]);
+    }
+
+    EXPECT_EQ(objects_seen, 2);
+  }
+}
+
+TEST_F(TestModelNorm, test_model_norm_2) {
+  ProcLoadMap proc_load = {
+    {0,
+     LoadMapType{
+       {ElementIDType{1}, TimeType{60}}, {ElementIDType{2}, TimeType{150}}}}};
+
+  ProcSubphaseLoadMap proc_subphase_load = {
+    {0,
+     SubphaseLoadMapType{
+       {ElementIDType{1}, {TimeType{10}, TimeType{20}, TimeType{30}}},
+       {ElementIDType{2}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}};
+
+  // finite 'power' value
+  auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
+  test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+
+  std::array<TimeType, 2> expected_norms = {
+    TimeType{33.019}, TimeType{73.986}};
+
+  int objects_seen = 0;
+  for (auto&& obj : *test_model) {
+    EXPECT_TRUE(obj == 1 || obj == 2);
+    ++objects_seen;
+
+    auto work_val =
+      test_model->getWork(obj, PhaseOffset{0, PhaseOffset::WHOLE_PHASE});
+    EXPECT_NEAR(work_val, expected_norms[obj - 1], 0.001);
+  }
+
+  EXPECT_EQ(objects_seen, 2);
+}
+
+TEST_F(TestModelNorm, test_model_norm_3) {
+  ProcLoadMap proc_load = {
+    {0,
+     LoadMapType{
+       {ElementIDType{1}, TimeType{60}}, {ElementIDType{2}, TimeType{150}}}}};
+
+  ProcSubphaseLoadMap proc_subphase_load = {
+    {0,
+     SubphaseLoadMapType{
+       {ElementIDType{1}, {TimeType{10}, TimeType{20}, TimeType{30}}},
+       {ElementIDType{2}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}};
+
+  // infinite 'power' value
+  auto test_model =
+    std::make_shared<Norm>(std::make_shared<StubModel>(), std::exp(800));
+  test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+
+  std::array<TimeType, 2> expected_norms = {TimeType{30}, TimeType{60}};
+
+  int objects_seen = 0;
+  for (auto&& obj : *test_model) {
+    EXPECT_TRUE(obj == 1 || obj == 2);
+    ++objects_seen;
+
+    auto work_val =
+      test_model->getWork(obj, PhaseOffset{0, PhaseOffset::WHOLE_PHASE});
+    EXPECT_EQ(work_val, expected_norms[obj - 1]);
+  }
+
+  EXPECT_EQ(objects_seen, 2);
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_model_select_subphases.nompi.cc
+++ b/tests/unit/collection/test_model_select_subphases.nompi.cc
@@ -1,0 +1,195 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                     test_model_select_subphases.nompi.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <vt/vrt/collection/balance/model/load_model.h>
+#include <vt/vrt/collection/balance/model/select_subphases.h>
+
+#include <gtest/gtest.h>
+
+#include "test_harness.h"
+
+#include <memory>
+
+namespace vt { namespace tests { namespace unit {
+
+using TestModelSelectSubphases = TestHarness;
+
+using vt::vrt::collection::balance::CommMapType;
+using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::LoadMapType;
+using vt::vrt::collection::balance::LoadModel;
+using vt::vrt::collection::balance::ObjectIterator;
+using vt::vrt::collection::balance::PhaseOffset;
+using vt::vrt::collection::balance::SelectSubphases;
+using vt::vrt::collection::balance::SubphaseLoadMapType;
+
+using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
+using ProcSubphaseLoadMap = std::unordered_map<PhaseType, SubphaseLoadMapType>;
+using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+
+constexpr auto num_subphases = 3;
+
+struct StubModel : LoadModel {
+
+  StubModel() = default;
+  virtual ~StubModel() = default;
+
+  void setLoads(
+    ProcLoadMap const* proc_load, ProcSubphaseLoadMap const* proc_subphase_load,
+    ProcCommMap const*) override {
+    proc_load_ = proc_load;
+    proc_subphase_load_ = proc_subphase_load;
+  }
+
+  void updateLoads(PhaseType) override {}
+
+  TimeType getWork(ElementIDType id, PhaseOffset phase) override {
+    return proc_subphase_load_->at(0).at(id).at(phase.subphase);
+  }
+
+  ObjectIterator begin() override {
+    return ObjectIterator(proc_load_->at(0).begin());
+  }
+  ObjectIterator end() override {
+    return ObjectIterator(proc_load_->at(0).end());
+  }
+
+  int getNumSubphases() override { return num_subphases; }
+
+  // Not used in this test
+  int getNumObjects() override { return 0; }
+  int getNumCompletedPhases() override { return 0; }
+  int getNumPastPhasesNeeded(int look_back = 0) override { return look_back; }
+
+private:
+  ProcLoadMap const* proc_load_ = nullptr;
+  ProcSubphaseLoadMap const* proc_subphase_load_ = nullptr;
+};
+
+TEST_F(TestModelSelectSubphases, test_model_select_subphases_1) {
+  ProcLoadMap proc_load = {
+    {0,
+     LoadMapType{
+       {ElementIDType{1}, TimeType{60}}, {ElementIDType{2}, TimeType{150}}}}};
+
+  ProcSubphaseLoadMap proc_subphase_load = {
+    {0,
+     SubphaseLoadMapType{
+       {ElementIDType{1}, {TimeType{10}, TimeType{20}, TimeType{30}}},
+       {ElementIDType{2}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}};
+
+  std::vector<unsigned int> subphases{2, 0, 1};
+  auto test_model =
+    std::make_shared<SelectSubphases>(std::make_shared<StubModel>(), subphases);
+
+  EXPECT_EQ(test_model->getNumSubphases(), subphases.size());
+
+  test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+
+  std::unordered_map<ElementIDType, std::vector<TimeType>> expected_values = {
+    {1,
+     {proc_subphase_load[0][1][subphases[0]],
+      proc_subphase_load[0][1][subphases[1]],
+      proc_subphase_load[0][1][subphases[2]]}},
+    {2,
+     {proc_subphase_load[0][2][subphases[0]],
+      proc_subphase_load[0][2][subphases[1]],
+      proc_subphase_load[0][2][subphases[2]]}}};
+
+  for (unsigned int iter = 0; iter < num_subphases; ++iter) {
+    int objects_seen = 0;
+
+    for (auto&& obj : *test_model) {
+      EXPECT_TRUE(obj == 1 || obj == 2);
+      ++objects_seen;
+
+      // offset.subphase != PhaseOffset::WHOLE_PHASE
+      // expect work load value for given subphase
+      auto work_val = test_model->getWork(obj, PhaseOffset{0, iter});
+      EXPECT_EQ(work_val, expected_values[obj][iter]);
+    }
+
+    EXPECT_EQ(objects_seen, 2);
+  }
+}
+
+TEST_F(TestModelSelectSubphases, test_model_select_subphases_2) {
+  ProcLoadMap proc_load = {
+    {0,
+     LoadMapType{
+       {ElementIDType{1}, TimeType{60}}, {ElementIDType{2}, TimeType{150}}}}};
+
+  ProcSubphaseLoadMap proc_subphase_load = {
+    {0,
+     SubphaseLoadMapType{
+       {ElementIDType{1}, {TimeType{10}, TimeType{20}, TimeType{30}}},
+       {ElementIDType{2}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}};
+
+  std::vector<unsigned int> subphases{2, 1};
+  auto test_model =
+    std::make_shared<SelectSubphases>(std::make_shared<StubModel>(), subphases);
+
+  EXPECT_EQ(test_model->getNumSubphases(), subphases.size());
+
+  test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+
+  std::unordered_map<ElementIDType, TimeType> expected_values = {
+    {1, TimeType{50}}, {2, TimeType{110}}};
+
+  int objects_seen = 0;
+
+  for (auto&& obj : *test_model) {
+    EXPECT_TRUE(obj == 1 || obj == 2);
+    ++objects_seen;
+
+    auto work_val =
+      test_model->getWork(obj, PhaseOffset{0, PhaseOffset::WHOLE_PHASE});
+    EXPECT_EQ(work_val, expected_values[obj]);
+  }
+
+  EXPECT_EQ(objects_seen, 2);
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_model_select_subphases.nompi.cc
+++ b/tests/unit/collection/test_model_select_subphases.nompi.cc
@@ -127,6 +127,7 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_1) {
   EXPECT_EQ(test_model->getNumSubphases(), subphases.size());
 
   test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+  test_model->updateLoads(0);
 
   std::unordered_map<ElementIDType, std::vector<TimeType>> expected_values = {
     {1,
@@ -174,6 +175,7 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_2) {
   EXPECT_EQ(test_model->getNumSubphases(), subphases.size());
 
   test_model->setLoads(&proc_load, &proc_subphase_load, nullptr);
+  test_model->updateLoads(0);
 
   std::unordered_map<ElementIDType, TimeType> expected_values = {
     {1, TimeType{50}}, {2, TimeType{110}}};


### PR DESCRIPTION
Fixes #959 

Part 2 of adding unit tests for load models (part 1 -> https://github.com/DARMA-tasking/vt/pull/1001)

Add unit tests for following load models:
- [x] - Norm
- [x] - CommOverhead
- [x] - SelectSubphases