### PR TITLE
1024 add a collective broadcast call for collections

### DIFF
--- a/docs/md/node-stats.md
+++ b/docs/md/node-stats.md
@@ -55,7 +55,7 @@ the code.
 | 4     | `CommCategory::Broadcast` | A broadcast from a collection element to a whole collection (receive-side) |
 | 5     | `CommCategory::CollectionToNodeBcast` | A broadcast from a collection element to all nodes (receive-side) |
 | 6     | `CommCategory::NodeToCollectionBcast` | A broadcast from a node to a whole collection (receive-side) |
-| 7     | `CommCategory::CollectiveNodeToCollectionEdges` | Collective broadcast from a node to all its edges (receive-side) |
+| 7     | `CommCategory::CollectiveToCollectionBcast` | Collective 'broadcast' from every node to the local collection elements (receive-side) |
 
 For all the broadcast-like edges, the communication logging will occur on the
 receive of the broadcast side (one entry per broadcast recipient).

--- a/docs/md/node-stats.md
+++ b/docs/md/node-stats.md
@@ -55,6 +55,7 @@ the code.
 | 4     | `CommCategory::Broadcast` | A broadcast from a collection element to a whole collection (receive-side) |
 | 5     | `CommCategory::CollectionToNodeBcast` | A broadcast from a collection element to all nodes (receive-side) |
 | 6     | `CommCategory::NodeToCollectionBcast` | A broadcast from a node to a whole collection (receive-side) |
+| 7     | `CommCategory::CollectiveNodeToCollectionEdges` | Collective broadcast from a node to all its edges (receive-side) |
 
 For all the broadcast-like edges, the communication logging will occur on the
 receive of the broadcast side (one entry per broadcast recipient).

--- a/examples/collection/jacobi1d_vt.cc
+++ b/examples/collection/jacobi1d_vt.cc
@@ -260,13 +260,13 @@ public:
     auto proxy = this->getCollectionProxy();
     if (myIdx > 0) {
       auto leftMsg = vt::makeMessage<VecMsg>(myIdx, told_[1]);
-      proxy[myIdx-1].send<VecMsg, &LinearPb1DJacobi::exchange>(leftMsg.get());
+      proxy[myIdx-1].sendMsg<VecMsg, &LinearPb1DJacobi::exchange>(leftMsg.get());
     }
 
     //--- Send values to the right
     if (size_t(myIdx) < numObjs_ - 1) {
       auto rightMsg = vt::makeMessage<VecMsg>(myIdx, told_[numRowsPerObject_]);
-      proxy[myIdx+1].send<VecMsg, &LinearPb1DJacobi::exchange>(rightMsg.get());
+      proxy[myIdx+1].sendMsg<VecMsg, &LinearPb1DJacobi::exchange>(rightMsg.get());
     }
   }
 

--- a/examples/collection/jacobi1d_vt.cc
+++ b/examples/collection/jacobi1d_vt.cc
@@ -132,7 +132,7 @@ public:
       //
       auto proxy = getCollectionProxy();
       auto loopMsg = vt::makeMessage<BlankMsg>();
-      proxy.broadcast<BlankMsg, &LinearPb1DJacobi::sendInfo>(loopMsg.get());
+      proxy.broadcastMsg<BlankMsg, &LinearPb1DJacobi::sendInfo>(loopMsg.get());
     }
     else if (iter > maxIter) {
       fmt::print("\n Maximum Number of Iterations Reached. \n\n");
@@ -375,7 +375,7 @@ int main(int argc, char** argv) {
     auto rootMsg = vt::makeMessage<LinearPb1DJacobi::LPMsg>(
       num_objs, numRowsPerObject, maxIter
     );
-    proxy.broadcast<LinearPb1DJacobi::LPMsg,&LinearPb1DJacobi::solve>(rootMsg.get());
+    proxy.broadcastMsg<LinearPb1DJacobi::LPMsg,&LinearPb1DJacobi::solve>(rootMsg.get());
 
   }
 

--- a/examples/collection/jacobi1d_vt.cc
+++ b/examples/collection/jacobi1d_vt.cc
@@ -265,7 +265,6 @@ public:
 
     //--- Send values to the right
     if (size_t(myIdx) < numObjs_ - 1) {
-      auto rightMsg = vt::makeMessage<VecMsg>();
       proxy[myIdx + 1].send<VecMsg, &LinearPb1DJacobi::exchange>(
         myIdx, told_[numRowsPerObject_]
       );

--- a/examples/collection/jacobi1d_vt.cc
+++ b/examples/collection/jacobi1d_vt.cc
@@ -131,8 +131,7 @@ public:
       // Start a new iteration
       //
       auto proxy = getCollectionProxy();
-      auto loopMsg = vt::makeMessage<BlankMsg>();
-      proxy.broadcastMsg<BlankMsg, &LinearPb1DJacobi::sendInfo>(loopMsg.get());
+      proxy.broadcast<BlankMsg, &LinearPb1DJacobi::sendInfo>();
     }
     else if (iter > maxIter) {
       fmt::print("\n Maximum Number of Iterations Reached. \n\n");
@@ -259,14 +258,17 @@ public:
     //--- Send the values to the left
     auto proxy = this->getCollectionProxy();
     if (myIdx > 0) {
-      auto leftMsg = vt::makeMessage<VecMsg>(myIdx, told_[1]);
-      proxy[myIdx-1].sendMsg<VecMsg, &LinearPb1DJacobi::exchange>(leftMsg.get());
+      proxy[myIdx - 1].send<VecMsg, &LinearPb1DJacobi::exchange>(
+        myIdx, told_[1]
+      );
     }
 
     //--- Send values to the right
     if (size_t(myIdx) < numObjs_ - 1) {
-      auto rightMsg = vt::makeMessage<VecMsg>(myIdx, told_[numRowsPerObject_]);
-      proxy[myIdx+1].sendMsg<VecMsg, &LinearPb1DJacobi::exchange>(rightMsg.get());
+      auto rightMsg = vt::makeMessage<VecMsg>();
+      proxy[myIdx + 1].send<VecMsg, &LinearPb1DJacobi::exchange>(
+        myIdx, told_[numRowsPerObject_]
+      );
     }
   }
 
@@ -372,11 +374,9 @@ int main(int argc, char** argv) {
     auto range = vt::Index1D(static_cast<BaseIndexType>(num_objs));
 
     auto proxy = vt::theCollection()->construct<LinearPb1DJacobi>(range);
-    auto rootMsg = vt::makeMessage<LinearPb1DJacobi::LPMsg>(
+    proxy.broadcast<LinearPb1DJacobi::LPMsg, &LinearPb1DJacobi::solve>(
       num_objs, numRowsPerObject, maxIter
     );
-    proxy.broadcastMsg<LinearPb1DJacobi::LPMsg,&LinearPb1DJacobi::solve>(rootMsg.get());
-
   }
 
   vt::finalize();

--- a/examples/collection/jacobi2d_vt.cc
+++ b/examples/collection/jacobi2d_vt.cc
@@ -145,7 +145,7 @@ public:
       //
       auto proxy = getCollectionProxy();
       auto loopMsg = vt::makeMessage<BlankMsg>();
-      proxy.broadcast<BlankMsg, &LinearPb2DJacobi::sendInfo>(loopMsg.get());
+      proxy.broadcastMsg<BlankMsg, &LinearPb2DJacobi::sendInfo>(loopMsg.get());
     }
     else if (iter > maxIter) {
       fmt::print("\n Maximum Number of Iterations Reached. \n\n");
@@ -508,7 +508,7 @@ int main(int argc, char** argv) {
       numY_objs,
       maxIter
     );
-    proxy.broadcast<LinearPb2DJacobi::LPMsg,&LinearPb2DJacobi::solve>(rootMsg.get());
+    proxy.broadcastMsg<LinearPb2DJacobi::LPMsg,&LinearPb2DJacobi::solve>(rootMsg.get());
 
   }
 

--- a/examples/collection/jacobi2d_vt.cc
+++ b/examples/collection/jacobi2d_vt.cc
@@ -144,8 +144,7 @@ public:
       // Start a new iteration
       //
       auto proxy = getCollectionProxy();
-      auto loopMsg = vt::makeMessage<BlankMsg>();
-      proxy.broadcastMsg<BlankMsg, &LinearPb2DJacobi::sendInfo>(loopMsg.get());
+      proxy.broadcast<BlankMsg, &LinearPb2DJacobi::sendInfo>();
     }
     else if (iter > maxIter) {
       fmt::print("\n Maximum Number of Iterations Reached. \n\n");
@@ -312,16 +311,14 @@ public:
       std::vector<double> tcopy(numRowsPerObject_ + 2, 0.0);
       for (size_t jy = 1; jy <= numRowsPerObject_; ++jy)
         tcopy[jy] = told_[1 + jy * (numRowsPerObject_ + 2)];
-      auto leftX = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x-1, y).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(leftX.get());
+      proxy(x-1, y).send<VecMsg, &LinearPb2DJacobi::exchange>(idx, tcopy);
     }
 
     if (y > 0) {
       std::vector<double> tcopy(numRowsPerObject_ + 2, 0.0);
       for (size_t jx = 1; jx <= numRowsPerObject_; ++jx)
         tcopy[jx] = told_[jx + (numRowsPerObject_ + 2)];
-      auto bottomY = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x, y-1).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(bottomY.get());
+      proxy(x, y-1).send<VecMsg, &LinearPb2DJacobi::exchange>(idx, tcopy);
     }
 
     if (size_t(x) < numObjsX_ - 1) {
@@ -330,16 +327,14 @@ public:
         tcopy[jy] = told_[numRowsPerObject_ +
                           jy * (numRowsPerObject_ + 2)];
       }
-      auto rightX = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x+1, y).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(rightX.get());
+      proxy(x+1, y).send<VecMsg, &LinearPb2DJacobi::exchange>(idx, tcopy);
     }
 
     if (size_t(y) < numObjsY_ - 1) {
       std::vector<double> tcopy(numRowsPerObject_ + 2, 0.0);
       for (size_t jx = 1; jx <= numRowsPerObject_; ++jx)
         tcopy[jx] = told_[jx + numRowsPerObject_ * (numRowsPerObject_ + 2)];
-      auto topY = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x, y+1).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(topY.get());
+      proxy(x, y+1).send<VecMsg, &LinearPb2DJacobi::exchange>(idx, tcopy);
     }
 
   }
