### PR TITLE
#1016 - Message Envelope Locking

### DIFF
--- a/src/vt/collective/reduce/reduce.h
+++ b/src/vt/collective/reduce/reduce.h
@@ -303,7 +303,7 @@ struct Reduce : virtual collective::tree::Tree {
    * \param[in] msg the reduce message
    */
   template <typename MsgT>
-  void reduceUp(MsgT* msg);
+  void reduceUpHan(MsgT* msg);
 
 private:
   detail::ReduceScope scope_;   /**< The reduce scope for this reducer */

--- a/src/vt/collective/reduce/reduce.impl.h
+++ b/src/vt/collective/reduce/reduce.impl.h
@@ -56,12 +56,14 @@
 namespace vt { namespace collective { namespace reduce {
 
 template <typename MsgT>
-void Reduce::reduceUp(MsgT* msg) {
+void Reduce::reduceUpHan(MsgT* msg) {
+  envelopeSetIsLocked(msg->env, false);
+
   vtAssert(msg->scope() == scope_, "Must match correct scope");
 
   vt_debug_print(
     reduce, node,
-    "reduceUp: scope={}, stamp={}, msg={}\n",
+    "reduceUpHan: scope={}, stamp={}, msg={}\n",
     msg->scope().str(), detail::stringizeStamp(msg->stamp()), print_ptr(msg)
   );
 
@@ -292,7 +294,7 @@ void Reduce::startReduce(detail::ReduceStamp id, bool use_num_contrib) {
         scope_.str(), detail::stringizeStamp(id), parent
       );
 
-      theMsg()->sendMsg<MsgT,ReduceManager::reduceUp<MsgT>>(parent, typed_msg);
+      theMsg()->sendMsg<MsgT,ReduceManager::reduceUpHan<MsgT>>(parent, typed_msg);
     }
   }
 }

--- a/src/vt/collective/reduce/reduce_manager.h
+++ b/src/vt/collective/reduce/reduce_manager.h
@@ -159,7 +159,7 @@ struct ReduceManager {
    * \param[in] msg the reduce message
    */
   template <typename MsgT>
-  static void reduceUp(MsgT* msg);
+  static void reduceUpHan(MsgT* msg);
 
 private:
   ReduceScopeType reducers_;            /**< Live reducers by scope */

--- a/src/vt/collective/reduce/reduce_manager.impl.h
+++ b/src/vt/collective/reduce/reduce_manager.impl.h
@@ -60,9 +60,9 @@ template <typename MsgT>
 }
 
 template <typename MsgT>
-/*static*/ void ReduceManager::reduceUp(MsgT* msg) {
+/*static*/ void ReduceManager::reduceUpHan(MsgT* msg) {
   auto const& scope = msg->scope();
-  theCollective()->getReducer(scope)->template reduceUp<MsgT>(msg);
+  theCollective()->getReducer(scope)->template reduceUpHan<MsgT>(msg);
 }
 
 }}} /* end namespace vt::collective::reduce */

--- a/src/vt/group/collective/group_info_collective.cc
+++ b/src/vt/group/collective/group_info_collective.cc
@@ -590,6 +590,8 @@ void InfoColl::collectiveFn(MsgSharedPtr<GroupCollectiveMsg> msg) {
 }
 
 /*static*/ void InfoColl::upHan(GroupCollectiveMsg* msg) {
+  envelopeSetIsLocked(msg->env, false);
+
   vt_debug_print(
     group, node,
     "InfoColl::upHan: group={:x}, op={:x}, child={}, extra={}\n",

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -862,11 +862,7 @@ void ActiveMessenger::finishPendingActiveMsgAsyncRecv(InProgressIRecv* irecv) {
 # endif
 
   MessageType* msg = reinterpret_cast<MessageType*>(buf);
-  // Reset envelope to avoid ref-count=not_shared_msg if the data
-  // comes from a 'new RecvMsgType(..)'.
-  // The MsgPtr will then acquire a ref-count itself.
-  // TODO: Maybe envelope ref-count should be 0 on initialize?
-  envelopeSetRef(msg->env, 0);
+  envelopeInitRecv(msg->env);
   MsgPtr<MessageType> base = MsgPtr<MessageType>{msg};
 
   auto const is_term = envelopeIsTerm(msg->env);

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -264,6 +264,8 @@ EventType ActiveMessenger::doMessageSend(
   auto const is_term = envelopeIsTerm(msg->env);
 
   #if vt_check_enabled(trace_enabled)
+    envelopeSetIsLocked(msg->env, false);
+
     // We are not allowed to hold a ref to anything in the envelope, get this,
     // modify it and put it back
     auto handler = envelopeGetHandler(msg->env);
@@ -290,6 +292,8 @@ EventType ActiveMessenger::doMessageSend(
       );
       envelopeSetTraceEvent(msg->env, event);
     }
+
+    envelopeSetIsLocked(msg->env, true);
   #endif
 
   if (!is_term || vt_check_enabled(print_term_msgs)) {

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -262,7 +262,6 @@ EventType ActiveMessenger::doMessageSend(
   auto const dest = envelopeGetDest(msg->env);
   auto const is_bcast = envelopeIsBcast(msg->env);
   auto const is_term = envelopeIsTerm(msg->env);
-  auto const is_epoch = envelopeIsEpochType(msg->env);
 
   #if vt_check_enabled(trace_enabled)
     // We are not allowed to hold a ref to anything in the envelope, get this,
@@ -300,10 +299,6 @@ EventType ActiveMessenger::doMessageSend(
       dest, envelopeGetHandler(msg->env), print_bool(is_bcast),
       print_bool(envelopeIsPut(msg->env))
     );
-  }
-
-  if (is_epoch) {
-    setupEpochMsg(msg);
   }
 
   bool deliver = false;

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1511,7 +1511,15 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
 private:
   bool testPendingActiveMsgAsyncRecv();
   bool testPendingDataMsgAsyncRecv();
+
+  /**
+   * \brief Called when a VT-MPI message has been received.
+   */
   void finishPendingActiveMsgAsyncRecv(InProgressIRecv* irecv);
+
+  /**
+   * \brief Called when a VT-MPI message has been received.
+   */
   void finishPendingDataMsgAsyncRecv(InProgressDataIRecv* irecv);
 
 private:

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -139,6 +139,11 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgSerializableImpl(
     tag == no_tag,
     "Tagged messages serialization not implemented."
   );
+
+  // Original message is locked even though it is not the actual message sent.
+  // This is for consistency with sending non-serialized messages.
+  envelopeSetIsLocked(msg->env, true);
+
   MsgT* msgp = msg.get();
   if (dest == broadcast_dest) {
     return SerializedMessenger::broadcastSerialMsg<MsgT>(msgp,han);
@@ -190,6 +195,8 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgCopyableImpl(
   }
   envelopeSetup(rawMsg->env, dest, han);
   setupEpochMsg(rawMsg);
+
+  envelopeSetIsLocked(rawMsg->env, true);
 
   auto base = msg.template to<BaseMsgType>();
   return PendingSendType(base, msg_size);

--- a/src/vt/messaging/envelope/envelope_base.h
+++ b/src/vt/messaging/envelope/envelope_base.h
@@ -94,6 +94,10 @@ struct ActiveEnvelope {
 
   /// True iff serialization is performed (through to base type).
   bool has_been_serialized : 1;
+
+  /// True iff the message is considered locked.
+  /// If locked, changes to the envelope will result in failure.
+  bool is_locked : 1;
 };
 
 }} /* end namespace vt::messaging */

--- a/src/vt/messaging/envelope/envelope_set.h
+++ b/src/vt/messaging/envelope/envelope_set.h
@@ -206,6 +206,22 @@ inline void envelopeSetTraceRuntimeEnabled(Env& env, bool is_trace_enabled);
 template <typename Env>
 inline void envelopeSetHasBeenSerialized(Env& env, bool has_been_serialized);
 
+/**
+ * \brief Set whether this message's envelope is locked.
+ *
+ * A locked message will prevent key parts of the envelope from being updated
+ * with a guard assert. This is to prevent accidental edge-cases such as
+ * sending a message twice.
+ *
+ * A message is locked when it is sent and recieved. Unlocking messages
+ * should be reserved for special cases as done in some core code.
+ *
+ * \param[in,out] env the envelope
+ * \param[in] is_locked value indicating if message is locked
+ */
+template <typename Env>
+inline void envelopeSetIsLocked(Env& env, bool is_locked);
+
 } /* end namespace vt */
 
 #include "vt/messaging/envelope/envelope_set.impl.h"

--- a/src/vt/messaging/envelope/envelope_set.impl.h
+++ b/src/vt/messaging/envelope/envelope_set.impl.h
@@ -53,67 +53,80 @@ namespace vt {
 // Set the type of Envelope
 template <typename Env>
 inline void setNormalType(Env& env) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->type = 0;
 }
 
 template <typename Env>
 inline void setPipeType(Env& env) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->type |= 1 << eEnvType::EnvPipe;
 }
 
 template <typename Env>
 inline void setPutType(Env& env) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->type |= 1 << eEnvType::EnvPut;
 }
 
 template <typename Env>
 inline void setTermType(Env& env) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->type |= 1 << eEnvType::EnvTerm;
 }
 
 template <typename Env>
 inline void setBroadcastType(Env& env) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->type |= 1 << eEnvType::EnvBroadcast;
 }
 
 template <typename Env>
 inline void setEpochType(Env& env) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->type |= 1 << eEnvType::EnvEpochType;
 }
 
 template <typename Env>
 inline void setTagType(Env& env) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->type |= 1 << eEnvType::EnvTagType;
 }
 
 template <typename Env>
 inline void envelopeSetHandler(Env& env, HandlerType const& handler) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->han = handler;
 }
 
 template <typename Env>
 inline void envelopeSetDest(Env& env, NodeType const& dest) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->dest = dest;
 }
 
 template <typename Env>
 inline void envelopeSetRef(Env& env, RefType const& ref) {
+  // nb. lock not checked
   reinterpret_cast<Envelope*>(&env)->ref = ref;
 }
 
 template <typename Env>
 inline void envelopeSetGroup(Env& env, GroupType const& group) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->group = group;
 }
 
 #if vt_check_enabled(priorities)
 template <typename Env>
 inline void envelopeSetPriority(Env& env, PriorityType priority) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->priority = priority;
 }
 
 template <typename Env>
 inline void envelopeSetPriorityLevel(Env& env, PriorityLevelType priority_level) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->priority_level = priority_level;
 }
 #endif
