### PR TITLE
#1069 runtime - don't re-initialize MPI in interop mode

### DIFF
--- a/src/vt/collective/collective_ops.cc
+++ b/src/vt/collective/collective_ops.cc
@@ -63,9 +63,11 @@ RuntimePtrType CollectiveAnyOps<instance>::initialize(
   using vt::runtime::Runtime;
   using vt::runtime::eRuntimeInstance;
 
+  MPI_Comm resolved_comm = comm not_eq nullptr ? *comm : MPI_COMM_WORLD;
+
 #pragma sst global rt
   RuntimeInst<instance>::rt = std::make_unique<Runtime>(
-    argc, argv, num_workers, is_interop, comm
+    argc, argv, num_workers, is_interop, resolved_comm
   );
 
 #pragma sst global rt

--- a/src/vt/configs/arguments/app_config.h
+++ b/src/vt/configs/arguments/app_config.h
@@ -209,9 +209,6 @@ struct AppConfig {
   /// Original char* object.
   char* argv_prog_name {const_cast<char*>("vt_unknown")};
 
-  /// Arguments to pass to MPI Init.
-  /// Does not include argv[0]. Original char* objects.
-  std::vector<char*> mpi_init_args;
   /// Arguments are being ref-returend as the result of parse(..).
   /// Does not include argv[0]. Original char* objects.
   std::vector<char*> passthru_args;

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -466,18 +466,17 @@ public:
     u << "\n"
 "Usage:"
 "\n"
-"[APP-ARGS..] [VT-ARGS] [--vt_mpi_args MPI-ARGS..] [-- APP-ARGS..]\n"
+"[APP-ARGS..] [VT-ARGS] [-- APP-ARGS..]\n"
 "\n"
 "Arguments up until the first '--vt_*' are treated as application arguments.\n"
 "\n"
 "After the first '--vt_*', additional arguments are treated as VT arguments\n"
-"unless '--vt_mpi_args' or '--' are used to switch the argument mode.\n"
+"unless '--' is used to switch the argument mode back to application args.\n"
 "The '--vt_args' flag can be used to switch back into VT argument mode.\n"
 "Modes can be switched indefinitely.\n"
 "\n"
 "Application pass-through arguments are supplied to the host program\n"
 "for further processing and are not used by VT for any configuration.\n"
-"MPI (and only MPI) arguments are given directly to MPI_Init.\n"
 "\n"
 "It is an error if an unexpected argument is encountered in VT argument mode.\n"
 "The currently recognized VT arguments are listed below; availability varies\n"
@@ -548,7 +547,6 @@ void ArgConfig::postParseTransform() {
 std::tuple<int, std::string> ArgConfig::parseArguments(CLI::App& app, int& argc, char**& argv) {
 
   std::vector<char*> vt_args;
-  std::vector<char*> mpi_args;
 
   // Load up vectors (has curious ability to altnerate vt/mpi/passthru)
   std::vector<char*>* rargs = nullptr;
@@ -556,8 +554,6 @@ std::tuple<int, std::string> ArgConfig::parseArguments(CLI::App& app, int& argc,
     char* c = argv[i];
     if (0 == strcmp(c, "--vt_args")) {
       rargs = &vt_args;
-    } else if (0 == strcmp(c, "--vt_mpi_args")) {
-      rargs = &mpi_args;
     } else if (0 == strcmp(c, "--")) {
       rargs = &config_.passthru_args;
     } else if (rargs) {
@@ -616,12 +612,10 @@ std::tuple<int, std::string> ArgConfig::parseArguments(CLI::App& app, int& argc,
 
   config_.prog_name = clean_prog_name;
   config_.argv_prog_name = argv[0];
-  config_.mpi_init_args = mpi_args;
 
   postParseTransform();
 
   // Rebuild passthru into ref-returned argc/argv
-  // (only pass-through, not MPI_Init-bound)
 
   // It should be possible to modify the original argv as the outgoing
   // number of arguments is always less. As currently allocated here,

--- a/src/vt/context/context.h
+++ b/src/vt/context/context.h
@@ -69,11 +69,16 @@ namespace vt {  namespace ctx {
  * functionality analogous to \c MPI_Comm_size and \c MPI_Comm_rank.
  */
 struct Context : runtime::component::Component<Context> {
-  /// Constructor with interop and args, not called by the user directly
-  Context(int argc, char** argv, bool const interop, MPI_Comm* comm = nullptr);
-
-  /// Constructor with only interop, not called by the user directly
-  Context(bool const interop, MPI_Comm* comm = nullptr);
+  /**
+   * \internal
+   * \brief Construct the context.
+   *
+   * \note MPI must already have been appropriately initialized.
+   *
+   * \param[in] interop running in interop mode?
+   * \param[in] comm the communicator
+   */
+  Context(bool const interop, MPI_Comm comm);
 
   /**
    * \brief Gets the current node (analagous to MPI's rank) currently being

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -125,8 +125,9 @@ Runtime::Runtime(
   ///   re-initialized \c arg_config_ will contain the configuration.
   ///
   ///  For this to all work correctly, the \c vt_debug_print infrastructure
-  ///  calls \c vt::config::getConfig() which always grabs the correct app
-  ///  config, either from the component singleton or the \c vt::Runtime
+  ///  calls \c vt::config::preConfig() which always grabs the correct app
+  ///  config, from the component singleton or the \c vt::Runtime,
+  ///  or provides stubbed arguments as a fallback.
   ///
   /// =========================================================================
 
@@ -171,8 +172,6 @@ Runtime::Runtime(
   setupSignalHandler();
   setupSignalHandlerINT();
   setupTerminateHandler();
-
-  setupArgs();
 }
 
 bool Runtime::hasSchedRun() const {
@@ -605,17 +604,6 @@ void Runtime::setup() {
   vt_debug_print(runtime, node, "end: setup\n");
 }
 
-void Runtime::setupArgs() {
-  std::vector<char*>& mpi_args = arg_config_->config_.mpi_init_args;
-  user_argc_ = mpi_args.size() + 1;
-  user_argv_ = std::make_unique<char*[]>(user_argc_ + 1);
-
-  int i = 0;
-  user_argv_[i++] = arg_config_->config_.argv_prog_name;
-  for (char*& arg : mpi_args) {
-    user_argv_[i++] = arg;
-  }
-  user_argv_[i++] = nullptr;
 void Runtime::initializeComponents() {
   vt_debug_print(runtime, node, "begin: initializeComponents\n");
 

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -131,10 +131,20 @@ Runtime::Runtime(
   ///
   /// =========================================================================
 
-  // Always initialize MPI first, before handling arguments.
-  // This also allows MPI a first-stab at dealing with arguments.
+  int prev_initialized;
+  MPI_Initialized(&prev_initialized);
+
   if (not is_interop_) {
+    vtAbortIf(
+      prev_initialized, "MPI is already initialzed. Run VT under interop-mode?"
+    );
+    // Always initialize MPI first, before handling arguments.
+    // This also allows MPI a first-stab at dealing with arguments.
     MPI_Init(&argc, &argv);
+  } else {
+    vtAbortIf(
+      not prev_initialized, "MPI must be already initialized in VT interop-mode."
+    );
   }
 
   // n.b. ref-update of args with pass-through arguments

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -84,6 +84,9 @@ struct Runtime {
   /**
    * \internal \brief Initialize a VT runtime
    *
+   * Under interop mode, MPI is not initialized or finalized by the runtime.
+   * This can be used to embed VT into a larger context.
+   *
    * \param[in] argc argument count (modified after VT extracts)
    * \param[in] argv arguments  (modified after VT extracts)
    * \param[in] in_num_workers number of worker threads to initialize
@@ -93,7 +96,8 @@ struct Runtime {
    */
   Runtime(
     int& argc, char**& argv,
-    WorkerCountType in_num_workers = no_workers, bool const interop_mode = false,
+    WorkerCountType in_num_workers = no_workers,
+    bool const interop_mode = false,
     MPI_Comm* in_comm = nullptr,
     RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance
   );

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -267,11 +267,6 @@ protected:
   bool tryFinalize(bool const disable_sig = true);
 
   /**
-   * \internal \brief Setup argument input
-   */
-  void setupArgs();
-
-  /**
    * \internal \brief Initialize error handlers
    */
   void initializeErrorHandlers();
@@ -432,8 +427,6 @@ protected:
   bool sig_handlers_disabled_ = false;
   WorkerCountType num_workers_ = no_workers;
   MPI_Comm communicator_ = MPI_COMM_NULL;
-  int user_argc_ = 0;
-  std::unique_ptr<char*[]> user_argv_ = nullptr;
   std::unique_ptr<component::ComponentPack> p_;
   std::unique_ptr<arguments::ArgConfig> arg_config_;
   arguments::AppConfig const* app_config_;   /**< App config during startup */

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -87,6 +87,9 @@ struct Runtime {
    * Under interop mode, MPI is not initialized or finalized by the runtime.
    * This can be used to embed VT into a larger context.
    *
+   * When not running in interop mode, MPI is initialized in the constructor
+   * and finalized in the destructor.
+   *
    * \param[in] argc argument count (modified after VT extracts)
    * \param[in] argv arguments  (modified after VT extracts)
    * \param[in] in_num_workers number of worker threads to initialize
@@ -98,7 +101,7 @@ struct Runtime {
     int& argc, char**& argv,
     WorkerCountType in_num_workers = no_workers,
     bool const interop_mode = false,
-    MPI_Comm* in_comm = nullptr,
+    MPI_Comm in_comm = MPI_COMM_WORLD,
     RuntimeInstType const in_instance = RuntimeInstType::DefaultInstance
   );
 
@@ -296,11 +299,6 @@ protected:
    * \return whether we should create it
    */
   bool needStatsRestartReader();
-
-  /**
-   * \internal \brief Finalize MPI
-   */
-  void finalizeMPI();
 
   /**
    * \internal \brief Perform a synchronization during startup/shutdown using an

--- a/src/vt/runtime/runtime_banner.cc
+++ b/src/vt/runtime/runtime_banner.cc
@@ -780,20 +780,12 @@ void Runtime::printStartupBanner() {
   auto f88 = fmt::format("{}Pass-through Arguments:{}\n", green, reset);
   fmt::print("{}{}{}", vt_pre, f88, reset);
 
-  std::vector<char*> const& mpi_args = getAppConfig()->mpi_init_args;
   std::vector<char*> const& passthru_args = getAppConfig()->passthru_args;
 
-  if (mpi_args.empty() and passthru_args.empty()) {
+  if (passthru_args.empty()) {
     auto f11 = fmt::format("None. All arguments handled.\n");
     fmt::print("{}\t{}{}", vt_pre, f11, reset);
   } else {
-    if (not mpi_args.empty()) {
-      auto f11 = fmt::format(
-        "MPI Init args: [{}]\n",
-        arg_str(mpi_args)
-      );
-      fmt::print("{}\t{}{}", vt_pre, f11, reset);
-    }
     if (not passthru_args.empty()) {
       auto f11 = fmt::format(
         "Application args: [{}]\n",


### PR DESCRIPTION
Don't crash processes by attempting to improperly call MPI_Init again.

Will still terminate a process, with diagnostic message, when there are invalid VT args. Invalid args are limited to those in the form `--vt_bad`.

Also moved any MPI_Init (when not interop) into the Runtime class itself, for parity with MPI_Finalize, full reliance on MPI_Init eating its own arguments, and some future update work.

Minor breaking: `--vt_mpi_args` is redundant and no longer supported.

fixes #1069 