@@ -503,13 +498,9 @@ int main(int argc, char** argv) {
       static_cast<BaseIndexType>(numY_objs)
     );
     auto proxy = vt::theCollection()->construct<LinearPb2DJacobi>(range);
-    auto rootMsg = vt::makeMessage<LinearPb2DJacobi::LPMsg>(
-      numX_objs,
-      numY_objs,
-      maxIter
+    proxy.broadcast<LinearPb2DJacobi::LPMsg, &LinearPb2DJacobi::solve>(
+      numX_objs, numY_objs, maxIter
     );
-    proxy.broadcastMsg<LinearPb2DJacobi::LPMsg,&LinearPb2DJacobi::solve>(rootMsg.get());
-
   }
 
   vt::finalize();

--- a/examples/collection/jacobi2d_vt.cc
+++ b/examples/collection/jacobi2d_vt.cc
@@ -313,7 +313,7 @@ public:
       for (size_t jy = 1; jy <= numRowsPerObject_; ++jy)
         tcopy[jy] = told_[1 + jy * (numRowsPerObject_ + 2)];
       auto leftX = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x-1, y).send<VecMsg, &LinearPb2DJacobi::exchange>(leftX.get());
+      proxy(x-1, y).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(leftX.get());
     }
 
     if (y > 0) {
@@ -321,7 +321,7 @@ public:
       for (size_t jx = 1; jx <= numRowsPerObject_; ++jx)
         tcopy[jx] = told_[jx + (numRowsPerObject_ + 2)];
       auto bottomY = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x, y-1).send<VecMsg, &LinearPb2DJacobi::exchange>(bottomY.get());
+      proxy(x, y-1).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(bottomY.get());
     }
 
     if (size_t(x) < numObjsX_ - 1) {
@@ -331,7 +331,7 @@ public:
                           jy * (numRowsPerObject_ + 2)];
       }
       auto rightX = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x+1, y).send<VecMsg, &LinearPb2DJacobi::exchange>(rightX.get());
+      proxy(x+1, y).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(rightX.get());
     }
 
     if (size_t(y) < numObjsY_ - 1) {
@@ -339,7 +339,7 @@ public:
       for (size_t jx = 1; jx <= numRowsPerObject_; ++jx)
         tcopy[jx] = told_[jx + numRowsPerObject_ * (numRowsPerObject_ + 2)];
       auto topY = vt::makeMessage<VecMsg>(idx, tcopy);
-      proxy(x, y+1).send<VecMsg, &LinearPb2DJacobi::exchange>(topY.get());
+      proxy(x, y+1).sendMsg<VecMsg, &LinearPb2DJacobi::exchange>(topY.get());
     }
 
   }

--- a/examples/collection/migrate_collection.cc
+++ b/examples/collection/migrate_collection.cc
@@ -106,20 +106,13 @@ int main(int argc, char** argv) {
     auto range = vt::Index1D(num_elms);
     auto proxy = vt::theCollection()->construct<Hello>(range, this_node);
 
-    vt::runInEpochRooted([=]{
-      auto msg = vt::makeMessage<ColMsg>(this_node);
-      proxy.broadcastMsg<ColMsg, doWork>(msg.get());
-    });
+    vt::runInEpochRooted([=] { proxy.broadcast<ColMsg, doWork>(this_node); });
 
-    vt::runInEpochRooted([=]{
-      auto msg = vt::makeMessage<ColMsg>(this_node);
-      proxy.broadcastMsg<ColMsg, migrateToNext>(msg.get());
-    });
+    vt::runInEpochRooted(
+      [=] { proxy.broadcast<ColMsg, migrateToNext>(this_node); }
+    );
 
-    vt::runInEpochRooted([=]{
-      auto msg = vt::makeMessage<ColMsg>(this_node);
-      proxy.broadcastMsg<ColMsg, doWork>(msg.get());
-    });
+    vt::runInEpochRooted([=] { proxy.broadcast<ColMsg, doWork>(this_node); });
   }
 
   vt::finalize();

--- a/examples/collection/migrate_collection.cc
+++ b/examples/collection/migrate_collection.cc
@@ -108,17 +108,17 @@ int main(int argc, char** argv) {
 
     vt::runInEpochRooted([=]{
       auto msg = vt::makeMessage<ColMsg>(this_node);
-      proxy.broadcast<ColMsg, doWork>(msg.get());
+      proxy.broadcastMsg<ColMsg, doWork>(msg.get());
     });
 
     vt::runInEpochRooted([=]{
       auto msg = vt::makeMessage<ColMsg>(this_node);
-      proxy.broadcast<ColMsg, migrateToNext>(msg.get());
+      proxy.broadcastMsg<ColMsg, migrateToNext>(msg.get());
     });
 
     vt::runInEpochRooted([=]{
       auto msg = vt::makeMessage<ColMsg>(this_node);
-      proxy.broadcast<ColMsg, doWork>(msg.get());
+      proxy.broadcastMsg<ColMsg, doWork>(msg.get());
     });
   }
 

--- a/examples/collection/transpose.cc
+++ b/examples/collection/transpose.cc
@@ -260,11 +260,10 @@ vt::NodeType my_map(IndexT* idx, IndexT* max_idx, vt::NodeType num_nodes) {
       solver_info.have_blocks_++;
     } else {
       // It's a remote collection block
-      auto msg2 = vt::makeMessage<RequestDataMsg<Block>>(this_node);
       // Here we will send "this_node" to indicate which nod it should come back
       // to.  Eventually, I will implement a "sub_rank" in VT which can use the
       // sub-rank instead of the global node id.
-      proxy[block_id].sendMsg<RequestDataMsg<Block>,&Block::dataRequest>(msg2.get());
+      proxy[block_id].send<RequestDataMsg<Block>,&Block::dataRequest>(this_node);
     }
   }
 

--- a/examples/collection/transpose.cc
+++ b/examples/collection/transpose.cc
@@ -264,7 +264,7 @@ vt::NodeType my_map(IndexT* idx, IndexT* max_idx, vt::NodeType num_nodes) {
       // Here we will send "this_node" to indicate which nod it should come back
       // to.  Eventually, I will implement a "sub_rank" in VT which can use the
       // sub-rank instead of the global node id.
-      proxy[block_id].send<RequestDataMsg<Block>,&Block::dataRequest>(msg2.get());
+      proxy[block_id].sendMsg<RequestDataMsg<Block>,&Block::dataRequest>(msg2.get());
     }
   }
 

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -102,7 +102,8 @@ public:
    * \param[in] msg raw pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
-  [[deprecated("Use broadcastMsg instead")]]
+  [[deprecated("For simple create and broadcast message use broadcast(Args...),\
+   otherwise use broadcastMsg(MsgPtrThief)")]]
   void broadcast(MsgT* msg) const;
 
   /**
@@ -112,7 +113,8 @@ public:
    * \param[in] msg managed pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
-  [[deprecated("Use broadcastMsg instead")]]
+  [[deprecated("For simple create and broadcast message use broadcast(Args...),\
+   otherwise use broadcastMsg(MsgPtrThief)")]]
   void broadcast(MsgPtr<MsgT> msg) const;
 
   /**

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -102,6 +102,7 @@ public:
    * \param[in] msg raw pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+  [[deprecated("Use broadcastMsg instead")]]
   void broadcast(MsgT* msg) const;
 
   /**
@@ -111,7 +112,18 @@ public:
    * \param[in] msg managed pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+  [[deprecated("Use broadcastMsg instead")]]
   void broadcast(MsgPtr<MsgT> msg) const;
+
+  /**
+   * \brief Broadcast a message to all nodes to be delivered to the local object
+   * instance
+   * \note Takes ownership of the supplied message
+   *
+   * \param[in] msg the message
+   */
+  template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+  void broadcastMsg(messaging::MsgPtrThief<MsgT> msg) const;
 
   /**
    * \brief Broadcast a message to all nodes to be delivered to the local object

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -71,9 +71,16 @@ void Proxy<ObjT>::broadcast(MsgPtr<MsgT> msg) const {
 }
 
 template <typename ObjT>
+template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+void Proxy<ObjT>::broadcastMsg(messaging::MsgPtrThief<MsgT> msg) const {
+  auto proxy = Proxy<ObjT>(*this);
+  theObjGroup()->broadcast<ObjT,MsgT,fn>(proxy,msg.msg_);
+}
+
+template <typename ObjT>
 template <typename MsgT, ActiveObjType<MsgT, ObjT> fn, typename... Args>
 void Proxy<ObjT>::broadcast(Args&&... args) const {
-  return broadcast<MsgT,fn>(makeMessage<MsgT>(std::forward<Args>(args)...));
+  return broadcastMsg<MsgT,fn>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
 template <typename ObjT>

--- a/src/vt/objgroup/proxy/proxy_objgroup_elm.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup_elm.h
@@ -92,6 +92,7 @@ struct ProxyElm {
    * \param[in] msg raw pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+  [[deprecated("Use sendMsg instead")]]
   void send(MsgT* msg) const;
 
   /**
@@ -101,7 +102,18 @@ struct ProxyElm {
    * \param[in] msg managed pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+  [[deprecated("Use sendMsg instead")]]
   void send(MsgSharedPtr<MsgT> msg) const;
+
+  /**
+   * \brief Send a message to the node/element indexed by this proxy to be
+   * delivered to the local object instance
+   * \note Takes ownership of the supplied message
+   *
+   * \param[in] msg the message
+   */
+  template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+  void sendMsg(messaging::MsgPtrThief<MsgT> msg) const;
 
   /**
    * \brief Send a message to the node/element indexed by this proxy to be

--- a/src/vt/objgroup/proxy/proxy_objgroup_elm.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup_elm.h
@@ -92,7 +92,8 @@ struct ProxyElm {
    * \param[in] msg raw pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
-  [[deprecated("Use sendMsg instead")]]
+  [[deprecated("For simple create and send message use send(Args...),\
+   otherwise use sendMsg(MsgPtrThief)")]]
   void send(MsgT* msg) const;
 
   /**
@@ -102,7 +103,8 @@ struct ProxyElm {
    * \param[in] msg managed pointer to the message
    */
   template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
