### PR TITLE
1075 Run PR description when edited

### DIFF
--- a/.github/workflows/check-pr-comment-fixes-issue.yml
+++ b/.github/workflows/check-pr-comment-fixes-issue.yml
@@ -1,6 +1,8 @@
 name: PR checks (PR description format)
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   check:


### PR DESCRIPTION
Fixes #1075

The check should run when edited now! The default set is:

> By default, a workflow only runs when a pull_request_target's activity type is opened, synchronize, or reopened. To trigger workflows for more activity types, use the types keyword. For more information, see "Workflow syntax for GitHub Actions."

Removing the set made it not run on `edited`. This should fix the problem