### PR TITLE
1111 Fix for large message sends

### DIFF
--- a/src/vt/configs/arguments/app_config.h
+++ b/src/vt/configs/arguments/app_config.h
@@ -161,6 +161,7 @@ struct AppConfig {
   bool vt_diag_csv_base_units = false;
 
   bool vt_pause = false;
+  std::size_t vt_max_mpi_send_size = 1ull << 30;
 
   bool vt_debug_all          = false;
   bool vt_debug_verbose      = false;

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -485,6 +485,18 @@ void ArgConfig::addConfigFileArgs(CLI::App& app) {
   a2->group(configGroup);
 }
 
+void ArgConfig::addRuntimeArgs(CLI::App& app) {
+  auto max_size = "Maximum MPI send size (causes larger messages to be split "
+                  "into multiple MPI sends)";
+
+  auto a1 = app.add_option(
+    "--vt_max_mpi_send_size", config_.vt_max_mpi_send_size, max_size, true
+  );
+
+  auto configRuntime = "Runtime";
+  a1->group(configRuntime);
+}
+
 class VtFormatter : public CLI::Formatter {
 public:
   std::string make_usage(const CLI::App *, std::string name) const override {
@@ -537,6 +549,7 @@ std::tuple<int, std::string> ArgConfig::parse(int& argc, char**& argv) {
   addUserArgs(app);
   addSchedulerArgs(app);
   addConfigFileArgs(app);
+  addRuntimeArgs(app);
 
   std::tuple<int, std::string> result = parseArguments(app, /*out*/ argc, /*out*/ argv);
   if (std::get<0>(result) not_eq -1) {

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -96,6 +96,7 @@ private:
   void addUserArgs(CLI::App& app);
   void addSchedulerArgs(CLI::App& app);
   void addConfigFileArgs(CLI::App& app);
+  void addRuntimeArgs(CLI::App& app);
 
   void postParseTransform();
 

--- a/src/vt/configs/types/types_type.h
+++ b/src/vt/configs/types/types_type.h
@@ -103,7 +103,7 @@ using UniqueIndexBitType      = uint64_t;
 /// Used for hold an identifier for a group
 using GroupType               = uint64_t;
 /// Used for hold the size of a message
-using MsgSizeType             = int32_t;
+using MsgSizeType             = int64_t;
 /// Used for hold a phase for load balancing
 using PhaseType               = uint64_t;
 /// Used for hold a sub-phase for load balancing

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -563,7 +563,6 @@ std::tuple<EventType, int> ActiveMessenger::sendDataMPI(
       std::min(static_cast<std::size_t>(remainder), max_per_send)
     );
     {
-      VT_ALLOW_MPI_CALLS;
       #if vt_check_enabled(trace_enabled)
         double tr_begin = 0;
         if (theConfig()->vt_trace_mpi) {
@@ -578,6 +577,7 @@ std::tuple<EventType, int> ActiveMessenger::sendDataMPI(
         remainder, dest, tag, num_sends, subsize, std::get<1>(payload)
       );
 
+      VT_ALLOW_MPI_CALLS;
       int const ret = MPI_Isend(
         ptr, subsize, MPI_BYTE, dest, tag, theContext()->getComm(),
         mpi_event->getRequest()
@@ -1088,8 +1088,6 @@ bool ActiveMessenger::tryProcessIncomingActiveMsg() {
     MPI_Request req;
 
     {
-      VT_ALLOW_MPI_CALLS;
-
       #if vt_check_enabled(trace_enabled)
         double tr_begin = 0;
         if (theConfig()->vt_trace_mpi) {
@@ -1097,6 +1095,7 @@ bool ActiveMessenger::tryProcessIncomingActiveMsg() {
         }
       #endif
 
+      VT_ALLOW_MPI_CALLS;
       MPI_Irecv(
         buf, num_probe_bytes, MPI_BYTE, sender, stat.MPI_TAG,
         theContext()->getComm(), &req

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -584,7 +584,7 @@ std::tuple<EventType, int> ActiveMessenger::sendDataMPI(
       #if vt_check_enabled(trace_enabled)
         if (theConfig()->vt_trace_mpi) {
           auto tr_end = vt::timing::Timing::getCurrentTime();
-          auto tr_note = fmt::format("Isend(Data): dest={}, bytes={}", dest, num_bytes);
+          auto tr_note = fmt::format("Isend(Data): dest={}, bytes={}", dest, subsize);
           trace::addUserBracketedNote(tr_begin, tr_end, tr_note, trace_isend);
         }
       #endif

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -266,8 +266,6 @@ private:
   MsgSizeType size = 0;
 };
 
-static constexpr std::size_t max_per_send = 1ull << 30;
-
 /*static*/ void ActiveMessenger::chunkedMultiMsg(MultiMsg* msg) {
   theMsg()->handleChunkedMultiMsg(msg);
 }
@@ -313,6 +311,7 @@ EventType ActiveMessenger::sendMsgMPI(
     dest, msg_size, send_tag
   );
 
+  auto const max_per_send = theConfig()->vt_max_mpi_send_size;
   if (static_cast<std::size_t>(msg_size) < max_per_send) {
     auto const event_id = theEvent()->createMPIEvent(this_node_);
     auto& holder = theEvent()->getEventHolder(event_id);
@@ -556,6 +555,7 @@ std::tuple<EventType, int> ActiveMessenger::sendDataMPI(
     auto const event_id = theEvent()->createMPIEvent(this_node_);
     auto& holder = theEvent()->getEventHolder(event_id);
     auto mpi_event = holder.get_event();
+    auto const max_per_send = theConfig()->vt_max_mpi_send_size;
     auto subsize = static_cast<ByteType>(
       std::min(static_cast<std::size_t>(remainder), max_per_send)
     );
@@ -747,6 +747,7 @@ void ActiveMessenger::recvDataDirect(
   char* cbuf = static_cast<char*>(buf);
   MsgSizeType remainder = len;
   for (int i = 0; i < nchunks; i++) {
+    auto const max_per_send = theConfig()->vt_max_mpi_send_size;
     auto sublen = static_cast<int>(
       std::min(static_cast<std::size_t>(remainder), max_per_send)
     );

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -352,13 +352,16 @@ EventType ActiveMessenger::sendMsgMPI(
     auto tag = allocateNewTag();
     auto this_node = theContext()->getNode();
 
+    // Send the actual data in multiple chunks
     PtrLenPairType tup = std::make_tuple(untyped_msg, msg_size);
     SendInfo info = sendData(tup, dest, tag);
+
     auto event_id = info.getEvent();
     auto& holder = theEvent()->getEventHolder(event_id);
     auto mpi_event = holder.get_event();
     mpi_event->setManagedMessage(base.to<ShortMessage>());
 
+    // Send the control message to receive the multiple chunks of data
     auto m = makeMessage<MultiMsg>(info, this_node, msg_size);
     sendMsg<MultiMsg, chunkedMultiMsg>(dest, m);
 

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -764,7 +764,7 @@ void ActiveMessenger::recvDataDirect(
         auto tr_end = vt::timing::Timing::getCurrentTime();
         auto tr_note = fmt::format(
           "Irecv(Data): from={}, bytes={}",
-          stat.MPI_SOURCE, num_probe_bytes
+          from, sublen
         );
         trace::addUserBracketedNote(tr_begin, tr_end, tr_note, trace_irecv);
       }

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -628,10 +628,10 @@ bool ActiveMessenger::tryProcessDataMsgRecv() {
   auto iter = pending_recvs_.begin();
 
   for (; iter != pending_recvs_.end(); ++iter) {
+    auto& elm = iter->second;
     auto const done = recvDataMsgBuffer(
-      iter->second.nchunks, iter->second.user_buf, iter->second.priority,
-      iter->first, iter->second.sender, false, iter->second.dealloc_user_buf,
-      iter->second.cont
+      elm.nchunks, elm.user_buf, elm.priority, iter->first, elm.sender, false,
+      elm.dealloc_user_buf, elm.cont
     );
     if (done) {
       erase = true;

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -630,7 +630,7 @@ bool ActiveMessenger::tryProcessDataMsgRecv() {
   for (; iter != pending_recvs_.end(); ++iter) {
     auto const done = recvDataMsgBuffer(
       iter->second.nchunks, iter->second.user_buf, iter->second.priority,
-      iter->first, iter->second.recv_node, false, iter->second.dealloc_user_buf,
+      iter->first, iter->second.sender, false, iter->second.dealloc_user_buf,
       iter->second.cont
     );
     if (done) {
@@ -849,11 +849,11 @@ void ActiveMessenger::finishPendingDataMsgAsyncRecv(InProgressDataIRecv* irecv) 
 
 bool ActiveMessenger::recvDataMsg(
   int nchunks, PriorityType priority, TagType const& tag,
-  NodeType const& recv_node, bool const& enqueue,
+  NodeType const& sender, bool const& enqueue,
   RDMA_ContinuationDeleteType next
 ) {
   return recvDataMsgBuffer(
-    nchunks, nullptr, priority, tag, recv_node, enqueue, nullptr, next
+    nchunks, nullptr, priority, tag, sender, enqueue, nullptr, next
   );
 }
 

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -396,6 +396,17 @@ EventType ActiveMessenger::doMessageSend(
   return ret_event;
 }
 
+MPI_TagType ActiveMessenger::allocateNewTag() {
+  auto const max_tag = util::MPI_Attr::getMaxTag();
+
+  if (cur_direct_buffer_tag_ == max_tag) {
+    cur_direct_buffer_tag_ = starting_direct_buffer_tag;
+  }
+  auto const ret_tag = cur_direct_buffer_tag_++;
+
+  return ret_tag;
+}
+
 ActiveMessenger::SendDataRetType ActiveMessenger::sendData(
   RDMA_GetType const& ptr, NodeType const& dest, TagType const& tag
 ) {
@@ -406,12 +417,7 @@ ActiveMessenger::SendDataRetType ActiveMessenger::sendData(
   if (tag != no_tag) {
     send_tag = tag;
   } else {
-    auto const max_tag = util::MPI_Attr::getMaxTag();
-
-    if (cur_direct_buffer_tag_ == max_tag) {
-      cur_direct_buffer_tag_ = starting_direct_buffer_tag;
-    }
-    send_tag = cur_direct_buffer_tag_++;
+    send_tag = allocateNewTag();
   }
 
   auto const event_id = theEvent()->createMPIEvent(this_node_);

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -551,11 +551,11 @@ std::tuple<EventType, int> ActiveMessenger::sendDataMPI(
   int num_sends = 0;
   std::vector<EventType> events;
   EventType ret_event = no_event;
+  auto const max_per_send = theConfig()->vt_max_mpi_send_size;
   while (remainder > 0) {
     auto const event_id = theEvent()->createMPIEvent(this_node_);
     auto& holder = theEvent()->getEventHolder(event_id);
     auto mpi_event = holder.get_event();
-    auto const max_per_send = theConfig()->vt_max_mpi_send_size;
     auto subsize = static_cast<ByteType>(
       std::min(static_cast<std::size_t>(remainder), max_per_send)
     );
@@ -746,8 +746,8 @@ void ActiveMessenger::recvDataDirect(
 
   char* cbuf = static_cast<char*>(buf);
   MsgSizeType remainder = len;
+  auto const max_per_send = theConfig()->vt_max_mpi_send_size;
   for (int i = 0; i < nchunks; i++) {
-    auto const max_per_send = theConfig()->vt_max_mpi_send_size;
     auto sublen = static_cast<int>(
       std::min(static_cast<std::size_t>(remainder), max_per_send)
     );

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -115,14 +115,15 @@ struct PendingRecv {
   ActionType dealloc_user_buf = nullptr;
   NodeType sender = uninitialized_destination;
   PriorityType priority = no_priority;
+  bool is_user_buf = false;
 
   PendingRecv(
     int in_nchunks, void* in_user_buf, ContinuationDeleterType in_cont,
     ActionType in_dealloc_user_buf, NodeType node,
-    PriorityType in_priority
+    PriorityType in_priority, bool in_is_user_buf
   ) : nchunks(in_nchunks), user_buf(in_user_buf), cont(in_cont),
       dealloc_user_buf(in_dealloc_user_buf), sender(node),
-      priority(in_priority)
+      priority(in_priority), is_user_buf(in_is_user_buf)
   { }
 };
 
@@ -1173,6 +1174,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] enqueue whether to enqueue the operation
    * \param[in] dealloc_user_buf the action to deallocate a user buffer
    * \param[in] next the continuation when the data is ready
+   * \param[in] is_user_buf is a user buffer that require user deallocation
    *
    * \return whether the data is ready or pending
    */
@@ -1180,7 +1182,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     int nchunks, void* const user_buf, PriorityType priority, TagType const& tag,
     NodeType const& node = uninitialized_destination, bool const& enqueue = true,
     ActionType dealloc_user_buf = nullptr,
-    ContinuationDeleterType next = nullptr
+    ContinuationDeleterType next = nullptr, bool is_user_buf = false
   );
 
   /**
@@ -1194,6 +1196,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] enqueue whether to enqueue the operation
    * \param[in] dealloc_user_buf the action to deallocate a user buffer
    * \param[in] next the continuation when the data is ready
+   * \param[in] is_user_buf is a user buffer that require user deallocation
    *
    * \return whether the data is ready or pending
    */
@@ -1201,7 +1204,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     int nchunks, void* const user_buf, TagType const& tag,
     NodeType const& node = uninitialized_destination, bool const& enqueue = true,
     ActionType dealloc_user_buf = nullptr,
-    ContinuationDeleterType next = nullptr
+    ContinuationDeleterType next = nullptr, bool is_user_buf = false
   );
 
   /**
@@ -1215,11 +1218,12 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] prio the priority for the continuation
    * \param[in] dealloc the action to deallocate the buffer
    * \param[in] next the continuation that gets passed the data when ready
+   * \param[in] is_user_buf is a user buffer that require user deallocation
    */
   void recvDataDirect(
     int nchunks, void* const buf, TagType const tag, NodeType const from,
     MsgSizeType len, PriorityType prio, ActionType dealloc = nullptr,
-    ContinuationDeleterType next = nullptr
+    ContinuationDeleterType next = nullptr, bool is_user_buf = false
   );
 
   /**

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -181,24 +181,18 @@ struct InProgressDataIRecv : InProgressBase {
   bool test(int& num_mpi_tests) {
     int flag = 0;
     MPI_Status stat;
-    for (std::size_t i = 0; i < reqs.size();) {
+    for ( ; cur < reqs.size(); cur++) {
       VT_ALLOW_MPI_CALLS; // MPI_Test
 
-      MPI_Test(&reqs[i], &flag, &stat);
+      MPI_Test(&reqs[cur], &flag, &stat);
       num_mpi_tests++;
 
       if (flag == 0) {
-        ++i;
-        continue;
+        return false;
       }
-
-      if (i < reqs.size() - 1) {
-        reqs[i] = std::move(reqs.back());
-      }
-      reqs.pop_back();
     }
 
-    return reqs.size() == 0;
+    return true;
   }
 
 public:
@@ -208,6 +202,7 @@ public:
   PriorityType priority = no_priority;
 
 private:
+  std::size_t cur = 0;
   std::vector<MPI_Request> reqs;
 };
 

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1496,8 +1496,10 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] base the message base pointer
    * \param[in] msg_size the size of the message
    * \param[in] send_tag the send tag on the message
+   *
+   * \return the event to test/wait for completion
    */
-  void sendMsgMPI(
+  EventType sendMsgMPI(
     NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base,
     MsgSizeType const& msg_size, TagType const& send_tag
   );

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1509,6 +1509,16 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   }
 
 private:
+  /**
+   * \internal \brief Allocate a new, unused tag.
+   *
+   * \note Wraps around when reaching max tag, determined by the MPI
+   * implementation.
+   *
+   * \return a new MPI tag
+   */
+  MPI_TagType allocateNewTag();
+
   bool testPendingActiveMsgAsyncRecv();
   bool testPendingDataMsgAsyncRecv();
 

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -123,7 +123,7 @@ struct InProgressIRecv {
 
   InProgressIRecv(
     char* in_buf, CountType in_probe_bytes, NodeType in_sender,
-    MPI_Request in_req
+    MPI_Request in_req = MPI_REQUEST_NULL
   ) : buf(in_buf), probe_bytes(in_probe_bytes), sender(in_sender),
       req(in_req), valid(true)
   { }

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -102,7 +102,7 @@ struct PendingRecv {
   void* user_buf = nullptr;
   RDMA_ContinuationDeleteType cont = nullptr;
   ActionType dealloc_user_buf = nullptr;
-  NodeType recv_node = uninitialized_destination;
+  NodeType sender = uninitialized_destination;
   PriorityType priority = no_priority;
 
   PendingRecv(
@@ -110,7 +110,7 @@ struct PendingRecv {
     ActionType in_dealloc_user_buf, NodeType node,
     PriorityType in_priority
   ) : nchunks(in_nchunks), user_buf(in_user_buf), cont(in_cont),
-      dealloc_user_buf(in_dealloc_user_buf), recv_node(node),
+      dealloc_user_buf(in_dealloc_user_buf), sender(node),
       priority(in_priority)
   { }
 };
@@ -1140,7 +1140,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] nchunks the number of chunks to receive
    * \param[in] priority the priority to receive the data
    * \param[in] tag the MPI tag to receive on
-   * \param[in] recv_node the node from which to receive
+   * \param[in] sender the sender node
    * \param[in] enqueue whether to enqueue the pending receive
    * \param[in] next a continuation to execute when data arrives
    *
@@ -1148,7 +1148,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    */
   bool recvDataMsg(
     int nchunks, PriorityType priority, TagType const& tag,
-    NodeType const& recv_node, bool const& enqueue,
+    NodeType const& sender, bool const& enqueue,
     RDMA_ContinuationDeleteType next = nullptr
   );
 

--- a/src/vt/messaging/irecv_holder.h
+++ b/src/vt/messaging/irecv_holder.h
@@ -97,8 +97,6 @@ struct IRecvHolder {
    */
   template <typename Callable>
   bool testAll(Callable c, int& num_mpi_tests) {
-    VT_ALLOW_MPI_CALLS; // MPI_Test in loop
-
 #   if vt_check_enabled(trace_enabled)
     std::size_t const holder_size_start = holder_.size();
     TimeType tr_begin = 0.0;
@@ -113,12 +111,9 @@ struct IRecvHolder {
       auto& e = holder_[i];
       vtAssert(e.valid, "Must be valid");
 
-      int flag = 0;
-      MPI_Status stat;
-      MPI_Test(&e.req, &flag, &stat);
-      num_mpi_tests++;
+      auto done = e.test(num_mpi_tests);
 
-      if (flag == 0) {
+      if (not done) {
         ++i;
         continue;
       }

--- a/src/vt/messaging/multitag_holder.h
+++ b/src/vt/messaging/multitag_holder.h
@@ -1,0 +1,101 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                              multitag_holder.h
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_MESSAGING_MULTITAG_HOLDER_H
+#define INCLUDED_VT_MESSAGING_MULTITAG_HOLDER_H
+
+#include <memory>
+
+namespace vt { namespace messaging {
+
+struct InProgressIRecv;
+
+/**
+ * \struct MultiTagHolder
+ *
+ * \internal \brief Holds a irecv holder along with a counter for when all
+ * receives fill the buffer from split sends arriving
+ */
+struct MultiTagHolder {
+  using IRecvPtrType = std::unique_ptr<InProgressIRecv>;
+
+  /**
+   * \brief Construct the holder
+   *
+   * \param[in] in_cnt the number of sends/recvs it was broken into
+   * \param[in] in_irecv the in-progress irecv holder with the buffer
+   */
+  MultiTagHolder(int in_cnt, IRecvPtrType in_irecv)
+    : cnt(in_cnt),
+      irecv(std::move(in_irecv))
+  { }
+
+  /**
+   * \brief Indicate that a recv has arrived
+   */
+  void decrement() { cnt--; }
+
+  /**
+   * \brief Check if the counter is zero indicating all that receives have
+   * arrived
+   *
+   * \return whether it is ready
+   */
+  bool ready() const { return cnt == 0; }
+
+  /**
+   * \brief Get the in-progress irecv holder
+   *
+   * \return passes ownership out of this container
+   */
+  IRecvPtrType getIrecv() { return std::move(irecv); }
+
+private:
+  int cnt = 0;                  /**< The number of split sends/recvs */
+  IRecvPtrType irecv = nullptr; /**< The in-progress irecv holder */
+};
+
+}} /* end namespace vt::messaging */
+
+#endif /*INCLUDED_VT_MESSAGING_MULTITAG_HOLDER_H*/

--- a/src/vt/rdma/collection/rdma_collection.cc
+++ b/src/vt/rdma/collection/rdma_collection.cc
@@ -197,7 +197,8 @@ namespace vt { namespace rdma {
 
     auto send_payload = [&](Active::SendFnType send){
       auto ret = send(put_ret, put_node, no_tag);
-      msg->mpi_tag_to_recv = std::get<1>(ret);
+      msg->mpi_tag_to_recv = ret.getTag();
+      msg->nchunks = ret.getNumChunks();
     };
 
     if (tag != no_tag) {

--- a/src/vt/rdma/rdma.cc
+++ b/src/vt/rdma/rdma.cc
@@ -87,7 +87,8 @@ RDMAManager::RDMAManager()
 
       auto send_payload = [&](Active::SendFnType send){
         auto ret = send(data, recv_node, no_tag);
-        new_msg->mpi_tag_to_recv = std::get<1>(ret);
+        new_msg->mpi_tag_to_recv = ret.getTag();
+        new_msg->nchunks = ret.getNumChunks();
         vt_debug_print(
           rdma, node,
           "data is sending: tag={}, node={}\n",
@@ -126,7 +127,7 @@ RDMAManager::RDMAManager()
 
   if (get_ptr == nullptr) {
     theMsg()->recvDataMsg(
-      msg->mpi_tag_to_recv, msg->send_back,
+      msg->nchunks, msg->mpi_tag_to_recv, msg->send_back,
       [=](RDMA_GetType ptr, ActionType deleter){
         theRDMA()->triggerGetRecvData(
           op_id, msg_tag, std::get<0>(ptr), std::get<1>(ptr), deleter
@@ -135,7 +136,8 @@ RDMAManager::RDMAManager()
     );
   } else {
     theMsg()->recvDataMsgBuffer(
-      get_ptr, msg->mpi_tag_to_recv, msg->send_back, true, [get_ptr_action]{
+      msg->nchunks, get_ptr, msg->mpi_tag_to_recv, msg->send_back, true,
+      [get_ptr_action]{
         vt_debug_print(
           rdma, node,
           "recv_data_msg_buffer finished\n"
@@ -209,6 +211,7 @@ RDMAManager::RDMAManager()
 
     if (put_ptr == nullptr) {
       theMsg()->recvDataMsg(
+        msg->nchunks,
         recv_tag, recv_node, [=](RDMA_GetType ptr, ActionType deleter){
           vt_debug_print(
             rdma, node,
@@ -238,7 +241,7 @@ RDMAManager::RDMAManager()
         msg->offset != no_byte ? static_cast<char*>(put_ptr) + msg->offset : put_ptr;
       // do a direct recv into the user buffer
       theMsg()->recvDataMsgBuffer(
-        put_ptr_offset, recv_tag, recv_node, true, []{},
+        msg->nchunks, put_ptr_offset, recv_tag, recv_node, true, []{},
         [=](RDMA_GetType ptr, ActionType deleter){
           vt_debug_print(
             rdma, node,
@@ -686,7 +689,8 @@ void RDMAManager::putData(
 
           auto send_payload = [&](Active::SendFnType send){
             auto ret = send(RDMA_GetType{ptr, num_bytes}, put_node, no_tag);
-            msg->mpi_tag_to_recv = std::get<1>(ret);
+            msg->mpi_tag_to_recv = ret.getTag();
+            msg->nchunks = ret.getNumChunks();
           };
 
           if (tag != no_tag) {

--- a/src/vt/rdma/rdma.cc
+++ b/src/vt/rdma/rdma.cc
@@ -145,7 +145,8 @@ RDMAManager::RDMAManager()
         if (get_ptr_action) {
           get_ptr_action();
         }
-      }
+      },
+      nullptr, true
     );
   }
 }

--- a/src/vt/rdma/rdma_msg.h
+++ b/src/vt/rdma/rdma_msg.h
@@ -82,12 +82,13 @@ struct SendDataMessage : ActiveMessage<EnvelopeT> {
     NodeType const& back = uninitialized_destination,
     NodeType const& in_recv_node = uninitialized_destination,
     bool const in_packed_direct = false
-  ) : ActiveMessage<EnvelopeT>(),
-    rdma_handle(in_han), send_back(back), recv_node(in_recv_node),
-    mpi_tag_to_recv(in_mpi_tag), op_id(in_op), num_bytes(in_num_bytes),
-    offset(in_offset), packed_direct(in_packed_direct)
+  ) : rdma_handle(in_han), send_back(back),
+      recv_node(in_recv_node), mpi_tag_to_recv(in_mpi_tag), op_id(in_op),
+      num_bytes(in_num_bytes), offset(in_offset),
+      packed_direct(in_packed_direct)
   { }
 
+  int nchunks = 0;
   RDMA_HandleType rdma_handle = no_rdma_handle;
   NodeType send_back = uninitialized_destination;
   NodeType recv_node = uninitialized_destination;

--- a/src/vt/serialization/messaging/serialized_data_msg.h
+++ b/src/vt/serialization/messaging/serialized_data_msg.h
@@ -64,6 +64,7 @@ struct SerializedDataMsgAny : MessageT {
   HandlerType handler = uninitialized_handler;
   TagType data_recv_tag = no_tag;
   NodeType from_node = uninitialized_destination;
+  int nchunks = 0;
 };
 
 template <typename T>

--- a/src/vt/utils/memory/memory_units.cc
+++ b/src/vt/utils/memory/memory_units.cc
@@ -74,4 +74,33 @@ MemoryUnitEnum getUnitFromString(std::string const& unit) {
   return MemoryUnitEnum::Bytes;
 }
 
+std::tuple<std::string, double> getBestMemoryUnit(std::size_t bytes) {
+  auto multiplier = static_cast<int8_t>(MemoryUnitEnum::Yottabytes);
+  for ( ; multiplier > 0; multiplier--) {
+    auto value_tmp = static_cast<double>(bytes);
+    for (int8_t i = 0; i < static_cast<int8_t>(multiplier); i++) {
+      value_tmp /= 1024.0;
+    }
+    if (value_tmp >= 1.) {
+      break;
+    }
+  }
+
+  // We found a multiplier that results in a value over 1.0, use it
+  vtAssert(
+    multiplier <= static_cast<int8_t>(MemoryUnitEnum::Yottabytes) and
+    multiplier >= 0,
+    "Must be a valid memory unit"
+  );
+
+  auto unit_name = getMemoryUnitName(static_cast<MemoryUnitEnum>(multiplier));
+
+  auto new_value = static_cast<double>(bytes);
+  for (int8_t i = 0; i < static_cast<int8_t>(multiplier); i++) {
+    new_value /= 1024.0;
+  }
+
+  return std::make_tuple(unit_name, new_value);
+}
+
 }}} /* end namespace vt::util::memory */

--- a/src/vt/utils/memory/memory_units.h
+++ b/src/vt/utils/memory/memory_units.h
@@ -65,6 +65,7 @@ enum struct MemoryUnitEnum : int8_t {
 
 std::string getMemoryUnitName(MemoryUnitEnum unit);
 MemoryUnitEnum getUnitFromString(std::string const& unit);
+std::tuple<std::string, double> getBestMemoryUnit(std::size_t bytes);
 
 }}} /* end namespace vt::util::memory */
 

--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -101,7 +101,8 @@ TYPED_TEST_P(TestActiveSendLarge, test_large_bytes_msg) {
   NodeType const this_node = theContext()->getNode();
   NodeType const num_nodes = theContext()->getNumNodes();
 
-  if (num_nodes < 2) {
+  // over two nodes will allocate a lot of memory for the run
+  if (num_nodes != 2) {
     return;
   }
 
@@ -126,7 +127,7 @@ REGISTER_TYPED_TEST_SUITE_P(TestActiveSendLarge, test_large_bytes_msg);
 using NonSerTestTypes = testing::Types<
   std::tuple<std::integral_constant<NumBytesType, 30>, NonSerializedTag>,
   std::tuple<std::integral_constant<NumBytesType, 31>, NonSerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 34>, NonSerializedTag>
+  std::tuple<std::integral_constant<NumBytesType, 32>, NonSerializedTag>
 >;
 
 using SerTestTypes = testing::Types<

--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -121,30 +121,28 @@ TYPED_TEST_P(TestActiveSendLarge, test_large_bytes_msg) {
   EXPECT_EQ(counter, 1);
 }
 
-struct PrintParam {
-  template <typename ParamType>
-  static std::string GetName(int i) {
-    using IntegralType = typename std::tuple_element<0,ParamType>::type;
-    using TagType = typename std::tuple_element<1,ParamType>::type;
-    static constexpr NumBytesType const nbytes = 1ll << IntegralType::value;
-    auto const serialized = std::is_same<TagType, SerializedTag>::value;
-    return fmt::format("bytes{}serialized{}", nbytes, serialized);
-  }
-};
-
 REGISTER_TYPED_TEST_SUITE_P(TestActiveSendLarge, test_large_bytes_msg);
 
-using TestTypes = testing::Types<
+using NonSerTestTypes = testing::Types<
   std::tuple<std::integral_constant<NumBytesType, 30>, NonSerializedTag>,
   std::tuple<std::integral_constant<NumBytesType, 31>, NonSerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 34>, NonSerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 34>, NonSerializedTag>
+>;
+
+using SerTestTypes = testing::Types<
   std::tuple<std::integral_constant<NumBytesType, 30>, SerializedTag>,
   std::tuple<std::integral_constant<NumBytesType, 31>, SerializedTag>,
   std::tuple<std::integral_constant<NumBytesType, 34>, SerializedTag>
 >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(
-  test_large_bytes_basic, TestActiveSendLarge, TestTypes, PrintParam
+  test_large_bytes_serialized, TestActiveSendLarge, NonSerTestTypes,
+  DEFAULT_NAME_GEN
+);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(
+  test_large_bytes_nonserialized, TestActiveSendLarge, SerTestTypes,
+  DEFAULT_NAME_GEN
 );
 
 }}}} // end namespace vt::tests::unit::large

--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -1,0 +1,150 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                          test_active_send_large.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "data_message.h"
+
+namespace vt { namespace tests { namespace unit { namespace large {
+
+struct SerializedTag {};
+struct NonSerializedTag {};
+
+using RecvMsg = vt::Message;
+
+struct CallbackMsg : vt::Message {
+  vt::Callback<RecvMsg> cb_;
+};
+
+template <NumBytesType nbytes, typename T, typename enabled_=void>
+struct LargeMsg;
+
+template <NumBytesType nbytes, typename T>
+struct LargeMsg<
+  nbytes,
+  T,
+  typename std::enable_if_t<std::is_same<T, SerializedTag>::value>
+> : TestStaticSerialBytesMsg<CallbackMsg, nbytes> { };
+
+template <NumBytesType nbytes, typename T>
+struct LargeMsg<
+  nbytes,
+  T,
+  typename std::enable_if_t<std::is_same<T, NonSerializedTag>::value>
+> : TestStaticBytesMsg<CallbackMsg, nbytes> { };
+
+template <typename T>
+struct TestActiveSendLarge : TestParallelHarness {
+  using TagType = typename std::tuple_element<1,T>::type;
+
+  template <typename MsgT>
+  static void myHandler(MsgT* m) {
+    auto msg = makeMessage<RecvMsg>();
+    m->cb_.send(msg.get());
+  }
+};
+
+TYPED_TEST_SUITE_P(TestActiveSendLarge);
+
+TYPED_TEST_P(TestActiveSendLarge, test_large_bytes_msg) {
+  using IntegralType = typename std::tuple_element<0,TypeParam>::type;
+  using TagType = typename std::tuple_element<1,TypeParam>::type;
+
+  static constexpr NumBytesType const nbytes = 1ll << IntegralType::value;
+
+  using ThisType = TestActiveSendLarge<TypeParam>;
+  using LargeMsgType = LargeMsg<nbytes, TagType>;
+
+  NodeType const this_node = theContext()->getNode();
+  NodeType const num_nodes = theContext()->getNumNodes();
+
+  if (num_nodes < 2) {
+    return;
+  }
+
+  int counter = 0;
+  auto e = pipe::LifetimeEnum::Once;
+  auto cb = theCB()->makeFunc<RecvMsg>(e, [&counter](RecvMsg*){ counter++; });
+
+  vt::runInEpochCollective([&]{
+    NodeType next_node = (this_node + 1) % num_nodes;
+    auto msg = makeMessage<LargeMsgType>();
+    msg->cb_ = cb;
+    theMsg()->sendMsg<LargeMsgType, ThisType::template myHandler<LargeMsgType>>(
+      next_node, msg
+    );
+  });
+
+  EXPECT_EQ(counter, 1);
+}
+
+struct PrintParam {
+  template <typename ParamType>
+  static std::string GetName(int i) {
+    using IntegralType = typename std::tuple_element<0,ParamType>::type;
+    using TagType = typename std::tuple_element<1,ParamType>::type;
+    static constexpr NumBytesType const nbytes = 1ll << IntegralType::value;
+    auto const serialized = std::is_same<TagType, SerializedTag>::value;
+    return fmt::format("bytes{}serialized{}", nbytes, serialized);
+  }
+};
+
+REGISTER_TYPED_TEST_SUITE_P(TestActiveSendLarge, test_large_bytes_msg);
+
+using TestTypes = testing::Types<
+  std::tuple<std::integral_constant<NumBytesType, 30>, NonSerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 31>, NonSerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 34>, NonSerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 30>, SerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 31>, SerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 34>, SerializedTag>
+>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(
+  test_large_bytes_basic, TestActiveSendLarge, TestTypes, PrintParam
+);
+
+}}}} // end namespace vt::tests::unit::large

--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -102,6 +102,15 @@ struct TestActiveSendLarge : TestParallelHarness {
     auto msg = makeMessage<RecvMsg>();
     m->cb_.send(msg.get());
   }
+
+  // Set max size to 16 KiB for testing
+  void addAdditionalArgs() override {
+    new_arg = fmt::format("--vt_max_mpi_send_size=16384");
+    addArgs(new_arg);
+  }
+
+private:
+  std::string new_arg;
 };
 
 TYPED_TEST_SUITE_P(TestActiveSendLarge);
@@ -143,14 +152,14 @@ TYPED_TEST_P(TestActiveSendLarge, test_large_bytes_msg) {
 REGISTER_TYPED_TEST_SUITE_P(TestActiveSendLarge, test_large_bytes_msg);
 
 using NonSerTestTypes = testing::Types<
-  std::tuple<std::integral_constant<NumBytesType, 30>, NonSerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 31>, NonSerializedTag>
+  std::tuple<std::integral_constant<NumBytesType, 20>, NonSerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 21>, NonSerializedTag>
   // std::tuple<std::integral_constant<NumBytesType, 32>, NonSerializedTag>
 >;
 
 using SerTestTypes = testing::Types<
-  std::tuple<std::integral_constant<NumBytesType, 30>, SerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 31>, SerializedTag>
+  std::tuple<std::integral_constant<NumBytesType, 20>, SerializedTag>,
+  std::tuple<std::integral_constant<NumBytesType, 21>, SerializedTag>
   // std::tuple<std::integral_constant<NumBytesType, 32>, SerializedTag>
 >;
 

--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -144,14 +144,14 @@ REGISTER_TYPED_TEST_SUITE_P(TestActiveSendLarge, test_large_bytes_msg);
 
 using NonSerTestTypes = testing::Types<
   std::tuple<std::integral_constant<NumBytesType, 30>, NonSerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 31>, NonSerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 32>, NonSerializedTag>
+  std::tuple<std::integral_constant<NumBytesType, 31>, NonSerializedTag>
+  // std::tuple<std::integral_constant<NumBytesType, 32>, NonSerializedTag>
 >;
 
 using SerTestTypes = testing::Types<
   std::tuple<std::integral_constant<NumBytesType, 30>, SerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 31>, SerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 32>, SerializedTag>
+  std::tuple<std::integral_constant<NumBytesType, 31>, SerializedTag>
+  // std::tuple<std::integral_constant<NumBytesType, 32>, SerializedTag>
 >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(

--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -133,7 +133,7 @@ using NonSerTestTypes = testing::Types<
 using SerTestTypes = testing::Types<
   std::tuple<std::integral_constant<NumBytesType, 30>, SerializedTag>,
   std::tuple<std::integral_constant<NumBytesType, 31>, SerializedTag>,
-  std::tuple<std::integral_constant<NumBytesType, 34>, SerializedTag>
+  std::tuple<std::integral_constant<NumBytesType, 32>, SerializedTag>
 >;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(


### PR DESCRIPTION
Fixes #1111 

- Start with tests that fail for serialized/non-serialized messages

- ~Make a **major** improvement to how tests are being dispatched. Currently, tests are being ignored due to deficiencies in the gtest cmake. Pull in the latest gtest cmake and fix the bugs in that version of the cmake. **This is causing "new" tests to fail on this PR that weren't running before which I am systematically trying to fix**~
  - Addressed & merged in separate PR

- Implement "multi-sends" for serialized and non-serialized messages (now passing!)

- Add a new runtime argument `--vt_max_mpi_send_size=X` that defaults to `1ull << 30`.

- Use the new argument injector to set the size for testing to `16384` bytes