### PR TITLE
1020 Fix callback lifetime

### DIFF
--- a/examples/callback/callback_context.cc
+++ b/examples/callback/callback_context.cc
@@ -105,7 +105,9 @@ int main(int argc, char** argv) {
     my_global_ctx.x = 1283;
 
     // Make a callback that triggers the callback with a context
-    auto cb = vt::theCB()->makeFunc<DataMsg,MyContext>(&my_global_ctx, callbackFn);
+    auto cb = vt::theCB()->makeFunc<DataMsg,MyContext>(
+      vt::pipe::LifetimeEnum::Once, &my_global_ctx, callbackFn
+    );
     auto msg = vt::makeMessage<CallbackMsg>(cb);
     vt::theMsg()->sendMsg<CallbackMsg,handler>(1, msg);
   }

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
@@ -99,20 +99,16 @@ void CallbackProxyBcastDirect::serialize(SerializerT& s) {
 template <typename MsgT>
 void CallbackProxyBcastDirect::trigger(MsgT* msg, PipeType const& pipe) {
   auto const& this_node = theContext()->getNode();
-  auto const& pipe_node = PipeIDBuilder::getNode(pipe);
   vt_debug_print(
     pipe, node,
     "CallbackProxyBcastDirect: trigger_: pipe={:x}, this_node={}, "
     "handler={}, vrt_handler={}\n",
     pipe, this_node, handler_, vrt_dispatch_han_
   );
-  if (this_node == pipe_node) {
-    triggerPipeTyped<MsgT>(pipe,msg);
-  } else {
-    auto dispatcher = vrt::collection::getDispatcher(vrt_dispatch_han_);
-    auto const& proxy = proxy_;
-    dispatcher->broadcast(proxy,msg,handler_,member_);
-  }
+
+  auto dispatcher = vrt::collection::getDispatcher(vrt_dispatch_han_);
+  auto const& proxy = proxy_;
+  dispatcher->broadcast(proxy,msg,handler_,member_);
 }
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/pipe_lifetime.h
+++ b/src/vt/pipe/pipe_lifetime.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                               pipe_manager.cc
+//                               pipe_lifetime.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,34 +42,23 @@
 //@HEADER
 */
 
+#if !defined INCLUDED_VT_PIPE_PIPE_LIFETIME_H
+#define INCLUDED_VT_PIPE_PIPE_LIFETIME_H
+
 #include "vt/config.h"
-#include "vt/pipe/pipe_common.h"
-#include "vt/pipe/pipe_manager.h"
-#include "vt/pipe/pipe_manager.fwd.h"
-#include "vt/group/group_common.h"
-#include "vt/group/group_manager.h"
 
 namespace vt { namespace pipe {
 
-PipeManager::PipeManager() {
-  group_id_ = theGroup()->newGroupCollectiveLabel(
-    group::GroupCollectiveLabelTag
-  );
-}
-
-Callback<PipeManager::Void> PipeManager::makeFunc(
-  LifetimeEnum life, FuncVoidType fn
-) {
-  return makeCallbackSingleAnonVoid<Callback<Void>>(life,fn);
-}
-
-// Functions pulled out of PipeManager for header deps, forward to manager
-void triggerPipe(PipeType const& pipe) {
-  return theCB()->triggerPipe(pipe);
-}
-
-void triggerCallbackHan(CallbackMsg* msg) {
-  return PipeManager::triggerCallbackHan(msg);
-}
+/**
+ * \brief Set the default lifetime for a callback. Once implies a callback can
+ * only be invoked once before it is deallocated. Indefinite means the callback
+ * can be used until the creator deletes it.
+ */
+enum struct LifetimeEnum : int8_t {
+  Once,
+  Indefinite
+};
 
 }} /* end namespace vt::pipe */
+
+#endif /*INCLUDED_VT_PIPE_PIPE_LIFETIME_H*/

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -55,6 +55,7 @@
 #include "vt/pipe/signal/signal_holder.h"
 #include "vt/pipe/callback/anon/callback_anon.fwd.h"
 #include "vt/pipe/callback/cb_union/cb_raw_base.h"
+#include "vt/pipe/pipe_lifetime.h"
 #include "vt/activefn/activefn.h"
 #include "vt/objgroup/proxy/proxy_objgroup.h"
 #include "vt/objgroup/proxy/proxy_objgroup_elm.h"
@@ -129,13 +130,16 @@ struct PipeManager
    *  }
    * \endcode
    *
