### PR TITLE
1031 add action to check PR's description format

### DIFF
--- a/.github/workflows/check-pr-comment-fixes-issue.yml
+++ b/.github/workflows/check-pr-comment-fixes-issue.yml
@@ -1,0 +1,16 @@
+name: PR checks (PR description format)
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  check:
+    name: Check PR description
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DARMA-tasking/check-pr-fixes-issue@master
+        with:
+          pr_branch: ${{ github.head_ref }}
+          pr_title: ${{ github.event.pull_request.title }}
+          pr_description: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
Fixes #1031

Most of the work is done in DARMA-tasking/check-pr-fixes-issue#1

The action is run every time the PR title or description (PR's first comment) is edited, and after opening and reopening the PR. If you want to play with it by yourself feel free to check this PR -> jstrzebonski/action_test#9 to not litter this PR anymore.