### PR TITLE
1105 Speed up and reduce memory for builds

### DIFF
--- a/.github/workflows/dockerimage-clang-3.9-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-3.9-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-clang-5.0-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-5.0-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-clang-8-alpine-mpich.yml
+++ b/.github/workflows/dockerimage-clang-8-alpine-mpich.yml
@@ -30,6 +30,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-gcc-10-ubuntu-openmpi.yml
+++ b/.github/workflows/dockerimage-gcc-10-ubuntu-openmpi.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-gcc-5-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-5-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-gcc-6-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-6-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-gcc-7-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-7-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-gcc-8-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-8-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 1
       VT_POOL: 0
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-gcc-9-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-9-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 1
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 1
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-intel-18-ubuntu-mpich-extended.yml
+++ b/.github/workflows/dockerimage-intel-18-ubuntu-mpich-extended.yml
@@ -33,6 +33,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 0
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-intel-18-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-intel-18-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 0
       VT_EXTENDED_TESTS: ${{ github.event_name != 'pull_request' }}
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich-extended.yml
+++ b/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich-extended.yml
@@ -33,6 +33,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 0
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 0
       VT_EXTENDED_TESTS: ${{ github.event_name != 'pull_request' }}
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich-extended.yml
+++ b/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich-extended.yml
@@ -33,6 +33,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 0
       VT_EXTENDED_TESTS: 1
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich.yml
@@ -35,6 +35,7 @@ jobs:
       VT_ASAN: 0
       VT_POOL: 0
       VT_EXTENDED_TESTS: ${{ github.event_name != 'pull_request' }}
+      VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
       CACHE: ~/.local/cache/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ include(cmake/build_git_info.cmake)
 
 include(cmake/check_compiler.cmake)
 
+option(vt_gold_linker_enabled "Build VT using the `gold' linker" ON)
+
 option(vt_fcontext_enabled "Build VT with fcontext (ULT) enabled" OFF)
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,19 @@ include(cmake/check_compiler.cmake)
 
 option(vt_gold_linker_enabled "Build VT using the `gold' linker" ON)
 
+option(vt_unity_build_enabled "Build VT with Unity/Jumbo mode enabled" OFF)
+
+if (vt_unity_build_enabled)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+    message(STATUS "Building VT in Unity/Jumbo build mode")
+  else()
+    message(
+      STATUS
+      "Could *not* build VT in Unity/Jumbo mode---version of CMake ${CMAKE_VERSION} < 3.16"
+    )
+  endif()
+endif()
+
 option(vt_fcontext_enabled "Build VT with fcontext (ULT) enabled" OFF)
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_CMAKE_BUILD_TYPE)

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -94,6 +94,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dvt_pool_enabled="${VT_POOL_ENABLED:-1}" \
       -Dvt_build_extended_tests="${VT_EXTENDED_TESTS_ENABLED:-1}" \
       -Dvt_zoltan_enabled="${VT_ZOLTAN_ENABLED:-0}" \
+      -Dvt_unity_build_enabled="${VT_UNITY_BUILD_ENABLED:-0}" \
       -Dzoltan_DIR="${ZOLTAN_CONFIG:-}" \
       -DCODE_COVERAGE="${CODE_COVERAGE:-0}" \
       -DMI_INTERPOSE:BOOL=ON \

--- a/ci/deps/cmake.sh
+++ b/ci/deps/cmake.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+if test $# -lt 1
+then
+    echo "usage: ./$0 <cmake-version>"
+    exit 1
+fi
+
+cmake_version=$1
+cmake_tar_name=cmake-${cmake_version}-Linux-x86_64.tar.gz
+
+echo "${cmake_version}"
+echo "${cmake_tar_name}"
+
+wget http://github.com/Kitware/CMake/releases/download/v${cmake_version}/${cmake_tar_name}
+
+tar xzf ${cmake_tar_name} --one-top-level=cmake --strip-components 1

--- a/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
     ca-certificates \
     curl \
-    cmake \
+    less \
     git \
     wget \
     ${compiler} \
@@ -34,6 +34,12 @@ RUN ln -s \
 
 ENV CC=${compiler} \
     CXX=clang++
+
+COPY ./ci/deps/cmake.sh cmake.sh
+RUN ./cmake.sh 3.18.4
+
+ENV PATH=/cmake/bin/:$PATH
+ENV LESSCHARSET=utf-8
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4
@@ -65,6 +71,7 @@ ENV VT_LB_ENABLED=${VT_LB_ENABLED} \
     VT_POOL_ENABLED=${VT_POOL_ENABLED} \
     VT_MPI_GUARD_ENABLED=${VT_MPI_GUARD_ENABLED} \
     VT_EXTENDED_TESTS_ENABLED=${VT_EXTENDED_TESTS_ENABLED} \
+    VT_UNITY_BUILD_ENABLED=${VT_UNITY_BUILD_ENABLED} \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
 RUN /vt/ci/build_cpp.sh /vt /build

--- a/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update -y -q && \
     less \
     curl \
     ${zoltan_enabled:+gfortran-$(echo ${compiler} | cut -d- -f2)} \
-    cmake \
     git \
     wget \
     ${compiler} \
@@ -49,6 +48,12 @@ RUN if test ${zoltan_enabled} -eq 1; then \
 
 ENV CC=gcc \
     CXX=g++
+
+COPY ./ci/deps/cmake.sh cmake.sh
+RUN ./cmake.sh 3.18.4
+
+ENV PATH=/cmake/bin/:$PATH
+ENV LESSCHARSET=utf-8
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4
@@ -94,6 +99,7 @@ ENV VT_LB_ENABLED=${VT_LB_ENABLED} \
     VT_MPI_GUARD_ENABLED=${VT_MPI_GUARD_ENABLED} \
     VT_ZOLTAN_ENABLED=${VT_ZOLTAN_ENABLED} \
     VT_EXTENDED_TESTS_ENABLED=${VT_EXTENDED_TESTS_ENABLED} \
+    VT_UNITY_BUILD_ENABLED=${VT_UNITY_BUILD_ENABLED} \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
 RUN /vt/ci/build_cpp.sh /vt /build

--- a/ci/docker/ubuntu-18.04-intel-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-intel-cpp.dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update -y -q && \
     ca-certificates \
     less \
     curl \
-    cmake \
     git \
     wget \
     zlib1g \
@@ -34,6 +33,12 @@ RUN ln -s \
 RUN ln -s \
     /opt/intel/install/bin/icc \
     /opt/intel/install/bin/gcc
+
+COPY ./ci/deps/cmake.sh cmake.sh
+RUN ./cmake.sh 3.18.4
+
+ENV PATH=/cmake/bin/:$PATH
+ENV LESSCHARSET=utf-8
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4
@@ -67,6 +72,7 @@ ENV VT_LB_ENABLED=${VT_LB_ENABLED} \
     VT_POOL_ENABLED=${VT_POOL_ENABLED} \
     VT_MPI_GUARD_ENABLED=${VT_MPI_GUARD_ENABLED} \
     VT_EXTENDED_TESTS_ENABLED=${VT_EXTENDED_TESTS_ENABLED} \
+    VT_UNITY_BUILD_ENABLED=${VT_UNITY_BUILD_ENABLED} \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
 RUN /vt/ci/build_cpp.sh /vt /build

