### PR TITLE
1094 Fix collective scope de-allocation

### DIFF
--- a/src/vt/collective/collective_alg.cc
+++ b/src/vt/collective/collective_alg.cc
@@ -75,6 +75,12 @@ CollectiveScope CollectiveAlg::makeCollectiveScope(TagType in_scope_tag) {
   return CollectiveScope(is_user_tag, scope_tag);
 }
 
+bool CollectiveAlg::isDeallocated(bool is_user_tag, TagType scope_bits) const {
+  auto const& scopes = is_user_tag ? user_scope_ : system_scope_ ;
+  auto iter = scopes.find(scope_bits);
+  return iter == scopes.end();
+}
+
 // We can not use a VT broadcast here because it involves the scheduler and
 // MPI progress and there's no safe way to guarantee that the message has been
 // received and processed and doesn't require progress from another node

--- a/src/vt/collective/collective_alg.h
+++ b/src/vt/collective/collective_alg.h
@@ -132,6 +132,19 @@ private:
 
   static void runCollective(CollectiveMsg* msg);
 
+public:
+  /**
+   * \internal \brief Check if a scope has been deallocated
+   *
+   * \note Used for testing purposes
+   *
+   * \param[in] is_user_tag whether it's a user-tagged scope
+   * \param[in] scope_bits the scope bits
+   *
+   * \return whether it is deallocated
+   */
+  bool isDeallocated(bool is_user_tag, TagType scope_bits) const;
+
 private:
   using ScopeMapType = std::unordered_map<TagType, std::unique_ptr<detail::ScopeImpl>>;
 

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -55,6 +55,7 @@ namespace vt { namespace collective {
 
 TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
   auto impl = getScope();
+  vtAssert(impl != nullptr, "Must have a valid, allocated scope");
   auto tag = impl->next_seq_++;
   auto epoch = theMsg()->getEpoch();
 
@@ -99,6 +100,7 @@ TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
 
 bool CollectiveScope::isCollectiveDone(TagType tag) {
   auto impl = getScope();
+  vtAssert(impl != nullptr, "Must have a valid, allocated scope");
   return impl->planned_collective_.find(tag) == impl->planned_collective_.end();
 }
 
@@ -111,6 +113,10 @@ void CollectiveScope::mpiCollectiveWait(ActionType action) {
 }
 
 detail::ScopeImpl* CollectiveScope::getScope() {
+  if (scope_ == no_tag) {
+    return nullptr;
+  }
+
   auto& scopes = is_user_tag_ ?
     theCollective()->user_scope_ :
     theCollective()->system_scope_;
@@ -122,16 +128,18 @@ detail::ScopeImpl* CollectiveScope::getScope() {
 
 CollectiveScope::~CollectiveScope() {
   auto impl = getScope();
-  impl->live_ = false;
+  if (impl != nullptr) {
+    impl->live_ = false;
 
-  if (impl->planned_collective_.size() == 0) {
-    auto& scopes = is_user_tag_ ?
-      theCollective()->user_scope_ :
-      theCollective()->system_scope_;
+    if (impl->planned_collective_.size() == 0) {
+      auto& scopes = is_user_tag_ ?
+        theCollective()->user_scope_ :
+        theCollective()->system_scope_;
 
-    auto scope_iter = scopes.find(scope_);
-    if (scope_iter != scopes.end()) {
-      scopes.erase(scope_iter);
+      auto scope_iter = scopes.find(scope_);
+      if (scope_iter != scopes.end()) {
+        scopes.erase(scope_iter);
+      }
     }
   }
 }

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -123,6 +123,17 @@ detail::ScopeImpl* CollectiveScope::getScope() {
 CollectiveScope::~CollectiveScope() {
   auto impl = getScope();
   impl->live_ = false;
+
+  if (impl->planned_collective_.size() == 0) {
+    auto& scopes = is_user_tag_ ?
+      theCollective()->user_scope_ :
+      theCollective()->system_scope_;
+
+    auto scope_iter = scopes.find(scope_);
+    if (scope_iter != scopes.end()) {
+      scopes.erase(scope_iter);
+    }
+  }
 }
 
 }} /* end namespace vt::collective */

--- a/src/vt/collective/collective_scope.h
+++ b/src/vt/collective/collective_scope.h
@@ -167,6 +167,24 @@ public:
    */
   void mpiCollectiveWait(ActionType action);
 
+  /**
+   * \internal \brief Get whether this scope is a user-tagged scope
+   *
+   * \note Used for testing purposes
+   *
+   * \return whether this scope is a user tag
+   */
+  bool isUserTag() const { return is_user_tag_; }
+
+  /**
+   * \internal \brief Get the scope tag bits
+   *
+   * \note Used for testing purposes
+   *
+   * \return the scope bits
+   */
+  TagType getScopeBits() const { return scope_; }
+
 private:
 
   /**

--- a/src/vt/collective/collective_scope.h
+++ b/src/vt/collective/collective_scope.h
@@ -113,7 +113,14 @@ private:
   friend struct CollectiveAlg;
 
 public:
-  CollectiveScope(CollectiveScope&&) = default;
+  CollectiveScope(CollectiveScope&& other)
+    : is_user_tag_(other.is_user_tag_),
+      scope_(other.scope_)
+  {
+    // invalidate scope for deallocation
+    other.scope_ = no_tag;
+  }
+
   CollectiveScope(CollectiveScope const&) = delete;
   CollectiveScope& operator=(CollectiveScope&&) = delete;
   CollectiveScope& operator=(CollectiveScope const&) = delete;

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -275,8 +275,6 @@ TEST_F(TestMPICollective, test_mpi_collective_5) {
     is_user_scope = scope2.isUserTag();
     scope_bits = scope2.getScopeBits();
 
-    // These three collective can execute in any order, but it will always be
-    // consistent across all the nodes
     vt::runInEpochCollective([&]{
       scope2.mpiCollectiveAsync([&done]{
         auto comm = theContext()->getComm();

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -261,4 +261,34 @@ TEST_F(TestMPICollective, test_mpi_collective_4) {
   }
 }
 
+TEST_F(TestMPICollective, test_mpi_collective_5) {
+  // Test std::move for a scope ensuring that de-allocation still works properly
+
+  int done = 0;
+  bool is_user_scope = false;
+  TagType scope_bits;
+
+  {
+    vt::collective::CollectiveScope scope = theCollective()->makeCollectiveScope();
+    vt::collective::CollectiveScope scope2{std::move(scope)};
+
+    is_user_scope = scope2.isUserTag();
+    scope_bits = scope2.getScopeBits();
+
+    // These three collective can execute in any order, but it will always be
+    // consistent across all the nodes
+    vt::runInEpochCollective([&]{
+      scope2.mpiCollectiveAsync([&done]{
+        auto comm = theContext()->getComm();
+        vt_print(barrier, "run MPI_Barrier\n");
+        MPI_Barrier(comm);
+        done++;
+      });
+    });
+  }
+
+  EXPECT_TRUE(theCollective()->isDeallocated(is_user_scope, scope_bits));
+  EXPECT_EQ(done, 1);
+}
+
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -65,41 +65,48 @@ TEST_F(TestMPICollective, test_mpi_collective_1) {
 }
 
 TEST_F(TestMPICollective, test_mpi_collective_2) {
-  int done = 0;
-
-  vt::collective::CollectiveScope scope = theCollective()->makeCollectiveScope();
-
-  // These three collective can execute in any order, but it will always be
-  // consistent across all the nodes
   auto this_node = theContext()->getNode();
+  int done = 0;
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
-
   int reduce_val_out = 0;
+  bool is_user_scope = false;
+  TagType scope_bits;
 
-  vt::runInEpochCollective([&]{
-    scope.mpiCollectiveAsync([&done]{
-      auto comm = theContext()->getComm();
-      vt_print(barrier, "run MPI_Barrier\n");
-      MPI_Barrier(comm);
-      done++;
-    });
+  {
+    vt::collective::CollectiveScope scope = theCollective()->makeCollectiveScope();
 
-    scope.mpiCollectiveAsync([&done,&bcast_val,root]{
-      auto comm = theContext()->getComm();
-      vt_print(barrier, "run MPI_Bcast\n");
-      MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
-      done++;
-    });
+    is_user_scope = scope.isUserTag();
+    scope_bits = scope.getScopeBits();
 
-    scope.mpiCollectiveAsync([&done,&reduce_val_out]{
-      auto comm = theContext()->getComm();
-      int val_in = 1;
-      vt_print(barrier, "run MPI_Allreduce\n");
-      MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
-      done++;
+    // These three collective can execute in any order, but it will always be
+    // consistent across all the nodes
+    vt::runInEpochCollective([&]{
+      scope.mpiCollectiveAsync([&done]{
+        auto comm = theContext()->getComm();
+        vt_print(barrier, "run MPI_Barrier\n");
+        MPI_Barrier(comm);
+        done++;
+      });
+
+      scope.mpiCollectiveAsync([&done,&bcast_val,root]{
+        auto comm = theContext()->getComm();
+        vt_print(barrier, "run MPI_Bcast\n");
+        MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
+        done++;
+      });
+
+      scope.mpiCollectiveAsync([&done,&reduce_val_out]{
+        auto comm = theContext()->getComm();
+        int val_in = 1;
+        vt_print(barrier, "run MPI_Allreduce\n");
+        MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
+        done++;
+      });
     });
-  });
+  }
+
+  EXPECT_TRUE(theCollective()->isDeallocated(is_user_scope, scope_bits));
 
   auto num_nodes = theContext()->getNumNodes();
 
@@ -114,30 +121,38 @@ TEST_F(TestMPICollective, test_mpi_collective_3) {
   auto this_node = theContext()->getNode();
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
-
-  vt::collective::CollectiveScope scope = theCollective()->makeCollectiveScope();
-
-  auto tag = scope.mpiCollectiveAsync([&done,&bcast_val,root]{
-    auto comm = theContext()->getComm();
-    vt_print(barrier, "run MPI_Bcast\n");
-    MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
-    done++;
-  });
-
-  scope.waitCollective(tag);
-
-  EXPECT_EQ(done, 1);
-  EXPECT_EQ(bcast_val, 29);
-
   int reduce_val_out = 0;
+  bool is_user_scope = false;
+  TagType scope_bits;
 
-  scope.mpiCollectiveWait([&done,&reduce_val_out]{
-    auto comm = theContext()->getComm();
-    int val_in = 1;
-    vt_print(barrier, "run MPI_Allreduce\n");
-    MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
-    done++;
-  });
+  {
+    vt::collective::CollectiveScope scope = theCollective()->makeCollectiveScope();
+
+    is_user_scope = scope.isUserTag();
+    scope_bits = scope.getScopeBits();
+
+    auto tag = scope.mpiCollectiveAsync([&done,&bcast_val,root]{
+      auto comm = theContext()->getComm();
+      vt_print(barrier, "run MPI_Bcast\n");
+      MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
+      done++;
+    });
+
+    scope.waitCollective(tag);
+
+    EXPECT_EQ(done, 1);
+    EXPECT_EQ(bcast_val, 29);
+
+    scope.mpiCollectiveWait([&done,&reduce_val_out]{
+      auto comm = theContext()->getComm();
+      int val_in = 1;
+      vt_print(barrier, "run MPI_Allreduce\n");
+      MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
+      done++;
+    });
+  }
+
+  EXPECT_TRUE(theCollective()->isDeallocated(is_user_scope, scope_bits));
 
   EXPECT_EQ(done, 2);
   EXPECT_EQ(reduce_val_out, theContext()->getNumNodes());
@@ -163,62 +178,76 @@ void orderHan(OrderMsg* msg) {
 
 TEST_F(TestMPICollective, test_mpi_collective_4) {
   int done = 0;
-
   auto this_node = theContext()->getNode();
   bool is_even = this_node % 2 == 0;
-
-  // System scope (will have generated tag=1)
-  vt::collective::CollectiveScope scope1 = theCollective()->makeCollectiveScope();
-  // System scope (will have generated tag=2)
-  vt::collective::CollectiveScope scope2 = theCollective()->makeCollectiveScope();
-  // User scope with tag=1
-  vt::collective::CollectiveScope scope3 = theCollective()->makeCollectiveScope(1);
-
   int root = 0;
   int bcast_val = this_node == root ? 29 : 0;
   int reduce_val_out = 0;
+  bool is_user_scope[3] = { false, false, false };
+  TagType scope_bits[3];
 
-  // Reset run_order if the test runs multiple times
-  run_order[0] = 0;
-  run_order[1] = 0;
-  run_order[2] = 0;
+  {
+    // System scope (will have generated tag=1)
+    vt::collective::CollectiveScope scope1 = theCollective()->makeCollectiveScope();
+    // System scope (will have generated tag=2)
+    vt::collective::CollectiveScope scope2 = theCollective()->makeCollectiveScope();
+    // User scope with tag=1
+    vt::collective::CollectiveScope scope3 = theCollective()->makeCollectiveScope(1);
 
-  auto op1 = [&]{
-    scope1.mpiCollectiveAsync([&done,&bcast_val,root]{
-      auto comm = theContext()->getComm();
-      vt_print(barrier, "run MPI_Bcast\n");
-      MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
-      run_order[done++] = 1;
+    is_user_scope[0] = scope1.isUserTag();
+    is_user_scope[1] = scope2.isUserTag();
+    is_user_scope[2] = scope3.isUserTag();
+
+    scope_bits[0] = scope1.getScopeBits();
+    scope_bits[1] = scope2.getScopeBits();
+    scope_bits[2] = scope3.getScopeBits();
+
+    // Reset run_order if the test runs multiple times
+    run_order[0] = 0;
+    run_order[1] = 0;
+    run_order[2] = 0;
+
+    auto op1 = [&]{
+      scope1.mpiCollectiveAsync([&done,&bcast_val,root]{
+        auto comm = theContext()->getComm();
+        vt_print(barrier, "run MPI_Bcast\n");
+        MPI_Bcast(&bcast_val, 1, MPI_INT, root, comm);
+        run_order[done++] = 1;
+      });
+    };
+
+    auto op2 = [&]{
+      scope2.mpiCollectiveAsync([&done,&reduce_val_out]{
+        auto comm = theContext()->getComm();
+        int val_in = 1;
+        vt_print(barrier, "run MPI_Allreduce\n");
+        MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
+        run_order[done++] = 2;
+      });
+    };
+
+    auto op3 = [&]{
+      scope3.mpiCollectiveAsync([&done]{
+        auto comm = theContext()->getComm();
+        vt_print(barrier, "run MPI_barrier\n");
+        MPI_Barrier(comm);
+        run_order[done++] = 3;
+      });
+    };
+
+    // Execute them in different orders
+    vt::runInEpochCollective([&]{
+      if (is_even) {
+        op1(); op2(); op3();
+      } else {
+        op2(); op3(); op1();
+      }
     });
-  };
+  }
 
-  auto op2 = [&]{
-    scope2.mpiCollectiveAsync([&done,&reduce_val_out]{
-      auto comm = theContext()->getComm();
-      int val_in = 1;
-      vt_print(barrier, "run MPI_Allreduce\n");
-      MPI_Allreduce(&val_in, &reduce_val_out, 1, MPI_INT, MPI_SUM, comm);
-      run_order[done++] = 2;
-    });
-  };
-
-  auto op3 = [&]{
-    scope3.mpiCollectiveAsync([&done]{
-      auto comm = theContext()->getComm();
-      vt_print(barrier, "run MPI_barrier\n");
-      MPI_Barrier(comm);
-      run_order[done++] = 3;
-    });
-  };
-
-  // Execute them in different orders
-  vt::runInEpochCollective([&]{
-    if (is_even) {
-      op1(); op2(); op3();
-    } else {
-      op2(); op3(); op1();
-    }
-  });
+  EXPECT_TRUE(theCollective()->isDeallocated(is_user_scope[0], scope_bits[0]));
+  EXPECT_TRUE(theCollective()->isDeallocated(is_user_scope[1], scope_bits[1]));
+  EXPECT_TRUE(theCollective()->isDeallocated(is_user_scope[2], scope_bits[2]));
 
   auto num_nodes = theContext()->getNumNodes();
   EXPECT_EQ(done, 3);


### PR DESCRIPTION
Fixes #1094

- There's a race between the de-allocation of a scope (when it goes out of scope) and the completion of the work. If the work completes before it goes out of scope it doesn't erase
- There's a bug in the scope when it's moved causing double de-allocation if it goes out of scope before completion of work
- Add tests that expose these bugs and then fix them