@@ -121,18 +134,26 @@ inline void envelopeSetPriorityLevel(Env& env, PriorityLevelType priority_level)
 #if vt_check_enabled(trace_enabled)
 template <typename Env>
 inline void envelopeSetTraceEvent(Env& env, trace::TraceEventIDType const& evt) {
+  vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->trace_event = evt;
 }
 
 template <typename Env>
 inline void envelopeSetTraceRuntimeEnabled(Env& env, bool is_trace_enabled) {
+  // nb. lock not checked
   reinterpret_cast<Envelope*>(&env)->trace_rt_enabled = is_trace_enabled;
 }
 #endif
 
 template <typename Env>
 inline void envelopeSetHasBeenSerialized(Env& env, bool has_been_serialized) {
+  // nb. lock not checked
   reinterpret_cast<Envelope*>(&env)->has_been_serialized = has_been_serialized;
+}
+
+template <typename Env>
+inline void envelopeSetIsLocked(Env& env, bool is_locked) {
+  reinterpret_cast<Envelope*>(&env)->is_locked = is_locked;
 }
 
 } /* end namespace vt */

--- a/src/vt/messaging/envelope/envelope_setup.h
+++ b/src/vt/messaging/envelope/envelope_setup.h
@@ -80,6 +80,19 @@ inline void envelopeInit(Env& env);
  */
 inline void envelopeInitEmpty(Envelope& env);
 
