### PR TITLE
1092 - Use communicator given to VT Runtime; don't assume MPI_COMM_WORLD

### DIFF
--- a/src/vt/context/context.cc
+++ b/src/vt/context/context.cc
@@ -63,11 +63,8 @@ Context::Context(bool const is_interop, MPI_Comm comm) {
     );
   #endif
 
-  is_comm_world_ = comm == MPI_COMM_WORLD;
-
-  if (is_interop) {
-    MPI_Comm_dup(comm, &comm);
-  }
+  // Always duplicate, which may be MPI_COMM_WORLD.
+  MPI_Comm_dup(comm, &comm);
 
   int numNodesLocal = uninitialized_destination;
   int thisNodeLocal = uninitialized_destination;
@@ -80,6 +77,10 @@ Context::Context(bool const is_interop, MPI_Comm comm) {
   thisNode_ = static_cast<NodeType>(thisNodeLocal);
 
   setDefaultWorker();
+}
+
+Context::~Context() {
+  MPI_Comm_free(&communicator_);
 }
 
 void Context::setDefaultWorker() {

--- a/src/vt/context/context.h
+++ b/src/vt/context/context.h
@@ -80,6 +80,8 @@ struct Context : runtime::component::Component<Context> {
    */
   Context(bool const interop, MPI_Comm comm);
 
+  ~Context();
+
   /**
    * \brief Gets the current node (analagous to MPI's rank) currently being
    * used.
@@ -106,14 +108,6 @@ struct Context : runtime::component::Component<Context> {
    * \return the \c MPI_Comm being used by VT for communication
    */
   inline MPI_Comm getComm() const { return communicator_; }
-
-  /**
-   * \brief Informs whether the MPI_Comm being used by the runtime is
-   * \c MPI_COMM_WORLD
-   *
-   * \return whether \c MPI_COMM_WORLD is being used
-   */
-  inline bool isCommWorld() const { return is_comm_world_; }
 
   /**
    * \brief Relevant only in threaded mode (e.g., \c std::thread, or OpenMP
@@ -167,7 +161,6 @@ private:
   NodeType thisNode_ = uninitialized_destination;
   NodeType numNodes_ = uninitialized_destination;
   WorkerCountType numWorkers_ = no_workers;
-  bool is_comm_world_ = true;
   MPI_Comm communicator_ = MPI_COMM_WORLD;
   DeclareClassInsideInitTLS(Context, WorkerIDType, thisWorker_, no_worker_id)
 };

--- a/src/vt/group/collective/group_info_collective.cc
+++ b/src/vt/group/collective/group_info_collective.cc
@@ -98,14 +98,14 @@ void InfoColl::setupCollectiveSingular() {
 }
 
 MPI_Comm InfoColl::getComm() const {
-  return mpi_group_comm;
+  return mpi_group_comm_;
 }
 
 void InfoColl::freeComm() {
-  if (mpi_group_comm != MPI_COMM_WORLD) {
+  if (mpi_group_comm_ not_eq default_comm_) {
     theGroup()->collective_scope_.mpiCollectiveWait([this]{
-      MPI_Comm_free(&mpi_group_comm);
-      mpi_group_comm = MPI_COMM_WORLD;
+      MPI_Comm_free(&mpi_group_comm_);
+      mpi_group_comm_ = default_comm_;
     });
   }
 }
@@ -147,7 +147,7 @@ void InfoColl::setupCollective() {
         auto const this_node_impl = theContext()->getNode();
         auto const cur_comm = theContext()->getComm();
         int32_t const group_color = in_group;
-        MPI_Comm_split(cur_comm, group_color, this_node_impl, &mpi_group_comm);
+        MPI_Comm_split(cur_comm, group_color, this_node_impl, &mpi_group_comm_);
       }
     );
   }

--- a/src/vt/group/collective/group_info_collective.h
+++ b/src/vt/group/collective/group_info_collective.h
@@ -68,9 +68,13 @@ struct InfoColl : virtual InfoBase {
   using ReducePtrType          = ReduceType*;
   using GroupCollMsgPtrType    = MsgSharedPtr<GroupCollectiveMsg>;
 
-  explicit InfoColl(bool const in_is_in_group, bool make_mpi_group)
-    : is_in_group(in_is_in_group), make_mpi_group_(make_mpi_group)
-  { }
+  explicit InfoColl(bool const in_is_in_group, MPI_Comm default_comm, bool make_mpi_group)
+    : is_in_group(in_is_in_group),
+      default_comm_(default_comm),
+      mpi_group_comm_(default_comm),
+      make_mpi_group_(make_mpi_group)
+  {
+  }
 
 private:
   /*
@@ -147,8 +151,10 @@ private:
   std::list<ActionType> pending_ready_actions_ = {};
 
 private:
-  MPI_Comm mpi_group_comm = MPI_COMM_WORLD;
-  bool make_mpi_group_    = false;
+  //< Default, NON-OWNED, communicator.
+  MPI_Comm default_comm_   = MPI_COMM_NULL;
+  MPI_Comm mpi_group_comm_ = MPI_COMM_NULL;
+  bool make_mpi_group_     = false;
 };
 
 }} /* end namespace vt::group */

--- a/src/vt/group/group_info.cc
+++ b/src/vt/group/group_info.cc
@@ -65,6 +65,7 @@ const bool IsInGroup = true;
 const bool MakeMpiGroup = true;
 
 Info::Info(
+  MPI_Comm comm,
   bool const& in_is_collective, ActionType in_action, GroupType const in_group,
   bool const& in_is_remote, bool const& in_is_in_group, RegionPtrType in_region,
   RegionType::SizeType const& in_total_size, bool make_mpi_group
@@ -72,35 +73,39 @@ Info::Info(
       in_is_remote, in_region ? std::move(in_region) : nullptr, in_total_size
     ),
     InfoColl(
-      in_is_in_group, make_mpi_group
+      in_is_in_group, comm, make_mpi_group
     ),
     group_(in_group), is_collective_(in_is_collective),
     finished_setup_action_(in_action)
 { }
 
 Info::Info(
-  InfoRootedLocalConsType, RegionPtrType in_region, ActionType in_action,
+  InfoRootedLocalConsType,
+  MPI_Comm comm, RegionPtrType in_region, ActionType in_action,
   GroupType const in_group, RegionType::SizeType const& in_total_size
 ) : Info(
-      not InCollective, in_action, in_group, not IsRemote, not IsInGroup,
+      comm, not InCollective, in_action, in_group, not IsRemote, not IsInGroup,
       std::move(in_region), in_total_size, not MakeMpiGroup
     )
 { }
 
 Info::Info(
-  InfoRootedRemoteConsType, RegionPtrType in_region, GroupType const in_group,
+  InfoRootedRemoteConsType,
+  MPI_Comm comm, RegionPtrType in_region, GroupType const in_group,
   RegionType::SizeType const& in_total_size
 ) : Info(
-      not InCollective, nullptr, in_group, IsRemote, not IsInGroup,
+      comm, not InCollective, nullptr, in_group, IsRemote, not IsInGroup,
       std::move(in_region), in_total_size, not MakeMpiGroup
     )
 { }
 
 Info::Info(
-  InfoCollectiveConsType, ActionType in_action, GroupType const in_group,
+  InfoCollectiveConsType,
+  MPI_Comm comm,
+  ActionType in_action, GroupType const in_group,
   bool const in_is_in_group, bool make_mpi_group
 ) : Info(
-      InCollective, in_action, in_group, not IsRemote, in_is_in_group,
+      comm, InCollective, in_action, in_group, not IsRemote, in_is_in_group,
       nullptr, 0, make_mpi_group
     )
 { }

--- a/src/vt/group/group_info.cc
+++ b/src/vt/group/group_info.cc
@@ -59,6 +59,11 @@
 
 namespace vt { namespace group {
 
+const bool InCollective = true;
+const bool IsRemote = true;
+const bool IsInGroup = true;
+const bool MakeMpiGroup = true;
+
 Info::Info(
   bool const& in_is_collective, ActionType in_action, GroupType const in_group,
   bool const& in_is_remote, bool const& in_is_in_group, RegionPtrType in_region,
@@ -74,21 +79,11 @@ Info::Info(
 { }
 
 Info::Info(
-  InfoRootedConsType, RegionPtrType in_region, ActionType in_action,
-  GroupType const in_group, RegionType::SizeType const& in_total_size,
-  bool const& in_is_remote
-) : Info(
-      false, in_action, in_group, in_is_remote, false, std::move(in_region),
-      in_total_size, false
-    )
-{ }
-
-Info::Info(
   InfoRootedLocalConsType, RegionPtrType in_region, ActionType in_action,
   GroupType const in_group, RegionType::SizeType const& in_total_size
 ) : Info(
-      info_rooted_cons, std::move(in_region), in_action, in_group,
-      in_total_size, false
+      not InCollective, in_action, in_group, not IsRemote, not IsInGroup,
+      std::move(in_region), in_total_size, not MakeMpiGroup
     )
 { }
 
@@ -96,15 +91,18 @@ Info::Info(
   InfoRootedRemoteConsType, RegionPtrType in_region, GroupType const in_group,
   RegionType::SizeType const& in_total_size
 ) : Info(
-      info_rooted_cons, std::move(in_region), nullptr, in_group,
-      in_total_size, true
+      not InCollective, nullptr, in_group, IsRemote, not IsInGroup,
+      std::move(in_region), in_total_size, not MakeMpiGroup
     )
 { }
 
 Info::Info(
   InfoCollectiveConsType, ActionType in_action, GroupType const in_group,
-  bool const in_is_in_group, bool mpi
-) : Info(true, in_action, in_group, false, in_is_in_group, nullptr, 0, mpi)
+  bool const in_is_in_group, bool make_mpi_group
+) : Info(
+      InCollective, in_action, in_group, not IsRemote, in_is_in_group,
+      nullptr, 0, make_mpi_group
+    )
 { }
 
 void Info::setup() {

--- a/src/vt/group/group_info.h
+++ b/src/vt/group/group_info.h
@@ -68,7 +68,6 @@ static constexpr size_t const max_region_list_size = 4;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
-static struct InfoRootedConsType {} info_rooted_cons {};
 static struct InfoRootedLocalConsType {} info_rooted_local_cons {};
 static struct InfoRootedRemoteConsType {} info_rooted_remote_cons {};
 static struct InfoCollectiveConsType {} info_collective_cons {};
@@ -84,12 +83,6 @@ protected:
     GroupType const in_group, bool const& in_is_remote,
     bool const& in_is_in_group, RegionPtrType in_region,
     RegionType::SizeType const& in_total_size, bool make_mpi_group
-  );
-
-  Info(
-    InfoRootedConsType, RegionPtrType in_region, ActionType in_action,
-    GroupType const in_group, RegionType::SizeType const& total_size,
-    bool const& in_is_remote
   );
 
 public:

--- a/src/vt/group/group_info.h
+++ b/src/vt/group/group_info.h
@@ -79,6 +79,7 @@ struct Info : InfoRooted, InfoColl {
 
 protected:
   Info(
+    MPI_Comm comm,
     bool const& in_is_collective, ActionType in_action,
     GroupType const in_group, bool const& in_is_remote,
     bool const& in_is_in_group, RegionPtrType in_region,
@@ -87,17 +88,20 @@ protected:
 
 public:
   Info(
-    InfoRootedLocalConsType, RegionPtrType in_region, ActionType in_action,
+    InfoRootedLocalConsType,
+    MPI_Comm comm, RegionPtrType in_region, ActionType in_action,
     GroupType const in_group, RegionType::SizeType const& total_size
   );
 
   Info(
-    InfoRootedRemoteConsType, RegionPtrType in_region, GroupType const in_group,
+    InfoRootedRemoteConsType,
+    MPI_Comm comm, RegionPtrType in_region, GroupType const in_group,
     RegionType::SizeType const& total_size
   );
 
   Info(
-    InfoCollectiveConsType, ActionType in_action, GroupType const in_group,
+    InfoCollectiveConsType,
+    MPI_Comm comm, ActionType in_action, GroupType const in_group,
     bool const in_is_in_group, bool make_mpi_group
   );
 

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -181,7 +181,8 @@ void GroupManager::initializeRemoteGroup(
   RegionType::SizeType const group_size
 ) {
   auto group_info = std::make_unique<GroupInfoType>(
-    info_rooted_remote_cons, std::move(in_region), group, group_size
+    info_rooted_remote_cons, default_comm_,
+    std::move(in_region), group, group_size
   );
   auto group_ptr = group_info.get();
   remote_group_info_.emplace(
@@ -206,7 +207,7 @@ MPI_Comm GroupManager::getGroupComm(GroupType const group_id) {
   if (iter != local_collective_group_info_.end()) {
     return iter->second->getComm();
   } else {
-    return MPI_COMM_WORLD;
+    return default_comm_;
   }
 }
 
@@ -215,7 +216,8 @@ void GroupManager::initializeLocalGroupCollective(
   bool const in_group, bool make_mpi_group
 ) {
   auto group_info = std::make_unique<GroupInfoType>(
-    info_collective_cons, action, group, in_group, make_mpi_group
+    info_collective_cons, default_comm_,
+    action, group, in_group, make_mpi_group
   );
   auto group_ptr = group_info.get();
   local_collective_group_info_.emplace(
@@ -232,7 +234,8 @@ void GroupManager::initializeLocalGroup(
 
   auto const group_size = in_region->getSize();
   auto group_info = std::make_unique<GroupInfoType>(
-    info_rooted_local_cons, std::move(in_region), action, group, group_size
+    info_rooted_local_cons, default_comm_,
+    std::move(in_region), action, group, group_size
   );
   auto group_ptr = group_info.get();
   local_group_info_.emplace(
@@ -506,7 +509,8 @@ EventType GroupManager::sendGroup(
 }
 
 GroupManager::GroupManager()
-  : collective_scope_(theCollective()->makeCollectiveScope())
+  : default_comm_(theContext()->getComm()),
+    collective_scope_(theCollective()->makeCollectiveScope())
 {
   global::DefaultGroup::setupDefaultTree();
 }

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -179,8 +179,8 @@ struct GroupManager : runtime::component::Component<GroupManager> {
    *
    * \param[in] group_id the group ID
    *
-   * \return the MPI_Comm associated with the group; returns \c MPI_COMM_WORLD
-   * if group was created without a communicator
+   * \return the MPI_Comm associated with the group;
+   *         or the default communicator if none.
    */
   MPI_Comm getGroupComm(GroupType const group_id);
 
@@ -391,6 +391,8 @@ private:
   );
 
 private:
+  //< Default communicator to use when creating new groups.
+  MPI_Comm              default_comm_                 = MPI_COMM_NULL;
   GroupIDType           next_group_id_                = initial_group_id;
   GroupIDType           next_collective_group_id_     = initial_group_id;
   GroupContainerType    local_collective_group_info_  = {};

--- a/src/vt/rdmahandle/holder.impl.h
+++ b/src/vt/rdmahandle/holder.impl.h
@@ -70,17 +70,18 @@ void Holder<T,E>::allocateDataWindow(std::size_t const in_len) {
     "allocate: len={}, in_len={}, count_={}\n", len, in_len, count_
   );
   // Allocate data window
+  MPI_Comm comm = theContext()->getComm();
   MPI_Alloc_mem(len * sizeof(T), MPI_INFO_NULL, &data_base_);
   MPI_Win_create(
-    data_base_, len * sizeof(T), sizeof(T), MPI_INFO_NULL, MPI_COMM_WORLD,
+    data_base_, len * sizeof(T), sizeof(T), MPI_INFO_NULL, comm,
     &data_window_
   );
   if (not uniform_size_) {
     // Allocate control window
     MPI_Alloc_mem(sizeof(uint64_t), MPI_INFO_NULL, &control_base_);
     MPI_Win_create(
-      control_base_, sizeof(uint64_t), sizeof(uint64_t), MPI_INFO_NULL,
-      MPI_COMM_WORLD, &control_window_
+      control_base_, sizeof(uint64_t), sizeof(uint64_t), MPI_INFO_NULL, comm,
+      &control_window_
     );
     {
       auto this_node = theContext()->getNode();
@@ -92,7 +93,6 @@ void Holder<T,E>::allocateDataWindow(std::size_t const in_len) {
         "setting allocate size: size={}, window={}\n",
         count_, print_ptr(&control_window_)
       );
-
     }
   }
   ready_ = true;

--- a/src/vt/runtime/component/component_pack.cc
+++ b/src/vt/runtime/component/component_pack.cc
@@ -97,19 +97,6 @@ void ComponentPack::destruct() {
   }
 }
 
-std::unique_ptr<BaseComponent>
-ComponentPack::extractComponent(std::string const& name) {
-  std::unique_ptr<BaseComponent> ret = nullptr;
-  for (auto iter = live_components_.begin(); iter != live_components_.end(); ++iter) {
-    if ((*iter) != nullptr and (*iter)->name() == name) {
-      ret = std::move(*iter);
-      *iter = nullptr;
-      break;
-    }
-  }
-  return ret;
-}
-
 int ComponentPack::progress() {
   int total = 0;
   for (auto&& pollable : pollable_components_) {

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -116,13 +116,16 @@ public:
 
   /**
    * \internal \brief Extract the first component from a running pack that
-   * matches \c name
+   * matches \c name.
+   *
+   * The component will be cast to the specified component type \c T.
    *
    * \param[in] name the name of the component to remove
    *
    * \return pointer to the component to extract
    */
-  std::unique_ptr<BaseComponent> extractComponent(std::string const& name);
+  template <typename T>
+  std::unique_ptr<T> extractComponent(std::string const& name);
 
 private:
   /**

--- a/src/vt/runtime/component/component_pack.impl.h
+++ b/src/vt/runtime/component/component_pack.impl.h
@@ -126,6 +126,19 @@ void ComponentPack::add() {
   added_components_.insert(idx);
 }
 
+template <typename T>
+std::unique_ptr<T>
+ComponentPack::extractComponent(std::string const& name) {
+  for (auto iter = live_components_.begin(); iter != live_components_.end(); ++iter) {
+    if ((*iter) != nullptr and (*iter)->name() == name) {
+      T* raw = static_cast<T*>((*iter).release());
+      *iter = nullptr;
+      return std::unique_ptr<T>(raw);
+    }
+  }
+  return std::unique_ptr<T>(nullptr);
+}
+
 }}} /* end namespace vt::runtime::component */
 
 #endif /*INCLUDED_VT_RUNTIME_COMPONENT_COMPONENT_PACK_IMPL_H*/

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -388,7 +388,7 @@ bool Runtime::initialize(bool const force_now) {
 
     MPI_Comm comm = theContext->getComm();
 
-    sync(comm);
+    MPI_Barrier(comm);
     if (theContext->getNode() == 0) {
       printStartupBanner();
       // Enqueue a check for later in case arguments are modified before work
@@ -415,7 +415,7 @@ bool Runtime::initialize(bool const force_now) {
       sig_handlers_disabled_ = false;
     }
 
-    sync(comm);
+    MPI_Barrier(comm);
     initialized_ = true;
     return true;
   } else {
@@ -432,10 +432,10 @@ bool Runtime::finalize(bool const force_now, bool const disable_sig) {
     auto const is_zero = theContext->getNode() == 0;
     auto const num_units = theTerm->getNumUnits();
     auto const coll_epochs = theTerm->getNumTerminatedCollectiveEpochs();
-    sync(comm);
+    MPI_Barrier(comm);
     fflush(stdout);
     fflush(stderr);
-    sync(comm);
+    MPI_Barrier(comm);
 
     // Extract ArgConfig and keep it for use after VT is finalized
     arg_config_ = p_->extractComponent<vt::arguments::ArgConfig>("ArgConfig");
@@ -446,8 +446,8 @@ bool Runtime::finalize(bool const force_now, bool const disable_sig) {
 
     // Destroys and finalizes the remaining components in reverse initialization order
     p_.reset(nullptr);
-    sync(comm);
-    sync(comm);
+    MPI_Barrier(comm);
+    MPI_Barrier(comm);
 
     if (is_zero) {
       printShutdownBanner(num_units, coll_epochs);
@@ -460,7 +460,7 @@ bool Runtime::finalize(bool const force_now, bool const disable_sig) {
       sig_handlers_disabled_ = true;
     }
 
-    sync(comm);
+    MPI_Barrier(comm);
 
     theContext = nullptr; // used in some state checks
     context = nullptr;    // "use" to avoid warning
@@ -487,7 +487,7 @@ void Runtime::runScheduler() {
 
 void Runtime::reset() {
   MPI_Comm comm = theContext->getComm();
-  sync(comm);
+  MPI_Barrier(comm);
 
   runtime_active_ = true;
 
@@ -495,7 +495,7 @@ void Runtime::reset() {
   theTerm->addDefaultAction(action);
   theTerm->resetGlobalTerm();
 
-  sync(comm);
+  MPI_Barrier(comm);
 
   // Without workers running on the node, the termination detector should
   // assume its locally ready to propagate instead of waiting for them to

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -225,7 +225,7 @@ struct Runtime {
    *
    * \todo Remove this and fix the single one callsite in \c NodeStats
    */
-  void systemSync() { sync(); }
+  void systemSync();
 
 public:
   /**
@@ -296,10 +296,11 @@ protected:
   bool needStatsRestartReader();
 
   /**
-   * \internal \brief Perform a synchronization during startup/shutdown using an
-   * \c MPI_Barrier
+   * \internal \brief Perform a synchronization during startup/shutdown.
+   *
+   * \param[in] comm the communicator to use
    */
-  void sync();
+  void sync(MPI_Comm comm);
 
   /**
    * \internal \brief Perform setup actions, such as registering a termination
@@ -426,7 +427,8 @@ protected:
   bool is_interop_ = false;
   bool sig_handlers_disabled_ = false;
   WorkerCountType num_workers_ = no_workers;
-  MPI_Comm communicator_ = MPI_COMM_NULL;
+  //< Communicator to be given to theContext creation; don't use otherwise.
+  MPI_Comm initial_communicator_ = MPI_COMM_NULL;
   std::unique_ptr<component::ComponentPack> p_;
   std::unique_ptr<arguments::ArgConfig> arg_config_;
   arguments::AppConfig const* app_config_;   /**< App config during startup */

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -296,13 +296,6 @@ protected:
   bool needStatsRestartReader();
 
   /**
-   * \internal \brief Perform a synchronization during startup/shutdown.
-   *
-   * \param[in] comm the communicator to use
-   */
-  void sync(MPI_Comm comm);
-
-  /**
    * \internal \brief Perform setup actions, such as registering a termination
    * detector action for detecting global termination
    */

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -76,6 +76,9 @@ struct MPISingletonMultiTest {
     MPI_Finalize();
   }
 
+public:
+  const MPI_Comm getComm() { return comm_; }
+
 private:
   MPI_Comm comm_;
 };
@@ -95,10 +98,12 @@ struct TestParallelHarnessAny : TestHarnessAny<TestBase> {
         std::make_unique<MPISingletonMultiTest>(test_argc, test_argv);
     }
 
+    // communicator is duplicated.
+    MPI_Comm comm = mpi_singleton->getComm();
     auto const new_args = injectAdditionalArgs(test_argc, test_argv);
     auto custom_argc = new_args.first;
     auto custom_argv = new_args.second;
-    CollectiveOps::initialize(custom_argc, custom_argv, no_workers, true);
+    CollectiveOps::initialize(custom_argc, custom_argv, no_workers, true, &comm);
 
 #if vt_feature_cmake_test_trace_on
     vt::theConfig()->vt_trace = true;


### PR DESCRIPTION
Increases uniformity of communicator lifetimes and ensures that all VT constructs are limited to the supplied communicator.

Previously, various constructs could apply the MPI_COMM_WORLD, even under an 'interop' mode.

Some of these commits are from #1069 which is expected to be merged first.

fixes #1092 