+   * \param[in] life the lifetime for this callback
    * \param[in] ctx pointer to the object context passed to callback function
    * \param[in] fn endpoint function that takes a message and context pointer
    *
    * \return a new callback
    */
   template <typename MsgT, typename ContextT>
-  Callback<MsgT> makeFunc(ContextT* ctx, FuncMsgCtxType<MsgT, ContextT> fn);
+  Callback<MsgT> makeFunc(
+    LifetimeEnum life, ContextT* ctx, FuncMsgCtxType<MsgT, ContextT> fn
+  );
 
   /**
    * \brief Make a void callback to a function (including lambdas) with a
@@ -160,13 +164,16 @@ struct PipeManager
    *  }
    * \endcode
    *
+   * \param[in] life the lifetime for this callback
    * \param[in] ctx pointer to the object context passed to callback function
    * \param[in] fn endpoint function that takes a context pointer
    *
    * \return a new callback
    */
   template <typename ContextT>
-  Callback<Void> makeFunc(ContextT* ctx, FuncCtxType<ContextT> fn);
+  Callback<Void> makeFunc(
+    LifetimeEnum life, ContextT* ctx, FuncCtxType<ContextT> fn
+  );
 
   /**
    * \brief Make a callback to a function (including lambdas) on this node with
@@ -187,12 +194,13 @@ struct PipeManager
    *  }
    * \endcode
    *
+   * \param[in] life the lifetime for this callback
    * \param[in] fn endpoint function that takes a message
    *
    * \return the new callback
    */
   template <typename MsgT>
-  Callback<MsgT> makeFunc(FuncMsgType<MsgT> fn);
+  Callback<MsgT> makeFunc(LifetimeEnum life, FuncMsgType<MsgT> fn);
 
   /**
    * \brief Make a void callback to a function (including lambdas) on this node.
@@ -208,11 +216,12 @@ struct PipeManager
    *  }
    * \endcode
    *
+   * \param[in] life the lifetime for this callback
    * \param[in] fn void endpoint function
    *
    * \return the new callback
    */