+/**
+ * \brief Initialize an envelope via a copy.
+ *
+ * \notes
+ * Some properties of the target envelope are preserved.
+ * The target envelope is left unlocked.
+ *
+ * \param[in,out] env the target envelope to init
+ * \param[in] env the original envelope to use as a copy
+ */
+template <typename Env>
+inline void envelopeInitCopy(Env& env, Env const& src_env);
+
 } /* end namespace vt */
 
 #include "vt/messaging/envelope/envelope_setup.impl.h"

--- a/src/vt/messaging/envelope/envelope_setup.h
+++ b/src/vt/messaging/envelope/envelope_setup.h
@@ -83,7 +83,6 @@ inline void envelopeInitEmpty(Envelope& env);
 /**
  * \brief Initialize an envelope via a copy.
  *
- * \notes
  * Some properties of the target envelope are preserved.
  * The target envelope is left unlocked.
  *
@@ -92,6 +91,16 @@ inline void envelopeInitEmpty(Envelope& env);
  */
 template <typename Env>
 inline void envelopeInitCopy(Env& env, Env const& src_env);
+
+/**
+ * \brief Initialize/validate an envelope that has been received.
+ *
+ * The ref-count is set to zero.
+ *
+ * \param[in,out] env the envelope
+ */
+template <typename Env>
+inline void envelopeInitRecv(Env& env);
 
 } /* end namespace vt */
 