-  [[deprecated("Use sendMsg instead")]]
+  [[deprecated("For simple create and send message use send(Args...),\
+   otherwise use sendMsg(MsgPtrThief)")]]
   void send(MsgSharedPtr<MsgT> msg) const;
 
   /**

--- a/src/vt/objgroup/proxy/proxy_objgroup_elm.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup_elm.impl.h
@@ -66,9 +66,16 @@ void ProxyElm<ObjT>::send(MsgSharedPtr<MsgT> msg) const {
 }
 
 template <typename ObjT>
+template <typename MsgT, ActiveObjType<MsgT, ObjT> fn>
+void ProxyElm<ObjT>::sendMsg(messaging::MsgPtrThief<MsgT> msg) const {
+  auto proxy = ProxyElm<ObjT>(*this);
+  theObjGroup()->send<ObjT,MsgT,fn>(proxy,msg.msg_);
+}
+
+template <typename ObjT>
 template <typename MsgT, ActiveObjType<MsgT, ObjT> fn, typename... Args>
 void ProxyElm<ObjT>::send(Args&&... args) const {
-  return send<MsgT,fn>(makeMessage<MsgT>(std::forward<Args>(args)...));
+  return sendMsg<MsgT,fn>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
 template <typename ObjT>

--- a/src/vt/rdmahandle/manager.collection.impl.h
+++ b/src/vt/rdmahandle/manager.collection.impl.h
@@ -162,7 +162,7 @@ Handle<T, E, IndexT> Manager::makeCollectionHandles(
       auto msg = makeMessage<impl::InformRDMAMsg<ProxyT,IndexT>>(
         collection_proxy, next_handle, uniform_size, map_han, range
       );
-      proxy_.template broadcast<
+      proxy_.template broadcastMsg<
         impl::InformRDMAMsg<ProxyT,IndexT>,
         &Manager::informCollectionRDMA<T,E,ProxyT,ColT>
       >(msg.get());

--- a/src/vt/rdmahandle/manager.collection.impl.h
+++ b/src/vt/rdmahandle/manager.collection.impl.h
@@ -159,13 +159,10 @@ Handle<T, E, IndexT> Manager::makeCollectionHandles(
     // ObjGroup and all nodes might not have a collection element mapped to
     // them.
     if (this_node == min_node_mapped and in_next_handle == no_rdma_handle) {
-      auto msg = makeMessage<impl::InformRDMAMsg<ProxyT,IndexT>>(
-        collection_proxy, next_handle, uniform_size, map_han, range
-      );
-      proxy_.template broadcastMsg<
+      proxy_.template broadcast<
         impl::InformRDMAMsg<ProxyT,IndexT>,
         &Manager::informCollectionRDMA<T,E,ProxyT,ColT>
-      >(msg.get());
+      >(collection_proxy, next_handle, uniform_size, map_han, range);
     }
   } else {
     auto sub_proxy_bits = iter->second;

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -200,7 +200,7 @@ void TraceSpec::parse() {
 void TraceSpec::broadcastSpec() {
   auto root = theContext()->getNode();
   auto msg = makeMessage<SpecMsg>(spec_mod_, spec_exact_, root);
-  proxy_.template broadcast<SpecMsg, &TraceSpec::transferSpec>(msg.get());
+  proxy_.template broadcastMsg<SpecMsg, &TraceSpec::transferSpec>(msg.get());
 }
 
 void TraceSpec::transferSpec(SpecMsg* msg) {

--- a/src/vt/trace/file_spec/spec.cc
+++ b/src/vt/trace/file_spec/spec.cc
@@ -199,8 +199,9 @@ void TraceSpec::parse() {
 
 void TraceSpec::broadcastSpec() {
   auto root = theContext()->getNode();
-  auto msg = makeMessage<SpecMsg>(spec_mod_, spec_exact_, root);
-  proxy_.template broadcastMsg<SpecMsg, &TraceSpec::transferSpec>(msg.get());
+  proxy_.template broadcast<SpecMsg, &TraceSpec::transferSpec>(
+    spec_mod_, spec_exact_, root
+  );
 }
 
 void TraceSpec::transferSpec(SpecMsg* msg) {

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -216,8 +216,7 @@ void BaseLB::applyMigrations(TransferVecType const &transfers) {
 
 void BaseLB::transferSend(NodeType from, TransferVecType const& transfer) {
   using MsgType = TransferMsg<TransferVecType>;
-  auto msg = makeMessage<MsgType>(transfer);
-  proxy_[from].template sendMsg<MsgType,&BaseLB::transferMigrations>(msg);
+  proxy_[from].template send<MsgType,&BaseLB::transferMigrations>(transfer);
 }
 
 void BaseLB::transferMigrations(TransferMsg<TransferVecType>* msg) {

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -217,7 +217,7 @@ void BaseLB::applyMigrations(TransferVecType const &transfers) {
 void BaseLB::transferSend(NodeType from, TransferVecType const& transfer) {
   using MsgType = TransferMsg<TransferVecType>;
   auto msg = makeMessage<MsgType>(transfer);
-  proxy_[from].template send<MsgType,&BaseLB::transferMigrations>(msg);
+  proxy_[from].template sendMsg<MsgType,&BaseLB::transferMigrations>(msg);
 }
 
 void BaseLB::transferMigrations(TransferMsg<TransferVecType>* msg) {

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -262,7 +262,7 @@ void GossipLB::propagateRound(EpochType epoch) {
       envelopeSetEpoch(msg->env, epoch);
     }
     msg->addNodeLoad(this_node, this_new_load_);
-    proxy_[random_node].send<GossipMsg, &GossipLB::propagateIncoming>(msg.get());
+    proxy_[random_node].sendMsg<GossipMsg, &GossipLB::propagateIncoming>(msg.get());
   }
 }
 
@@ -495,7 +495,7 @@ void GossipLB::lazyMigrateObjsTo(
   using LazyMsg = balance::LazyMigrationMsg;
   auto msg = makeMessage<LazyMsg>(node, objs);
   envelopeSetEpoch(msg->env, epoch);
-  proxy_[node].send<LazyMsg, &GossipLB::inLazyMigrations>(msg);
+  proxy_[node].sendMsg<LazyMsg, &GossipLB::inLazyMigrations>(msg);
 }
 
 void GossipLB::migrate() {

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -328,8 +328,9 @@ void HierarchicalLB::downTreeSend(
   NodeType const node, NodeType const from, ObjSampleType const& excess,
   bool const final_child, std::size_t const& approx_size
 ) {
-  auto msg = makeMessage<LBTreeDownMsg>(from,excess,final_child);
-  proxy[node].template sendMsg<LBTreeDownMsg,&HierarchicalLB::downTreeHandler>(msg);
+  proxy[node].template send<LBTreeDownMsg, &HierarchicalLB::downTreeHandler>(
+    from, excess, final_child
+  );
 }
 
 void HierarchicalLB::downTree(
@@ -385,8 +386,9 @@ void HierarchicalLB::lbTreeUpSend(
   NodeType const node, LoadType const child_load, NodeType const child,
   ObjSampleType const& load, NodeType const child_size
 ) {
-  auto msg = makeMessage<LBTreeUpMsg>(child_load,child,load,child_size);
-  proxy[node].template sendMsg<LBTreeUpMsg,&HierarchicalLB::lbTreeUpHandler>(msg);
+  proxy[node].template send<LBTreeUpMsg, &HierarchicalLB::lbTreeUpHandler>(
+    child_load, child, load, child_size
+  );
 }
 
 void HierarchicalLB::lbTreeUp(

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -329,7 +329,7 @@ void HierarchicalLB::downTreeSend(
   bool const final_child, std::size_t const& approx_size
 ) {
   auto msg = makeMessage<LBTreeDownMsg>(from,excess,final_child);
-  proxy[node].template send<LBTreeDownMsg,&HierarchicalLB::downTreeHandler>(msg);
+  proxy[node].template sendMsg<LBTreeDownMsg,&HierarchicalLB::downTreeHandler>(msg);
 }
 
 void HierarchicalLB::downTree(
@@ -386,7 +386,7 @@ void HierarchicalLB::lbTreeUpSend(
   ObjSampleType const& load, NodeType const child_size
 ) {
   auto msg = makeMessage<LBTreeUpMsg>(child_load,child,load,child_size);
-  proxy[node].template send<LBTreeUpMsg,&HierarchicalLB::lbTreeUpHandler>(msg);
+  proxy[node].template sendMsg<LBTreeUpMsg,&HierarchicalLB::lbTreeUpHandler>(msg);
 }
 
 void HierarchicalLB::lbTreeUp(

--- a/src/vt/vrt/collection/balance/lb_comm.h
+++ b/src/vt/vrt/collection/balance/lb_comm.h
@@ -59,6 +59,7 @@ enum struct CommCategory : int8_t {
   Broadcast = 4,
   CollectionToNodeBcast = 5,
   NodeToCollectionBcast = 6,
+  CollectiveNodeToCollectionEdges = 7
 };
 
 inline NodeType objGetNode(ElementIDType const id) {

--- a/src/vt/vrt/collection/balance/lb_comm.h
+++ b/src/vt/vrt/collection/balance/lb_comm.h
@@ -59,7 +59,7 @@ enum struct CommCategory : int8_t {
   Broadcast = 4,
   CollectionToNodeBcast = 5,
   NodeToCollectionBcast = 6,
-  CollectiveNodeToCollectionEdges = 7
+  CollectiveToCollectionBcast = 7
 };
 
 inline NodeType objGetNode(ElementIDType const id) {

--- a/src/vt/vrt/collection/balance/node_stats.cc
+++ b/src/vt/vrt/collection/balance/node_stats.cc
@@ -243,7 +243,7 @@ getRecvSendDirection(CommKeyType const& comm) {
 
   // Comm stats are not recorded for collective bcast
   // this case is just to avoid warning of not handled enum
-  case CommCategory::CollectiveNodeToCollectionEdges:
+  case CommCategory::CollectiveToCollectionBcast:
     return std::make_pair(ElementIDType{}, ElementIDType{});
   }
 

--- a/src/vt/vrt/collection/balance/node_stats.cc
+++ b/src/vt/vrt/collection/balance/node_stats.cc
@@ -240,6 +240,11 @@ getRecvSendDirection(CommKeyType const& comm) {
   case CommCategory::CollectionToNode:
   case CommCategory::CollectionToNodeBcast:
     return std::make_pair(comm.toNode(), comm.fromObj());
+
+  // Comm stats are not recorded for collective bcast
+  // this case is just to avoid warning of not handled enum
+  case CommCategory::CollectiveNodeToCollectionEdges:
+    return std::make_pair(ElementIDType{}, ElementIDType{});
   }
 
   vtAssert(false, "Invalid balance::CommCategory enum value");

--- a/src/vt/vrt/collection/balance/stats_restart_reader.cc
+++ b/src/vt/vrt/collection/balance/stats_restart_reader.cc
@@ -212,8 +212,7 @@ void StatsRestartReader::createMigrationInfo(
     //
     // Create a message storing the vector
     //
-    auto msg = makeMessage<VecMsg>(myList);
-    proxy_[0].sendMsg<VecMsg, &StatsRestartReader::gatherMsgs>(msg.get());
+    proxy_[0].send<VecMsg, &StatsRestartReader::gatherMsgs>(myList);
     //
     // Clear old distribution of elements
     //
@@ -272,8 +271,7 @@ void StatsRestartReader::gatherMsgs(VecMsg *msg) {
       }
     }
     if (in > 0) {
-      auto msg2 = makeMessage<VecMsg>(toMove);
-      proxy_[in].sendMsg<VecMsg, &StatsRestartReader::scatterMsgs>(msg2.get());
+      proxy_[in].send<VecMsg, &StatsRestartReader::scatterMsgs>(toMove);
     } else {
       proc_phase_runs_LB_[phaseID] = (!migrate.empty());
       auto& myList = proc_move_list_[phaseID];

--- a/src/vt/vrt/collection/balance/stats_restart_reader.cc
+++ b/src/vt/vrt/collection/balance/stats_restart_reader.cc
@@ -213,7 +213,7 @@ void StatsRestartReader::createMigrationInfo(
     // Create a message storing the vector
     //
     auto msg = makeMessage<VecMsg>(myList);
-    proxy_[0].send<VecMsg, &StatsRestartReader::gatherMsgs>(msg.get());
+    proxy_[0].sendMsg<VecMsg, &StatsRestartReader::gatherMsgs>(msg.get());
     //
     // Clear old distribution of elements
     //
@@ -273,7 +273,7 @@ void StatsRestartReader::gatherMsgs(VecMsg *msg) {
     }
     if (in > 0) {
       auto msg2 = makeMessage<VecMsg>(toMove);
-      proxy_[in].send<VecMsg, &StatsRestartReader::scatterMsgs>(msg2.get());
+      proxy_[in].sendMsg<VecMsg, &StatsRestartReader::scatterMsgs>(msg2.get());
     } else {
       proc_phase_runs_LB_[phaseID] = (!migrate.empty());
       auto& myList = proc_move_list_[phaseID];

--- a/src/vt/vrt/collection/broadcast/broadcastable.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.h
@@ -79,6 +79,15 @@ struct Broadcastable : BaseProxyT {
     typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
   >
   messaging::PendingSend broadcast(Args&&... args) const;
+
+  template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+  messaging::PendingSend broadcastCollective(MsgT* msg) const;
+  template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+  messaging::PendingSend broadcastCollective(MsgSharedPtr<MsgT> msg) const;
+  template <
+    typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
+  >
+  messaging::PendingSend broadcastCollective(Args&&... args) const;
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/broadcast/broadcastable.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.h
@@ -80,6 +80,15 @@ struct Broadcastable : BaseProxyT {
   >
   messaging::PendingSend broadcast(Args&&... args) const;
 
+  template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+  messaging::PendingSend broadcastCollective(MsgT* msg) const;
+  template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+  messaging::PendingSend broadcastCollective(MsgSharedPtr<MsgT> msg) const;
+  template <
+    typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args
+  >
+  messaging::PendingSend broadcastCollective(Args&&... args) const;
+
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
   messaging::PendingSend broadcastCollective(MsgT* msg) const;
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>

--- a/src/vt/vrt/collection/broadcast/broadcastable.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.h
@@ -63,10 +63,12 @@ struct Broadcastable : BaseProxyT {
   Broadcastable& operator=(Broadcastable const&) = default;
 
   template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
-  [[deprecated("Use broadcastMsg instead")]]
+  [[deprecated("For simple create and broadcast message use broadcast(Args...),\
+   otherwise use broadcastMsg(MsgPtrThief)")]]
   messaging::PendingSend broadcast(MsgT* msg) const;
   template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
-  [[deprecated("Use broadcastMsg instead")]]
+  [[deprecated("For simple create and broadcast message use broadcast(Args...),\
+   otherwise use broadcastMsg(MsgPtrThief)")]]
   messaging::PendingSend broadcast(MsgSharedPtr<MsgT> msg) const;
 
   /**
@@ -93,10 +95,12 @@ struct Broadcastable : BaseProxyT {
   messaging::PendingSend broadcast(Args&&... args) const;
 
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
-  [[deprecated("Use broadcastMsg instead")]]
+  [[deprecated("For simple create and broadcast message use broadcast(Args...),\
+   otherwise use broadcastMsg(MsgPtrThief)")]]
   messaging::PendingSend broadcast(MsgT* msg) const;
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
-  [[deprecated("Use broadcastMsg instead")]]
+  [[deprecated("For simple create and broadcast message use broadcast(Args...),\
+   otherwise use broadcastMsg(MsgPtrThief)")]]
   messaging::PendingSend broadcast(MsgSharedPtr<MsgT> msg) const;
 
   /**

--- a/src/vt/vrt/collection/broadcast/broadcastable.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.h
@@ -63,32 +63,108 @@ struct Broadcastable : BaseProxyT {
   Broadcastable& operator=(Broadcastable const&) = default;
 
   template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+  [[deprecated("Use broadcastMsg instead")]]
   messaging::PendingSend broadcast(MsgT* msg) const;
   template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+  [[deprecated("Use broadcastMsg instead")]]
   messaging::PendingSend broadcast(MsgSharedPtr<MsgT> msg) const;
+
+  /**
+   * \brief Rooted broadcast with action function handler
+   * \note Takes ownership of the supplied message
+   *
+   * \param[in] msg the message
+   *
+   * \return a pending send
+   */
+  template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+  messaging::PendingSend broadcastMsg(messaging::MsgPtrThief<MsgT> msg) const;
+
+  /**
+   * \brief Rooted broadcast with action function handler
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
   template <
     typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args
   >
   messaging::PendingSend broadcast(Args&&... args) const;
 
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+  [[deprecated("Use broadcastMsg instead")]]
   messaging::PendingSend broadcast(MsgT* msg) const;
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+  [[deprecated("Use broadcastMsg instead")]]
   messaging::PendingSend broadcast(MsgSharedPtr<MsgT> msg) const;
+
+  /**
+   * \brief Rooted broadcast with action member handler
+   * \note Takes ownership of the supplied message
+   *
+   * \param[in] msg the message
+   *
+   * \return a pending send
+   */
+  template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+  messaging::PendingSend broadcastMsg(messaging::MsgPtrThief<MsgT> msg) const;
+
+  /**
+   * \brief Rooted broadcast with action member handler
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
   template <
     typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
   >
   messaging::PendingSend broadcast(Args&&... args) const;
 
+  /**
+   * \brief Collective broadcast with action function handler
+   * \note Takes ownership of the supplied message
+   *
+   * \param[in] msg the message
+   *
+   * \return a pending send
+   */
   template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
   messaging::PendingSend broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const;
