### PR TITLE
1098 Enable assertions during CI when release builds are used

### DIFF
--- a/.github/workflows/dockerimage-clang-3.9-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-3.9-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-clang-5.0-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-clang-5.0-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-clang-8-alpine-mpich.yml
+++ b/.github/workflows/dockerimage-clang-8-alpine-mpich.yml
@@ -32,6 +32,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-gcc-10-ubuntu-openmpi.yml
+++ b/.github/workflows/dockerimage-gcc-10-ubuntu-openmpi.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-gcc-5-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-5-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-gcc-6-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-6-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-gcc-7-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-7-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-gcc-8-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-8-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-gcc-9-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-gcc-9-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 1
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-intel-18-ubuntu-mpich-extended.yml
+++ b/.github/workflows/dockerimage-intel-18-ubuntu-mpich-extended.yml
@@ -35,6 +35,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-intel-18-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-intel-18-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: ${{ github.event_name != 'pull_request' }}
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich-extended.yml
+++ b/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich-extended.yml
@@ -35,6 +35,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-nvidia-10-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: ${{ github.event_name != 'pull_request' }}
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich-extended.yml
+++ b/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich-extended.yml
@@ -35,6 +35,7 @@ jobs:
       VT_EXTENDED_TESTS: 1
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich.yml
+++ b/.github/workflows/dockerimage-nvidia-11-ubuntu-mpich.yml
@@ -37,6 +37,7 @@ jobs:
       VT_EXTENDED_TESTS: ${{ github.event_name != 'pull_request' }}
       VT_UNITY_BUILD: 1
       VT_ZOLTAN: 0
+      VT_CI_BUILD: 1
       CACHE: ~/.local/cache/
 
     steps:

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -111,6 +111,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dcheckpoint_DIR="$CHECKPOINT_BUILD/install" \
       -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}" \
       -DCMAKE_INSTALL_PREFIX="$VT_BUILD/install" \
+      -Dvt_ci_build="${VT_CI_BUILD:-0}" \
       "$VT"
 
 if test "${VT_DOXYGEN_ENABLED:-0}" -eq 1

--- a/cmake/define_build_types.cmake
+++ b/cmake/define_build_types.cmake
@@ -164,6 +164,9 @@ else()
   set(vt_feature_cmake_zoltan "0")
 endif()
 
+message(STATUS "CI_BUILD = ${vt_ci_build}")
+set(vt_feature_cmake_ci_build ${vt_ci_build})
+
 set(vt_feature_cmake_no_feature "0")
 set(vt_feature_cmake_production "0")
 

--- a/cmake/define_build_types.cmake
+++ b/cmake/define_build_types.cmake
@@ -212,8 +212,8 @@ foreach(loop_build_type ${VT_CONFIG_TYPES})
     ${cmake_vt_debug_modes_${loop_build_type}}
   )
 
-  # assume production mode for everything except debug
-  if (loop_build_type STREQUAL "debug")
+  # assume production mode for everything except debug or CI build
+  if (loop_build_type STREQUAL "debug" OR ${vt_ci_build})
     set(vt_feature_cmake_production "0")
   else()
     set(vt_feature_cmake_production "1")

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -67,6 +67,7 @@
 #define vt_feature_cmake_mimalloc            @vt_feature_cmake_mimalloc@
 #define vt_feature_cmake_mpi_access_guards   @vt_feature_cmake_mpi_access_guards@
 #define vt_feature_cmake_zoltan              @vt_feature_cmake_zoltan@
+#define vt_feature_cmake_ci_build            @vt_feature_cmake_ci_build@
 
 #cmakedefine vt_quirked_trivially_copyable_on_msg
 #cmakedefine vt_quirked_serialize_method_detection

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ x-vtopts: &vtopts
   CODE_COVERAGE: ${CODE_COVERAGE:-0}
   https_proxy: ${PROXY-}
   http_proxy: ${PROXY-}
+  VT_CI_BUILD: ${VT_CI_BUILD:-0}
 
 services:
   ##############################################################################

--- a/scripts/workflow-template.yml
+++ b/scripts/workflow-template.yml
@@ -30,6 +30,7 @@ jobs:
       VT_EXTENDED_TESTS: [% vt_extended_tests %]
       VT_UNITY_BUILD: [% vt_unity_build %]
       VT_ZOLTAN: [% vt_zoltan %]
+      VT_CI_BUILD: [% vt_ci_build %]
       CACHE: [% cache_dir %]
 
     steps:

--- a/scripts/workflows.ini
+++ b/scripts/workflows.ini
@@ -10,6 +10,7 @@ vt_pool = 1
 vt_extended_tests = 1
 vt_unity_build = 1
 vt_zoltan = 0
+vt_ci_build = 1
 ulimit_core = 0
 code_coverage = 0
 build_type = release

--- a/src/vt/configs/features/features_defines.h
+++ b/src/vt/configs/features/features_defines.h
@@ -69,5 +69,6 @@
 #define vt_feature_mimalloc           0 || vt_feature_cmake_mimalloc
 #define vt_feature_mpi_access_guards  0 || vt_feature_cmake_mpi_access_guards
 #define vt_feature_zoltan             0 || vt_feature_cmake_zoltan
+#define vt_feature_ci_build           0 || vt_feature_cmake_ci_build
 
 #endif /*INCLUDED_VT_CONFIGS_FEATURES_FEATURES_DEFINES_H*/


### PR DESCRIPTION
Added new flag `vt_ci_build` to distinguish CI build from normal one. By default this only affects CI runs, meaning that if VT is built in Release mode locally (via docker containter or cmake) this will still have `production` flag set on.

Also, I think having the option to check for build type in the code can be useful in future (i.e. for unit tests we might want different behaviour in CI and different locally). So now you can check for CI build using `vt_check_enabled(ci_build)`


Fixes #1098