--- a/src/vt/messaging/envelope/envelope_setup.impl.h
+++ b/src/vt/messaging/envelope/envelope_setup.impl.h
@@ -75,6 +75,7 @@ inline void envelopeInit(Env& env) {
   envelopeSetTraceEvent(env, trace::no_trace_event);
 #endif
   envelopeSetHasBeenSerialized(env, false);
+  envelopeSetIsLocked(env, false);
 }
 
 inline void envelopeInitEmpty(Envelope& env) {

--- a/src/vt/messaging/envelope/envelope_setup.impl.h
+++ b/src/vt/messaging/envelope/envelope_setup.impl.h
@@ -61,6 +61,7 @@ inline void envelopeSetup(
 
 template <typename Env>
 inline void envelopeInit(Env& env) {
+  envelopeSetIsLocked(env, false);
   setNormalType(env);
   envelopeSetDest(env, uninitialized_destination);
   envelopeSetHandler(env, uninitialized_handler);
@@ -75,7 +76,6 @@ inline void envelopeInit(Env& env) {
   envelopeSetTraceEvent(env, trace::no_trace_event);
 #endif
   envelopeSetHasBeenSerialized(env, false);
-  envelopeSetIsLocked(env, false);
 }
 
 inline void envelopeInitEmpty(Envelope& env) {

--- a/src/vt/messaging/envelope/envelope_setup.impl.h
+++ b/src/vt/messaging/envelope/envelope_setup.impl.h
@@ -82,6 +82,14 @@ inline void envelopeInitEmpty(Envelope& env) {
   envelopeInit(env);
 }
 
+template <typename Env>
+inline void envelopeInitCopy(Env& env, Env const& src_env) {
+  auto cur_ref = envelopeGetRef(env);
+  env = src_env;
+  envelopeSetRef(env, cur_ref);
+  envelopeSetIsLocked(env, false);
+}
+
 } /* end namespace vt */
 
 #endif /*INCLUDED_MESSAGING_ENVELOPE_ENVELOPE_SETUP_IMPL_H*/

--- a/src/vt/messaging/envelope/envelope_setup.impl.h
+++ b/src/vt/messaging/envelope/envelope_setup.impl.h
@@ -90,6 +90,17 @@ inline void envelopeInitCopy(Env& env, Env const& src_env) {
   envelopeSetIsLocked(env, false);
 }
 
+template <typename Env>
+inline void envelopeInitRecv(Env& env) {
+  // Reset the local ref-count. The sender ref-count is not relevant.
+  envelopeSetRef(env, 0);
+  // Ensure locked; implies all received messages are also locked.
+  vtAssert(
+    envelopeIsLocked(env),
+    "Envelope is not locked. It should have been locked for sending."
+  );
+}
+
 } /* end namespace vt */
 
 #endif /*INCLUDED_MESSAGING_ENVELOPE_ENVELOPE_SETUP_IMPL_H*/

--- a/src/vt/messaging/envelope/envelope_test.h
+++ b/src/vt/messaging/envelope/envelope_test.h
@@ -128,6 +128,14 @@ inline bool envelopeIsTagType(Env const& env);
 template <typename Env>
 inline bool envelopeHasBeenSerialized(Env& env);
 
+/**
+ * \brief Test if the message's envelope has been locked.
+ *
+ * \param[in] env the envelope
+ */
+template <typename Env>
+inline bool envelopeIsLocked(Env& env);
+
 }} //end namespace vt::messaging
 
 #include "vt/messaging/envelope/envelope_test.impl.h"