+
+  /**
+   * \brief Create message (with action function handler) and broadcast it in a
+   * collective manner to the collection
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
   template <
     typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args
   >
   messaging::PendingSend broadcastCollective(Args&&... args) const;
 
+  /**
+   * \brief Collective broadcast with action member handler
+   * \note Takes ownership of the supplied message
+   *
+   * \param[in] msg the message
+   *
+   * \return a pending send
+   */
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
   messaging::PendingSend broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const;
+
+  /**
+   * \brief Create message (with action member handler) and broadcast it in a
+   * collective manner to the collection
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
   template <
     typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
   >

--- a/src/vt/vrt/collection/broadcast/broadcastable.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.h
@@ -81,18 +81,14 @@ struct Broadcastable : BaseProxyT {
   messaging::PendingSend broadcast(Args&&... args) const;
 
   template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
-  messaging::PendingSend broadcastCollective(MsgT* msg) const;
-  template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
-  messaging::PendingSend broadcastCollective(MsgSharedPtr<MsgT> msg) const;
+  messaging::PendingSend broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const;
   template <
     typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args
   >
   messaging::PendingSend broadcastCollective(Args&&... args) const;
 
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
-  messaging::PendingSend broadcastCollective(MsgT* msg) const;
-  template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
-  messaging::PendingSend broadcastCollective(MsgSharedPtr<MsgT> msg) const;
+  messaging::PendingSend broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const;
   template <
     typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
   >

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -97,12 +97,34 @@ messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(Args&&..
   return broadcast<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
-
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
 messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(MsgT* msg) const {
   auto proxy = this->getProxy();
   return theCollection()->broadcastMsg<MsgT, f>(proxy,msg);
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgSharedPtr<MsgT> msg) const {
+  return broadcastCollective<MsgT, f>(msg.get());
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <
+  typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(Args&&... args) const {
+  return broadcastCollective<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgT* msg) const {
+  auto proxy = this->getProxy();
+  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -105,6 +105,29 @@ messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(MsgT* ms
   return theCollection()->broadcastMsg<MsgT, f>(proxy,msg);
 }
 
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgSharedPtr<MsgT> msg) const {
+  return broadcastCollective<MsgT, f>(msg.get());
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <
+  typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(Args&&... args) const {
+  return broadcastCollective<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgT* msg) const {
+  auto proxy = this->getProxy();
+  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
+}
+
 }}} /* end namespace vt::vrt::collection */
 
 #endif /*INCLUDED_VRT_COLLECTION_BROADCAST_BROADCASTABLE_IMPL_H*/

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -78,7 +78,16 @@ template <
   typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args
 >
 messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(Args&&... args) const {
-  return broadcast<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+  return broadcastMsg<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastMsg(messaging::MsgPtrThief<MsgT> msg) const {
+  auto proxy = this->getProxy();
+
+  return theCollection()->broadcastMsg<MsgT, f>(proxy, msg.msg_.get());
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -94,7 +103,15 @@ template <
   typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
 >
 messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(Args&&... args) const {
-  return broadcast<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+  return broadcastMsg<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+messaging::PendingSend
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastMsg(messaging::MsgPtrThief<MsgT> msg) const {
+  auto proxy = this->getProxy();
+  return theCollection()->broadcastMsg<MsgT, f>(proxy, msg.msg_.get());
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -109,7 +126,7 @@ template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
 messaging::PendingSend
 Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const {
   auto proxy = this->getProxy();
-  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
+  return theCollection()->broadcastCollectiveMsg<MsgT, f>(proxy, msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -126,7 +143,7 @@ template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
 messaging::PendingSend
 Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const {
   auto proxy = this->getProxy();
-  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
+  return theCollection()->broadcastCollectiveMsg<MsgT, f>(proxy, msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -101,14 +101,15 @@ template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
 messaging::PendingSend Broadcastable<ColT,IndexT,BaseProxyT>::broadcast(MsgT* msg) const {
   auto proxy = this->getProxy();
-  return theCollection()->broadcastMsg<MsgT, f>(proxy,msg);
+  return theCollection()->broadcastMsg<MsgT, f>(proxy, msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
 messaging::PendingSend
-Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgSharedPtr<MsgT> msg) const {
-  return broadcastCollective<MsgT, f>(msg.get());
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const {
+  auto proxy = this->getProxy();
+  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -117,22 +118,15 @@ template <
 >
 messaging::PendingSend
 Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(Args&&... args) const {
-  return broadcastCollective<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));
-}
-
-template <typename ColT, typename IndexT, typename BaseProxyT>
-template <typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f>
-messaging::PendingSend
-Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgT* msg) const {
-  auto proxy = this->getProxy();
-  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
+  return broadcastCollectiveMsg<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
 messaging::PendingSend
-Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgSharedPtr<MsgT> msg) const {
-  return broadcastCollective<MsgT, f>(msg.get());
+Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollectiveMsg(messaging::MsgPtrThief<MsgT> msg) const {
+  auto proxy = this->getProxy();
+  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -141,15 +135,7 @@ template <
 >
 messaging::PendingSend
 Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(Args&&... args) const {
-  return broadcastCollective<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));
-}
-
-template <typename ColT, typename IndexT, typename BaseProxyT>
-template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
-messaging::PendingSend
-Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgT* msg) const {
-  auto proxy = this->getProxy();
-  return theCollection()->broadcastMsgCollective<MsgT, f>(proxy, msg);
+  return broadcastCollectiveMsg<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -113,7 +113,8 @@ Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgSharedPtr<MsgT> 
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <
-  typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args>
+  typename MsgT, ActiveColTypedFnType<MsgT, ColT> *f, typename... Args
+>
 messaging::PendingSend
 Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(Args&&... args) const {
   return broadcastCollective<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));
@@ -136,7 +137,8 @@ Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(MsgSharedPtr<MsgT> 
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <
-  typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args>
+  typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f, typename... Args
+>
 messaging::PendingSend
 Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(Args&&... args) const {
   return broadcastCollective<MsgT, f>(makeMessage<MsgT>(std::forward<Args>(args)...));

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -960,7 +960,8 @@ public:
    */
   template <
     typename MsgT,
-    ActiveColTypedFnType<MsgT,typename MsgT::CollectionType> *f>
+    ActiveColTypedFnType<MsgT,typename MsgT::CollectionType> *f
+  >
   messaging::PendingSend broadcastMsgCollective(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
     MsgT* msg, bool instrument = true);
@@ -977,7 +978,8 @@ public:
    */
   template <
     typename MsgT,
-    ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f>
+    ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
+  >
   messaging::PendingSend broadcastMsgCollective(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
     MsgT* msg, bool instrument = true);

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -948,6 +948,13 @@ public:
     bool instrument
   );
 
+  template <
+    typename MsgT,
+    ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f>
+  messaging::PendingSend broadcastMsgCollective(
+    CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
+    MsgT* msg, bool instrument = true);
+
   /**
    * \brief Broadcast a message with action function handler
    *

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -948,6 +948,16 @@ public:
     bool instrument
   );
 
+  /**
+   * \brief Broadcast collective a message with action function handler
+   *
+   * \param[in] proxy the collection proxy
+   * \param[in] msg the message
+   * \param[in] instrument whether to instrument the broadcast for load
+   * balancing (some system calls use this to disable instrumentation)
+   *
+   * \return a pending send
+   */
   template <
     typename MsgT,
     ActiveColTypedFnType<MsgT,typename MsgT::CollectionType> *f>
@@ -955,6 +965,16 @@ public:
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
     MsgT* msg, bool instrument = true);
 
+  /**
+   * \brief Broadcast collective a message with action member handler
+   *
+   * \param[in] proxy the collection proxy
+   * \param[in] msg the message
+   * \param[in] instrument whether to instrument the broadcast for load
+   * balancing (some system calls use this to disable instrumentation)
+   *
+   * \return a pending send
+   */
   template <
     typename MsgT,
     ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f>
@@ -962,9 +982,20 @@ public:
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
     MsgT* msg, bool instrument = true);
 
+  /**
+   * \internal \brief Broadcast collective a message
+   *
+   * \param[in] proxy the collection proxy
+   * \param[in] msg the message
+   * \param[in] instrument whether to instrument the broadcast for load
+   * balancing (some system calls use this to disable instrumentation)
+   *
+   * \return a pending send
+   */
   template <typename MsgT, typename ColT>
   messaging::PendingSend broadcastMsgCollectiveImpl(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg);
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+    bool instrument = true);
 
   /**
    * \brief Broadcast a message with action function handler

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -950,6 +950,7 @@ public:
 
   /**
    * \brief Broadcast collective a message with action function handler
+   * \note Takes ownership of the supplied message
    *
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
@@ -962,12 +963,13 @@ public:
     typename MsgT,
     ActiveColTypedFnType<MsgT,typename MsgT::CollectionType> *f
   >
-  messaging::PendingSend broadcastMsgCollective(
+  messaging::PendingSend broadcastCollectiveMsg(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
     messaging::MsgPtrThief<MsgT> msg, bool instrument = true);
 
   /**
    * \brief Broadcast collective a message with action member handler
+   * \note Takes ownership of the supplied message
    *
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
@@ -980,7 +982,7 @@ public:
     typename MsgT,
     ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
   >
-  messaging::PendingSend broadcastMsgCollective(
+  messaging::PendingSend broadcastCollectiveMsg(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
     messaging::MsgPtrThief<MsgT> msg, bool instrument = true);
 
@@ -995,7 +997,7 @@ public:
    * \return a pending send
    */
   template <typename MsgT, typename ColT>
-  messaging::PendingSend broadcastMsgCollectiveImpl(
+  messaging::PendingSend broadcastCollectiveMsgImpl(
     CollectionProxyWrapType<ColT> const& proxy, MsgPtr<MsgT>& msg,
     bool instrument);
 

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -950,10 +950,21 @@ public:
 
   template <
     typename MsgT,
+    ActiveColTypedFnType<MsgT,typename MsgT::CollectionType> *f>
+  messaging::PendingSend broadcastMsgCollective(
+    CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
+    MsgT* msg, bool instrument = true);
+
+  template <
+    typename MsgT,
     ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f>
   messaging::PendingSend broadcastMsgCollective(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
     MsgT* msg, bool instrument = true);
+
+  template <typename MsgT, typename ColT>
+  messaging::PendingSend broadcastMsgCollectiveImpl(
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg);
 
   /**
    * \brief Broadcast a message with action function handler

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -964,7 +964,7 @@ public:
   >
   messaging::PendingSend broadcastMsgCollective(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
-    MsgT* msg, bool instrument = true);
+    messaging::MsgPtrThief<MsgT> msg, bool instrument = true);
 
   /**
    * \brief Broadcast collective a message with action member handler
@@ -982,7 +982,7 @@ public:
   >
   messaging::PendingSend broadcastMsgCollective(
     CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
-    MsgT* msg, bool instrument = true);
+    messaging::MsgPtrThief<MsgT> msg, bool instrument = true);
 
   /**
    * \internal \brief Broadcast collective a message
@@ -996,8 +996,8 @@ public:
    */
   template <typename MsgT, typename ColT>
   messaging::PendingSend broadcastMsgCollectiveImpl(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
-    bool instrument = true);
+    CollectionProxyWrapType<ColT> const& proxy, MsgPtr<MsgT>& msg,
+    bool instrument);
 
   /**
    * \brief Broadcast a message with action function handler

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -908,7 +908,7 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
 
 #if vt_check_enabled(lblite)
   msg->setLBLiteInstrument(instrument);
-  msg->setCat(balance::CommCategory::NodeToCollectionBcast);
+  msg->setCat(balance::CommCategory::CollectiveToCollectionBcast);
 #endif
 
   auto const cur_epoch = theMsg()->setupEpochMsg(msg);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -898,8 +898,8 @@ messaging::PendingSend CollectionManager::broadcastMsgCollectiveImpl(
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
-  auto event =
-    theMsg()->makeTraceCreationSend(msg, handler, reg_type, msg_size, true);
+  auto event = theMsg()->makeTraceCreationSend(
+    msg, msg->getVrtHandler(), reg_type, msg_size, true);
   msg->setFromTraceEvent(event);
 #endif
 
@@ -908,7 +908,7 @@ messaging::PendingSend CollectionManager::broadcastMsgCollectiveImpl(
   msg->setCat(balance::CommCategory::NodeToCollection);
 #endif
 
-  auto const cur_epoch = theMsg()->setupEpochMsg(msg);
+  theMsg()->setupEpochMsg(msg);
 
   return messaging::PendingSend(
     msg, [proxy](MsgSharedPtr<BaseMsgType>& msgIn) {

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -875,7 +875,8 @@ messaging::PendingSend CollectionManager::broadcastMsgCollective(
   using ColT = typename MsgT::CollectionType;
 
   msg->setVrtHandler(
-    auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>());
+    auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>()
+  );
   msg->setMember(true);
 
   return broadcastMsgCollectiveImpl<MsgT, ColT>(proxy, msg, instrument);
@@ -899,7 +900,8 @@ messaging::PendingSend CollectionManager::broadcastMsgCollectiveImpl(
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
   auto event = theMsg()->makeTraceCreationSend(
-    msg, msg->getVrtHandler(), reg_type, msg_size, true);
+    msg, msg->getVrtHandler(), reg_type, msg_size, true
+  );
   msg->setFromTraceEvent(event);
 #endif
 
@@ -911,7 +913,7 @@ messaging::PendingSend CollectionManager::broadcastMsgCollectiveImpl(
   theMsg()->setupEpochMsg(msg);
 
   return messaging::PendingSend(
-    msg, [proxy](MsgSharedPtr<BaseMsgType>& msgIn) {
+    msg, [proxy](MsgSharedPtr<BaseMsgType>& msgIn){
       auto col_msg = reinterpret_cast<MsgT*>(msgIn.get());
 
       auto elm_holder = theCollection()->findElmHolder<ColT, IndexT>(proxy);
@@ -921,7 +923,8 @@ messaging::PendingSend CollectionManager::broadcastMsgCollectiveImpl(
       theMsg()->markAsCollectionMessage(col_msg);
 
       collectionBcastHandler<ColT, IndexT, MsgT>(col_msg);
-    });
+    }
+  );
 }
 
 template <

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -908,7 +908,7 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
 
 #if vt_check_enabled(lblite)
   msg->setLBLiteInstrument(instrument);
-  msg->setCat(balance::CommCategory::NodeToCollection);
+  msg->setCat(balance::CommCategory::NodeToCollectionBcast);
 #endif
 
   auto const cur_epoch = theMsg()->setupEpochMsg(msg);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -852,7 +852,7 @@ messaging::PendingSend CollectionManager::broadcastFromRoot(MsgT* raw_msg) {
 template <
   typename MsgT, ActiveColTypedFnType<MsgT, typename MsgT::CollectionType>* f
 >
-messaging::PendingSend CollectionManager::broadcastMsgCollective(
+messaging::PendingSend CollectionManager::broadcastCollectiveMsg(
   CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
   messaging::MsgPtrThief<MsgT> msg, bool instrument
 ) {
@@ -862,14 +862,14 @@ messaging::PendingSend CollectionManager::broadcastMsgCollective(
   msgPtr->setVrtHandler(auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>());
   msgPtr->setMember(false);
 
-  return broadcastMsgCollectiveImpl<MsgT, ColT>(proxy, msgPtr, instrument);
+  return broadcastCollectiveMsgImpl<MsgT, ColT>(proxy, msgPtr, instrument);
 }
 
 template <
   typename MsgT,
   ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
 >
-messaging::PendingSend CollectionManager::broadcastMsgCollective(
+messaging::PendingSend CollectionManager::broadcastCollectiveMsg(
   CollectionProxyWrapType<typename MsgT::CollectionType> const& proxy,
   messaging::MsgPtrThief<MsgT> msg, bool instrument
 ) {
@@ -881,11 +881,11 @@ messaging::PendingSend CollectionManager::broadcastMsgCollective(
   );
   msgPtr->setMember(true);
 
-  return broadcastMsgCollectiveImpl<MsgT, ColT>(proxy, msgPtr, instrument);
+  return broadcastCollectiveMsgImpl<MsgT, ColT>(proxy, msgPtr, instrument);
 }
 
 template <typename MsgT, typename ColT>
-messaging::PendingSend CollectionManager::broadcastMsgCollectiveImpl(
+messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
   CollectionProxyWrapType<ColT> const& proxy, MsgPtr<MsgT>& msg, bool instrument
 ) {
   using IndexT = typename ColT::IndexType;

--- a/src/vt/vrt/collection/send/sendable.h
+++ b/src/vt/vrt/collection/send/sendable.h
@@ -64,16 +64,56 @@ struct Sendable : BaseProxyT {
   void serialize(SerializerT& s);
 
   template <typename MsgT, ActiveColTypedFnType<MsgT,ColT> *f>
+  [[deprecated("Use sendMsg instead")]]
   messaging::PendingSend send(MsgT* msg) const;
   template <typename MsgT, ActiveColTypedFnType<MsgT,ColT> *f>
+  [[deprecated("Use sendMsg instead")]]
   messaging::PendingSend send(MsgSharedPtr<MsgT> msg) const;
+
+  /**
+   * \brief Create message (with action function handler) and send to collection element
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
+  template <typename MsgT, ActiveColTypedFnType<MsgT,ColT> *f>
+  messaging::PendingSend sendMsg(messaging::MsgPtrThief<MsgT> msg) const;
+
+  /**
+   * \brief Create message (with action function handler) and send to collection element
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
   template <typename MsgT, ActiveColTypedFnType<MsgT,ColT> *f, typename... Args>
   messaging::PendingSend send(Args&&... args) const;
 
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT,ColT> f>
+  [[deprecated("Use sendMsg instead")]]
   messaging::PendingSend send(MsgT* msg) const;
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT,ColT> f>
+  [[deprecated("Use sendMsg instead")]]
   messaging::PendingSend send(MsgSharedPtr<MsgT> msg) const;
+
+  /**
+   * \brief Create message (with action member handler) and send to collection element
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
+  template <typename MsgT, ActiveColMemberTypedFnType<MsgT,ColT> f>
+  messaging::PendingSend sendMsg(messaging::MsgPtrThief<MsgT> msg) const;
+
+  /**
+   * \brief Create message (with action member handler) and send to collection element
+   *
+   * \param[in] args arguments needed for creteating the message
+   *
+   * \return a pending send
+   */
   template <
     typename MsgT, ActiveColMemberTypedFnType<MsgT,ColT> f, typename... Args
   >

--- a/src/vt/vrt/collection/send/sendable.h
+++ b/src/vt/vrt/collection/send/sendable.h
@@ -64,10 +64,12 @@ struct Sendable : BaseProxyT {
   void serialize(SerializerT& s);
 
   template <typename MsgT, ActiveColTypedFnType<MsgT,ColT> *f>
-  [[deprecated("Use sendMsg instead")]]
+  [[deprecated("For simple create and send message use send(Args...),\
+   otherwise use sendMsg(MsgPtrThief)")]]
   messaging::PendingSend send(MsgT* msg) const;
   template <typename MsgT, ActiveColTypedFnType<MsgT,ColT> *f>
-  [[deprecated("Use sendMsg instead")]]
+  [[deprecated("For simple create and send message use send(Args...),\
+   otherwise use sendMsg(MsgPtrThief)")]]
   messaging::PendingSend send(MsgSharedPtr<MsgT> msg) const;
 
   /**
@@ -91,10 +93,12 @@ struct Sendable : BaseProxyT {
   messaging::PendingSend send(Args&&... args) const;
 
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT,ColT> f>
-  [[deprecated("Use sendMsg instead")]]
+  [[deprecated("For simple create and send message use send(Args...),\
+   otherwise use sendMsg(MsgPtrThief)")]]
   messaging::PendingSend send(MsgT* msg) const;
   template <typename MsgT, ActiveColMemberTypedFnType<MsgT,ColT> f>
-  [[deprecated("Use sendMsg instead")]]
+  [[deprecated("For simple create and send message use send(Args...),\
+   otherwise use sendMsg(MsgPtrThief)")]]
   messaging::PendingSend send(MsgSharedPtr<MsgT> msg) const;
 
   /**

--- a/src/vt/vrt/collection/send/sendable.impl.h
+++ b/src/vt/vrt/collection/send/sendable.impl.h
@@ -80,9 +80,20 @@ messaging::PendingSend Sendable<ColT,IndexT,BaseProxyT>::send(MsgSharedPtr<MsgT>
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColTypedFnType<MsgT, ColT>* f>
+messaging::PendingSend Sendable<ColT, IndexT, BaseProxyT>::sendMsg(
+  messaging::MsgPtrThief<MsgT> msg
+) const {
+  auto col_proxy = this->getCollectionProxy();
+  auto elm_proxy = this->getElementProxy();
+  auto proxy = VrtElmProxy<ColT, IndexT>(col_proxy, elm_proxy);
+  return theCollection()->sendMsg<MsgT, f>(proxy, msg.msg_.get());
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename MsgT, ActiveColTypedFnType<MsgT,ColT> *f, typename... Args>
 messaging::PendingSend Sendable<ColT,IndexT,BaseProxyT>::send(Args&&... args) const {
-  return send<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+  return sendMsg<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
@@ -101,11 +112,22 @@ messaging::PendingSend Sendable<ColT,IndexT,BaseProxyT>::send(MsgSharedPtr<MsgT>
 }
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
+template <typename MsgT, ActiveColMemberTypedFnType<MsgT, ColT> f>
+messaging::PendingSend Sendable<ColT, IndexT, BaseProxyT>::sendMsg(
+  messaging::MsgPtrThief<MsgT> msg
+) const {
+  auto col_proxy = this->getCollectionProxy();
+  auto elm_proxy = this->getElementProxy();
+  auto proxy = VrtElmProxy<ColT, IndexT>(col_proxy, elm_proxy);
+  return theCollection()->sendMsg<MsgT, f>(proxy, msg.msg_.get());
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
 template <
   typename MsgT, ActiveColMemberTypedFnType<MsgT,ColT> f, typename... Args
 >
 messaging::PendingSend Sendable<ColT,IndexT,BaseProxyT>::send(Args&&... args) const {
-  return send<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
+  return sendMsg<MsgT,f>(makeMessage<MsgT>(std::forward<Args>(args)...));
 }
 
 

--- a/tests/unit/collection/test_broadcast.h
+++ b/tests/unit/collection/test_broadcast.h
@@ -129,7 +129,7 @@ TYPED_TEST_P(TestBroadcast, test_broadcast_1) {
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = theCollection()->construct<ColType>(range);
     auto msg = makeMessage<MsgType>(args);
-    proxy.template broadcast<
+    proxy.template broadcastMsg<
       MsgType,
       BroadcastHandlers<ColType>::handler
     >(msg.get());

--- a/tests/unit/collection/test_broadcast.h
+++ b/tests/unit/collection/test_broadcast.h
@@ -128,16 +128,16 @@ TYPED_TEST_P(TestBroadcast, test_broadcast_1) {
     auto range = TestIndex(col_size);
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = theCollection()->construct<ColType>(range);
-    auto msg = makeMessage<MsgType>(args);
-    proxy.template broadcastMsg<
+
+    proxy.template broadcast<
       MsgType,
       BroadcastHandlers<ColType>::handler
-    >(msg.get());
+    >(args);
 
-    auto msg2 = makeMessage<MsgType>(args);
+    auto msg = makeMessage<MsgType>(args);
     theCollection()->broadcastMsg<
       MsgType,BroadcastHandlers<ColType>::handler
-    >(proxy, msg2.get());
+    >(proxy, msg.get());
   }
 }
 

--- a/tests/unit/collection/test_collection_construct_common.h
+++ b/tests/unit/collection/test_collection_construct_common.h
@@ -151,11 +151,10 @@ TYPED_TEST_P(TestConstruct, test_construct_1) {
     auto rng = TestIndex(col_size);
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = ConstructParams<ColType,TestParamType>::constructTup(rng,args);
-    auto msg = makeMessage<MsgType>();
-    proxy.template broadcastMsg<
+    proxy.template broadcast<
       MsgType,
       ConstructHandlers::handler<ColType,MsgType>
-    >(msg.get());
+    >();
   }
 }
 
@@ -170,11 +169,10 @@ TYPED_TEST_P(TestConstructDist, test_construct_distributed_1) {
   auto proxy = ConstructParams<ColType,TestParamType>::constructTupCollective(
     rng,args
   );
-  auto msg = makeMessage<MsgType>();
-  proxy.template broadcastMsg<
+  proxy.template broadcast<
     MsgType,
     ConstructHandlers::handler<ColType,MsgType>
-  >(msg.get());
+  >();
 }
 
 REGISTER_TYPED_TEST_SUITE_P(TestConstruct,     test_construct_1);

--- a/tests/unit/collection/test_collection_construct_common.h
+++ b/tests/unit/collection/test_collection_construct_common.h
@@ -152,7 +152,7 @@ TYPED_TEST_P(TestConstruct, test_construct_1) {
     TestParamType args = ConstructTuple<TestParamType>::construct();
     auto proxy = ConstructParams<ColType,TestParamType>::constructTup(rng,args);
     auto msg = makeMessage<MsgType>();
-    proxy.template broadcast<
+    proxy.template broadcastMsg<
       MsgType,
       ConstructHandlers::handler<ColType,MsgType>
     >(msg.get());
@@ -171,7 +171,7 @@ TYPED_TEST_P(TestConstructDist, test_construct_distributed_1) {
     rng,args
   );
   auto msg = makeMessage<MsgType>();
-  proxy.template broadcast<
+  proxy.template broadcastMsg<
     MsgType,
     ConstructHandlers::handler<ColType,MsgType>
   >(msg.get());

--- a/tests/unit/collection/test_collection_group.extended.cc
+++ b/tests/unit/collection/test_collection_group.extended.cc
@@ -159,11 +159,11 @@ TEST_F(TestCollectionGroup, test_collection_group_3){
   proxy.broadcastCollective<ColA::TestDataMsg, colHanlder>(msg.get());
   EXPECT_EQ(elem_counter, 0);
 
-  proxy.broadcastCollective<ColA::TestDataMsg, &ColA::memberHanlder>(msg);
+  proxy.broadcastCollective<ColA::TestDataMsg, colHanlder>(msg);
   EXPECT_EQ(elem_counter, -numElems);
 
   proxy.broadcastCollective<
-    ColA::TestDataMsg, &ColA::memberHanlder, ColA::TestDataMsg>(my_node);
+    ColA::TestDataMsg, colHanlder, ColA::TestDataMsg>(my_node);
   EXPECT_EQ(elem_counter, -2 * numElems);
 }
 

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -114,9 +114,9 @@ TEST_F(TestDestroy, test_destroy_1) {
     if (this_node == 0) {
       auto const& range = Index1D(num_nodes * num_elms_per_node);
       auto proxy = theCollection()->construct<DestroyTest>(range);
-      auto msg = makeMessage<WorkMsg>();
+
       // ::fmt::print("broadcasting proxy={:x}\n", proxy.getProxy());
-      proxy.broadcastMsg<WorkMsg,DestroyTest::work>(msg.get());
+      proxy.broadcast<WorkMsg,DestroyTest::work>();
     }
   });
     // ::fmt::print("num destroyed={}\n", num_destroyed);

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -116,7 +116,7 @@ TEST_F(TestDestroy, test_destroy_1) {
       auto proxy = theCollection()->construct<DestroyTest>(range);
       auto msg = makeMessage<WorkMsg>();
       // ::fmt::print("broadcasting proxy={:x}\n", proxy.getProxy());
-      proxy.broadcast<WorkMsg,DestroyTest::work>(msg.get());
+      proxy.broadcastMsg<WorkMsg,DestroyTest::work>(msg.get());
     }
   });
     // ::fmt::print("num destroyed={}\n", num_destroyed);

--- a/tests/unit/collection/test_index_types.extended.cc
+++ b/tests/unit/collection/test_index_types.extended.cc
@@ -109,7 +109,7 @@ TYPED_TEST_P(TestCollectionIndexTypes, test_collection_index_1) {
     for (BaseIndexType i = 0; i < static_cast<BaseIndexType>(col_size); i++) {
       auto msg = makeMessage<MsgType>(34);
       if (i % 2 == 0) {
-        proxy[i].template send<MsgType,&ColType::handler>(msg.get());
+        proxy[i].template sendMsg<MsgType,&ColType::handler>(msg.get());
       } else {
         theCollection()->sendMsg<MsgType,&ColType::handler>(
           proxy[i], msg.get()

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -174,8 +174,7 @@ TEST_F(TestInsert, test_insert_send_dense_node_1) {
       auto proxy = theCollection()->construct<InsertTest>(range);
       for (auto i = 0; i < range.x(); i++) {
         proxy[i].insert((this_node + 1) % num_nodes);
-        auto msg = makeMessage<WorkMsg>();
-        proxy[i].sendMsg<WorkMsg,&InsertTest::work>(msg.get());
+        proxy[i].send<WorkMsg,&InsertTest::work>();
         // ::fmt::print("sending to {}\n", i);
       }
     }
@@ -200,8 +199,7 @@ TEST_F(TestInsert, test_insert_send_sparse_node_1) {
       auto proxy = theCollection()->construct<InsertTest>(range);
       for (auto i = 0; i < range.x(); i+=16) {
         proxy[i].insert((this_node + 1) % num_nodes);
-        auto msg = makeMessage<WorkMsg>();
-        proxy[i].sendMsg<WorkMsg,&InsertTest::work>(msg.get());
+        proxy[i].send<WorkMsg,&InsertTest::work>();
       }
     }
   });

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -175,7 +175,7 @@ TEST_F(TestInsert, test_insert_send_dense_node_1) {
       for (auto i = 0; i < range.x(); i++) {
         proxy[i].insert((this_node + 1) % num_nodes);
         auto msg = makeMessage<WorkMsg>();
-        proxy[i].send<WorkMsg,&InsertTest::work>(msg.get());
+        proxy[i].sendMsg<WorkMsg,&InsertTest::work>(msg.get());
         // ::fmt::print("sending to {}\n", i);
       }
     }
@@ -201,7 +201,7 @@ TEST_F(TestInsert, test_insert_send_sparse_node_1) {
       for (auto i = 0; i < range.x(); i+=16) {
         proxy[i].insert((this_node + 1) % num_nodes);
         auto msg = makeMessage<WorkMsg>();
-        proxy[i].send<WorkMsg,&InsertTest::work>(msg.get());
+        proxy[i].sendMsg<WorkMsg,&InsertTest::work>(msg.get());
       }
     }
   });

--- a/tests/unit/collection/test_lb_lite.extended.cc
+++ b/tests/unit/collection/test_lb_lite.extended.cc
@@ -169,8 +169,8 @@ static void startIter(int32_t const iter, ColProxyType proxy) {
   ::fmt::print(
     "startIter: iter={}, cur_iter={}\n", iter, iter
   );
-  auto msg = makeMessage<IterMsg>(iter);
-  proxy.broadcastMsg<IterMsg,LBTest::iterWork>(msg.get());
+
+  proxy.broadcast<IterMsg,LBTest::iterWork>(iter);
 }
 
 struct TestLB : TestParallelHarness { };

--- a/tests/unit/collection/test_lb_lite.extended.cc
+++ b/tests/unit/collection/test_lb_lite.extended.cc
@@ -170,7 +170,7 @@ static void startIter(int32_t const iter, ColProxyType proxy) {
     "startIter: iter={}, cur_iter={}\n", iter, iter
   );
   auto msg = makeMessage<IterMsg>(iter);
-  proxy.broadcast<IterMsg,LBTest::iterWork>(msg.get());
+  proxy.broadcastMsg<IterMsg,LBTest::iterWork>(msg.get());
 }
 
 struct TestLB : TestParallelHarness { };

--- a/tests/unit/collection/test_reduce_collection.cc
+++ b/tests/unit/collection/test_reduce_collection.cc
@@ -62,16 +62,16 @@ TEST_P(TestReduceCollection, test_reduce_op) {
     auto msg = makeMessage<ColMsg>(my_node);
 
     switch (reduce_case) {
-    case 0: proxy.broadcast<ColMsg, colHanBasic>(msg.get()); break;
-    case 1: proxy.broadcast<ColMsg, colHanVec>(msg.get()); break;
-    case 2: proxy.broadcast<ColMsg, colHanVecProxy>(msg.get()); break;
-    case 3: proxy.broadcast<ColMsg, colHanVecProxyCB>(msg.get()); break;
-    case 4: proxy.broadcast<ColMsg, colHanNoneCB>(msg.get()); break;
+    case 0: proxy.broadcastMsg<ColMsg, colHanBasic>(msg.get()); break;
+    case 1: proxy.broadcastMsg<ColMsg, colHanVec>(msg.get()); break;
+    case 2: proxy.broadcastMsg<ColMsg, colHanVecProxy>(msg.get()); break;
+    case 3: proxy.broadcastMsg<ColMsg, colHanVecProxyCB>(msg.get()); break;
+    case 4: proxy.broadcastMsg<ColMsg, colHanNoneCB>(msg.get()); break;
 
       #if ENABLE_REDUCE_EXPR_CALLBACK
-    case 5: proxy.broadcast<ColMsg, colHanPartial>(msg.get()); break;
-    case 6: proxy.broadcast<ColMsg, colHanPartialMulti>(msg.get()); break;
-    case 7: proxy.broadcast<ColMsg, colHanPartialProxy>(msg.get()); break;
+    case 5: proxy.broadcastMsg<ColMsg, colHanPartial>(msg.get()); break;
+    case 6: proxy.broadcastMsg<ColMsg, colHanPartialMulti>(msg.get()); break;
+    case 7: proxy.broadcastMsg<ColMsg, colHanPartialProxy>(msg.get()); break;
       #endif
       default: vtAbort("Failure: should not be reached");
     }

--- a/tests/unit/collection/test_reduce_collection.cc
+++ b/tests/unit/collection/test_reduce_collection.cc
@@ -59,19 +59,18 @@ TEST_P(TestReduceCollection, test_reduce_op) {
     auto size = (reduce_case == 5 ? collect_size * 4 : collect_size);
     auto const& range = Index1D(size);
     auto proxy = theCollection()->construct<MyCol>(range);
-    auto msg = makeMessage<ColMsg>(my_node);
 
     switch (reduce_case) {
-    case 0: proxy.broadcastMsg<ColMsg, colHanBasic>(msg.get()); break;
-    case 1: proxy.broadcastMsg<ColMsg, colHanVec>(msg.get()); break;
-    case 2: proxy.broadcastMsg<ColMsg, colHanVecProxy>(msg.get()); break;
-    case 3: proxy.broadcastMsg<ColMsg, colHanVecProxyCB>(msg.get()); break;
-    case 4: proxy.broadcastMsg<ColMsg, colHanNoneCB>(msg.get()); break;
+    case 0: proxy.broadcast<ColMsg, colHanBasic>(my_node); break;
+    case 1: proxy.broadcast<ColMsg, colHanVec>(my_node); break;
+    case 2: proxy.broadcast<ColMsg, colHanVecProxy>(my_node); break;
+    case 3: proxy.broadcast<ColMsg, colHanVecProxyCB>(my_node); break;
+    case 4: proxy.broadcast<ColMsg, colHanNoneCB>(my_node); break;
 
       #if ENABLE_REDUCE_EXPR_CALLBACK
-    case 5: proxy.broadcastMsg<ColMsg, colHanPartial>(msg.get()); break;
-    case 6: proxy.broadcastMsg<ColMsg, colHanPartialMulti>(msg.get()); break;
-    case 7: proxy.broadcastMsg<ColMsg, colHanPartialProxy>(msg.get()); break;
+    case 5: proxy.broadcast<ColMsg, colHanPartial>(my_node); break;
+    case 6: proxy.broadcast<ColMsg, colHanPartialMulti>(my_node); break;
+    case 7: proxy.broadcast<ColMsg, colHanPartialProxy>(my_node); break;
       #endif
       default: vtAbort("Failure: should not be reached");
     }

--- a/tests/unit/collection/test_send.h
+++ b/tests/unit/collection/test_send.h
@@ -153,7 +153,7 @@ TYPED_TEST_P(TestCollectionSend, test_collection_send_1) {
       auto msg = makeMessage<MsgType>(args);
       //proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg);
       if (i % 2 == 0) {
-        proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg.get());
+        proxy[i].template sendMsg<MsgType,SendHandlers<ColType>::handler>(msg.get());
       } else {
         theCollection()->sendMsg<MsgType,SendHandlers<ColType>::handler>(
           proxy[i], msg.get()
@@ -178,7 +178,7 @@ TYPED_TEST_P(TestCollectionSendMem, test_collection_send_ptm_1) {
       auto msg = makeMessage<MsgType>(args);
       //proxy[i].template send<MsgType,SendHandlers<ColType>::handler>(msg);
       if (i % 2 == 0) {
-        proxy[i].template send<MsgType,&ColType::handler>(msg.get());
+        proxy[i].template sendMsg<MsgType,&ColType::handler>(msg.get());
       } else {
         theCollection()->sendMsg<MsgType,&ColType::handler>(
           proxy[i], msg.get()

--- a/tests/unit/pipe/test_callback_bcast_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_bcast_collection.extended.cc
@@ -151,7 +151,7 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_1) {
   runInEpochCollective([&]{
     if (this_node == 0) {
       auto msg = makeMessage<TestColMsg>();
-      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }
@@ -184,7 +184,7 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_2) {
   runInEpochCollective([&]{
     if (this_node == 0) {
       auto msg = makeMessage<TestColMsg>();
-      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }
@@ -217,7 +217,7 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_3) {
   runInEpochCollective([&]{
     if (this_node == 0) {
       auto msg = makeMessage<TestColMsg>();
-      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }

--- a/tests/unit/pipe/test_callback_bcast_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_bcast_collection.extended.cc
@@ -150,8 +150,7 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_1) {
 
   runInEpochCollective([&]{
     if (this_node == 0) {
-      auto msg = makeMessage<TestColMsg>();
-      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcast<TestColMsg, &TestCol::check>();
     }
   });
 }
@@ -183,8 +182,7 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_2) {
 
   runInEpochCollective([&]{
     if (this_node == 0) {
-      auto msg = makeMessage<TestColMsg>();
-      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcast<TestColMsg, &TestCol::check>();
     }
   });
 }
@@ -216,8 +214,7 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_3) {
 
   runInEpochCollective([&]{
     if (this_node == 0) {
-      auto msg = makeMessage<TestColMsg>();
-      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcast<TestColMsg, &TestCol::check>();
     }
   });
 }

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -157,8 +157,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
 
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
-      auto msg = makeMessage<TestColMsg>();
-      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcast<TestColMsg, &TestCol::check>();
     }
   });
 }
@@ -200,8 +199,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
 
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
-      auto msg = makeMessage<TestColMsg>();
-      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcast<TestColMsg, &TestCol::check>();
     }
   });
 }
@@ -235,8 +233,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
 
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
-      auto msg = makeMessage<TestColMsg>();
-      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcast<TestColMsg, &TestCol::check>();
     }
   });
 }

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -158,7 +158,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
       auto msg = makeMessage<TestColMsg>();
-      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }
@@ -201,7 +201,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
       auto msg = makeMessage<TestColMsg>();
-      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }
@@ -236,7 +236,7 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
   runInEpochCollective([this_node, proxy]{
     if (this_node == 0) {
       auto msg = makeMessage<TestColMsg>();
-      proxy.broadcast<TestColMsg, &TestCol::check>(msg.get());
+      proxy.broadcastMsg<TestColMsg, &TestCol::check>(msg.get());
     }
   });
 }

--- a/tests/unit/scheduler/test_scheduler_priorities.extended.cc
+++ b/tests/unit/scheduler/test_scheduler_priorities.extended.cc
@@ -225,7 +225,7 @@ struct ObjGroup {
         "NEW enqueue: priority={:x}, level={:x}\n", np, npl
       );
 
-      proxy[0].send<TestMsg,&ObjGroup::enqueue>(new_msg);
+      proxy[0].sendMsg<TestMsg,&ObjGroup::enqueue>(new_msg);
     }
   }
 

--- a/tutorial/tutorial_2a.h
+++ b/tutorial/tutorial_2a.h
@@ -98,7 +98,7 @@ static inline void collection() {
 
     // Send a message to the 5th element of the collection
     auto msg2 = ::vt::makeMessage<MyCollMsg>();
-    proxy[5].send<MyCollMsg,&MyCol::msgHandler>(msg2.get());
+    proxy[5].sendMsg<MyCollMsg,&MyCol::msgHandler>(msg2.get());
   }
 }
 /// [Tutorial2A]

--- a/tutorial/tutorial_2a.h
+++ b/tutorial/tutorial_2a.h
@@ -94,7 +94,7 @@ static inline void collection() {
     // Broadcast a message to the entire collection. The msgHandler will be
     // invoked on every element to the collection
     auto msg = ::vt::makeMessage<MyCollMsg>();
-    proxy.broadcast<MyCollMsg,&MyCol::msgHandler>(msg.get());
+    proxy.broadcastMsg<MyCollMsg,&MyCol::msgHandler>(msg.get());
 
     // Send a message to the 5th element of the collection
     auto msg2 = ::vt::makeMessage<MyCollMsg>();

--- a/tutorial/tutorial_2a.h
+++ b/tutorial/tutorial_2a.h
@@ -93,12 +93,10 @@ static inline void collection() {
 
     // Broadcast a message to the entire collection. The msgHandler will be
     // invoked on every element to the collection
-    auto msg = ::vt::makeMessage<MyCollMsg>();
-    proxy.broadcastMsg<MyCollMsg,&MyCol::msgHandler>(msg.get());
+    proxy.broadcast<MyCollMsg,&MyCol::msgHandler>();
 
     // Send a message to the 5th element of the collection
-    auto msg2 = ::vt::makeMessage<MyCollMsg>();
-    proxy[5].sendMsg<MyCollMsg,&MyCol::msgHandler>(msg2.get());
+    proxy[5].send<MyCollMsg,&MyCol::msgHandler>();
   }
 }
 /// [Tutorial2A]

--- a/tutorial/tutorial_2b.h
+++ b/tutorial/tutorial_2b.h
@@ -123,8 +123,7 @@ static inline void collectionReduce() {
 
     // Broadcast a message to the entire collection. The reduceHandler will be
     // invoked on every element to the collection
-    auto msg = ::vt::makeMessage<ColRedMsg>();
-    proxy.broadcastMsg<ColRedMsg,&ReduceCol::reduceHandler>(msg.get());
+    proxy.broadcast<ColRedMsg,&ReduceCol::reduceHandler>();
   }
 }
 /// [Tutorial2B]

--- a/tutorial/tutorial_2b.h
+++ b/tutorial/tutorial_2b.h
@@ -124,7 +124,7 @@ static inline void collectionReduce() {
     // Broadcast a message to the entire collection. The reduceHandler will be
     // invoked on every element to the collection
     auto msg = ::vt::makeMessage<ColRedMsg>();
-    proxy.broadcast<ColRedMsg,&ReduceCol::reduceHandler>(msg.get());
+    proxy.broadcastMsg<ColRedMsg,&ReduceCol::reduceHandler>(msg.get());
   }
 }
 /// [Tutorial2B]


### PR DESCRIPTION
What needs to be done:

1. Add colective bcast for collection:
- [x] with member msg hanldler
- [x] with non-member msg hanldler
- [x] lb and trace related calls
2. Add unittests:
- [x] for member handler version
- [x] for non-member handler version

3. Add documentation:
- [x]  documentation

Fixes #1024 