-  Callback<Void> makeFunc(FuncVoidType fn);
+  Callback<Void> makeFunc(LifetimeEnum life, FuncVoidType fn);
 
   /**
    * \brief Make a callback to a active message handler to be invoked on a

--- a/src/vt/pipe/pipe_manager.impl.h
+++ b/src/vt/pipe/pipe_manager.impl.h
@@ -78,18 +78,22 @@ void PipeManager::triggerSendBack(PipeType const& pipe, MsgT* data) {
 }
 
 template <typename C>
-Callback<PipeManager::Void> PipeManager::makeFunc(C* ctx, FuncCtxType<C> fn) {
-  return makeCallbackSingleAnon<C,Callback<Void>>(ctx,fn);
+Callback<PipeManager::Void> PipeManager::makeFunc(
+  LifetimeEnum life, C* ctx, FuncCtxType<C> fn
+) {
+  return makeCallbackSingleAnon<C,Callback<Void>>(life,ctx,fn);
 }
 
 template <typename MsgT, typename C>
-Callback<MsgT> PipeManager::makeFunc(C* ctx, FuncMsgCtxType<MsgT, C> fn) {
-  return makeCallbackSingleAnon<MsgT,C,Callback<MsgT>>(ctx,fn);
+Callback<MsgT> PipeManager::makeFunc(
+  LifetimeEnum life, C* ctx, FuncMsgCtxType<MsgT, C> fn
+) {
+  return makeCallbackSingleAnon<MsgT,C,Callback<MsgT>>(life,ctx,fn);
 }
 
 template <typename MsgT>
-Callback<MsgT> PipeManager::makeFunc(FuncMsgType<MsgT> fn) {
-  return makeCallbackSingleAnon<MsgT,Callback<MsgT>>(fn);
+Callback<MsgT> PipeManager::makeFunc(LifetimeEnum life, FuncMsgType<MsgT> fn) {
+  return makeCallbackSingleAnon<MsgT,Callback<MsgT>>(life,fn);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>

--- a/src/vt/pipe/pipe_manager_tl.h
+++ b/src/vt/pipe/pipe_manager_tl.h
@@ -49,6 +49,7 @@
 #include "vt/pipe/pipe_common.h"
 #include "vt/pipe/pipe_manager_base.h"
 #include "vt/pipe/callback/cb_union/cb_raw_base.h"
+#include "vt/pipe/pipe_lifetime.h"
 #include "vt/activefn/activefn.h"
 #include "vt/vrt/collection/active/active_funcs.h"
 #include "vt/vrt/proxy/collection_proxy.h"
@@ -123,16 +124,16 @@ struct PipeManagerTL : virtual PipeManagerBase {
 
   // Single active message anon func-handler
   template <typename CbkT = DefType<V>>
-  CbkT makeCallbackSingleAnonVoid(FuncVoidType fn);
+  CbkT makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn);
 
   template <typename T, typename CbkT = DefType<T>>
-  CbkT makeCallbackSingleAnon(FuncMsgType<T> fn);
+  CbkT makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<T> fn);
 
   template <typename T, typename U, typename CbkT = DefType<T>>
-  CbkT makeCallbackSingleAnon(U* u, FuncMsgCtxType<T, U> fn);
+  CbkT makeCallbackSingleAnon(LifetimeEnum life, U* u, FuncMsgCtxType<T, U> fn);
 
   template <typename U, typename CbkT = DefType<V>>
-  CbkT makeCallbackSingleAnon(U* u, FuncCtxType<U> fn);
+  CbkT makeCallbackSingleAnon(LifetimeEnum life, U* u, FuncCtxType<U> fn);
 
   // Single active message collection proxy send
   template <

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -250,21 +250,13 @@ CallbackT
 PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
   bool const persist = true;
   bool const send_back = false;
-  bool const dispatch = true;
   auto const& pipe_id = makePipeID(persist,send_back);
-  newPipeState(pipe_id,persist,dispatch,-1,-1,0);
   auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
   auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
   bool const member = false;
   auto cb = CallbackT(
     callback::cbunion::RawBcastColDirTag,pipe_id,handler,vrt_handler,member,
     proxy.getProxy()
-  );
-  addListenerAny<MsgT>(
-    cb.getPipe(),
-    std::make_unique<callback::CallbackProxyBcast<ColT,MsgT>>(
-      handler,proxy,member
-    )
   );
   return cb;
 }
@@ -277,9 +269,7 @@ CallbackT
 PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
   bool const persist = true;
   bool const send_back = false;
-  bool const dispatch = true;
   auto const& pipe_id = makePipeID(persist,send_back);
-  newPipeState(pipe_id,persist,dispatch,-1,-1,0);
   auto const& handler =
     auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
   auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
@@ -287,12 +277,6 @@ PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
   auto cb = CallbackT(
     callback::cbunion::RawBcastColDirTag,pipe_id,handler,vrt_handler,member,
     proxy.getProxy()
-  );
-  addListenerAny<MsgT>(
-    cb.getPipe(),
-    std::make_unique<callback::CallbackProxyBcast<ColT,MsgT>>(
-      handler,proxy,member
-    )
   );
   return cb;
 }

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -316,8 +316,13 @@ PipeManagerTL::makeCallbackSingleBcast(bool const& inc) {
 
 template <typename CallbackT>
 CallbackT
-PipeManagerTL::makeCallbackSingleAnonVoid(FuncVoidType fn) {
-  auto const& new_pipe_id = makeCallbackFuncVoid(true,fn,true);
+PipeManagerTL::makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn) {
+  PipeType new_pipe_id = no_pipe;
+  if (life == LifetimeEnum::Once) {
+    new_pipe_id = makeCallbackFuncVoid(false,fn,true,1,1);
+  } else {
+    new_pipe_id = makeCallbackFuncVoid(true,fn,true);
+  }
   auto cb = CallbackT(callback::cbunion::RawAnonTag,new_pipe_id);
 
   vt_debug_print(
@@ -331,7 +336,9 @@ PipeManagerTL::makeCallbackSingleAnonVoid(FuncVoidType fn) {
 
 template <typename C, typename CallbackT>
 CallbackT
-PipeManagerTL::makeCallbackSingleAnon(C* ctx, FuncCtxType<C> fn) {
+PipeManagerTL::makeCallbackSingleAnon(
+  LifetimeEnum life, C* ctx, FuncCtxType<C> fn
+) {
   auto fn_closure = [ctx,fn] { fn(ctx); };
 
   vt_debug_print(
@@ -339,12 +346,14 @@ PipeManagerTL::makeCallbackSingleAnon(C* ctx, FuncCtxType<C> fn) {
     "makeCallbackSingleAnon: created closure\n"
   );
 
-  return makeCallbackSingleAnonVoid(fn_closure);
+  return makeCallbackSingleAnonVoid(life,fn_closure);
 }
 
 template <typename MsgT, typename C, typename CallbackT>
 CallbackT
-PipeManagerTL::makeCallbackSingleAnon(C* ctx, FuncMsgCtxType<MsgT, C> fn) {
+PipeManagerTL::makeCallbackSingleAnon(
+  LifetimeEnum life, C* ctx, FuncMsgCtxType<MsgT, C> fn
+) {
   auto fn_closure = [ctx,fn](MsgT* msg) { fn(msg, ctx); };
 
   vt_debug_print(
@@ -352,13 +361,19 @@ PipeManagerTL::makeCallbackSingleAnon(C* ctx, FuncMsgCtxType<MsgT, C> fn) {
     "makeCallbackSingleAnon: created closure\n"
   );
 
-  return makeCallbackSingleAnon<MsgT,CallbackT>(fn_closure);
+  return makeCallbackSingleAnon<MsgT,CallbackT>(life,fn_closure);
 }
 
 template <typename MsgT, typename CallbackT>
 CallbackT
-PipeManagerTL::makeCallbackSingleAnon(FuncMsgType<MsgT> fn) {
-  auto const& new_pipe_id = makeCallbackFunc<MsgT>(true,fn,true);
+PipeManagerTL::makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<MsgT> fn) {
+  PipeType new_pipe_id = no_pipe;
+  if (life == LifetimeEnum::Once) {
+    new_pipe_id = makeCallbackFunc<MsgT>(false,fn,true,1,1);
+  } else {
+    new_pipe_id = makeCallbackFunc<MsgT>(true,fn,true);
+  }
+
   auto cb = CallbackT(callback::cbunion::RawAnonTag,new_pipe_id);
 
   vt_debug_print(

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -191,9 +191,7 @@ CallbackT
 PipeManagerTL::makeCallbackObjGrpSend(objgroup::proxy::ProxyElm<ObjT> proxy) {
   bool const persist = true;
   bool const send_back = false;
-  bool const dispatch = true;
   auto const& pipe_id = makePipeID(persist,send_back);
-  newPipeState(pipe_id,persist,dispatch,-1,-1,0);
   auto const proxy_bits = proxy.getProxy();
   auto const dest_node = proxy.getNode();
   auto const ctrl = objgroup::proxy::ObjGroupProxy::getID(proxy_bits);
@@ -212,9 +210,7 @@ CallbackT
 PipeManagerTL::makeCallbackObjGrpBcast(objgroup::proxy::Proxy<ObjT> proxy) {
   bool const persist = true;
   bool const send_back = false;
-  bool const dispatch = true;
   auto const& pipe_id = makePipeID(persist,send_back);
-  newPipeState(pipe_id,persist,dispatch,-1,-1,0);
   auto const proxy_bits = proxy.getProxy();
   auto const ctrl = objgroup::proxy::ObjGroupProxy::getID(proxy_bits);
   auto const han = auto_registry::makeAutoHandlerObjGroup<ObjT,MsgT,fn>(ctrl);

--- a/src/vt/rdma/rdma.cc
+++ b/src/vt/rdma/rdma.cc
@@ -1087,8 +1087,7 @@ void RDMAManager::setupChannelWithRemote(
       han, dest, override_target, target
     );
 
-    auto cb = theCB()->makeFunc(action);
-
+    auto cb = theCB()->makeFunc(pipe::LifetimeEnum::Once, action);
     auto msg = makeMessage<ChannelMessage>(
       type, han, num_bytes, tag, cb, dest, override_target
     );
@@ -1280,14 +1279,15 @@ void RDMAManager::createDirectChannelInternal(
       "Should not have a tag assigned at this point"
     );
 
-    auto cb = theCB()->makeFunc<GetInfoChannel>([=](GetInfoChannel* msg){
-      auto const& my_num_bytes = msg->num_bytes;
-      createDirectChannelFinish(
-        type, han, non_target, action, unique_channel_tag, is_target, my_num_bytes,
-        override_target
-      );
-    });
-
+    auto cb = theCB()->makeFunc<GetInfoChannel>(
+      pipe::LifetimeEnum::Once, [=](GetInfoChannel* msg){
+        auto const& my_num_bytes = msg->num_bytes;
+        createDirectChannelFinish(
+          type, han, non_target, action, unique_channel_tag, is_target, my_num_bytes,
+          override_target
+        );
+      }
+    );
     auto msg = makeMessage<CreateChannel>(
       type, han, unique_channel_tag, target, this_node, cb
     );
@@ -1317,7 +1317,7 @@ void RDMAManager::removeDirectChannel(
   auto const target = getTarget(han, override_target);
 
   if (this_node != target) {
-    auto cb = theCB()->makeFunc([=]{
+    auto cb = theCB()->makeFunc(pipe::LifetimeEnum::Once, [=]{
       auto iter = channels_.find(
         makeChannelLookup(han,RDMA_TypeType::Put,target,this_node)
       );

--- a/tests/unit/memory/test_memory_lifetime.cc
+++ b/tests/unit/memory/test_memory_lifetime.cc
@@ -234,7 +234,9 @@ TEST_F(TestMemoryLifetime, test_active_send_callback_lifetime_1) {
   auto const& num_nodes = theContext()->getNumNodes();
 
   if (num_nodes > 1) {
-    auto cb = theCB()->makeFunc<NormalTestMsg>([](NormalTestMsg* msg){ });
+    auto cb = theCB()->makeFunc<NormalTestMsg>(
+      vt::pipe::LifetimeEnum::Indefinite, [](NormalTestMsg* msg){ }
+    );
 
     for (int i = 0; i < num_msgs_sent; i++) {
       auto msg = makeMessage<CallbackMsg<NormalTestMsg>>(cb);
@@ -268,7 +270,9 @@ TEST_F(TestMemoryLifetime, test_active_serial_callback_lifetime_1) {
   auto const& num_nodes = theContext()->getNumNodes();
 
   if (num_nodes > 1) {
-    auto cb = theCB()->makeFunc<SerialTestMsg>([](SerialTestMsg* msg){ });
+    auto cb = theCB()->makeFunc<SerialTestMsg>(
+      vt::pipe::LifetimeEnum::Indefinite, [](SerialTestMsg* msg){ }
+    );
 
     for (int i = 0; i < num_msgs_sent; i++) {
       auto msg = makeMessage<CallbackMsg<SerialTestMsg>>(cb);

--- a/tests/unit/pipe/test_callback_func.cc
+++ b/tests/unit/pipe/test_callback_func.cc
@@ -73,7 +73,7 @@ struct TestCallbackFunc : TestParallelHarness {
 
 TEST_F(TestCallbackFunc, test_callback_func_1) {
   called = 0;
-  auto cb = theCB()->makeFunc([]{ called = 900; });
+  auto cb = theCB()->makeFunc(vt::pipe::LifetimeEnum::Once, []{ called = 900; });
   cb.send();
   EXPECT_EQ(called, 900);
 }
@@ -90,7 +90,9 @@ TEST_F(TestCallbackFunc, test_callback_func_2) {
 
   runInEpochCollective([this_node]{
     if (this_node == 0) {
-      auto cb = theCB()->makeFunc([]{ called = 400; });
+      auto cb = theCB()->makeFunc(
+        vt::pipe::LifetimeEnum::Once, []{ called = 400; }
+      );
       auto msg = makeMessage<CallbackMsg>(cb);
       theMsg()->sendMsg<CallbackMsg, test_handler>(1, msg);
     }

--- a/tests/unit/pipe/test_callback_func_ctx.cc
+++ b/tests/unit/pipe/test_callback_func_ctx.cc
@@ -98,6 +98,7 @@ TEST_F(TestCallbackFuncCtx, test_callback_func_ctx_1) {
   ctx->val = this_node;
 
   auto cb = theCB()->makeFunc<Context>(
+    vt::pipe::LifetimeEnum::Once,
     ctx.get(), [](Context* my_ctx){
       called = 200;
       EXPECT_EQ(my_ctx->val, theContext()->getNode());
@@ -121,6 +122,7 @@ TEST_F(TestCallbackFuncCtx, test_callback_func_ctx_2) {
 
     auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeFunc<DataMsg, Context>(
+      vt::pipe::LifetimeEnum::Once,
       ctx.get(), [next](DataMsg* msg, Context* my_ctx) {
         called = 500;
         EXPECT_EQ(my_ctx->val, theContext()->getNode());

--- a/tests/unit/pipe/test_signal_cleanup.cc
+++ b/tests/unit/pipe/test_signal_cleanup.cc
@@ -78,10 +78,12 @@ TEST_F(TestSignalCleanup, test_signal_cleanup_3) {
   int c1 = 0, c2 = 0;
 
   if (this_node == 0) {
-    auto cb = theCB()->makeFunc<DataMsg>([&c1](DataMsg* msg){
-      c1++;
-      fmt::print("called A");
-    });
+    auto cb = theCB()->makeFunc<DataMsg>(
+      vt::pipe::LifetimeEnum::Once, [&c1](DataMsg* msg){
+        c1++;
+        fmt::print("called A");
+      }
+    );
     auto msg = makeMessage<CallbackMsg>(cb);
     theMsg()->sendMsg<CallbackMsg, bounce>(1, msg);
   }
@@ -103,10 +105,12 @@ TEST_F(TestSignalCleanup, test_signal_cleanup_3) {
   // the same as the one before.
   //
   if (this_node == 0) {
-    auto cb = theCB()->makeFunc<DataMsg>([&c2](DataMsg* msg){
-      c2++;
-      fmt::print("called B");
-    });
+    auto cb = theCB()->makeFunc<DataMsg>(
+      vt::pipe::LifetimeEnum::Once, [&c2](DataMsg* msg){
+        c2++;
+        fmt::print("called B");
+      }
+    );
     auto msg = makeMessage<CallbackMsg>(cb);
     theMsg()->sendMsg<CallbackMsg, bounce>(1, msg);
   }

--- a/tutorial/tutorial_1g.h
+++ b/tutorial/tutorial_1g.h
@@ -112,7 +112,7 @@ static inline void activeMessageCallback() {
 
     // Example of a void lambda callback
     {
-      auto cb = ::vt::theCB()->makeFunc(void_fn);
+      auto cb = ::vt::theCB()->makeFunc(vt::pipe::LifetimeEnum::Once, void_fn);
       auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
       ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node, msg);
     }
@@ -133,7 +133,9 @@ static inline void activeMessageCallback() {
 
     // Example of context callback
     {
-      auto cb = ::vt::theCB()->makeFunc<DataMsg,MyContext>(&ctx, callbackCtx);
+      auto cb = ::vt::theCB()->makeFunc<DataMsg,MyContext>(
+        vt::pipe::LifetimeEnum::Once, &ctx, callbackCtx
+      );
       auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
       ::vt::theMsg()->sendMsg<MsgWithCallback,getCallbackHandler>(to_node, msg);
     }


### PR DESCRIPTION
Fixes #1020

This address 95% of the problems with callbacks:
  - Fix useless state that was building up
  - Reroute collection bcast callback always through the virtual dispatcher to eliminate required state
  - Change `makeFunc` to have a lifetime associated so it gets deleted if it one-time use