--- a/ci/docker/ubuntu-18.04-nvidia-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-nvidia-cpp.dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update -y -q && \
     ca-certificates \
     g++-7 \
     curl \
-    cmake \
     less \
     git \
     wget \
@@ -60,6 +59,12 @@ RUN if test ${compiler} = "nvcc-10"; then \
 ENV CC=gcc \
     CXX=g++
 
+COPY ./ci/deps/cmake.sh cmake.sh
+RUN ./cmake.sh 3.18.4
+
+ENV PATH=/cmake/bin/:$PATH
+ENV LESSCHARSET=utf-8
+
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4
 
@@ -97,6 +102,7 @@ ENV VT_LB_ENABLED=${VT_LB_ENABLED} \
     VT_ASAN_ENABLED=${VT_ASAN_ENABLED} \
     VT_POOL_ENABLED=${VT_POOL_ENABLED} \
     VT_EXTENDED_TESTS_ENABLED=${VT_EXTENDED_TESTS_ENABLED} \
+    VT_UNITY_BUILD_ENABLED=${VT_UNITY_BUILD_ENABLED} \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
 RUN /vt/ci/build_cpp.sh /vt /build

--- a/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
     ca-certificates \
     curl \
-    cmake \
+    less \
     git \
     wget \
     ${compiler} \
@@ -34,6 +34,12 @@ RUN ln -s \
 
 ENV CC=${compiler} \
     CXX=clang++
+
+COPY ./ci/deps/cmake.sh cmake.sh
+RUN ./cmake.sh 3.18.4
+
+ENV PATH=/cmake/bin/:$PATH
+ENV LESSCHARSET=utf-8
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4
@@ -65,6 +71,7 @@ ENV VT_LB_ENABLED=${VT_LB_ENABLED} \
     VT_POOL_ENABLED=${VT_POOL_ENABLED} \
     VT_MPI_GUARD_ENABLED=${VT_MPI_GUARD_ENABLED} \
     VT_EXTENDED_TESTS_ENABLED=${VT_EXTENDED_TESTS_ENABLED} \
+    VT_UNITY_BUILD_ENABLED=${VT_UNITY_BUILD_ENABLED} \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
 RUN /vt/ci/build_cpp.sh /vt /build

--- a/ci/docker/ubuntu-20.04-gnu-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-gnu-cpp.dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update -y -q && \
     less \
     curl \
     ${zoltan_enabled:+gfortran-$(echo ${compiler} | cut -d- -f2)} \
-    cmake \
     git \
     wget \
     ${compiler} \
@@ -49,6 +48,12 @@ RUN if test ${zoltan_enabled} -eq 1; then \
 
 ENV CC=gcc \
     CXX=g++
+
+COPY ./ci/deps/cmake.sh cmake.sh
+RUN ./cmake.sh 3.18.4
+
+ENV PATH=/cmake/bin/:$PATH
+ENV LESSCHARSET=utf-8
 
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4
@@ -88,6 +93,7 @@ ENV VT_LB_ENABLED=${VT_LB_ENABLED} \
     VT_MPI_GUARD_ENABLED=${VT_MPI_GUARD_ENABLED} \
     VT_ZOLTAN_ENABLED=${VT_ZOLTAN_ENABLED} \
     VT_EXTENDED_TESTS_ENABLED=${VT_EXTENDED_TESTS_ENABLED} \
+    VT_UNITY_BUILD_ENABLED=${VT_UNITY_BUILD_ENABLED} \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
 RUN /vt/ci/build_cpp.sh /vt /build

--- a/ci/docker/ubuntu-20.04-gnu-openmpi-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-gnu-openmpi-cpp.dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update -y -q && \
     less \
     curl \
     ${zoltan_enabled:+gfortran-$(echo ${compiler} | cut -d- -f2)} \
-    cmake \
     git \
     wget \
     ${compiler} \
@@ -50,6 +49,12 @@ RUN if test ${zoltan_enabled} -eq 1; then \
 
 ENV CC=gcc \
     CXX=g++
+
+COPY ./ci/deps/cmake.sh cmake.sh
+RUN ./cmake.sh 3.18.4
+
+ENV PATH=/cmake/bin/:$PATH
+ENV LESSCHARSET=utf-8
 
 COPY ./ci/deps/openmpi.sh openmpi.sh
 RUN ./openmpi.sh v4.0 4.0.4 -j4
@@ -92,6 +97,7 @@ ENV VT_LB_ENABLED=${VT_LB_ENABLED} \
     VT_MPI_GUARD_ENABLED=${VT_MPI_GUARD_ENABLED} \
     VT_ZOLTAN_ENABLED=${VT_ZOLTAN_ENABLED} \
     VT_EXTENDED_TESTS_ENABLED=${VT_EXTENDED_TESTS_ENABLED} \
+    VT_UNITY_BUILD_ENABLED=${VT_UNITY_BUILD_ENABLED} \
     CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
 RUN /vt/ci/build_cpp.sh /vt /build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@
 #   VT_ASAN=0            # Enable address sanitizer
 #   VT_EXTENDED_TESTS=1  # Build all the extended testing
 #   VT_ZOLTAN=0          # Build with Zoltan enabled
+#   VT_UNITY_BUILD=0     # Build with Unity/Jumbo mode enabled
 #   BUILD_TYPE=release   # CMake build type
 #   CODE_COVERAGE=0      # Enable generation of code coverage reports
 #
@@ -122,6 +123,7 @@ x-vtopts: &vtopts
   VT_ASAN_ENABLED: ${VT_ASAN:-0}
   VT_POOL_ENABLED: ${VT_POOL:-1}
   VT_ZOLTAN_ENABLED: ${VT_ZOLTAN:-0}
+  VT_UNITY_BUILD_ENABLED: ${VT_UNITY_BUILD:-0}
   CMAKE_BUILD_TYPE: ${BUILD_TYPE:-release}
   VT_MPI_GUARD_ENABLED: ${VT_MPI_GUARD:-1}
   VT_EXTENDED_TESTS_ENABLED: ${VT_EXTENDED_TESTS:-1}

--- a/docs/md/building.md
+++ b/docs/md/building.md
@@ -56,6 +56,7 @@ build configuration:
 | `vt_priorities_enabled`         | 1               | Enable prioritization of work (adds bits in envelope) |
 | `vt_priority_bits_per_level`    | 3               | Number of bits per level of priority in envelope |
 | `vt_build_extended_tests`       | 1               | Build with full, extended testing |
+| `vt_unity_build_enabled`        | 0               | Build with Unity/Jumbo mode enabled (requires CMake >= 3.16) |
 | `CODE_COVERAGE`                 | 0               | Enable code coverage for VT examples/tests |
 | `VT_BUILD_TESTS`                | 1               | Build all VT tests |
 | `VT_BUILD_EXAMPLES`             | 1               | Build all VT examples |
@@ -83,6 +84,7 @@ parameters.
 | `ZOLTAN_DIR `               | <empty>         | Directory pointing to Zoltan installation |
 | `VT_MPI_GUARD_ENABLED `     | 0               | Guards against mis-use of MPI calls in code using *vt* |
 | `VT_EXTENDED_TESTS_ENABLED` | 1               | Build with full, extended testing |
