### PR TITLE
1040 Fix objgroup leak in base registration code

### DIFF
--- a/src/vt/objgroup/manager.impl.h
+++ b/src/vt/objgroup/manager.impl.h
@@ -140,6 +140,7 @@ void ObjGroupManager::destroyCollective(ProxyType<ObjT> proxy) {
         dispatch_.erase(iter);
       }
     }
+    derived_to_bases_.erase(derived_iter);
   }
   auto iter = dispatch_.find(proxy_bits);
   if (iter != dispatch_.end()) {


### PR DESCRIPTION
Fixes #1040 

Another memory leak down, leaked as EMPIRE is running LB each timestep
Green line-- with the fix
Red line--w/o the fix

[stria-8color-pipe-beta.10.1-objgroup.mallinfo.pdf](https://github.com/DARMA-tasking/vt/files/5205357/stria-8color-pipe-beta.10.1-objgroup.mallinfo.pdf)
.