--- a/src/vt/messaging/envelope/envelope_test.impl.h
+++ b/src/vt/messaging/envelope/envelope_test.impl.h
@@ -93,6 +93,11 @@ inline bool envelopeHasBeenSerialized(Env& env) {
   return reinterpret_cast<Envelope const*>(&env)->has_been_serialized;
 }
 
+template <typename Env>
+inline bool envelopeIsLocked(Env& env) {
+  return reinterpret_cast<Envelope const*>(&env)->is_locked;
+}
+
 }} //end namespace vt::messaging
 
 #endif /*INCLUDED_MESSAGING_ENVELOPE_ENVELOPE_TEST_IMPL_H*/

--- a/src/vt/messaging/pending_send.h
+++ b/src/vt/messaging/pending_send.h
@@ -96,7 +96,11 @@ struct PendingSend final {
   }
 
   /**
-   * \brief Construct a pending send from a message and complex action.
+   * \brief Construct a pending send that invokes a callback.
+   *
+   * \note This form does not implictly send a message. The callback
+   * action is responsible for all further work. It is a useful
+   * construct to delay the callback and ensure an epoch is produced.
    *
    * This constructor is for a complex \c PendingSend that holds a \c
    * std::function for performing the send (e.g., sending to a collection
@@ -107,9 +111,10 @@ struct PendingSend final {
    * \param[in] in_action the "send" action to run
    */
   template <typename MsgT>
-  //  [[deprecated("Should not used by internal VT code")]]
-  PendingSend(MsgSharedPtr<MsgT>& in_msg, SendActionType in_action)
-    : msg_(in_msg.template toVirtual<BaseMsgType>())
+  PendingSend(
+    MsgSharedPtr<MsgT>& in_msg,
+    SendActionType in_action
+  ) : msg_(in_msg.template toVirtual<BaseMsgType>())
     , msg_size_(sizeof(MsgT))
     , send_action_(in_action)
   {
@@ -117,27 +122,13 @@ struct PendingSend final {
   }
 
   /**
-   * \deprecated Use constructor that accepts non-const in_msg.
-   * \brief Construct a pending send from a message and complex action.
+   * \brief Construct a pending send to push an epoch.
    *
-   * This constructor is for a complex \c PendingSend that holds a \c
-   * std::function for performing the send (e.g., sending to a collection
-   * element). When released, it will run the \c in_action of type \c
-   * SendActionType.
+   * \note This form does not implictly send a message.
    *
    * \param[in] in_msg the message to send
    * \param[in] in_action the "send" action to run
    */
-  template <typename MsgT>
-  [[deprecated("Use constructor that accepts non-const in_msg")]]
-  PendingSend(MsgSharedPtr<MsgT> const& in_msg, SendActionType in_action)
-    : msg_(in_msg.template toVirtual<BaseMsgType>())
-    , msg_size_(sizeof(MsgT))
-    , send_action_(in_action)
-  {
-    produceMsg();
-  }
-
   PendingSend(EpochType ep, EpochActionType const& in_action);
 
   explicit PendingSend(std::nullptr_t) { }

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -77,12 +77,11 @@ template <typename UserMsgT>
 ) {
   auto const& handler = sys_msg->handler;
   auto const& ptr_size = sys_msg->ptr_size;
-  auto const& group_ = envelopeGetGroup(sys_msg->env);
 
   vt_debug_print(
     serial_msg, node,
     "serialMsgHandlerBcast: group_={:x}, handler={}, ptr_size={}\n",
-    group_, handler, ptr_size
+    envelopeGetGroup(sys_msg->env), handler, ptr_size
   );
 
   auto ptr_offset = reinterpret_cast<char*>(sys_msg)
@@ -155,13 +154,11 @@ template <typename UserMsgT, typename BaseEagerMsgT>
   auto msg_data = sys_msg->payload.data();
   auto user_msg = deserializeFullMessage<UserMsgT>(msg_data);
 
-  auto const& group_ = envelopeGetGroup(sys_msg->env);
-
   vt_debug_print(
     serial_msg, node,
     "payloadMsgHandler: group={:x}, msg={}, handler={}, bytes={}, "
     "user ref={}, sys ref={}, user_msg={}, epoch={}\n",
-    group_, print_ptr(sys_msg), handler, sys_msg->bytes,
+    envelopeGetGroup(sys_msg->env), print_ptr(sys_msg), handler, sys_msg->bytes,
     envelopeGetRef(user_msg->env), envelopeGetRef(sys_msg->env),
     print_ptr(user_msg.get()), envelopeGetEpoch(sys_msg->env)
   );
@@ -230,8 +227,6 @@ template <typename MsgT, typename BaseT>
     typeid(MsgT).name()
   );
 