+| `VT_UNITY_BUILD_ENABLED`    | 0               | Build with Unity/Jumbo mode enabled (requires CMake >= 3.16) |
 
 With these set, invoke the script with two arguments: the path to the *vt* root
 directory and the build path. Here's an example assuming that *vt* is cloned
@@ -142,6 +144,7 @@ which `docker-compose` will read.
 #   VT_ASAN=0            # Enable address sanitizer
 #   VT_EXTENDED_TESTS=1  # Build all the extended testing
 #   VT_ZOLTAN=0          # Build with Zoltan enabled
+#   VT_UNITY_BUILD=0     # Build with Unity/Jumbo mode enabled
 #   BUILD_TYPE=release   # CMake build type
 #   CODE_COVERAGE=0      # Enable generation of code coverage reports
 ```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,10 @@ macro(add_example example_name)
   add_executable(${example_name} ${EXAMPLE_FILE})
   add_dependencies(examples ${example_name})
 
+  if (vt_unity_build_enabled)
+    set_target_properties(${example_name} PROPERTIES UNITY_BUILD ON)
+  endif()
+
   link_target_with_vt(
     TARGET ${example_name}
     DEFAULT_LINK_SET

--- a/scripts/workflow-template.yml
+++ b/scripts/workflow-template.yml
@@ -28,6 +28,7 @@ jobs:
       VT_ASAN: [% vt_asan %]
       VT_POOL: [% vt_pool %]
       VT_EXTENDED_TESTS: [% vt_extended_tests %]
+      VT_UNITY_BUILD: [% vt_unity_build %]
       VT_ZOLTAN: [% vt_zoltan %]
       CACHE: [% cache_dir %]
 

--- a/scripts/workflows.ini
+++ b/scripts/workflows.ini
@@ -8,6 +8,7 @@ vt_docs = 0
 vt_asan = 0
 vt_pool = 1
 vt_extended_tests = 1
+vt_unity_build = 1
 vt_zoltan = 0
 ulimit_core = 0
 code_coverage = 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,6 +234,26 @@ target_compile_features(
 target_compile_options(${VIRTUAL_TRANSPORT_LIBRARY} PUBLIC ${CXX_STANDARD_FLAGS})
 target_compile_options(${VIRTUAL_TRANSPORT_LIBRARY} PUBLIC ${VT_TARGET_CXX_FLAGS})
 
+if (vt_gold_linker_enabled)
+  if (UNIX AND NOT APPLE)
+    execute_process(
+      COMMAND
+        ${CMAKE_C_COMPILER}
+        -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE ld_version
+    )
+    if ("${ld_version}" MATCHES "GNU gold")
+      set(
+        CMAKE_EXE_LINKER_FLAGS
+        "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags"
+      )
+      set(
+        CMAKE_SHARED_LINKER_FLAGS
+        "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags"
+      )
+    endif()
+  endif()
+endif()
+
 link_target_with_vt(
   TARGET ${VIRTUAL_TRANSPORT_LIBRARY}
   LINK_VT_LIB

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -254,6 +254,10 @@ if (vt_gold_linker_enabled)
   endif()
 endif()
 
+if (vt_unity_build_enabled)
+  set_target_properties(${VIRTUAL_TRANSPORT_LIBRARY} PROPERTIES UNITY_BUILD ON)
+endif()
+
 link_target_with_vt(
   TARGET ${VIRTUAL_TRANSPORT_LIBRARY}
   LINK_VT_LIB

--- a/src/vt/pipe/signal/signal_holder.h
+++ b/src/vt/pipe/signal/signal_holder.h
@@ -60,7 +60,7 @@ namespace vt { namespace pipe { namespace signal {
 
 /// Used to assign a ID to each signal holder instance to generate unique
 /// cleanup lambdas
-static unsigned signal_holder_next_id_ = 1;
+extern unsigned signal_holder_next_id_;
 
 template <typename SignalT>
 struct SignalHolder {

--- a/src/vt/vrt/collection/balance/model/norm.h
+++ b/src/vt/vrt/collection/balance/model/norm.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                 norm.h
+//                                    norm.h
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,8 +42,8 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VRT_COLLECTION_BALANCE_NAIVE_PERSISTENCE_H
-#define INCLUDED_VRT_COLLECTION_BALANCE_NAIVE_PERSISTENCE_H
+#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_MODEL_NORM_H
+#define INCLUDED_VT_VRT_COLLECTION_BALANCE_MODEL_NORM_H
 
 #include "vt/vrt/collection/balance/model/composed_model.h"
 #include <unordered_map>
@@ -73,4 +73,4 @@ private:
 
 }}}} // end namespace
 
-#endif
+#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_MODEL_NORM_H*/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,69 +67,33 @@ set_target_properties(gtest_main PROPERTIES FOLDER extern)
 
 include(GoogleTest)
 
-function(add_unit_test sub_dir unit_test_file)
-  GET_FILENAME_COMPONENT(
-    UNIT_TEST
-    ${unit_test_file}
-    NAME_WE
-  )
-
-  GET_FILENAME_COMPONENT(
-    UNIT_TEST_FULL_EXTENSION
-    ${unit_test_file}
-    EXT
-  )
-
-  # Extended tests are designated with an particular extension: *.extended.cc
-  if(UNIT_TEST_FULL_EXTENSION MATCHES "[.]extended[.]")
-    # message(
-    #   STATUS "found extended test >>>> ${UNIT_TEST_FULL_EXTENSION}"
-    # )
-
-    set(UNIT_TEST "${UNIT_TEST}_extended")
-
-    # Drop out if we are not supposed to build the extended testing
-    if (NOT vt_build_extended_tests)
-      return()
-    endif()
-  else()
-    set(UNIT_TEST "${UNIT_TEST}_basic")
-  endif()
-
-  # Does this test bypass MPI?
-  set(USES_MPI ON)
-  if(UNIT_TEST_FULL_EXTENSION MATCHES "[.]nompi[.]")
-    set(USES_MPI OFF)
-    set(UNIT_TEST "${UNIT_TEST}_nompi")
-  endif()
-
-  # message(
-  #  STATUS "Building unit test >>>> dir=${sub_dir} test=${UNIT_TEST}, "
-  #  "path=${unit_test_file}"
-  # )
-
+function(add_unit_test unit_test_name unit_test_files uses_mpi)
   add_executable(
-    ${UNIT_TEST}
+    ${unit_test_name}
     ${TEST_SOURCE_FILES}
     ${TEST_HEADER_FILES}
-    ${PROJECT_TEST_UNIT_DIR}/${unit_test_file}
+    ${${unit_test_files}}
   )
 
-  add_dependencies(unit_tests ${UNIT_TEST})
+  add_dependencies(unit_tests ${unit_test_name})
 
-  target_include_directories(${UNIT_TEST} PRIVATE ${PROJECT_TEST_UNIT_DIR})
-  target_include_directories(${UNIT_TEST} PRIVATE ${PROJECT_GTEST_INCLUDE_DIR})
+  target_include_directories(${unit_test_name} PRIVATE ${PROJECT_TEST_UNIT_DIR})
+  target_include_directories(${unit_test_name} PRIVATE ${PROJECT_GTEST_INCLUDE_DIR})
 
   link_target_with_vt(
-    TARGET ${UNIT_TEST}
+    TARGET ${unit_test_name}
     DEFAULT_LINK_SET
     LINK_GTEST ON
   )
 
-  if(USES_MPI)
+  if (vt_unity_build_enabled)
+    set_target_properties(${unit_test_name} PROPERTIES UNITY_BUILD ON)
+  endif()
+
+  if(uses_mpi)
     foreach(PROC ${PROC_TEST_LIST})
       gtest_add_tests(
-        TARGET                 ${UNIT_TEST}
+        TARGET                 ${unit_test_name}
         WORKING_DIRECTORY      ${CMAKE_CURRENT_BINARY_DIR}
         TEST_SUFFIX            _proc_${PROC}
         TEST_PREFIX            vt:
@@ -146,7 +110,7 @@ function(add_unit_test sub_dir unit_test_file)
     endforeach()
   else()
     gtest_add_tests(
-      TARGET                 ${UNIT_TEST}
+      TARGET                 ${unit_test_name}
       WORKING_DIRECTORY      ${CMAKE_CURRENT_BINARY_DIR}
       TEST_SUFFIX            _no_mpi
       TEST_PREFIX            vt:
@@ -176,15 +140,49 @@ foreach(SUB_DIR ${UNIT_TEST_SUBDIRS_LIST})
     GLOB
     "${SUB_DIR}_UNIT_TEST_SOURCE_FILES"
     RELATIVE
-    "${PROJECT_TEST_UNIT_DIR}"
+    ""
     "${PROJECT_TEST_UNIT_DIR}/${SUB_DIR}/*.cc"
   )
 
   set(CUR_TEST_LIST "${SUB_DIR}_test_list")
 
+  set(UNIT_LIST_EXTENDED "")
+  set(UNIT_LIST_BASIC "")
+  set(UNIT_LIST_NOMPI "")
+
   foreach (unit_test_file ${${SUB_DIR}_UNIT_TEST_SOURCE_FILES})
-    add_unit_test(${SUB_DIR} ${unit_test_file})
+    #message(STATUS "Considering ${unit_test_file}")
+
+    GET_FILENAME_COMPONENT(
+      UNIT_TEST
+      ${unit_test_file}
+      NAME_WE
+    )
+
+    GET_FILENAME_COMPONENT(
+      UNIT_TEST_FULL_EXTENSION
+      ${unit_test_file}
+      EXT
+    )
+
+    # Extended tests are designated with an particular extension: *.extended.cc
+    if(UNIT_TEST_FULL_EXTENSION MATCHES "[.]extended[.]")
+      list(APPEND UNIT_LIST_EXTENDED ${unit_test_file})
+    else()
+      if(UNIT_TEST_FULL_EXTENSION MATCHES "[.]nompi[.]")
+        list(APPEND UNIT_LIST_NOMPI ${unit_test_file})
+      else()
+        list(APPEND UNIT_LIST_BASIC ${unit_test_file})
+      endif()
+    endif()
   endforeach()
+
+  add_unit_test("${SUB_DIR}_basic" UNIT_LIST_BASIC ON)
+  add_unit_test("${SUB_DIR}_nompi" UNIT_LIST_NOMPI OFF)
+
+  if (vt_build_extended_tests)
+    add_unit_test("${SUB_DIR}_extended" UNIT_LIST_EXTENDED ON)
+  endif()
 endforeach()
 
 #

--- a/tests/unit/active/test_active_bcast_put.cc
+++ b/tests/unit/active/test_active_bcast_put.cc
@@ -49,7 +49,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace bcast_put {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -147,4 +147,4 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Range(static_cast<NodeType>(0), static_cast<NodeType>(16), 1)
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::bcast_put

--- a/tests/unit/active/test_active_broadcast.cc
+++ b/tests/unit/active/test_active_broadcast.cc
@@ -49,7 +49,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace bcast {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -120,4 +120,4 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Range(static_cast<NodeType>(0), static_cast<NodeType>(16), 1)
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::bcast

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -49,7 +49,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace send {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -213,4 +213,4 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send_large_put) {
 }
 
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::send

--- a/tests/unit/active/test_active_send_put.cc
+++ b/tests/unit/active/test_active_send_put.cc
@@ -49,7 +49,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace send_put {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -126,4 +126,4 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Range(static_cast<NodeType>(2), static_cast<NodeType>(512), 4)
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::send_put

--- a/tests/unit/collection/test_broadcast.cc
+++ b/tests/unit/collection/test_broadcast.cc
@@ -53,7 +53,7 @@
 
 #include <cstdint>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace bcast {
 
 REGISTER_TYPED_TEST_SUITE_P(TestBroadcast, test_broadcast_1);
 
@@ -65,4 +65,4 @@ INSTANTIATE_TYPED_TEST_SUITE_P(
   test_bcast_basic, TestBroadcast, CollectionTestTypesBasic, DEFAULT_NAME_GEN
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::bcast

--- a/tests/unit/collection/test_broadcast.extended.cc
+++ b/tests/unit/collection/test_broadcast.extended.cc
@@ -53,7 +53,7 @@
 
 #include <cstdint>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace bcast {
 
 REGISTER_TYPED_TEST_SUITE_P(TestBroadcast, test_broadcast_1);
 
@@ -72,4 +72,4 @@ INSTANTIATE_TYPED_TEST_SUITE_P(
   DEFAULT_NAME_GEN
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::bcast

--- a/tests/unit/collection/test_broadcast.h
+++ b/tests/unit/collection/test_broadcast.h
@@ -52,7 +52,7 @@
 
 #include <cstdint>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace bcast {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -141,4 +141,4 @@ TYPED_TEST_P(TestBroadcast, test_broadcast_1) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::bcast

--- a/tests/unit/collection/test_construct_idx_fst.extended.cc
+++ b/tests/unit/collection/test_construct_idx_fst.extended.cc
@@ -51,7 +51,7 @@
 #include <tuple>
 #include <string>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace idx_fst {
 
 namespace multi_param_idx_fst_ {
 template <typename... Args> struct ColMsg;
@@ -95,4 +95,4 @@ using CollectionTestTypes = testing::Types<
 
 #endif /*vt_check_enabled(detector)*/
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::idx_fst

--- a/tests/unit/collection/test_construct_idx_snd.extended.cc
+++ b/tests/unit/collection/test_construct_idx_snd.extended.cc
@@ -51,7 +51,7 @@
 #include <tuple>
 #include <string>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace idx_snd {
 
 namespace multi_param_idx_snd_ {
 template <typename... Args> struct ColMsg;
@@ -95,4 +95,4 @@ using CollectionTestTypes = testing::Types<
 
 #endif /*vt_check_enabled(detector)*/
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::idx_snd

--- a/tests/unit/collection/test_construct_no_idx.extended.cc
+++ b/tests/unit/collection/test_construct_no_idx.extended.cc
@@ -51,7 +51,7 @@
 #include <tuple>
 #include <string>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace no_idx {
 
 namespace multi_param_no_idx_ {
 template <typename... Args> struct ColMsg;
@@ -93,4 +93,4 @@ INSTANTIATE_TYPED_TEST_SUITE_P(
   test_construct_no_idx_dist, TestConstructDist, CollectionTestTypes, DEFAULT_NAME_GEN
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::no_idx

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -52,7 +52,7 @@
 
 #include <cstdint>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace destroy {
 
 using namespace vt;
 using namespace vt::collective;
@@ -124,4 +124,4 @@ TEST_F(TestDestroy, test_destroy_1) {
   EXPECT_EQ(num_destroyed, num_elms_per_node);
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::destroy

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -52,7 +52,7 @@
 
 #include <cstdint>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace insert {
 
 using namespace vt;
 using namespace vt::collective;
@@ -213,4 +213,4 @@ TEST_F(TestInsert, test_insert_send_sparse_node_1) {
   num_work = 0;
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::insert

--- a/tests/unit/collection/test_lb_lite.extended.cc
+++ b/tests/unit/collection/test_lb_lite.extended.cc
@@ -52,7 +52,7 @@
 
 #include <cstdint>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace lb_lite {
 
 using namespace vt;
 using namespace vt::collective;
@@ -211,4 +211,4 @@ TEST_F(TestLB, test_lb_1) {
 //   }
 // }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::lb_lite

--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -53,7 +53,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace comm {
 
 using TestModelCommOverhead = TestHarness;
 
@@ -181,4 +181,4 @@ TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::comm

--- a/tests/unit/collection/test_model_linear_model.nompi.cc
+++ b/tests/unit/collection/test_model_linear_model.nompi.cc
@@ -52,7 +52,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace linear {
 
 using TestLinearModel = TestHarness;
 
@@ -157,4 +157,4 @@ TEST_F(TestLinearModel, test_model_linear_model_1) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::linear

--- a/tests/unit/collection/test_model_multiple_phases.nompi.cc
+++ b/tests/unit/collection/test_model_multiple_phases.nompi.cc
@@ -52,7 +52,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace multiple {
 
 using TestModelMultiplePhases = TestHarness;
 
@@ -125,4 +125,4 @@ TEST_F(TestModelMultiplePhases, test_model_multiple_phases_1) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::multiple

--- a/tests/unit/collection/test_model_naive_persistence.nompi.cc
+++ b/tests/unit/collection/test_model_naive_persistence.nompi.cc
@@ -52,7 +52,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace naive {
 
 using TestModelNaivePersistence = TestHarness;
 
@@ -130,4 +130,4 @@ TEST_F(TestModelNaivePersistence, test_model_naive_persistence_1) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::naive

--- a/tests/unit/collection/test_model_norm.nompi.cc
+++ b/tests/unit/collection/test_model_norm.nompi.cc
@@ -53,7 +53,7 @@
 #include <limits>
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace norm {
 
 using TestModelNorm = TestHarness;
 
@@ -207,4 +207,4 @@ TEST_F(TestModelNorm, test_model_norm_3) {
   EXPECT_EQ(objects_seen, 2);
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::norm

--- a/tests/unit/collection/test_model_per_collection.extended.cc
+++ b/tests/unit/collection/test_model_per_collection.extended.cc
@@ -53,7 +53,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace per {
 
 struct TestCol1 : vt::Collection<TestCol1,vt::Index1D> { };
 struct TestCol2 : vt::Collection<TestCol2,vt::Index1D> { };
@@ -165,4 +165,4 @@ TEST_F(TestModelPerCollection, test_model_per_collection_1) {
 #endif
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::per

--- a/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
+++ b/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
@@ -52,7 +52,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace persistence {
 
 using TestModelPersistenceMedianLastN = TestHarness;
 
@@ -155,4 +155,4 @@ TEST_F(TestModelPersistenceMedianLastN, test_model_persistence_median_last_n_1) 
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::persistence

--- a/tests/unit/collection/test_model_raw_data.nompi.cc
+++ b/tests/unit/collection/test_model_raw_data.nompi.cc
@@ -52,7 +52,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace raw {
 
 using TestRawData = TestHarness;
 
@@ -117,4 +117,4 @@ TEST_F(TestRawData, test_model_raw_data_scalar) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::raw

--- a/tests/unit/collection/test_model_select_subphases.nompi.cc
+++ b/tests/unit/collection/test_model_select_subphases.nompi.cc
@@ -52,7 +52,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace select {
 
 using TestModelSelectSubphases = TestHarness;
 
@@ -194,4 +194,4 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_2) {
   EXPECT_EQ(objects_seen, 2);
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::select

--- a/tests/unit/collection/test_query_context.cc
+++ b/tests/unit/collection/test_query_context.cc
@@ -52,7 +52,7 @@
 
 #include <cstdint>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace query {
 
 struct TestQueryContext : TestParallelHarness { };
 
@@ -97,4 +97,4 @@ TEST_F(TestQueryContext, test_query_context_send_1) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::query

--- a/tests/unit/collection/test_send.cc
+++ b/tests/unit/collection/test_send.cc
@@ -54,7 +54,7 @@
 #include <cstdint>
 #include <tuple>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace send {
 
 REGISTER_TYPED_TEST_SUITE_P(TestCollectionSend, test_collection_send_1);
 REGISTER_TYPED_TEST_SUITE_P(TestCollectionSendMem, test_collection_send_ptm_1);
@@ -72,4 +72,4 @@ INSTANTIATE_TYPED_TEST_SUITE_P(
   DEFAULT_NAME_GEN
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::send

--- a/tests/unit/collection/test_send.extended.cc
+++ b/tests/unit/collection/test_send.extended.cc
@@ -54,7 +54,7 @@
 #include <cstdint>
 #include <tuple>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace send {
 
 REGISTER_TYPED_TEST_SUITE_P(TestCollectionSend, test_collection_send_1);
 REGISTER_TYPED_TEST_SUITE_P(TestCollectionSendMem, test_collection_send_ptm_1);
@@ -78,4 +78,4 @@ INSTANTIATE_TYPED_TEST_SUITE_P(
   CollectionTestTypesExtended, DEFAULT_NAME_GEN
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::send

--- a/tests/unit/collection/test_send.h
+++ b/tests/unit/collection/test_send.h
@@ -53,7 +53,7 @@
 #include <cstdint>
 #include <tuple>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace send {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -188,4 +188,4 @@ TYPED_TEST_P(TestCollectionSendMem, test_collection_send_ptm_1) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::send

--- a/tests/unit/index/test_index_linearization.nompi.cc
+++ b/tests/unit/index/test_index_linearization.nompi.cc
@@ -48,19 +48,11 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace linear {
 
-class TestIndex : public TestHarness {
-  virtual void SetUp() {
-    TestHarness::SetUp();
-  }
+struct TestIndexLinear : TestHarness { };
 
-  virtual void TearDown() {
-    TestHarness::TearDown();
-  }
-};
-
-TEST_F(TestIndex, test_index_1d_linearization) {
+TEST_F(TestIndexLinear, test_index_1d_linearization) {
   using namespace vt;
 
   static constexpr int const dim1 = 92;
@@ -103,7 +95,7 @@ TEST_F(TestIndex, test_index_1d_linearization) {
   #endif
 }
 
-TEST_F(TestIndex, test_index_2d_linearization) {
+TEST_F(TestIndexLinear, test_index_2d_linearization) {
   using namespace vt;
 
   static constexpr int const dim1 = 10, dim2 = 12;
@@ -164,7 +156,7 @@ TEST_F(TestIndex, test_index_2d_linearization) {
   #endif
 }
 
-TEST_F(TestIndex, test_index_3d_linearization) {
+TEST_F(TestIndexLinear, test_index_3d_linearization) {
   using namespace vt;
 
   static constexpr int const dim1 = 3, dim2 = 9, dim3 = 23;
@@ -231,4 +223,4 @@ TEST_F(TestIndex, test_index_3d_linearization) {
   #endif
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::linear

--- a/tests/unit/pipe/test_callback_bcast.cc
+++ b/tests/unit/pipe/test_callback_bcast.cc
@@ -51,7 +51,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace bcast {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -206,4 +206,4 @@ TEST_F(TestCallbackBcast, test_callback_bcast_remote_3) {
 }
 
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::bcast

--- a/tests/unit/pipe/test_callback_bcast_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_bcast_collection.extended.cc
@@ -51,7 +51,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace bcast {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -219,4 +219,4 @@ TEST_F(TestCallbackBcastCollection, test_callback_bcast_collection_3) {
   });
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::bcast

--- a/tests/unit/pipe/test_callback_func.cc
+++ b/tests/unit/pipe/test_callback_func.cc
@@ -49,7 +49,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace func {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -103,4 +103,4 @@ TEST_F(TestCallbackFunc, test_callback_func_2) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::func

--- a/tests/unit/pipe/test_callback_func_ctx.cc
+++ b/tests/unit/pipe/test_callback_func_ctx.cc
@@ -51,7 +51,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace func_ctx {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -140,4 +140,4 @@ TEST_F(TestCallbackFuncCtx, test_callback_func_ctx_2) {
   EXPECT_EQ(called, 500);
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::func_ctx

--- a/tests/unit/pipe/test_callback_send.cc
+++ b/tests/unit/pipe/test_callback_send.cc
@@ -51,7 +51,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace send {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -198,4 +198,4 @@ TEST_F(TestCallbackSend, test_callback_send_remote_3) {
 }
 
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::send

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -51,7 +51,7 @@
 
 #include <memory>
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace send {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -239,4 +239,4 @@ TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
 }
 
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::send

--- a/tests/unit/pool/test_pool_message_sizes.cc
+++ b/tests/unit/pool/test_pool_message_sizes.cc
@@ -52,7 +52,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace msg_size {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -130,4 +130,4 @@ TEST_F(TestPoolMessageSizes, pool_message_sizes_alloc) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::msg_size

--- a/tests/unit/rdma/test_rdma_static_sub_handle.extended.cc
+++ b/tests/unit/rdma/test_rdma_static_sub_handle.extended.cc
@@ -50,10 +50,10 @@
 
 namespace vt { namespace tests { namespace unit {
 
-struct TestObjGroup {
-  using ProxyType = vt::objgroup::proxy::Proxy<TestObjGroup>;
+struct TestObjGroupExt {
+  using ProxyType = vt::objgroup::proxy::Proxy<TestObjGroupExt>;
 
-  TestObjGroup() = default;
+  TestObjGroupExt() = default;
 
   void initialize(ProxyType in_proxy) {
     proxy_ = in_proxy;
@@ -78,7 +78,7 @@ struct TestObjGroup {
   }
 
   static ProxyType construct() {
-    auto proxy = vt::theObjGroup()->makeCollective<TestObjGroup>();
+    auto proxy = vt::theObjGroup()->makeCollective<TestObjGroupExt>();
     proxy.get()->initialize(proxy);
     return proxy;
   }
@@ -94,7 +94,7 @@ TYPED_TEST_SUITE_P(TestRDMAHandleSet);
 
 TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_1) {
   using T = TypeParam;
-  auto proxy = TestObjGroup::construct();
+  auto proxy = TestObjGroupExt::construct();
 
   int32_t num_hans = 4;
   std::size_t num_vals = 8;
@@ -133,7 +133,7 @@ TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_1) {
 
 TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_2) {
   using T = TypeParam;
-  auto proxy = TestObjGroup::construct();
+  auto proxy = TestObjGroupExt::construct();
 
   auto this_node = theContext()->getNode();
   auto num_nodes = theContext()->getNumNodes();
@@ -178,7 +178,7 @@ TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_2) {
 
 TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_3) {
   using T = TypeParam;
-  auto proxy = TestObjGroup::construct();
+  auto proxy = TestObjGroupExt::construct();
 
   auto this_node = theContext()->getNode();
   auto num_nodes = theContext()->getNumNodes();
@@ -261,7 +261,7 @@ TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_3) {
 
 TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_4) {
   using T = TypeParam;
-  auto proxy = TestObjGroup::construct();
+  auto proxy = TestObjGroupExt::construct();
 
   auto this_node = theContext()->getNode();
   auto num_nodes = theContext()->getNumNodes();
@@ -316,7 +316,7 @@ TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_4) {
 
 TYPED_TEST_P(TestRDMAHandleSet, test_rdma_handle_set_5) {
   using T = TypeParam;
-  auto proxy = TestObjGroup::construct();
+  auto proxy = TestObjGroupExt::construct();
 
   auto this_node = theContext()->getNode();
   auto num_nodes = theContext()->getNumNodes();

--- a/tests/unit/sequencer/test_sequencer_extensive.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_extensive.extended.cc
@@ -70,7 +70,7 @@ using namespace vt::tests::unit;
 #define VT_DEBUG_PRINT(str, ...)
 #endif
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace extensive {
 
 static constexpr SeqType const FinalizeAtomicValue = -1;
 static constexpr SeqType const ResetAtomicValue = -2;
@@ -273,4 +273,4 @@ INSTANTIATE_TEST_SUITE_P(
   testing::ValuesIn(make_values())
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::extensive

--- a/tests/unit/sequencer/test_sequencer_for.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_for.extended.cc
@@ -51,7 +51,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace for_ {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -117,4 +117,4 @@ TEST_F(TestSequencerFor, test_for) {
   }
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::for_

--- a/tests/unit/sequencer/test_sequencer_nested.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_nested.extended.cc
@@ -51,7 +51,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace nested {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -321,4 +321,4 @@ TEST_F(TestSequencerNested, test_multi_deep_nested_wait) {
   );
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::nested

--- a/tests/unit/sequencer/test_sequencer_parallel.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_parallel.extended.cc
@@ -56,7 +56,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace parallel {
 
 using namespace vt;
 using namespace vt::tests::unit;
@@ -356,4 +356,4 @@ TEST_F(TestSequencerParallel, test_parallel_4) {
   PAR_EXPAND(seqParHan4, seqParFn4, node, TestMsg, 4, false);
 }
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::parallel

--- a/tests/unit/sequencer/test_sequencer_vrt.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_vrt.extended.cc
@@ -51,7 +51,7 @@
 
 #include "vt/transport.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace vrt {
 
 using namespace vt;
 using namespace vt::vrt;
@@ -262,4 +262,5 @@ TEST_F(TestSequencerVirtual, test_seq_vc_distinct_inst_3) {
     testSeqFn3b(FinalizeAtomicValue);
   }
 }
-}}} // end namespace vt::tests::unit
+
+}}}} // end namespace vt::tests::unit::vrt

--- a/tests/unit/termination/test_termination_action_callable.extended.cc
+++ b/tests/unit/termination/test_termination_action_callable.extended.cc
@@ -54,6 +54,7 @@ vt::NodeType root = vt::uninitialized_destination;
 vt::NodeType node = vt::uninitialized_destination;
 vt::NodeType all  = vt::uninitialized_destination;
 std::unordered_map<vt::EpochType,Data> data;
+bool ok = false;
 
 }}}} /* end namespace vt::tests::unit::channel */
 

--- a/tests/unit/termination/test_termination_action_callable.extended.cc
+++ b/tests/unit/termination/test_termination_action_callable.extended.cc
@@ -47,6 +47,16 @@
 #if !defined INCLUDED_TERMINATION_ACTION_CALLABLE_H
 #define INCLUDED_TERMINATION_ACTION_CALLABLE_H
 
+namespace vt { namespace tests { namespace unit { namespace channel {
+
+// set channel counting ranks
+vt::NodeType root = vt::uninitialized_destination;
+vt::NodeType node = vt::uninitialized_destination;
+vt::NodeType all  = vt::uninitialized_destination;
+std::unordered_map<vt::EpochType,Data> data;
+
+}}}} /* end namespace vt::tests::unit::channel */
+
 namespace vt { namespace tests { namespace unit {
 
 static bool finished[2] = {false, false};

--- a/tests/unit/termination/test_termination_action_common.cc
+++ b/tests/unit/termination/test_termination_action_common.cc
@@ -52,5 +52,6 @@ vt::NodeType root = vt::uninitialized_destination;
 vt::NodeType node = vt::uninitialized_destination;
 vt::NodeType all  = vt::uninitialized_destination;
 std::unordered_map<vt::EpochType,Data> data;
+bool ok = false;
 
 }}}} /* end namespace vt::tests::unit::channel */

--- a/tests/unit/termination/test_termination_action_common.cc
+++ b/tests/unit/termination/test_termination_action_common.cc
@@ -1,0 +1,57 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                       test_termination_action_common.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include "test_parallel_harness.h"
+#include "test_termination_channel_counting.h"
+
+namespace vt { namespace tests { namespace unit { namespace channel {
+
+// set channel counting ranks
+vt::NodeType root = vt::uninitialized_destination;
+vt::NodeType node = vt::uninitialized_destination;
+vt::NodeType all  = vt::uninitialized_destination;
+std::unordered_map<vt::EpochType,Data> data;
+
+}}}} /* end namespace vt::tests::unit::channel */
+

--- a/tests/unit/termination/test_termination_action_common.cc
+++ b/tests/unit/termination/test_termination_action_common.cc
@@ -54,4 +54,3 @@ vt::NodeType all  = vt::uninitialized_destination;
 std::unordered_map<vt::EpochType,Data> data;
 
 }}}} /* end namespace vt::tests::unit::channel */
-

--- a/tests/unit/termination/test_termination_action_common.h
+++ b/tests/unit/termination/test_termination_action_common.h
@@ -61,6 +61,7 @@ extern vt::NodeType root;
 extern vt::NodeType node;
 extern vt::NodeType all;
 extern std::unordered_map<vt::EpochType,channel::Data> data;
+extern bool ok;
 
 }}}} /* end namespace vt::tests::unit::channel */
 
@@ -74,8 +75,6 @@ namespace vt { namespace tests { namespace unit { namespace action {
 // shortcuts
 using epoch_manip = ::vt::epoch::EpochManip;
 using Base = TestParallelHarnessParam<std::tuple<int, bool, int>>;
-
-static bool ok = false;
 
 struct BaseFixture : Base {
   void SetUp() override {
@@ -131,7 +130,7 @@ inline void add(vt::EpochType const& epoch, int order);
 inline void finish(vt::EpochType const& epoch);
 // set the flag indicating that the current
 // epoch of the sequence is finished
-inline void setOk(vt::Message* /*unused*/) { ok = true; }
+inline void setOk(vt::Message* /*unused*/) { channel::ok = true; }
 
 
 /*

--- a/tests/unit/termination/test_termination_action_common.h
+++ b/tests/unit/termination/test_termination_action_common.h
@@ -53,11 +53,16 @@
 #define INCLUDED_TERMINATION_ACTION_COMMON_H
 
 using namespace vt::tests::unit;
+
+namespace vt { namespace tests { namespace unit { namespace channel {
+
 // set channel counting ranks
-vt::NodeType channel::root = vt::uninitialized_destination;
-vt::NodeType channel::node = vt::uninitialized_destination;
-vt::NodeType channel::all  = vt::uninitialized_destination;
-std::unordered_map<vt::EpochType,channel::Data> channel::data;
+extern vt::NodeType root;
+extern vt::NodeType node;
+extern vt::NodeType all;
+extern std::unordered_map<vt::EpochType,channel::Data> data;
+
+}}}} /* end namespace vt::tests::unit::channel */
 
 /*
  * common actions and fixtures for:
@@ -115,15 +120,15 @@ struct SimpleFixture : TestParallelHarness {
 };
 
 // epoch sequence creation
-std::vector<vt::EpochType> generateEpochs(
+inline std::vector<vt::EpochType> generateEpochs(
   int nb = 1, bool rooted = false, bool useDS = false
 );
 // fictive distributed computation
-void compute(vt::EpochType const& epoch);
+inline void compute(vt::EpochType const& epoch);
 // add the termination checker algorithm as a pending action
-void add(vt::EpochType const& epoch, int order);
+inline void add(vt::EpochType const& epoch, int order);
 // finish the epoch
-void finish(vt::EpochType const& epoch);
+inline void finish(vt::EpochType const& epoch);
 // set the flag indicating that the current
 // epoch of the sequence is finished
 inline void setOk(vt::Message* /*unused*/) { ok = true; }
@@ -135,7 +140,7 @@ inline void setOk(vt::Message* /*unused*/) { ok = true; }
  * - trigger termination detection
  * - finish epoch
  */
-void finalize(vt::EpochType const& epoch, int order);
+inline void finalize(vt::EpochType const& epoch, int order);
 
 }}}} // end namespace vt::tests::unit::action
 

--- a/tests/unit/termination/test_termination_action_common.impl.h
+++ b/tests/unit/termination/test_termination_action_common.impl.h
@@ -48,7 +48,7 @@
 namespace vt { namespace tests { namespace unit { namespace action {
 
 // epoch sequence creation [rooted,collect]
-std::vector<vt::EpochType> generateEpochs(int nb, bool rooted, bool useDS) {
+inline std::vector<vt::EpochType> generateEpochs(int nb, bool rooted, bool useDS) {
   vtAssert(nb > 0, "Invalid epoch sequence size");
   // the epoch sequence to be generated
   std::vector<vt::EpochType> sequence(nb);
@@ -74,7 +74,7 @@ std::vector<vt::EpochType> generateEpochs(int nb, bool rooted, bool useDS) {
 }
 
 // fictive distributed computation of a given epoch
-void compute(vt::EpochType const& epoch) {
+inline void compute(vt::EpochType const& epoch) {
 
   std::random_device device;
   std::mt19937 engine(device());
@@ -103,7 +103,7 @@ void compute(vt::EpochType const& epoch) {
   }
 }
 
-void finish(vt::EpochType const& epoch) {
+inline void finish(vt::EpochType const& epoch) {
   if (epoch != vt::no_epoch) {
     vt::theTerm()->finishedEpoch(epoch);
   }
@@ -115,7 +115,7 @@ void finish(vt::EpochType const& epoch) {
  * - trigger termination detection
  * - finish epoch
  */
-void finalize(vt::EpochType const& epoch, int order) {
+inline void finalize(vt::EpochType const& epoch, int order) {
 
   vt_debug_print(
     term, node,
@@ -146,7 +146,7 @@ void finalize(vt::EpochType const& epoch, int order) {
   }
 }
 
-void add(vt::EpochType const& epoch, int order){
+inline void add(vt::EpochType const& epoch, int order){
   if (channel::node == channel::root) {
     if (epoch == vt::no_epoch) {
       vt::theTerm()->addAction([=]{

--- a/tests/unit/termination/test_termination_action_common.impl.h
+++ b/tests/unit/termination/test_termination_action_common.impl.h
@@ -142,7 +142,7 @@ inline void finalize(vt::EpochType const& epoch, int order) {
     finish(epoch);
     vt::theCollective()->barrier();
     // spin until termination of the epoch
-    while (not ok) { vt::rt->runScheduler(); }
+    while (not channel::ok) { vt::rt->runScheduler(); }
   }
 }
 
@@ -167,7 +167,7 @@ inline void add(vt::EpochType const& epoch, int order){
         );
         // check channel counters
         EXPECT_TRUE(channel::hasEnded(epoch));
-        ok = true;
+        channel::ok = true;
         auto msg = vt::makeMessage<vt::Message>();
         vt::theMsg()->broadcastMsg<vt::Message, &setOk>(msg);
       });

--- a/tests/unit/termination/test_termination_action_epochs.cc
+++ b/tests/unit/termination/test_termination_action_epochs.cc
@@ -44,7 +44,7 @@
 
 #include "test_termination_action_common.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace epochs {
 
 struct TestTermCollect : action::BaseFixture {};
 struct TestTermRooted  : action::BaseFixture {};
@@ -101,4 +101,4 @@ INSTANTIATE_TEST_SUITE_P(
   )
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::epochs

--- a/tests/unit/termination/test_termination_action_epochs.cc
+++ b/tests/unit/termination/test_termination_action_epochs.cc
@@ -54,7 +54,7 @@ TEST_P(TestTermCollect, test_term_detect_collect_epoch) /* NOLINT */{
   auto&& sequence = action::generateEpochs(5);
 
   for (auto&& epoch : sequence) {
-    action::ok = false;
+    channel::ok = false;
     if (channel::node == channel::root) {
       action::compute(epoch);
       channel::trigger(epoch);

--- a/tests/unit/termination/test_termination_action_global.cc
+++ b/tests/unit/termination/test_termination_action_global.cc
@@ -44,7 +44,7 @@
 
 #include "test_termination_action_common.h"
 
-namespace vt { namespace tests { namespace unit {
+namespace vt { namespace tests { namespace unit { namespace global {
 
 struct TestTermGlobal : action::BaseFixture {};
 
@@ -77,4 +77,4 @@ INSTANTIATE_TEST_SUITE_P(
   )
 );
 
-}}} // end namespace vt::tests::unit
+}}}} // end namespace vt::tests::unit::global

--- a/tests/unit/termination/test_termination_channel_counting.h
+++ b/tests/unit/termination/test_termination_channel_counting.h
@@ -56,6 +56,11 @@
  */
 namespace vt { namespace tests { namespace unit { namespace channel {
 
+// ranks
+extern vt::NodeType node;
+extern vt::NodeType root;
+extern vt::NodeType all;
+
 // data per rank and epoch
 struct Data {
   struct Counters {
@@ -64,13 +69,24 @@ struct Data {
     int ack_ = 0; // acknowledged
   };
 
-  Data();
-  ~Data();
+  Data()
+    : degree_(0),
+      activator_(0)
+  {
+    for (vt::NodeType dst = 0; dst < all; ++dst) {
+      count_[dst] = {0, 0, 0};
+    }
+  }
+
+  ~Data() { count_.clear(); }
 
   int degree_ = 0;
   vt::NodeType activator_ = 0;
   std::unordered_map<vt::NodeType,Counters> count_;
 };
+
+// channel counters per epoch and per rank
+extern std::unordered_map<vt::EpochType,Data> data;
 
 // send any kind of message
 template <typename Msg, vt::ActiveTypedFnType<Msg>* handler>
@@ -80,28 +96,21 @@ template <vt::ActiveTypedFnType<BasicMsg>* handler>
 void broadcast(int count, vt::EpochType ep);
 
 // route basic message, send control messages
-void routeBasic(vt::NodeType dst, int ttl, vt::EpochType ep);
-void sendPing(vt::NodeType dst, int count, vt::EpochType ep);
-void sendEcho(vt::NodeType dst, int count, vt::EpochType ep);
+inline void routeBasic(vt::NodeType dst, int ttl, vt::EpochType ep);
+inline void sendPing(vt::NodeType dst, int count, vt::EpochType ep);
+inline void sendEcho(vt::NodeType dst, int count, vt::EpochType ep);
 
 // on receipt of a basic message.
-void basicHandler(BasicMsg* msg);
-void routedHandler(BasicMsg* msg);
-void echoHandler(CtrlMsg* msg);
-void pingHandler(CtrlMsg* msg);
+inline void basicHandler(BasicMsg* msg);
+inline void routedHandler(BasicMsg* msg);
+inline void echoHandler(CtrlMsg* msg);
+inline void pingHandler(CtrlMsg* msg);
 
 // trigger, propagate and check
 // termination of an epoch
-void trigger(vt::EpochType ep);
-void propagate(vt::EpochType ep);
-bool hasEnded(vt::EpochType ep);
-
-// ranks
-extern vt::NodeType node;
-extern vt::NodeType root;
-extern vt::NodeType all;
-// channel counters per epoch and per rank
-extern std::unordered_map<vt::EpochType,Data> data;
+inline void trigger(vt::EpochType ep);
+inline void propagate(vt::EpochType ep);
+inline bool hasEnded(vt::EpochType ep);
 
 }}}} // end namespace vt::tests::unit::channel
 


### PR DESCRIPTION
Fixes #1105

- Switch to using the `gold` linker by default when applicable--ELF format (less memory, and faster)
- Update all docker CI images to use CMake >=3.16 to take advantage of Unity/Jumbo builds
- Fix ODR violations/header bugs discovered from Unity builds
- Combine tests by directory into a single executable per type (basic, extended, nompi)
- With combined tests, Unity builds now invoke one build/link command per test directly per type of test

With these changes, **up to 50% faster** in build performance across the board. The faster CI targets now take 15 minutes completely out of cache. We use half as much disk space as before with these changes!

Still waiting for all my images to build/push to see how it affects nvcc/intel performance.

The only downside of Unity builds is that more will need to be rebuilt if you modify a file. By default, Unity is not enabled unless running in CI (which we could change?)