### PR TITLE
#872: add encoding member bits in handler field

### DIFF
--- a/src/vt/handler/handler.cc
+++ b/src/vt/handler/handler.cc
@@ -48,13 +48,14 @@
 namespace vt {
 
 /*static*/ HandlerType HandlerManager::makeHandler(
-  bool is_auto, bool is_functor, HandlerIdentifierType id, bool is_objgroup,
-  HandlerControlType control, bool is_trace
+  bool is_auto, bool is_functor, HandlerIdentifierType id, bool is_member,
+  bool is_objgroup, HandlerControlType control, bool is_trace
 ) {
   HandlerType new_han = blank_handler;
   HandlerManager::setHandlerAuto(new_han, is_auto);
   HandlerManager::setHandlerObjGroup(new_han, is_objgroup);
   HandlerManager::setHandlerFunctor(new_han, is_functor);
+  HandlerManager::setHandlerMember(new_han, is_member);
   HandlerManager::setHandlerIdentifier(new_han, id);
 
 #if vt_check_enabled(trace_enabled)
@@ -68,8 +69,9 @@ namespace vt {
   vt_debug_print(
     handler, node,
     "HandlerManager::makeHandler: is_functor={}, is_auto={}, is_objgroup={},"
-    " id={:x}, control={:x}, han={:x}, is_trace={}\n",
-    is_functor, is_auto, is_objgroup, id, control, new_han, is_trace
+    "is_memer={} id={:x}, control={:x}, han={:x}, is_trace={}\n",
+    is_functor, is_auto, is_objgroup, is_member, id, control, new_han,
+    is_trace
   );
 
   return new_han;
@@ -123,6 +125,12 @@ namespace vt {
   BitPackerType::boolSetField<HandlerBitsType::Functor>(han, is_functor);
 }
 
+/*static*/ void HandlerManager::setHandlerMember(
+  HandlerType& han, bool is_member
+) {
+  BitPackerType::boolSetField<HandlerBitsType::Member>(han, is_member);
+}
+
 /*static*/ bool HandlerManager::isHandlerAuto(HandlerType han) {
   return BitPackerType::boolGetField<HandlerBitsType::Auto>(han);
 }
@@ -133,6 +141,10 @@ namespace vt {
 
 /*static*/ bool HandlerManager::isHandlerObjGroup(HandlerType han) {
   return BitPackerType::boolGetField<HandlerBitsType::ObjGroup>(han);
+}
+
+/*static*/ bool HandlerManager::isHandlerMember(HandlerType han) {
+  return BitPackerType::boolGetField<HandlerBitsType::Member>(han);
 }
 
 #if vt_check_enabled(trace_enabled)
@@ -148,4 +160,3 @@ namespace vt {
 #endif
 
 } // end namespace vt
-

--- a/src/vt/handler/handler.h
+++ b/src/vt/handler/handler.h
@@ -70,6 +70,7 @@ static constexpr BitCountType const functor_num_bits = 1;
 static constexpr BitCountType const objgroup_num_bits = 1;
 static constexpr BitCountType const trace_num_bits = 1;
 static constexpr BitCountType const control_num_bits = 20;
+static constexpr BitCountType const member_num_bits = 1;
 static constexpr BitCountType const handler_id_num_bits =
  BitCounterType<HandlerType>::value - (
      auto_num_bits
@@ -77,17 +78,19 @@ static constexpr BitCountType const handler_id_num_bits =
    + objgroup_num_bits
    + control_num_bits
    + trace_num_bits
+   + member_num_bits
  );
 
 // eHandlerBits::ObjGroup identifies the handler as targeting an objgroup; the
 // control bits are an extensible field used for module-specific sub-handlers
 enum eHandlerBits {
   ObjGroup   = 0,
-  Auto       = eHandlerBits::ObjGroup   + objgroup_num_bits,
-  Functor    = eHandlerBits::Auto       + auto_num_bits,
-  Trace      = eHandlerBits::Functor    + functor_num_bits,
-  Control    = eHandlerBits::Trace      + trace_num_bits,
-  Identifier = eHandlerBits::Control    + control_num_bits
+  Auto       = eHandlerBits::ObjGroup + objgroup_num_bits,
+  Functor    = eHandlerBits::Auto     + auto_num_bits,
+  Trace      = eHandlerBits::Functor  + functor_num_bits,
+  Control    = eHandlerBits::Trace    + trace_num_bits,
+  Member     = eHandlerBits::Control  + control_num_bits,
+  Identifier = eHandlerBits::Member   + member_num_bits,
 };
 
 struct HandlerManager {
@@ -97,8 +100,8 @@ struct HandlerManager {
 
   static HandlerType makeHandler(
     bool is_auto, bool is_functor, HandlerIdentifierType id,
-    bool is_objgroup = false, HandlerControlType control = 0,
-    bool is_trace = true
+    bool is_member = false, bool is_objgroup = false,
+    HandlerControlType control = 0, bool is_trace = true
   );
   static void setHandlerIdentifier(HandlerType& han, HandlerIdentifierType id);
   static void setHandlerControl(HandlerType& han, HandlerControlType control);
@@ -108,9 +111,11 @@ struct HandlerManager {
   static void setHandlerAuto(HandlerType& han, bool is_auto);
   static void setHandlerFunctor(HandlerType& han, bool is_functor);
   static void setHandlerObjGroup(HandlerType& han, bool is_objgroup);
+  static void setHandlerMember(HandlerType& han, bool is_member);
   static bool isHandlerAuto(HandlerType han);
   static bool isHandlerFunctor(HandlerType han);
   static bool isHandlerObjGroup(HandlerType han);
+  static bool isHandlerMember(HandlerType han);
 #if vt_check_enabled(trace_enabled)
   static void setHandlerTrace(HandlerType& han, bool is_trace);
   static bool isHandlerTrace(HandlerType han);

--- a/src/vt/pipe/callback/cb_union/cb_raw.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw.h
@@ -91,8 +91,8 @@ struct BcastColDirCB : CallbackProxyBcastDirect {
   BcastColDirCB(
     HandlerType const& in_handler,
     CallbackProxyBcastDirect::AutoHandlerType const& in_vrt_handler,
-    bool const& in_member, VirtualProxyType const& in_proxy
-  ) : CallbackProxyBcastDirect(in_handler, in_vrt_handler, in_member, in_proxy)
+    VirtualProxyType const& in_proxy
+  ) : CallbackProxyBcastDirect(in_handler, in_vrt_handler, in_proxy)
   { }
 };
 

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.cc
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.cc
@@ -76,10 +76,9 @@ CallbackRawBaseSingle::CallbackRawBaseSingle(
 { }
 
 CallbackRawBaseSingle::CallbackRawBaseSingle(
-  RawBcastColDirTagType, PipeType const& in_pipe,
-  HandlerType const& in_handler, AutoHandlerType const& in_vrt,
-  bool const& in_member, VirtualProxyType const& in_proxy
-) : pipe_(in_pipe), cb_(BcastColDirCB{in_handler,in_vrt,in_member,in_proxy})
+  RawBcastColDirTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+  AutoHandlerType const& in_vrt, VirtualProxyType const& in_proxy
+) : pipe_(in_pipe), cb_(BcastColDirCB{in_handler, in_vrt, in_proxy})
 { }
 
 CallbackRawBaseSingle::CallbackRawBaseSingle(

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -98,7 +98,7 @@ struct CallbackRawBaseSingle {
   CallbackRawBaseSingle(
     RawBcastColDirTagType, PipeType const& in_pipe,
     HandlerType const& in_handler, AutoHandlerType const& in_vrt,
-    bool const& in_member, VirtualProxyType const& in_proxy
+    VirtualProxyType const& in_proxy
   );
   CallbackRawBaseSingle(
     RawSendColDirTagType, PipeType const& in_pipe,
@@ -182,9 +182,9 @@ struct CallbackTyped : CallbackRawBaseSingle {
   CallbackTyped(
     RawBcastColDirTagType, PipeType const& in_pipe,
     HandlerType const& in_handler, AutoHandlerType const& in_vrt,
-    bool const& in_member, VirtualProxyType const& in_proxy
+    VirtualProxyType const& in_proxy
   ) : CallbackRawBaseSingle(
-        RawBcastColDirTag,in_pipe,in_handler,in_vrt,in_member,in_proxy
+        RawBcastColDirTag, in_pipe, in_handler, in_vrt, in_proxy
       )
   { }
   CallbackTyped(

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.h
@@ -68,10 +68,8 @@ struct CallbackProxyBcast : CallbackBase<signal::Signal<MsgT>> {
   CallbackProxyBcast(CallbackProxyBcast const&) = default;
   CallbackProxyBcast(CallbackProxyBcast&&) = default;
 
-  CallbackProxyBcast(
-    HandlerType const& in_handler, ProxyType const& in_proxy,
-    bool const& in_member
-  ) : proxy_(in_proxy), handler_(in_handler), member_(in_member)
+  CallbackProxyBcast(HandlerType const& in_handler, ProxyType const& in_proxy)
+    : proxy_(in_proxy), handler_(in_handler)
   { }
 
   template <typename SerializerT>
@@ -83,7 +81,6 @@ private:
 private:
   ProxyType proxy_     = {};
   HandlerType handler_ = uninitialized_handler;
-  bool member_         = false;
 };
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.impl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.impl.h
@@ -58,12 +58,11 @@ void CallbackProxyBcast<ColT,MsgT>::serialize(SerializerT& s) {
   CallbackBase<SignalBaseType>::serializer(s);
   s | proxy_;
   s | handler_;
-  s | member_;
 }
 
 template <typename ColT, typename MsgT>
 void CallbackProxyBcast<ColT,MsgT>::trigger_(SignalDataType* data) {
-  theCollection()->broadcastMsgWithHan(proxy_,data,handler_,member_,true);
+  theCollection()->broadcastMsgWithHan(proxy_, data, handler_, true);
 }
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.h
@@ -77,9 +77,8 @@ struct CallbackProxyBcastDirect : CallbackBaseTL<CallbackProxyBcastDirect> {
   CallbackProxyBcastDirect() = default;
   CallbackProxyBcastDirect(
     HandlerType const& in_han, AutoHandlerType const& in_vrt,
-    bool const& in_member, VirtualProxyType const& in_proxy
-  ) : vrt_dispatch_han_(in_vrt), handler_(in_han), proxy_(in_proxy),
-      member_(in_member)
+    VirtualProxyType const& in_proxy
+  ) : vrt_dispatch_han_(in_vrt), handler_(in_han), proxy_(in_proxy)
   { }
 
   template <typename SerializerT>
@@ -89,8 +88,7 @@ struct CallbackProxyBcastDirect : CallbackBaseTL<CallbackProxyBcastDirect> {
     return
       other.handler_ == handler_ &&
       other.vrt_dispatch_han_ == vrt_dispatch_han_ &&
-      other.proxy_ == proxy_ &&
-      other.member_ == member_;
+      other.proxy_ == proxy_;
   }
 
 public:
@@ -105,7 +103,6 @@ private:
   AutoHandlerType vrt_dispatch_han_ = uninitialized_handler;
   HandlerType handler_              = uninitialized_handler;
   VirtualProxyType proxy_           = no_vrt_proxy;
-  bool member_                      = false;
 };
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
@@ -92,7 +92,6 @@ template <typename SerializerT>
 void CallbackProxyBcastDirect::serialize(SerializerT& s) {
   s | handler_;
   s | vrt_dispatch_han_;
-  s | member_;
   s | proxy_;
 }
 
@@ -108,7 +107,7 @@ void CallbackProxyBcastDirect::trigger(MsgT* msg, PipeType const& pipe) {
 
   auto dispatcher = vrt::collection::getDispatcher(vrt_dispatch_han_);
   auto const& proxy = proxy_;
-  dispatcher->broadcast(proxy,msg,handler_,member_);
+  dispatcher->broadcast(proxy, msg, handler_);
 }
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_send/callback_proxy_send.h
+++ b/src/vt/pipe/callback/proxy_send/callback_proxy_send.h
@@ -68,17 +68,15 @@ struct CallbackProxySend : CallbackBase<signal::Signal<MsgT>> {
   using MessageType      = MsgT;
 
   CallbackProxySend(
-    HandlerType const& in_handler, IndexedProxyType const& in_proxy,
-    bool const& in_member
+    HandlerType const& in_handler, IndexedProxyType const& in_proxy
   ) : proxy_(in_proxy.getCollectionProxy()),
-      idx_(in_proxy.getElementProxy().getIndex()),
-      handler_(in_handler), member_(in_member)
+      idx_(in_proxy.getElementProxy().getIndex()), handler_(in_handler)
   { }
 
   CallbackProxySend(
     HandlerType const& in_handler, ProxyType const& in_proxy,
-    IndexType const& in_idx, bool const& in_member
-  ) : proxy_(in_proxy), idx_(in_idx), handler_(in_handler), member_(in_member)
+    IndexType const& in_idx
+  ) : proxy_(in_proxy), idx_(in_idx), handler_(in_handler)
   { }
 
   template <typename SerializerT>
@@ -91,7 +89,6 @@ private:
   ProxyType proxy_     = {};
   IndexType idx_       = {};
   HandlerType handler_ = uninitialized_handler;
-  bool member_         = false;
 };
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_send/callback_proxy_send.impl.h
+++ b/src/vt/pipe/callback/proxy_send/callback_proxy_send.impl.h
@@ -58,12 +58,11 @@ void CallbackProxySend<ColT,MsgT>::serialize(SerializerT& s) {
   CallbackBase<SignalBaseType>::serializer(s);
   s | proxy_ | idx_;
   s | handler_;
-  s | member_;
 }
 
 template <typename ColT, typename MsgT>
-void CallbackProxySend<ColT,MsgT>::trigger_(SignalDataType* data) {
-  theCollection()->sendMsgWithHan(proxy_.index(idx_),data,handler_,member_);
+void CallbackProxySend<ColT, MsgT>::trigger_(SignalDataType* data) {
+  theCollection()->sendMsgWithHan(proxy_.index(idx_), data, handler_);
 }
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -149,12 +149,9 @@ PipeManagerTL::makeCallbackSingleProxySend(typename ColT::ProxyType proxy) {
   newPipeState(pipe_id,persist,dispatch,-1,-1,0);
   auto cb = CallbackT(callback::cbunion::RawSendColMsgTag,pipe_id);
   auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  bool member = false;
   addListenerAny<MsgT>(
     cb.getPipe(),
-    std::make_unique<callback::CallbackProxySend<ColT,MsgT>>(
-      handler,proxy,member
-    )
+    std::make_unique<callback::CallbackProxySend<ColT, MsgT>>(handler, proxy)
   );
   return cb;
 }
@@ -173,12 +170,9 @@ PipeManagerTL::makeCallbackSingleProxySend(typename ColT::ProxyType proxy) {
   auto cb = CallbackT(callback::cbunion::RawSendColMsgTag,pipe_id);
   auto const& handler =
     auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  bool member = true;
   addListenerAny<MsgT>(
     cb.getPipe(),
-    std::make_unique<callback::CallbackProxySend<ColT,MsgT>>(
-      handler,proxy,member
-    )
+    std::make_unique<callback::CallbackProxySend<ColT, MsgT>>(handler, proxy)
   );
   return cb;
 }
@@ -253,9 +247,8 @@ PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
   auto const& pipe_id = makePipeID(persist,send_back);
   auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
   auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
-  bool const member = false;
   auto cb = CallbackT(
-    callback::cbunion::RawBcastColDirTag,pipe_id,handler,vrt_handler,member,
+    callback::cbunion::RawBcastColDirTag, pipe_id, handler, vrt_handler,
     proxy.getProxy()
   );
   return cb;
@@ -273,9 +266,8 @@ PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
   auto const& handler =
     auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
   auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
-  bool const member = true;
   auto cb = CallbackT(
-    callback::cbunion::RawBcastColDirTag,pipe_id,handler,vrt_handler,member,
+    callback::cbunion::RawBcastColDirTag, pipe_id, handler, vrt_handler,
     proxy.getProxy()
   );
   return cb;

--- a/src/vt/registry/auto/collection/auto_registry_collection.impl.h
+++ b/src/vt/registry/auto/collection/auto_registry_collection.impl.h
@@ -63,7 +63,10 @@ inline HandlerType makeAutoHandlerCollection() {
   using ContainerType = AutoActiveCollectionContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveCollectionType>;
   using FuncType = ActiveColFnPtrType;
-  return RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+
+  auto han = RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+  HandlerManager::setHandlerMember(han, false);
+  return han;
 }
 
 inline AutoActiveCollectionMemType getAutoHandlerCollectionMem(
@@ -81,7 +84,10 @@ inline HandlerType makeAutoHandlerCollectionMem() {
   using ContainerType = AutoActiveCollectionMemContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveCollectionMemType>;
   using FuncType = ActiveColMemberFnPtrType;
-  return RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+
+  auto han = RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+  HandlerManager::setHandlerMember(han, true);
+  return han;
 }
 
 template <typename ColT, typename MsgT, ActiveColTypedFnType<MsgT, ColT>* f>

--- a/src/vt/runnable/collection.h
+++ b/src/vt/runnable/collection.h
@@ -53,7 +53,6 @@ template <typename MsgT, typename ElementT>
 struct RunnableCollection {
   static void run(
     HandlerType handler, MsgT* msg, ElementT* elm, NodeType from_node,
-    bool member,
     uint64_t idx1 = 0, uint64_t idx2 = 0, uint64_t idx3 = 0, uint64_t idx4 = 0,
     trace::TraceEventIDType in_trace_event = trace::no_trace_event
   );

--- a/src/vt/runnable/collection.impl.h
+++ b/src/vt/runnable/collection.impl.h
@@ -58,11 +58,13 @@
 namespace vt { namespace runnable {
 
 template <typename MsgT, typename ElementT>
-/*static*/ void RunnableCollection<MsgT,ElementT>::run(
-  HandlerType handler, MsgT* msg, ElementT* elm, NodeType from,
-  bool member, uint64_t idx1, uint64_t idx2, uint64_t idx3, uint64_t idx4,
+/*static*/ void RunnableCollection<MsgT, ElementT>::run(
+  HandlerType handler, MsgT* msg, ElementT* elm, NodeType from, uint64_t idx1,
+  uint64_t idx2, uint64_t idx3, uint64_t idx4,
   trace::TraceEventIDType in_trace_event
 ) {
+  auto const member = HandlerManager::isHandlerMember(handler);
+
 #if vt_check_enabled(trace_enabled)
   trace::TraceProcessingTag processing_tag;
   {

--- a/src/vt/vrt/collection/dispatch/dispatch.h
+++ b/src/vt/vrt/collection/dispatch/dispatch.h
@@ -61,12 +61,10 @@ struct DispatchCollectionBase {
   DispatchCollectionBase() = default;
   virtual ~DispatchCollectionBase() {}
 
-  virtual void broadcast(
-    VirtualProxyType proxy, void* msg, HandlerType han, bool member
-  ) = 0;
-  virtual void send(
-    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
-  ) = 0;
+  virtual void
+  broadcast(VirtualProxyType proxy, void* msg, HandlerType han) = 0;
+  virtual void
+  send(VirtualProxyType proxy, void* idx, void* msg, HandlerType han) = 0;
 
   template <typename=void>
   VirtualProxyType getDefaultProxy() const;
@@ -81,11 +79,9 @@ private:
 template <typename ColT, typename MsgT>
 struct DispatchCollection final : DispatchCollectionBase {
 private:
-  void broadcast(
-    VirtualProxyType proxy, void* msg, HandlerType han, bool member
-  ) override;
+  void broadcast(VirtualProxyType proxy, void* msg, HandlerType han) override;
   void send(
-    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
+    VirtualProxyType proxy, void* idx, void* msg, HandlerType han
   ) override;
 };
 

--- a/src/vt/vrt/collection/dispatch/dispatch.impl.h
+++ b/src/vt/vrt/collection/dispatch/dispatch.impl.h
@@ -56,29 +56,27 @@
 namespace vt { namespace vrt { namespace collection {
 
 template <typename ColT, typename MsgT>
-void DispatchCollection<ColT,MsgT>::broadcast(
-  VirtualProxyType proxy, void* msg, HandlerType han, bool member
+void DispatchCollection<ColT, MsgT>::broadcast(
+  VirtualProxyType proxy, void* msg, HandlerType han
 ) {
   using IdxT = typename ColT::IndexType;
   auto const msg_typed = reinterpret_cast<MsgT*>(msg);
-  CollectionProxy<ColT,IdxT> typed_proxy{proxy};
-  theCollection()->broadcastMsgWithHan<MsgT,ColT>(
-    typed_proxy,msg_typed,han,member,true
+  CollectionProxy<ColT, IdxT> typed_proxy{proxy};
+  theCollection()->broadcastMsgWithHan<MsgT, ColT>(
+    typed_proxy, msg_typed, han, true
   );
 }
 
 template <typename ColT, typename MsgT>
-void DispatchCollection<ColT,MsgT>::send(
-  VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
+void DispatchCollection<ColT, MsgT>::send(
+  VirtualProxyType proxy, void* idx, void* msg, HandlerType han
 ) {
   using IdxT = typename ColT::IndexType;
   auto const msg_typed = reinterpret_cast<MsgT*>(msg);
   auto const idx_typed = reinterpret_cast<IdxT*>(idx);
   auto const& idx_typed_ref = *idx_typed;
-  VrtElmProxy<ColT,IdxT> typed_proxy{proxy,idx_typed_ref};
-  theCollection()->sendMsgWithHan<MsgT,ColT>(
-    typed_proxy,msg_typed,han,member
-  );
+  VrtElmProxy<ColT, IdxT> typed_proxy{proxy, idx_typed_ref};
+  theCollection()->sendMsgWithHan<MsgT, ColT>(typed_proxy, msg_typed, han);
 }
 
 template <typename always_void_>

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -540,7 +540,6 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    * \param[in] imm_context whether in an immediate context (running a
    * collection element handler vs. directly in the scheduler)--- if in a
    * handler, local delivery must be postponed
@@ -553,9 +552,8 @@ public:
     typename IdxT = typename ColT::IndexType
   >
   messaging::PendingSend sendMsgUntypedHandler(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool imm_context = true
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool imm_context = true
   );
 
   /**
@@ -568,12 +566,11 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    */
   template <typename MsgT, typename ColT>
   IsNotColMsgType<MsgT> sendMsgWithHan(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler
   );
 
   /**
@@ -585,12 +582,11 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    */
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> sendMsgWithHan(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler
   );
 
   /**
@@ -600,14 +596,13 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    *
    * \return the pending send
    */
   template <typename MsgT, typename ColT>
   messaging::PendingSend sendNormalMsg(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler
   );
 
   /**
@@ -744,12 +739,11 @@ public:
    * \param[in] msg the message
    * \param[in] col pointer to collection element
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from node that sent the message
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsWrapType<ColT,UserMsgT,MsgT> collectionMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+  static IsWrapType<ColT, UserMsgT, MsgT> collectionMsgDeliver(
+    MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from
   );
 
@@ -760,12 +754,11 @@ public:
    * \param[in] msg the message
    * \param[in] col pointer to collection element
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from node that sent the message
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsNotWrapType<ColT,UserMsgT,MsgT> collectionMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+  static IsNotWrapType<ColT, UserMsgT, MsgT> collectionMsgDeliver(
+    MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from
   );
 
@@ -882,15 +875,13 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    */
   template <typename MsgT, typename ColT>
   IsNotColMsgType<MsgT> broadcastMsgWithHan(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument = true
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument = true
   );
 
   /**
@@ -899,15 +890,13 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    */
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> broadcastMsgWithHan(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument = true
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument = true
   );
 
   /**
@@ -916,7 +905,6 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    *
@@ -924,9 +912,8 @@ public:
    */
   template <typename MsgT, typename ColT>
   messaging::PendingSend broadcastNormalMsg(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument = true
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument = true
   );
 
   /**
@@ -935,7 +922,6 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    *
@@ -943,9 +929,8 @@ public:
    */
   template <typename MsgT, typename ColT, typename IdxT>
   messaging::PendingSend broadcastMsgUntypedHandler(
-    CollectionProxyWrapType<ColT,IdxT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument
+    CollectionProxyWrapType<ColT, IdxT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument
   );
 
   /**
@@ -1233,13 +1218,12 @@ public:
    * \param[in] msg the message
    * \param[in] col the collection element pointer
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from the node that sent it
    * \param[in] event the associated trace event
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsWrapType<ColT,UserMsgT,MsgT> collectionAutoMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+    static IsWrapType<ColT, UserMsgT, MsgT> collectionAutoMsgDeliver(
+      MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from, trace::TraceEventIDType event
   );
 
@@ -1250,13 +1234,12 @@ public:
    * \param[in] msg the message
    * \param[in] col the collection element pointer
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from the node that sent it
    * \param[in] event the associated trace event
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsNotWrapType<ColT,UserMsgT,MsgT> collectionAutoMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+    static IsNotWrapType<ColT, UserMsgT, MsgT> collectionAutoMsgDeliver(
+      MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from, trace::TraceEventIDType event
   );
 

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -349,10 +349,10 @@ GroupType CollectionManager::createGroupCollection(
 }
 
 template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-/*static*/ CollectionManager::IsWrapType<ColT,UserMsgT,MsgT>
+/*static*/ CollectionManager::IsWrapType<ColT, UserMsgT, MsgT>
 CollectionManager::collectionAutoMsgDeliver(
-  MsgT* msg, CollectionBase<ColT,IndexT>* base, HandlerType han, bool member,
-  NodeType from, trace::TraceEventIDType event
+  MsgT* msg, CollectionBase<ColT, IndexT>* base, HandlerType han, NodeType from,
+  trace::TraceEventIDType event
 ) {
   using IdxContextHolder = InsertContextHolder<IndexT>;
 
@@ -378,7 +378,7 @@ CollectionManager::collectionAutoMsgDeliver(
   IdxContextHolder::set(&idx,proxy);
 
   runnable::RunnableCollection<UserMsgT,UntypedCollection>::run(
-    han, user_msg_ptr, ptr, from, member, idx1, idx2, idx3, idx4
+    han, user_msg_ptr, ptr, from, idx1, idx2, idx3, idx4
   );
 
   // Clear the current index context
@@ -386,10 +386,10 @@ CollectionManager::collectionAutoMsgDeliver(
 }
 
 template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-/*static*/ CollectionManager::IsNotWrapType<ColT,UserMsgT,MsgT>
+/*static*/ CollectionManager::IsNotWrapType<ColT, UserMsgT, MsgT>
 CollectionManager::collectionAutoMsgDeliver(
-  MsgT* msg, CollectionBase<ColT,IndexT>* base, HandlerType han, bool member,
-  NodeType from, trace::TraceEventIDType event
+  MsgT* msg, CollectionBase<ColT, IndexT>* base, HandlerType han, NodeType from,
+  trace::TraceEventIDType event
 ) {
   using IdxContextHolder = InsertContextHolder<IndexT>;
 
@@ -413,7 +413,7 @@ CollectionManager::collectionAutoMsgDeliver(
   IdxContextHolder::set(&idx,proxy);
 
   runnable::RunnableCollection<MsgT,UntypedCollection>::run(
-    han, msg, ptr, from, member, idx1, idx2, idx3, idx4, event
+    han, msg, ptr, from, idx1, idx2, idx3, idx4, event
   );
 
   // Clear the current index context
@@ -439,12 +439,11 @@ template <typename ColT, typename IndexT, typename MsgT>
   auto elm_holder = theCollection()->findElmHolder<ColT,IndexT>(bcast_proxy);
   if (elm_holder) {
     auto const handler = col_msg->getVrtHandler();
-    auto const member = col_msg->getMember();
     vt_debug_print(
       vrt_coll, node,
       "broadcast apply: size={}\n", elm_holder->numElements()
     );
-    elm_holder->foreach([col_msg,msg,handler,member](
+    elm_holder->foreach([col_msg, msg, handler](
       IndexT const& idx, CollectionBase<ColT,IndexT>* base
     ) {
       vt_debug_print(
@@ -501,7 +500,7 @@ template <typename ColT, typename IndexT, typename MsgT>
         trace_event = col_msg->getFromTraceEvent();
       #endif
       collectionAutoMsgDeliver<ColT,IndexT,MsgT,typename MsgT::UserMsgType>(
-        msg,base,handler,member,from,trace_event
+        msg, base, handler, from, trace_event
       );
 
       #if vt_check_enabled(lblite)
@@ -667,7 +666,6 @@ template <typename ColT, typename IndexT, typename MsgT>
   auto& inner_holder = elm_holder->lookup(idx);
 
   auto const sub_handler = col_msg->getVrtHandler();
-  auto const member = col_msg->getMember();
   auto const col_ptr = inner_holder.getCollection();
 
   vt_debug_print(
@@ -677,7 +675,7 @@ template <typename ColT, typename IndexT, typename MsgT>
 
   vtAssertInfo(
     col_ptr != nullptr, "Must be valid pointer",
-    sub_handler, member, cur_epoch, idx, exists
+    sub_handler, HandlerManager::isHandlerMember(sub_handler), cur_epoch, idx, exists
   );
 
 
@@ -728,7 +726,7 @@ template <typename ColT, typename IndexT, typename MsgT>
     trace_event = col_msg->getFromTraceEvent();
   #endif
   collectionAutoMsgDeliver<ColT,IndexT,MsgT,typename MsgT::UserMsgType>(
-    msg,col_ptr,sub_handler,member,from,trace_event
+    msg, col_ptr, sub_handler, from, trace_event
   );
   theMsg()->popEpoch(cur_epoch);
 
@@ -860,7 +858,6 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsg(
 
   auto& msgPtr = msg.msg_;
   msgPtr->setVrtHandler(auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>());
-  msgPtr->setMember(false);
 
   return broadcastCollectiveMsgImpl<MsgT, ColT>(proxy, msgPtr, instrument);
 }
@@ -879,7 +876,6 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsg(
   msgPtr->setVrtHandler(
     auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>()
   );
-  msgPtr->setMember(true);
 
   return broadcastCollectiveMsgImpl<MsgT, ColT>(proxy, msgPtr, instrument);
 }
@@ -896,12 +892,13 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
 #if vt_check_enabled(trace_enabled)
   // Create the trace creation event for the broadcast here to connect it a
   // higher semantic level
-  auto reg_type = msg->getMember() ?
+  auto const han = msg->getVrtHandler();
+  auto reg_type = HandlerManager::isHandlerMember(han) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
   auto event = theMsg()->makeTraceCreationSend(
-    msg, msg->getVrtHandler(), reg_type, msg_size, true
+    msg, han, reg_type, msg_size, true
   );
   msg->setFromTraceEvent(event);
 #endif
@@ -958,13 +955,12 @@ CollectionManager::broadcastMsg(
   return broadcastMsgImpl<MsgT,ColT,f>(proxy,msg,instrument);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, bool instrument
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsg(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, bool instrument
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,false,instrument);
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return broadcastNormalMsg<MsgT, ColT>(proxy, msg, h, instrument);
 }
 
 template <
@@ -981,75 +977,67 @@ CollectionManager::broadcastMsg(
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,ColT> f
+  typename MsgT, typename ColT, ActiveColMemberTypedFnType<MsgT, ColT> f
 >
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, bool instrument
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsg(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, bool instrument
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,true,instrument);
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return broadcastNormalMsg<MsgT, ColT>(proxy, msg, h, instrument);
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,ColT> f
+  typename MsgT, typename ColT, ActiveColMemberTypedFnType<MsgT, ColT> f
 >
 messaging::PendingSend CollectionManager::broadcastMsgImpl(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, bool inst
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* const msg, bool inst
 ) {
   // register the user's handler
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,true,inst);
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return broadcastMsgUntypedHandler<MsgT>(proxy, msg, h, inst);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
 messaging::PendingSend CollectionManager::broadcastMsgImpl(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, bool inst
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* const msg, bool inst
 ) {
   // register the user's handler
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,false,inst);
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return broadcastMsgUntypedHandler<MsgT>(proxy, msg, h, inst);
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsColMsgType<MsgT>
-CollectionManager::broadcastMsgWithHan(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& h, bool const mem, bool inst
+CollectionManager::IsColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const& h,
+  bool inst
 ) {
   using IdxT = typename ColT::IndexType;
-  return broadcastMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,h,mem,inst);
+  return broadcastMsgUntypedHandler<MsgT, ColT, IdxT>(proxy, msg, h, inst);
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::broadcastMsgWithHan(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& h, bool const mem, bool inst
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const& h,
+  bool inst
 ) {
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,mem,inst);
+  return broadcastNormalMsg<MsgT, ColT>(proxy, msg, h, inst);
 }
 
 template <typename MsgT, typename ColT>
 messaging::PendingSend CollectionManager::broadcastNormalMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member,
-  bool instrument
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler, bool instrument
 ) {
-  auto wrap_msg = makeMessage<ColMsgWrap<ColT,MsgT>>(*msg);
-  return broadcastMsgUntypedHandler<ColMsgWrap<ColT,MsgT>,ColT>(
-    proxy, wrap_msg.get(), handler, member, instrument
+  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
+  return broadcastMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
+    proxy, wrap_msg.get(), handler, instrument
   );
 }
 
 template <typename MsgT, typename ColT, typename IdxT>
 messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
-  CollectionProxyWrapType<ColT, IdxT> const& toProxy, MsgT *raw_msg,
-  HandlerType const& handler, bool const member, bool instrument
+  CollectionProxyWrapType<ColT, IdxT> const& toProxy, MsgT* raw_msg,
+  HandlerType const& handler, bool instrument
 ) {
   auto const idx = makeVrtDispatch<MsgT,ColT>();
   auto const col_proxy = toProxy.getProxy();
@@ -1065,12 +1053,11 @@ messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
   msg->setFromNode(theContext()->getNode());
   msg->setVrtHandler(handler);
   msg->setBcastProxy(col_proxy);
-  msg->setMember(member);
 
 # if vt_check_enabled(trace_enabled)
   // Create the trace creation event for the broadcast here to connect it a
   // higher semantic level
-  auto reg_type = member ?
+  auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
@@ -1273,32 +1260,30 @@ messaging::PendingSend CollectionManager::reduceMsgExpr(
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::sendMsgWithHan(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::sendMsgWithHan(
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler
 ) {
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,handler,member);
+  return sendNormalMsg<MsgT, ColT>(proxy, msg, handler);
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsColMsgType<MsgT>
-CollectionManager::sendMsgWithHan(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member
+CollectionManager::IsColMsgType<MsgT> CollectionManager::sendMsgWithHan(
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler
 ) {
   using IdxT = typename ColT::IndexType;
-  return sendMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,handler,member);
+  return sendMsgUntypedHandler<MsgT, ColT, IdxT>(proxy, msg, handler);
 }
 
 template <typename MsgT, typename ColT>
 messaging::PendingSend CollectionManager::sendNormalMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler
 ) {
-  auto wrap_msg = makeMessage<ColMsgWrap<ColT,MsgT>>(*msg);
-  return sendMsgUntypedHandler<ColMsgWrap<ColT,MsgT>,ColT>(
-    proxy, wrap_msg.get(), handler, member
+  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
+  return sendMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
+    proxy, wrap_msg.get(), handler
   );
 }
 
@@ -1331,13 +1316,11 @@ CollectionManager::sendMsg(
   return sendMsgImpl<MsgT,ColT,f>(proxy,msg);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
 CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
-) {
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,false);
+CollectionManager::sendMsg(VirtualElmProxyType<ColT> const& proxy, MsgT* msg) {
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return sendNormalMsg<MsgT, ColT>(proxy, msg, h);
 }
 
 template <
@@ -1353,43 +1336,37 @@ CollectionManager::sendMsg(
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,ColT> f
+  typename MsgT, typename ColT, ActiveColMemberTypedFnType<MsgT, ColT> f
 >
 CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
-) {
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,true);
+CollectionManager::sendMsg(VirtualElmProxyType<ColT> const& proxy, MsgT* msg) {
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return sendNormalMsg<MsgT, ColT>(proxy, msg, h);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
 messaging::PendingSend CollectionManager::sendMsgImpl(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,false);
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return sendMsgUntypedHandler<MsgT>(proxy, msg, h);
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,typename MsgT::CollectionType> f
+  typename MsgT, typename ColT,
+  ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
 >
 messaging::PendingSend CollectionManager::sendMsgImpl(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,true);
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return sendMsgUntypedHandler<MsgT>(proxy, msg, h);
 }
 
 template <typename MsgT, typename ColT, typename IdxT>
 messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
-  VirtualElmProxyType<ColT> const& toProxy, MsgT *raw_msg,
-  HandlerType const& handler, bool const member,
-  bool imm_context
+  VirtualElmProxyType<ColT> const& toProxy, MsgT* raw_msg,
+  HandlerType const& handler, bool imm_context
 ) {
   auto const& col_proxy = toProxy.getCollectionProxy();
   auto const& elm_proxy = toProxy.getElementProxy();
@@ -1421,7 +1398,7 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   // level. Do it in the imm_context so we see the send event when the user
   // actually invokes send on the proxy (not outside the event that actually
   // sent it)
-  auto reg_type = member ?
+  auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
@@ -1435,7 +1412,6 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   msg->setFromNode(theContext()->getNode());
   msg->setVrtHandler(handler);
   msg->setProxy(toProxy);
-  msg->setMember(member);
 
   auto idx = elm_proxy.getIndex();
   vt_debug_print(
@@ -2920,7 +2896,7 @@ void CollectionManager::elmReadyLB(
   auto pmsg = promoteMsg(msg);
 
 #if !vt_check_enabled(lblite)
-  theCollection()->sendMsgUntypedHandler<MsgT>(proxy, pmsg.get(), lb_han,true);
+  theCollection()->sendMsgUntypedHandler<MsgT>(proxy, pmsg.get(), lb_han);
   return;
 #endif
 
@@ -2941,8 +2917,8 @@ void CollectionManager::elmReadyLB(
   );
 
   theTerm()->produce(cur_epoch);
-  elm_holder->addLBCont(idx,[pmsg,proxy,lb_han,cur_epoch]{
-    theCollection()->sendMsgUntypedHandler<MsgT>(proxy,pmsg.get(),lb_han,true);
+  elm_holder->addLBCont(idx, [pmsg, proxy, lb_han, cur_epoch] {
+    theCollection()->sendMsgUntypedHandler<MsgT>(proxy, pmsg.get(), lb_han);
     theTerm()->consume(cur_epoch);
   });
 

--- a/src/vt/vrt/collection/messages/user.h
+++ b/src/vt/vrt/collection/messages/user.h
@@ -104,9 +104,6 @@ struct CollectionMessage : RoutedMessageType<BaseMsgT, ColT> {
   NodeType getFromNode() const;
   void setFromNode(NodeType const& node);
 
-  bool getMember() const;
-  void setMember(bool const& member);
-
   bool getWrap() const;
   void setWrap(bool const& wrap);
 
@@ -136,7 +133,6 @@ private:
   HandlerType vt_sub_handler_ = uninitialized_handler;
   EpochType bcast_epoch_ = no_epoch;
   NodeType from_node_ = uninitialized_destination;
-  bool member_ = false;
   bool is_wrap_ = false;
 
   #if vt_check_enabled(lblite)

--- a/src/vt/vrt/collection/messages/user.impl.h
+++ b/src/vt/vrt/collection/messages/user.impl.h
@@ -120,7 +120,6 @@ void CollectionMessage<ColT, BaseMsgT>::serialize(SerializerT& s) {
   s | to_proxy_;
   s | bcast_proxy_;
   s | bcast_epoch_;
-  s | member_;
   s | is_wrap_;
 
   #if vt_check_enabled(lblite)
@@ -133,16 +132,6 @@ void CollectionMessage<ColT, BaseMsgT>::serialize(SerializerT& s) {
   #if vt_check_enabled(trace_enabled)
     s | trace_event_;
   #endif
-}
-
-template <typename ColT, typename BaseMsgT>
-bool CollectionMessage<ColT,BaseMsgT>::getMember() const {
-  return member_;
-}
-
-template <typename ColT, typename BaseMsgT>
-void CollectionMessage<ColT,BaseMsgT>::setMember(bool const& member) {
-  member_ = member;
 }
 
 template <typename ColT, typename BaseMsgT>

--- a/tests/unit/collection/test_collection_group.extended.cc
+++ b/tests/unit/collection/test_collection_group.extended.cc
@@ -85,7 +85,7 @@ struct ColA : Collection<ColA,Index1D> {
     reduce_test = true;
   }
 
-  void memberHanlder(TestDataMsg* msg) {
+  void memberHandler(TestDataMsg* msg) {
     EXPECT_EQ(msg->value_, theContext()->getNode());
     --elem_counter;
     handler_executed = true;
@@ -146,7 +146,7 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
   // raw msg pointer case
   runBcastTestHelper([proxy, my_node]{
     auto msg = ::vt::makeMessage<ColA::TestDataMsg>(my_node);
-    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHanlder>(
+    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHandler>(
       msg.get()
     );
   });
@@ -156,7 +156,7 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
   // smart msg pointer case
   runBcastTestHelper([proxy, my_node]{
     auto msg = ::vt::makeMessage<ColA::TestDataMsg>(my_node);
-    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHanlder>(msg);
+    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHandler>(msg);
   });
 
   EXPECT_EQ(elem_counter, -numElems);
@@ -164,7 +164,7 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
   // msg constructed on the fly case
   runBcastTestHelper([proxy, my_node] {
     proxy.broadcastCollective<
-      ColA::TestDataMsg, &ColA::memberHanlder, ColA::TestDataMsg>(my_node);
+      ColA::TestDataMsg, &ColA::memberHandler, ColA::TestDataMsg>(my_node);
   });
 
   EXPECT_EQ(elem_counter, -2 * numElems);


### PR DESCRIPTION
* adds encoding member bit in handler field
* cleans up all the places that previously used `member` boolean

Fixes #872 