-  auto const& group_ = envelopeGetGroup(msg->env);
-
   if (ptr_size < serialized_msg_eager_size) {
     vtAssert(
       ptr_size < serialized_msg_eager_size,
@@ -243,13 +238,12 @@ template <typename MsgT, typename BaseT>
     payload_msg->from_node = theContext()->getNode();
     // setup envelope
     envelopeInitCopy(payload_msg->env, msg->env);
-    envelopeSetGroup(payload_msg->env, group_);
 
     vt_debug_print(
       serial_msg, node,
       "broadcastSerialMsg (eager): han={}, size={}, "
       "serialized_msg_eager_size={}, group={:x}\n",
-      han, ptr_size, serialized_msg_eager_size, group_
+      han, ptr_size, serialized_msg_eager_size, envelopeGetGroup(msg->env)
     );
 
     theMsg()->markAsSerialMsgMessage(payload_msg);
@@ -273,13 +267,12 @@ template <typename MsgT, typename BaseT>
     sys_msg->ptr_size = ptr_size;
     // setup envelope
     envelopeInitCopy(sys_msg->env, msg->env);
-    envelopeSetGroup(sys_msg->env, group_);
 
     vt_debug_print(
       serial_msg, node,
       "broadcastSerialMsg (non-eager): container: han={}, sys_size={}, "
       "ptr_size={}, total_size={}, group={:x}\n",
-      traceable_han, sys_size, ptr_size, total_size, group_
+      traceable_han, sys_size, ptr_size, total_size, envelopeGetGroup(msg->env)
     );
 
     using MsgType = SerialWrapperMsgType<MsgT>;

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -242,10 +242,7 @@ template <typename MsgT, typename BaseT>
     payload_msg->handler = han;
     payload_msg->from_node = theContext()->getNode();
     // setup envelope
-    auto cur_ref = envelopeGetRef(payload_msg->env);
-    payload_msg->env = msg->env;
-    envelopeSetRef(payload_msg->env, cur_ref);
-    envelopeSetIsLocked(payload_msg->env, false);
+    envelopeInitCopy(payload_msg->env, msg->env);
     envelopeSetGroup(payload_msg->env, group_);
 
     vt_debug_print(
@@ -275,10 +272,7 @@ template <typename MsgT, typename BaseT>
     sys_msg->from_node = theContext()->getNode();
     sys_msg->ptr_size = ptr_size;
     // setup envelope
-    auto cur_ref = envelopeGetRef(sys_msg->env);
-    sys_msg->env = msg->env;
-    envelopeSetRef(sys_msg->env, cur_ref);
-    envelopeSetIsLocked(sys_msg->env, false);
+    envelopeInitCopy(sys_msg->env, msg->env);
     envelopeSetGroup(sys_msg->env, group_);
 
     vt_debug_print(
@@ -380,10 +374,7 @@ template <typename MsgT, typename BaseT>
         sys_msg->handler = typed_handler;
         sys_msg->from_node = theContext()->getNode();
         // setup envelope
-        auto cur_ref = envelopeGetRef(sys_msg->env);
-        sys_msg->env = msg->env;
-        envelopeSetRef(sys_msg->env, cur_ref);
-        envelopeSetIsLocked(sys_msg->env, false);
+        envelopeInitCopy(sys_msg->env, msg->env);
 
         vt_debug_print(
           serial_msg, node,
@@ -427,10 +418,7 @@ template <typename MsgT, typename BaseT>
     payload_msg->handler = typed_handler;
     payload_msg->from_node = theContext()->getNode();
     // setup envelope
-    auto cur_ref = envelopeGetRef(payload_msg->env);
-    payload_msg->env = msg->env;
-    envelopeSetRef(payload_msg->env, cur_ref);
-    envelopeSetIsLocked(payload_msg->env, false);
+    envelopeInitCopy(payload_msg->env, msg->env);
 
     return eager_sender(payload_msg);
   }

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -787,6 +787,7 @@ template <typename ColT, typename IndexT>
 
 template <typename ColT, typename IndexT, typename MsgT>
 /*static*/ void CollectionManager::broadcastRootHandler(MsgT* msg) {
+  envelopeSetIsLocked(msg->env, false);
   theCollection()->broadcastFromRoot<ColT,IndexT,MsgT>(msg);
 }
 

--- a/tests/unit/active/test_active_broadcast.cc
+++ b/tests/unit/active/test_active_broadcast.cc
@@ -72,6 +72,8 @@ struct TestActiveBroadcast : TestParameterHarnessNode {
   }
 
   static void test_handler(TestMsg* msg) {
+    EXPECT_TRUE(envelopeIsLocked(msg->env)) << "Should be locked on recv";
+
     #if DEBUG_TEST_HARNESS_PRINT
       auto const& this_node = theContext()->getNode();
       fmt::print("{}: test_handler: cnt={}\n", this_node, ack_count);
@@ -99,7 +101,10 @@ TEST_P(TestActiveBroadcast, test_type_safe_active_fn_bcast2) {
       if (my_node == root) {
         for (int i = 0; i < num_msg_sent; i++) {
           auto msg = makeMessage<TestMsg>();
+          auto msg_hold = promoteMsg(msg.get());
+
           theMsg()->broadcastMsg<TestMsg, test_handler>(msg);
+          EXPECT_TRUE(envelopeIsLocked(msg_hold->env)) << "Should be locked on send";
         }
       }
     });

--- a/tests/unit/serialization/test_serialize_messenger.cc
+++ b/tests/unit/serialization/test_serialize_messenger.cc
@@ -92,6 +92,9 @@ struct MyDataMsg : Message {
 };
 
 static void myDataMsgHan(MyDataMsg* msg) {
+  // checks the lock is carried through serialization
+  EXPECT_TRUE(envelopeIsLocked(msg->env)) << "Should be locked on recv";
+
   fmt::print("myDataMsgHandler: calling check\n");
   msg->check();
 }


### PR DESCRIPTION
Note: will rebase on 962 merge.

A message envelope is marked as "locked" on a send (this state is also carried through transmission).

A locked message cannot have certain envelope properties updated and will fail a vtAssert if this is not true. This prevents code from sending the same message multiple times. If a handler wishes to send a message it receives it must explicitly unlock the message (this is not expected to be common).

There is no protection against the content of a message being modified - no `const` is carried through (from a handler argument or otherwise). Although, perhaps handlers can elect to be const..

The main entry to handlers (receiving a message) must ensure to capture all envelope state prior to passing such down if it's required later. There are few touch-points here.

Fixes: #1016