### PR TITLE
#872: add encoding member bits in handler field

### DIFF
--- a/src/vt/handler/handler.cc
+++ b/src/vt/handler/handler.cc
@@ -49,12 +49,13 @@ namespace vt {
 
 /*static*/ HandlerType HandlerManager::makeHandler(
   bool is_auto, bool is_functor, HandlerIdentifierType id, bool is_objgroup,
-  HandlerControlType control, bool is_trace
+  HandlerControlType control, bool is_trace, bool is_member
 ) {
   HandlerType new_han = blank_handler;
   HandlerManager::setHandlerAuto(new_han, is_auto);
   HandlerManager::setHandlerObjGroup(new_han, is_objgroup);
   HandlerManager::setHandlerFunctor(new_han, is_functor);
+  HandlerManager::setHandlerMember(new_han, is_member);
   HandlerManager::setHandlerIdentifier(new_han, id);
 
 #if vt_check_enabled(trace_enabled)
@@ -68,8 +69,9 @@ namespace vt {
   vt_debug_print(
     handler, node,
     "HandlerManager::makeHandler: is_functor={}, is_auto={}, is_objgroup={},"
-    " id={:x}, control={:x}, han={:x}, is_trace={}\n",
-    is_functor, is_auto, is_objgroup, id, control, new_han, is_trace
+    "is_member={} id={:x}, control={:x}, han={:x}, is_trace={}\n",
+    is_functor, is_auto, is_objgroup, is_member, id, control, new_han,
+    is_trace
   );
 
   return new_han;
@@ -123,6 +125,12 @@ namespace vt {
   BitPackerType::boolSetField<HandlerBitsType::Functor>(han, is_functor);
 }
 
+/*static*/ void HandlerManager::setHandlerMember(
+  HandlerType& han, bool is_member
+) {
+  BitPackerType::boolSetField<HandlerBitsType::Member>(han, is_member);
+}
+
 /*static*/ bool HandlerManager::isHandlerAuto(HandlerType han) {
   return BitPackerType::boolGetField<HandlerBitsType::Auto>(han);
 }
@@ -133,6 +141,10 @@ namespace vt {
 
 /*static*/ bool HandlerManager::isHandlerObjGroup(HandlerType han) {
   return BitPackerType::boolGetField<HandlerBitsType::ObjGroup>(han);
+}
+
+/*static*/ bool HandlerManager::isHandlerMember(HandlerType han) {
+  return BitPackerType::boolGetField<HandlerBitsType::Member>(han);
 }
 
 #if vt_check_enabled(trace_enabled)
@@ -148,4 +160,3 @@ namespace vt {
 #endif
 
 } // end namespace vt
-

--- a/src/vt/handler/handler.h
+++ b/src/vt/handler/handler.h
@@ -70,6 +70,7 @@ static constexpr BitCountType const functor_num_bits = 1;
 static constexpr BitCountType const objgroup_num_bits = 1;
 static constexpr BitCountType const trace_num_bits = 1;
 static constexpr BitCountType const control_num_bits = 20;
+static constexpr BitCountType const member_num_bits = 1;
 static constexpr BitCountType const handler_id_num_bits =
  BitCounterType<HandlerType>::value - (
      auto_num_bits
@@ -77,17 +78,19 @@ static constexpr BitCountType const handler_id_num_bits =
    + objgroup_num_bits
    + control_num_bits
    + trace_num_bits
+   + member_num_bits
  );
 
 // eHandlerBits::ObjGroup identifies the handler as targeting an objgroup; the
 // control bits are an extensible field used for module-specific sub-handlers
 enum eHandlerBits {
   ObjGroup   = 0,
-  Auto       = eHandlerBits::ObjGroup   + objgroup_num_bits,
-  Functor    = eHandlerBits::Auto       + auto_num_bits,
-  Trace      = eHandlerBits::Functor    + functor_num_bits,
-  Control    = eHandlerBits::Trace      + trace_num_bits,
-  Identifier = eHandlerBits::Control    + control_num_bits
+  Auto       = eHandlerBits::ObjGroup + objgroup_num_bits,
+  Functor    = eHandlerBits::Auto     + auto_num_bits,
+  Trace      = eHandlerBits::Functor  + functor_num_bits,
+  Control    = eHandlerBits::Trace    + trace_num_bits,
+  Member     = eHandlerBits::Control  + control_num_bits,
+  Identifier = eHandlerBits::Member   + member_num_bits,
 };
 
 struct HandlerManager {
@@ -98,7 +101,7 @@ struct HandlerManager {
   static HandlerType makeHandler(
     bool is_auto, bool is_functor, HandlerIdentifierType id,
     bool is_objgroup = false, HandlerControlType control = 0,
-    bool is_trace = true
+    bool is_trace = true, bool is_member = false
   );
   static void setHandlerIdentifier(HandlerType& han, HandlerIdentifierType id);
   static void setHandlerControl(HandlerType& han, HandlerControlType control);
@@ -108,9 +111,11 @@ struct HandlerManager {
   static void setHandlerAuto(HandlerType& han, bool is_auto);
   static void setHandlerFunctor(HandlerType& han, bool is_functor);
   static void setHandlerObjGroup(HandlerType& han, bool is_objgroup);
+  static void setHandlerMember(HandlerType& han, bool is_member);
   static bool isHandlerAuto(HandlerType han);
   static bool isHandlerFunctor(HandlerType han);
   static bool isHandlerObjGroup(HandlerType han);
+  static bool isHandlerMember(HandlerType han);
 #if vt_check_enabled(trace_enabled)
   static void setHandlerTrace(HandlerType& han, bool is_trace);
   static bool isHandlerTrace(HandlerType han);

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -1073,7 +1073,7 @@ HandlerType ActiveMessenger::collectiveRegisterHandler(
 }
 
 void ActiveMessenger::swapHandlerFn(
-  HandlerType const& han, ActiveClosureFnType fn, TagType const& tag
+  HandlerType const han, ActiveClosureFnType fn, TagType const& tag
 ) {
   vt_debug_print(
     active, node,
@@ -1088,7 +1088,7 @@ void ActiveMessenger::swapHandlerFn(
 }
 
 void ActiveMessenger::deliverPendingMsgsHandler(
-  HandlerType const& han, TagType const& tag
+  HandlerType const han, TagType const& tag
 ) {
   vt_debug_print(
     active, node,
@@ -1118,7 +1118,7 @@ void ActiveMessenger::deliverPendingMsgsHandler(
 }
 
 void ActiveMessenger::registerHandlerFn(
-  HandlerType const& han, ActiveClosureFnType fn, TagType const& tag
+  HandlerType const han, ActiveClosureFnType fn, TagType const& tag
 ) {
   vt_debug_print(
     active, node,
@@ -1133,7 +1133,7 @@ void ActiveMessenger::registerHandlerFn(
 }
 
 void ActiveMessenger::unregisterHandlerFn(
-  HandlerType const& han, TagType const& tag
+  HandlerType const han, TagType const& tag
 ) {
   vt_debug_print(
     active, node,

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1185,7 +1185,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] tag the tag this handler will accept (\c vt::no_tag means any)
    */
   void swapHandlerFn(
-    HandlerType const& han, ActiveClosureFnType fn, TagType const& tag = no_tag
+    HandlerType const han, ActiveClosureFnType fn, TagType const& tag = no_tag
   );
 
   /**
@@ -1195,7 +1195,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] han the handler to de-register
    * \param[in] tag the tag this handler will accept (\c vt::no_tag means any)
    */
-  void unregisterHandlerFn(HandlerType const& han, TagType const& tag = no_tag);
+  void unregisterHandlerFn(HandlerType const han, TagType const& tag = no_tag);
 
   /**
    * \internal
@@ -1206,7 +1206,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] tag the tag this handler will accept (\c vt::no_tag means any)
    */
   void registerHandlerFn(
-    HandlerType const& han, ActiveClosureFnType fn, TagType const& tag = no_tag
+    HandlerType const han, ActiveClosureFnType fn, TagType const& tag = no_tag
   );
 
   /**
@@ -1338,7 +1338,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] tag the tag for that handler
    */
   void deliverPendingMsgsHandler(
-    HandlerType const& han, TagType const& tag = no_tag
+    HandlerType const han, TagType const& tag = no_tag
   );
 
   /**

--- a/src/vt/messaging/envelope/envelope_set.h
+++ b/src/vt/messaging/envelope/envelope_set.h
@@ -124,7 +124,7 @@ inline void setTagType(Env& env);
  * \param[in] handler the handler
  */
 template <typename Env>
-inline void envelopeSetHandler(Env& env, HandlerType const& handler);
+inline void envelopeSetHandler(Env& env, HandlerType const handler);
 
 /**
  * \brief Set destination \c dest field in envelope

--- a/src/vt/messaging/envelope/envelope_set.impl.h
+++ b/src/vt/messaging/envelope/envelope_set.impl.h
@@ -94,7 +94,7 @@ inline void setTagType(Env& env) {
 }
 
 template <typename Env>
-inline void envelopeSetHandler(Env& env, HandlerType const& handler) {
+inline void envelopeSetHandler(Env& env, HandlerType const handler) {
   vtAssert(not envelopeIsLocked(env), "Envelope locked.");
   reinterpret_cast<Envelope*>(&env)->han = handler;
 }

--- a/src/vt/messaging/envelope/envelope_setup.h
+++ b/src/vt/messaging/envelope/envelope_setup.h
@@ -62,7 +62,7 @@ namespace vt {
  */
 template <typename Env>
 inline void envelopeSetup(
-  Env& env, NodeType const& dest, HandlerType const& handler
+  Env& env, NodeType const& dest, HandlerType const handler
 );
 
 /**

--- a/src/vt/messaging/envelope/envelope_setup.impl.h
+++ b/src/vt/messaging/envelope/envelope_setup.impl.h
@@ -53,7 +53,7 @@ namespace vt {
 
 template <typename Env>
 inline void envelopeSetup(
-  Env& env, NodeType const& dest, HandlerType const& handler
+  Env& env, NodeType const& dest, HandlerType const handler
 ) {
   envelopeSetDest(env, dest);
   envelopeSetHandler(env, handler);

--- a/src/vt/parameterization/parameterization.h
+++ b/src/vt/parameterization/parameterization.h
@@ -73,12 +73,12 @@ struct DataMsg : vt::Message {
   HandlerType sub_han = uninitialized_handler;
 
   DataMsg() = default;
-  DataMsg(HandlerType const& in_sub_han, Tuple&& a)
+  DataMsg(HandlerType const in_sub_han, Tuple&& a)
     : Message(), tup(std::forward<Tuple>(a)), sub_han(in_sub_han)
   { }
 
   template <typename... Args>
-  DataMsg(HandlerType const& in_sub_han, Args&&... a)
+  DataMsg(HandlerType const in_sub_han, Args&&... a)
     : Message(), tup(std::forward<Args>(a)...), sub_han(in_sub_han)
   { }
 
@@ -144,7 +144,7 @@ struct Param : runtime::component::Component<Param> {
 
   template <typename... Args>
   void sendDataTuple(
-    NodeType const& dest, HandlerType const& han, std::tuple<Args...>&& tup
+    NodeType const& dest, HandlerType const han, std::tuple<Args...>&& tup
   ) {
     staticCheckCopyable<Args...>();
 
@@ -168,7 +168,7 @@ struct Param : runtime::component::Component<Param> {
 
   template <typename DataMsg>
   void sendDataMsg(
-    NodeType const& dest, HandlerType const& __attribute__((unused)) han,
+    NodeType const& dest, HandlerType const __attribute__((unused)) han,
     MsgSharedPtr<DataMsg> m
   ) {
     auto pmsg = promoteMsg(m.get());

--- a/src/vt/pipe/callback/cb_union/cb_raw.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw.h
@@ -65,7 +65,7 @@ struct AnonCB : CallbackAnonTypeless { };
 struct SendMsgCB : CallbackSendTypeless {
   SendMsgCB() = default;
   SendMsgCB(
-    HandlerType const& in_handler, NodeType const& in_send_node
+    HandlerType const in_handler, NodeType const& in_send_node
   ) : CallbackSendTypeless(in_handler, in_send_node)
   { }
 };
@@ -73,7 +73,7 @@ struct SendMsgCB : CallbackSendTypeless {
 struct BcastMsgCB : CallbackBcastTypeless {
   BcastMsgCB() = default;
   BcastMsgCB(
-    HandlerType const& in_handler, bool const& in_include
+    HandlerType const in_handler, bool const& in_include
   ) : CallbackBcastTypeless(in_handler, in_include)
   { }
 };
@@ -89,8 +89,8 @@ struct BcastColMsgCB : CallbackProxyBcastTypeless {
 struct BcastColDirCB : CallbackProxyBcastDirect {
   BcastColDirCB() = default;
   BcastColDirCB(
-    HandlerType const& in_handler,
-    CallbackProxyBcastDirect::AutoHandlerType const& in_vrt_handler,
+    HandlerType const in_handler,
+    CallbackProxyBcastDirect::AutoHandlerType const in_vrt_handler,
     VirtualProxyType const& in_proxy
   ) : CallbackProxyBcastDirect(in_handler, in_vrt_handler, in_proxy)
   { }

--- a/src/vt/pipe/callback/cb_union/cb_raw.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw.h
@@ -91,8 +91,8 @@ struct BcastColDirCB : CallbackProxyBcastDirect {
   BcastColDirCB(
     HandlerType const& in_handler,
     CallbackProxyBcastDirect::AutoHandlerType const& in_vrt_handler,
-    bool const& in_member, VirtualProxyType const& in_proxy
-  ) : CallbackProxyBcastDirect(in_handler, in_vrt_handler, in_member, in_proxy)
+    VirtualProxyType const& in_proxy
+  ) : CallbackProxyBcastDirect(in_handler, in_vrt_handler, in_proxy)
   { }
 };
 

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.cc
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.cc
@@ -76,10 +76,9 @@ CallbackRawBaseSingle::CallbackRawBaseSingle(
 { }
 
 CallbackRawBaseSingle::CallbackRawBaseSingle(
-  RawBcastColDirTagType, PipeType const& in_pipe,
-  HandlerType const& in_handler, AutoHandlerType const& in_vrt,
-  bool const& in_member, VirtualProxyType const& in_proxy
-) : pipe_(in_pipe), cb_(BcastColDirCB{in_handler,in_vrt,in_member,in_proxy})
+  RawBcastColDirTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+  AutoHandlerType const& in_vrt, VirtualProxyType const& in_proxy
+) : pipe_(in_pipe), cb_(BcastColDirCB{in_handler, in_vrt, in_proxy})
 { }
 
 CallbackRawBaseSingle::CallbackRawBaseSingle(

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.cc
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.cc
@@ -49,13 +49,13 @@
 namespace vt { namespace pipe { namespace callback { namespace cbunion {
 
 CallbackRawBaseSingle::CallbackRawBaseSingle(
-  RawSendMsgTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+  RawSendMsgTagType, PipeType const& in_pipe, HandlerType const in_handler,
   NodeType const& in_node
 ) : pipe_(in_pipe), cb_(SendMsgCB{in_handler,in_node})
 { }
 
 CallbackRawBaseSingle::CallbackRawBaseSingle(
-  RawBcastMsgTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+  RawBcastMsgTagType, PipeType const& in_pipe, HandlerType const in_handler,
   bool const& in_inc
 ) : pipe_(in_pipe), cb_(BcastMsgCB{in_handler,in_inc})
 { }
@@ -76,8 +76,8 @@ CallbackRawBaseSingle::CallbackRawBaseSingle(
 { }
 
 CallbackRawBaseSingle::CallbackRawBaseSingle(
-  RawBcastColDirTagType, PipeType const& in_pipe, HandlerType const& in_handler,
-  AutoHandlerType const& in_vrt, VirtualProxyType const& in_proxy
+  RawBcastColDirTagType, PipeType const& in_pipe, HandlerType const in_handler,
+  AutoHandlerType const in_vrt, VirtualProxyType const& in_proxy
 ) : pipe_(in_pipe), cb_(BcastColDirCB{in_handler, in_vrt, in_proxy})
 { }
 

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -98,7 +98,7 @@ struct CallbackRawBaseSingle {
   CallbackRawBaseSingle(
     RawBcastColDirTagType, PipeType const& in_pipe,
     HandlerType const& in_handler, AutoHandlerType const& in_vrt,
-    bool const& in_member, VirtualProxyType const& in_proxy
+    VirtualProxyType const& in_proxy
   );
   CallbackRawBaseSingle(
     RawSendColDirTagType, PipeType const& in_pipe,
@@ -188,9 +188,9 @@ struct CallbackTyped : CallbackRawBaseSingle {
   CallbackTyped(
     RawBcastColDirTagType, PipeType const& in_pipe,
     HandlerType const& in_handler, AutoHandlerType const& in_vrt,
-    bool const& in_member, VirtualProxyType const& in_proxy
+    VirtualProxyType const& in_proxy
   ) : CallbackRawBaseSingle(
-        RawBcastColDirTag,in_pipe,in_handler,in_vrt,in_member,in_proxy
+        RawBcastColDirTag, in_pipe, in_handler, in_vrt, in_proxy
       )
   { }
   CallbackTyped(

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -85,11 +85,11 @@ struct CallbackRawBaseSingle {
 
   // Constructors for different types of callbacks
   CallbackRawBaseSingle(
-    RawSendMsgTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+    RawSendMsgTagType, PipeType const& in_pipe, HandlerType const in_handler,
     NodeType const& in_node
   );
   CallbackRawBaseSingle(
-    RawBcastMsgTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+    RawBcastMsgTagType, PipeType const& in_pipe, HandlerType const in_handler,
     bool const& in_inc
   );
   CallbackRawBaseSingle(RawAnonTagType, PipeType const& in_pipe);
@@ -97,12 +97,12 @@ struct CallbackRawBaseSingle {
   CallbackRawBaseSingle(RawBcastColMsgTagType, PipeType const& in_pipe);
   CallbackRawBaseSingle(
     RawBcastColDirTagType, PipeType const& in_pipe,
-    HandlerType const& in_handler, AutoHandlerType const& in_vrt,
+    HandlerType const in_handler, AutoHandlerType const in_vrt,
     VirtualProxyType const& in_proxy
   );
   CallbackRawBaseSingle(
     RawSendColDirTagType, PipeType const& in_pipe,
-    HandlerType const& in_handler, AutoHandlerType const& in_vrt_handler,
+    HandlerType const in_handler, AutoHandlerType const in_vrt_handler,
     void* index_bits
   );
   CallbackRawBaseSingle(
@@ -167,12 +167,12 @@ struct CallbackTyped : CallbackRawBaseSingle {
 
   // Forwarding constructors for different types of callbacks
   CallbackTyped(
-    RawSendMsgTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+    RawSendMsgTagType, PipeType const& in_pipe, HandlerType const in_handler,
     NodeType const& in_node
   ) : CallbackRawBaseSingle(RawSendMsgTag,in_pipe,in_handler,in_node)
   { }
   CallbackTyped(
-    RawBcastMsgTagType, PipeType const& in_pipe, HandlerType const& in_handler,
+    RawBcastMsgTagType, PipeType const& in_pipe, HandlerType const in_handler,
     bool const& in_inc
   )  : CallbackRawBaseSingle(RawBcastMsgTag,in_pipe,in_handler,in_inc)
   { }
@@ -187,7 +187,7 @@ struct CallbackTyped : CallbackRawBaseSingle {
   { }
   CallbackTyped(
     RawBcastColDirTagType, PipeType const& in_pipe,
-    HandlerType const& in_handler, AutoHandlerType const& in_vrt,
+    HandlerType const in_handler, AutoHandlerType const in_vrt,
     VirtualProxyType const& in_proxy
   ) : CallbackRawBaseSingle(
         RawBcastColDirTag, in_pipe, in_handler, in_vrt, in_proxy
@@ -195,7 +195,7 @@ struct CallbackTyped : CallbackRawBaseSingle {
   { }
   CallbackTyped(
     RawSendColDirTagType, PipeType const& in_pipe,
-    HandlerType const& in_handler, AutoHandlerType const& in_vrt_handler,
+    HandlerType const in_handler, AutoHandlerType const in_vrt_handler,
     void* index_bits
   ) : CallbackRawBaseSingle(
         RawSendColDirTag,in_pipe,in_handler,in_vrt_handler,index_bits

--- a/src/vt/pipe/callback/handler_bcast/callback_bcast.h
+++ b/src/vt/pipe/callback/handler_bcast/callback_bcast.h
@@ -74,7 +74,7 @@ struct CallbackBcast : CallbackBase<signal::Signal<MsgT>> {
   CallbackBcast(CallbackBcast&&) = default;
 
   CallbackBcast(
-    HandlerType const& in_handler, bool const& in_include
+    HandlerType const in_handler, bool const& in_include
   );
 
   HandlerType getHandler() const { return handler_; }

--- a/src/vt/pipe/callback/handler_bcast/callback_bcast.impl.h
+++ b/src/vt/pipe/callback/handler_bcast/callback_bcast.impl.h
@@ -59,7 +59,7 @@ namespace vt { namespace pipe { namespace callback {
 
 template <typename MsgT>
 CallbackBcast<MsgT>::CallbackBcast(
-  HandlerType const& in_handler, bool const& in_include
+  HandlerType const in_handler, bool const& in_include
 ) : handler_(in_handler), include_sender_(in_include)
 { }
 

--- a/src/vt/pipe/callback/handler_bcast/callback_bcast_tl.cc
+++ b/src/vt/pipe/callback/handler_bcast/callback_bcast_tl.cc
@@ -55,7 +55,7 @@
 namespace vt { namespace pipe { namespace callback {
 
 CallbackBcastTypeless::CallbackBcastTypeless(
-  HandlerType const& in_handler, bool const& in_include
+  HandlerType const in_handler, bool const& in_include
 ) : handler_(in_handler), include_sender_(in_include)
 { }
 

--- a/src/vt/pipe/callback/handler_bcast/callback_bcast_tl.h
+++ b/src/vt/pipe/callback/handler_bcast/callback_bcast_tl.h
@@ -60,7 +60,7 @@ struct CallbackBcastTypeless : CallbackBaseTL<CallbackBcastTypeless> {
   CallbackBcastTypeless& operator=(CallbackBcastTypeless const&) = default;
 
   CallbackBcastTypeless(
-    HandlerType const& in_handler, bool const& in_include
+    HandlerType const in_handler, bool const& in_include
   );
 
   HandlerType getHandler() const { return handler_; }

--- a/src/vt/pipe/callback/handler_send/callback_send.h
+++ b/src/vt/pipe/callback/handler_send/callback_send.h
@@ -76,7 +76,7 @@ struct CallbackSend : CallbackBase<signal::Signal<MsgT>> {
   CallbackSend(CallbackSend&&) = default;
 
   CallbackSend(
-    HandlerType const& in_handler, NodeType const& in_send_node
+    HandlerType const in_handler, NodeType const& in_send_node
   );
 
   HandlerType getHandler() const { return handler_; }

--- a/src/vt/pipe/callback/handler_send/callback_send.impl.h
+++ b/src/vt/pipe/callback/handler_send/callback_send.impl.h
@@ -56,7 +56,7 @@ namespace vt { namespace pipe { namespace callback {
 
 template <typename MsgT>
 CallbackSend<MsgT>::CallbackSend(
-  HandlerType const& in_handler, NodeType const& in_send_node
+  HandlerType const in_handler, NodeType const& in_send_node
 ) : send_node_(in_send_node), handler_(in_handler)
 { }
 

--- a/src/vt/pipe/callback/handler_send/callback_send_tl.cc
+++ b/src/vt/pipe/callback/handler_send/callback_send_tl.cc
@@ -54,7 +54,7 @@
 namespace vt { namespace pipe { namespace callback {
 
 CallbackSendTypeless::CallbackSendTypeless(
-  HandlerType const& in_handler, NodeType const& in_send_node
+  HandlerType const in_handler, NodeType const& in_send_node
 ) : send_node_(in_send_node), handler_(in_handler)
 { }
 

--- a/src/vt/pipe/callback/handler_send/callback_send_tl.h
+++ b/src/vt/pipe/callback/handler_send/callback_send_tl.h
@@ -59,7 +59,7 @@ struct CallbackSendTypeless : CallbackBaseTL<CallbackSendTypeless> {
   CallbackSendTypeless& operator=(CallbackSendTypeless const&) = default;
 
   CallbackSendTypeless(
-    HandlerType const& in_handler, NodeType const& in_send_node
+    HandlerType const in_handler, NodeType const& in_send_node
   );
 
   template <typename SerializerT>

--- a/src/vt/pipe/callback/objgroup_bcast/callback_objgroup_bcast.h
+++ b/src/vt/pipe/callback/objgroup_bcast/callback_objgroup_bcast.h
@@ -55,7 +55,7 @@ namespace vt { namespace pipe { namespace callback {
 struct CallbackObjGroupBcast : CallbackBaseTL<CallbackObjGroupBcast> {
   CallbackObjGroupBcast() = default;
   CallbackObjGroupBcast(
-    HandlerType const& in_han, ObjGroupProxyType const& in_objgroup
+    HandlerType const in_han, ObjGroupProxyType const& in_objgroup
   ) : handler_(in_han), objgroup_(in_objgroup)
   { }
 

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.h
@@ -68,7 +68,7 @@ struct CallbackProxyBcast : CallbackBase<signal::Signal<MsgT>> {
   CallbackProxyBcast(CallbackProxyBcast const&) = default;
   CallbackProxyBcast(CallbackProxyBcast&&) = default;
 
-  CallbackProxyBcast(HandlerType const& in_handler, ProxyType const& in_proxy)
+  CallbackProxyBcast(HandlerType const in_handler, ProxyType const& in_proxy)
     : proxy_(in_proxy), handler_(in_handler)
   { }
 

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.h
@@ -68,10 +68,8 @@ struct CallbackProxyBcast : CallbackBase<signal::Signal<MsgT>> {
   CallbackProxyBcast(CallbackProxyBcast const&) = default;
   CallbackProxyBcast(CallbackProxyBcast&&) = default;
 
-  CallbackProxyBcast(
-    HandlerType const& in_handler, ProxyType const& in_proxy,
-    bool const& in_member
-  ) : proxy_(in_proxy), handler_(in_handler), member_(in_member)
+  CallbackProxyBcast(HandlerType const& in_handler, ProxyType const& in_proxy)
+    : proxy_(in_proxy), handler_(in_handler)
   { }
 
   template <typename SerializerT>
@@ -83,7 +81,6 @@ private:
 private:
   ProxyType proxy_     = {};
   HandlerType handler_ = uninitialized_handler;
-  bool member_         = false;
 };
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.impl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast.impl.h
@@ -58,12 +58,11 @@ void CallbackProxyBcast<ColT,MsgT>::serialize(SerializerT& s) {
   CallbackBase<SignalBaseType>::serializer(s);
   s | proxy_;
   s | handler_;
-  s | member_;
 }
 
 template <typename ColT, typename MsgT>
 void CallbackProxyBcast<ColT,MsgT>::trigger_(SignalDataType* data) {
-  theCollection()->broadcastMsgWithHan(proxy_,data,handler_,member_,true);
+  theCollection()->broadcastMsgWithHan(proxy_, data, handler_, true);
 }
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.h
@@ -76,7 +76,7 @@ struct CallbackProxyBcastDirect : CallbackBaseTL<CallbackProxyBcastDirect> {
 
   CallbackProxyBcastDirect() = default;
   CallbackProxyBcastDirect(
-    HandlerType const& in_han, AutoHandlerType const& in_vrt,
+    HandlerType const in_han, AutoHandlerType const in_vrt,
     VirtualProxyType const& in_proxy
   ) : vrt_dispatch_han_(in_vrt), handler_(in_han), proxy_(in_proxy)
   { }

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.h
@@ -77,9 +77,8 @@ struct CallbackProxyBcastDirect : CallbackBaseTL<CallbackProxyBcastDirect> {
   CallbackProxyBcastDirect() = default;
   CallbackProxyBcastDirect(
     HandlerType const& in_han, AutoHandlerType const& in_vrt,
-    bool const& in_member, VirtualProxyType const& in_proxy
-  ) : vrt_dispatch_han_(in_vrt), handler_(in_han), proxy_(in_proxy),
-      member_(in_member)
+    VirtualProxyType const& in_proxy
+  ) : vrt_dispatch_han_(in_vrt), handler_(in_han), proxy_(in_proxy)
   { }
 
   template <typename SerializerT>
@@ -89,8 +88,7 @@ struct CallbackProxyBcastDirect : CallbackBaseTL<CallbackProxyBcastDirect> {
     return
       other.handler_ == handler_ &&
       other.vrt_dispatch_han_ == vrt_dispatch_han_ &&
-      other.proxy_ == proxy_ &&
-      other.member_ == member_;
+      other.proxy_ == proxy_;
   }
 
 public:
@@ -105,7 +103,6 @@ private:
   AutoHandlerType vrt_dispatch_han_ = uninitialized_handler;
   HandlerType handler_              = uninitialized_handler;
   VirtualProxyType proxy_           = no_vrt_proxy;
-  bool member_                      = false;
 };
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
+++ b/src/vt/pipe/callback/proxy_bcast/callback_proxy_bcast_tl.impl.h
@@ -92,7 +92,6 @@ template <typename SerializerT>
 void CallbackProxyBcastDirect::serialize(SerializerT& s) {
   s | handler_;
   s | vrt_dispatch_han_;
-  s | member_;
   s | proxy_;
 }
 
@@ -108,7 +107,7 @@ void CallbackProxyBcastDirect::trigger(MsgT* msg, PipeType const& pipe) {
 
   auto dispatcher = vrt::collection::getDispatcher(vrt_dispatch_han_);
   auto const& proxy = proxy_;
-  dispatcher->broadcast(proxy,msg,handler_,member_);
+  dispatcher->broadcast(proxy, msg, handler_);
 }
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_send/callback_proxy_send.h
+++ b/src/vt/pipe/callback/proxy_send/callback_proxy_send.h
@@ -68,13 +68,13 @@ struct CallbackProxySend : CallbackBase<signal::Signal<MsgT>> {
   using MessageType      = MsgT;
 
   CallbackProxySend(
-    HandlerType const& in_handler, IndexedProxyType const& in_proxy
+    HandlerType const in_handler, IndexedProxyType const& in_proxy
   ) : proxy_(in_proxy.getCollectionProxy()),
       idx_(in_proxy.getElementProxy().getIndex()), handler_(in_handler)
   { }
 
   CallbackProxySend(
-    HandlerType const& in_handler, ProxyType const& in_proxy,
+    HandlerType const in_handler, ProxyType const& in_proxy,
     IndexType const& in_idx
   ) : proxy_(in_proxy), idx_(in_idx), handler_(in_handler)
   { }

--- a/src/vt/pipe/callback/proxy_send/callback_proxy_send.h
+++ b/src/vt/pipe/callback/proxy_send/callback_proxy_send.h
@@ -68,17 +68,15 @@ struct CallbackProxySend : CallbackBase<signal::Signal<MsgT>> {
   using MessageType      = MsgT;
 
   CallbackProxySend(
-    HandlerType const& in_handler, IndexedProxyType const& in_proxy,
-    bool const& in_member
+    HandlerType const& in_handler, IndexedProxyType const& in_proxy
   ) : proxy_(in_proxy.getCollectionProxy()),
-      idx_(in_proxy.getElementProxy().getIndex()),
-      handler_(in_handler), member_(in_member)
+      idx_(in_proxy.getElementProxy().getIndex()), handler_(in_handler)
   { }
 
   CallbackProxySend(
     HandlerType const& in_handler, ProxyType const& in_proxy,
-    IndexType const& in_idx, bool const& in_member
-  ) : proxy_(in_proxy), idx_(in_idx), handler_(in_handler), member_(in_member)
+    IndexType const& in_idx
+  ) : proxy_(in_proxy), idx_(in_idx), handler_(in_handler)
   { }
 
   template <typename SerializerT>
@@ -91,7 +89,6 @@ private:
   ProxyType proxy_     = {};
   IndexType idx_       = {};
   HandlerType handler_ = uninitialized_handler;
-  bool member_         = false;
 };
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_send/callback_proxy_send.impl.h
+++ b/src/vt/pipe/callback/proxy_send/callback_proxy_send.impl.h
@@ -58,12 +58,11 @@ void CallbackProxySend<ColT,MsgT>::serialize(SerializerT& s) {
   CallbackBase<SignalBaseType>::serializer(s);
   s | proxy_ | idx_;
   s | handler_;
-  s | member_;
 }
 
 template <typename ColT, typename MsgT>
-void CallbackProxySend<ColT,MsgT>::trigger_(SignalDataType* data) {
-  theCollection()->sendMsgWithHan(proxy_.index(idx_),data,handler_,member_);
+void CallbackProxySend<ColT, MsgT>::trigger_(SignalDataType* data) {
+  theCollection()->sendMsgWithHan(proxy_.index(idx_), data, handler_);
 }
 
 }}} /* end namespace vt::pipe::callback */

--- a/src/vt/pipe/callback/proxy_send/callback_proxy_send_tl.h
+++ b/src/vt/pipe/callback/proxy_send/callback_proxy_send_tl.h
@@ -75,7 +75,7 @@ struct CallbackProxySendDirect : CallbackBaseTL<CallbackProxySendDirect> {
   using AutoHandlerType = auto_registry::AutoHandlerType;
 
   CallbackProxySendDirect() = default;
-  CallbackProxySendDirect(HandlerType const& in_han, AutoHandlerType in_vrt)
+  CallbackProxySendDirect(HandlerType const in_han, AutoHandlerType in_vrt)
     : vrt_dispatch_han_(in_vrt), handler_(in_han)
   { }
 

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -149,12 +149,9 @@ PipeManagerTL::makeCallbackSingleProxySend(typename ColT::ProxyType proxy) {
   newPipeState(pipe_id,persist,dispatch,-1,-1,0);
   auto cb = CallbackT(callback::cbunion::RawSendColMsgTag,pipe_id);
   auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  bool member = false;
   addListenerAny<MsgT>(
     cb.getPipe(),
-    std::make_unique<callback::CallbackProxySend<ColT,MsgT>>(
-      handler,proxy,member
-    )
+    std::make_unique<callback::CallbackProxySend<ColT, MsgT>>(handler, proxy)
   );
   return cb;
 }
@@ -173,12 +170,9 @@ PipeManagerTL::makeCallbackSingleProxySend(typename ColT::ProxyType proxy) {
   auto cb = CallbackT(callback::cbunion::RawSendColMsgTag,pipe_id);
   auto const& handler =
     auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  bool member = true;
   addListenerAny<MsgT>(
     cb.getPipe(),
-    std::make_unique<callback::CallbackProxySend<ColT,MsgT>>(
-      handler,proxy,member
-    )
+    std::make_unique<callback::CallbackProxySend<ColT, MsgT>>(handler, proxy)
   );
   return cb;
 }
@@ -253,9 +247,8 @@ PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
   auto const& pipe_id = makePipeID(persist,send_back);
   auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
   auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
-  bool const member = false;
   auto cb = CallbackT(
-    callback::cbunion::RawBcastColDirTag,pipe_id,handler,vrt_handler,member,
+    callback::cbunion::RawBcastColDirTag, pipe_id, handler, vrt_handler,
     proxy.getProxy()
   );
   return cb;
@@ -273,9 +266,8 @@ PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
   auto const& handler =
     auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
   auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
-  bool const member = true;
   auto cb = CallbackT(
-    callback::cbunion::RawBcastColDirTag,pipe_id,handler,vrt_handler,member,
+    callback::cbunion::RawBcastColDirTag, pipe_id, handler, vrt_handler,
     proxy.getProxy()
   );
   return cb;

--- a/src/vt/registry/auto/auto_registry.cc
+++ b/src/vt/registry/auto/auto_registry.cc
@@ -52,77 +52,67 @@
 namespace vt { namespace auto_registry {
 
 #if vt_check_enabled(trace_enabled)
-trace::TraceEntryIDType handlerTraceID(
-  HandlerType const& handler, RegistryTypeEnum reg_type
-) {
+
+template <typename ContType>
+trace::TraceEntryIDType getTraceID(HandlerType const handler) {
+  auto const han_id = HandlerManagerType::getHandlerIdentifier(handler);
+  return getAutoRegistryGen<ContType>().at(han_id).theTraceID();
+}
+
+trace::TraceEntryIDType
+handlerTraceID(HandlerType const handler, RegistryTypeEnum const reg_type) {
   switch (reg_type) {
   case RegistryTypeEnum::RegGeneral: {
-    bool const& is_functor = HandlerManagerType::isHandlerFunctor(handler);
-    auto const& han_id = HandlerManagerType::getHandlerIdentifier(handler);
-    if (not is_functor) {
-      using ContType = AutoActiveContainerType;
-      return getAutoRegistryGen<ContType>().at(han_id).theTraceID();
-    } else {
-      using ContType = AutoActiveFunctorContainerType;
-      return getAutoRegistryGen<ContType>().at(han_id).theTraceID();
+    if (HandlerManagerType::isHandlerFunctor(handler)) {
+      return getTraceID<AutoActiveFunctorContainerType>(handler);
     }
-    break;
+
+    return getTraceID<AutoActiveContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegMap: {
-    bool const& is_functor = HandlerManagerType::isHandlerFunctor(handler);
-    auto const& han_id = HandlerManagerType::getHandlerIdentifier(handler);
-    if (not is_functor) {
-      using ContType = AutoActiveMapContainerType;
-      return getAutoRegistryGen<ContType>().at(han_id).theTraceID();
-    } else {
-      using ContType = AutoActiveMapFunctorContainerType;
-      return getAutoRegistryGen<ContType>().at(han_id).theTraceID();
+    if (HandlerManagerType::isHandlerFunctor(handler)) {
+      return getTraceID<AutoActiveMapFunctorContainerType>(handler);
     }
-    break;
+
+    return getTraceID<AutoActiveMapContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegVrt: {
-    using ContType = AutoActiveVCContainerType;
-    return getAutoRegistryGen<ContType>().at(handler).theTraceID();
-    break;
+    return getTraceID<AutoActiveVCContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegObjGroup: {
-    using ContType = AutoActiveObjGroupContainerType;
-    auto const han_id = HandlerManagerType::getHandlerIdentifier(handler);
-    return getAutoRegistryGen<ContType>().at(han_id).theTraceID();
-    break;
+    return getTraceID<AutoActiveObjGroupContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegVrtCollection: {
-    using ContType = AutoActiveCollectionContainerType;
-    return getAutoRegistryGen<ContType>().at(handler).theTraceID();
-    break;
+    return getTraceID<AutoActiveCollectionContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegVrtCollectionMember: {
-    using ContType = AutoActiveCollectionMemContainerType;
-    return getAutoRegistryGen<ContType>().at(handler).theTraceID();
-    break;
+    return getTraceID<AutoActiveCollectionMemContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegRDMAGet: {
-    using ContType = AutoActiveRDMAGetContainerType;
-    return getAutoRegistryGen<ContType>().at(handler).theTraceID();
-    break;
+    return getTraceID<AutoActiveRDMAGetContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegRDMAPut: {
-    using ContType = AutoActiveRDMAPutContainerType;
-    return getAutoRegistryGen<ContType>().at(handler).theTraceID();
-    break;
+    return getTraceID<AutoActiveRDMAPutContainerType>(handler);
   }
+
   case RegistryTypeEnum::RegSeed: {
-    using ContType = AutoActiveSeedMapContainerType;
-    auto const& han_id = HandlerManagerType::getHandlerIdentifier(handler);
-    return getAutoRegistryGen<ContType>().at(han_id).theTraceID();
-    break;
+    return getTraceID<AutoActiveSeedMapContainerType>(handler);
   }
-  default:
+
+  default: {
     assert(0 && "Should not be reachable");
     return trace::TraceEntryIDType{};
-    break;
+  }
   }
 }
+
 #endif
 
 }} // end namespace vt::auto_registry

--- a/src/vt/registry/auto/auto_registry.h
+++ b/src/vt/registry/auto/auto_registry.h
@@ -62,7 +62,7 @@
 
 namespace vt { namespace auto_registry {
 
-AutoActiveType getAutoHandler(HandlerType const& handler);
+AutoActiveType getAutoHandler(HandlerType const handler);
 
 AutoActiveObjGroupType getAutoHandlerObjGroup(HandlerType han);
 AutoHandlerType getAutoHandlerObjTypeIdx(HandlerType han);

--- a/src/vt/registry/auto/auto_registry_impl.h
+++ b/src/vt/registry/auto/auto_registry_impl.h
@@ -57,12 +57,14 @@ namespace vt { namespace auto_registry {
 
 inline AutoActiveObjGroupType getAutoHandlerObjGroup(HandlerType han) {
   using ContainerType = AutoActiveObjGroupContainerType;
+
   auto const id = HandlerManagerType::getHandlerIdentifier(han);
   return getAutoRegistryGen<ContainerType>().at(id).getFun();
 }
 
 inline AutoHandlerType getAutoHandlerObjTypeIdx(HandlerType han) {
   using ContainerType = AutoActiveObjGroupContainerType;
+
   auto const id = HandlerManagerType::getHandlerIdentifier(han);
   return getAutoRegistryGen<ContainerType>().at(id).getObjIdx();
 }
@@ -114,10 +116,10 @@ inline HandlerType makeAutoHandlerParam() {
   return HandlerManagerType::makeHandler(is_auto, is_functor, RunType::idx);
 }
 
-inline AutoActiveType getAutoHandler(HandlerType const& handler) {
-  auto const& han_id = HandlerManagerType::getHandlerIdentifier(handler);
-  bool const& is_auto = HandlerManagerType::isHandlerAuto(handler);
-  bool const& is_functor = HandlerManagerType::isHandlerFunctor(handler);
+inline AutoActiveType getAutoHandler(HandlerType const handler) {
+  auto const han_id = HandlerManagerType::getHandlerIdentifier(handler);
+  bool const is_auto = HandlerManagerType::isHandlerAuto(handler);
+  bool const is_functor = HandlerManagerType::isHandlerFunctor(handler);
 
   vt_debug_print(
     handler, node,

--- a/src/vt/registry/auto/auto_registry_impl.h
+++ b/src/vt/registry/auto/auto_registry_impl.h
@@ -69,17 +69,20 @@ inline AutoHandlerType getAutoHandlerObjTypeIdx(HandlerType han) {
 
 template <typename ObjT, typename MsgT, objgroup::ActiveObjType<MsgT, ObjT> f>
 inline HandlerType makeAutoHandlerObjGroup(HandlerControlType ctrl) {
-  using AdapterT = FunctorAdapterMember<
-    objgroup::ActiveObjType<MsgT, ObjT>, f, ObjT
-  >;
+  using AdapterT =
+    FunctorAdapterMember<objgroup::ActiveObjType<MsgT, ObjT>, f, ObjT>;
   using ContainerType = AutoActiveObjGroupContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveObjGroupType>;
   using FuncType = objgroup::ActiveObjAnyType;
   using RunType = RunnableGen<AdapterT, ContainerType, RegInfoType, FuncType>;
 
-  auto const obj = true;
+  constexpr bool is_auto = true;
+  constexpr bool is_functor = false;
+  constexpr bool is_objgroup = true;
   auto const idx = RunType::idx;
-  auto const han = HandlerManagerType::makeHandler(true, false, idx, obj, ctrl);
+  auto const han =
+    HandlerManagerType::makeHandler(is_auto, is_functor, idx, is_objgroup, ctrl
+  );
   auto obj_idx = objgroup::registry::makeObjIdx<ObjT>();
   getAutoRegistryGen<ContainerType>().at(idx).setObjIdx(obj_idx);
   return han;
@@ -93,7 +96,9 @@ inline HandlerType makeAutoHandler() {
   using FuncType = ActiveFnPtrType;
   using RunType = RunnableGen<AdapterT, ContainerType, RegInfoType, FuncType>;
 
-  return HandlerManagerType::makeHandler(true, false, RunType::idx);
+  constexpr bool is_auto = true;
+  constexpr bool is_functor = false;
+  return HandlerManagerType::makeHandler(is_auto, is_functor, RunType::idx);
 }
 
 template <typename T, T value>
@@ -104,7 +109,9 @@ inline HandlerType makeAutoHandlerParam() {
   using FuncType = ActiveFnPtrType;
   using RunType = RunnableGen<AdapterT, ContainerType, RegInfoType, FuncType>;
 
-  return HandlerManagerType::makeHandler(true, false, RunType::idx);
+  constexpr bool is_auto = true;
+  constexpr bool is_functor = false;
+  return HandlerManagerType::makeHandler(is_auto, is_functor, RunType::idx);
 }
 
 inline AutoActiveType getAutoHandler(HandlerType const& handler) {

--- a/src/vt/registry/auto/auto_registry_interface.h
+++ b/src/vt/registry/auto/auto_registry_interface.h
@@ -60,9 +60,9 @@ HandlerType makeAutoHandlerParam();
 template <typename T, bool is_msg, typename... Args>
 HandlerType makeAutoHandlerFunctor();
 
-AutoActiveType getAutoHandler(HandlerType const& handler);
+AutoActiveType getAutoHandler(HandlerType const handler);
 
-AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const& handler);
+AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const handler);
 
 #if vt_check_enabled(trace_enabled)
   trace::TraceEntryIDType handlerTraceID(

--- a/src/vt/registry/auto/auto_registry_interface.h
+++ b/src/vt/registry/auto/auto_registry_interface.h
@@ -66,7 +66,7 @@ AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const& handler);
 
 #if vt_check_enabled(trace_enabled)
   trace::TraceEntryIDType handlerTraceID(
-    HandlerType const& handler, RegistryTypeEnum reg_type
+    HandlerType const handler, RegistryTypeEnum reg_type
   );
 #endif
 

--- a/src/vt/registry/auto/collection/auto_registry_collection.h
+++ b/src/vt/registry/auto/collection/auto_registry_collection.h
@@ -56,13 +56,13 @@ namespace vt { namespace auto_registry {
 
 using namespace ::vt::vrt::collection;
 
-AutoActiveCollectionType getAutoHandlerCollection(HandlerType const& handler);
+AutoActiveCollectionType getAutoHandlerCollection(HandlerType const handler);
 
 template <typename ColT, typename MsgT, ActiveColTypedFnType<MsgT, ColT>* f>
 HandlerType makeAutoHandlerCollection();
 
 AutoActiveCollectionMemType getAutoHandlerCollectionMem(
-  HandlerType const& handler
+  HandlerType const handler
 );
 
 template <

--- a/src/vt/registry/auto/collection/auto_registry_collection.impl.h
+++ b/src/vt/registry/auto/collection/auto_registry_collection.impl.h
@@ -51,7 +51,7 @@
 namespace vt { namespace auto_registry {
 
 inline AutoActiveCollectionType getAutoHandlerCollection(
-  HandlerType const& handler
+  HandlerType const handler
 ) {
   using ContainerType = AutoActiveCollectionContainerType;
 
@@ -74,7 +74,7 @@ inline HandlerType makeAutoHandlerCollection() {
 }
 
 inline AutoActiveCollectionMemType getAutoHandlerCollectionMem(
-  HandlerType const& handler
+  HandlerType const handler
 ) {
   using ContainerType = AutoActiveCollectionMemContainerType;
 

--- a/src/vt/registry/auto/collection/auto_registry_collection.impl.h
+++ b/src/vt/registry/auto/collection/auto_registry_collection.impl.h
@@ -54,7 +54,9 @@ inline AutoActiveCollectionType getAutoHandlerCollection(
   HandlerType const& handler
 ) {
   using ContainerType = AutoActiveCollectionContainerType;
-  return getAutoRegistryGen<ContainerType>().at(handler).getFun();
+
+  auto const han_id = HandlerManagerType::getHandlerIdentifier(handler);
+  return getAutoRegistryGen<ContainerType>().at(han_id).getFun();
 }
 
 template <typename ColT, typename MsgT, ActiveColTypedFnType<MsgT, ColT>* f>
@@ -63,14 +65,21 @@ inline HandlerType makeAutoHandlerCollection() {
   using ContainerType = AutoActiveCollectionContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveCollectionType>;
   using FuncType = ActiveColFnPtrType;
-  return RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+
+  auto const id =
+    RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+  auto handler = HandlerManager::makeHandler(false, false, id);
+  HandlerManager::setHandlerMember(handler, false);
+  return handler;
 }
 
 inline AutoActiveCollectionMemType getAutoHandlerCollectionMem(
   HandlerType const& handler
 ) {
   using ContainerType = AutoActiveCollectionMemContainerType;
-  return getAutoRegistryGen<ContainerType>().at(handler).getFun();
+
+  auto const han_id = HandlerManagerType::getHandlerIdentifier(handler);
+  return getAutoRegistryGen<ContainerType>().at(han_id).getFun();
 }
 
 template <
@@ -81,7 +90,12 @@ inline HandlerType makeAutoHandlerCollectionMem() {
   using ContainerType = AutoActiveCollectionMemContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveCollectionMemType>;
   using FuncType = ActiveColMemberFnPtrType;
-  return RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+
+  auto const id =
+    RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+  auto handler = HandlerManager::makeHandler(false, false, id);
+  HandlerManager::setHandlerMember(handler, true);
+  return handler;
 }
 
 template <typename ColT, typename MsgT, ActiveColTypedFnType<MsgT, ColT>* f>

--- a/src/vt/registry/auto/functor/auto_registry_functor.h
+++ b/src/vt/registry/auto/functor/auto_registry_functor.h
@@ -61,8 +61,8 @@ struct RegistrarFunctor {
   RegistrarFunctor();
 };
 
-AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const& handler);
-NumArgsType getAutoHandlerFunctorArgs(HandlerType const& handler);
+AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const handler);
+NumArgsType getAutoHandlerFunctorArgs(HandlerType const handler);
 
 template <typename FunctorT, bool is_msg, typename... Args>
 HandlerType makeAutoHandlerFunctor();

--- a/src/vt/registry/auto/functor/auto_registry_functor_impl.h
+++ b/src/vt/registry/auto/functor/auto_registry_functor_impl.h
@@ -84,7 +84,7 @@ RegistrarFunctor<RunnableT, RegT, InfoT, FnT>::RegistrarFunctor() {
   // trace
   std::string event_type_name = AdapterType::traceGetEventType();
   std::string event_name = AdapterType::traceGetEventName();
-  auto const& trace_ep = trace::TraceRegistry::registerEventHashed(
+  auto const trace_ep = trace::TraceRegistry::registerEventHashed(
     event_type_name, event_name);
   reg.emplace_back(InfoT{NumArgsTag, fn, trace_ep, num_args});
   #else
@@ -93,17 +93,17 @@ RegistrarFunctor<RunnableT, RegT, InfoT, FnT>::RegistrarFunctor() {
   #endif
 }
 
-inline NumArgsType getAutoHandlerFunctorArgs(HandlerType const& han) {
-  auto const& id = HandlerManagerType::getHandlerIdentifier(han);
+inline NumArgsType getAutoHandlerFunctorArgs(HandlerType const han) {
+  auto const id = HandlerManagerType::getHandlerIdentifier(han);
 
   using ContainerType = AutoActiveFunctorContainerType;
   return getAutoRegistryGen<ContainerType>().at(id).getNumArgs();
 }
 
-inline AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const& han) {
-  auto const& id = HandlerManagerType::getHandlerIdentifier(han);
-  bool const& is_auto = HandlerManagerType::isHandlerAuto(han);
-  bool const& is_functor = HandlerManagerType::isHandlerFunctor(han);
+inline AutoActiveFunctorType getAutoHandlerFunctor(HandlerType const han) {
+  auto const id = HandlerManagerType::getHandlerIdentifier(han);
+  bool const is_auto = HandlerManagerType::isHandlerAuto(han);
+  bool const is_functor = HandlerManagerType::isHandlerFunctor(han);
 
   vt_debug_print(
     handler, node,

--- a/src/vt/registry/auto/functor/auto_registry_functor_impl.h
+++ b/src/vt/registry/auto/functor/auto_registry_functor_impl.h
@@ -62,10 +62,12 @@ inline HandlerType makeAutoHandlerFunctor() {
   using ContainerType = AutoActiveFunctorContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveFunctorType>;
   using FuncType = ActiveFnPtrType;
-  using RunType = RunnableFunctor<
-    AdapterType, ContainerType, RegInfoType, FuncType, msg
-  >;
-  return HandlerManagerType::makeHandler(true, true, RunType::idx);
+  using RunType =
+    RunnableFunctor<AdapterType, ContainerType, RegInfoType, FuncType, msg>;
+
+  constexpr bool is_auto = true;
+  constexpr bool is_functor = true;
+  return HandlerManagerType::makeHandler(is_auto, is_functor, RunType::idx);
 }
 
 template <typename RunnableT, typename RegT, typename InfoT, typename FnT>

--- a/src/vt/registry/auto/map/auto_registry_map.h
+++ b/src/vt/registry/auto/map/auto_registry_map.h
@@ -56,24 +56,24 @@ namespace vt { namespace auto_registry {
 
 using namespace mapping;
 
-AutoActiveMapFunctorType getAutoHandlerFunctorMap(HandlerType const& han);
+AutoActiveMapFunctorType getAutoHandlerFunctorMap(HandlerType const han);
 
 template <typename FunctorT, typename... Args>
 HandlerType makeAutoHandlerFunctorMap();
 
 // Registration for collection index mapping functions
-AutoActiveMapType getAutoHandlerMap(HandlerType const& handler);
+AutoActiveMapType getAutoHandlerMap(HandlerType const handler);
 
 template <typename IndexT, ActiveMapTypedFnType<IndexT>* f>
 HandlerType makeAutoHandlerMap();
 
 // Registration for seed mapping singletons
-AutoActiveSeedMapType getAutoHandlerSeedMap(HandlerType const& handler);
+AutoActiveSeedMapType getAutoHandlerSeedMap(HandlerType const handler);
 
 template <ActiveSeedMapFnType* f>
 HandlerType makeAutoHandlerSeedMap();
 
-AutoActiveMapType getHandlerMap(HandlerType const& han);
+AutoActiveMapType getHandlerMap(HandlerType const han);
 
 }} // end namespace vt::auto_registry
 

--- a/src/vt/registry/auto/map/auto_registry_map_impl.h
+++ b/src/vt/registry/auto/map/auto_registry_map_impl.h
@@ -81,12 +81,12 @@ inline HandlerType makeAutoHandlerFunctorMap() {
 }
 
 inline AutoActiveMapFunctorType getAutoHandlerFunctorMap(
-  HandlerType const& han
+  HandlerType const han
 ) {
   using ContainerType = AutoActiveMapFunctorContainerType;
-  auto const& id = HandlerManagerType::getHandlerIdentifier(han);
-  bool const& is_auto = HandlerManagerType::isHandlerAuto(han);
-  bool const& is_functor = HandlerManagerType::isHandlerFunctor(han);
+  auto const id = HandlerManagerType::getHandlerIdentifier(han);
+  bool const is_auto = HandlerManagerType::isHandlerAuto(han);
+  bool const is_functor = HandlerManagerType::isHandlerFunctor(han);
 
   vt_debug_print(
     handler, node,
@@ -120,9 +120,9 @@ inline HandlerType makeAutoHandlerMap() {
   return han;
 }
 
-inline AutoActiveMapType getAutoHandlerMap(HandlerType const& handler) {
+inline AutoActiveMapType getAutoHandlerMap(HandlerType const handler) {
   using ContainerType = AutoActiveMapContainerType;
-  auto const& id = HandlerManagerType::getHandlerIdentifier(handler);
+  auto const id = HandlerManagerType::getHandlerIdentifier(handler);
   vt_debug_print(
     handler, node,
     "getAutoHandlerMap: id={}, handler={}\n", id, handler
@@ -146,9 +146,9 @@ inline HandlerType makeAutoHandlerSeedMap() {
 }
 
 // Registration for seed mapping singletons
-inline AutoActiveSeedMapType getAutoHandlerSeedMap(HandlerType const& handler) {
+inline AutoActiveSeedMapType getAutoHandlerSeedMap(HandlerType const handler) {
   using ContainerType = AutoActiveSeedMapContainerType;
-  auto const& id = HandlerManagerType::getHandlerIdentifier(handler);
+  auto const id = HandlerManagerType::getHandlerIdentifier(handler);
   vt_debug_print(
     handler, node,
     "getAutoHandlerSeedMap: id={}, handler={}\n", id, handler
@@ -156,8 +156,8 @@ inline AutoActiveSeedMapType getAutoHandlerSeedMap(HandlerType const& handler) {
   return getAutoRegistryGen<ContainerType>().at(id).getFun();
 }
 
-inline AutoActiveMapType getHandlerMap(HandlerType const& han) {
-  bool const& is_functor = HandlerManagerType::isHandlerFunctor(han);
+inline AutoActiveMapType getHandlerMap(HandlerType const han) {
+  bool const is_functor = HandlerManagerType::isHandlerFunctor(han);
   if (is_functor) {
     return getAutoHandlerFunctorMap(han);
   } else {

--- a/src/vt/registry/auto/map/auto_registry_map_impl.h
+++ b/src/vt/registry/auto/map/auto_registry_map_impl.h
@@ -71,11 +71,12 @@ inline HandlerType makeAutoHandlerFunctorMap() {
   using RunnableT = RunnableFunctor<
     FunctorT, ContainerType, RegInfoType, FuncType, true, Args...
   >;
-  auto const& han = HandlerManagerType::makeHandler(true, true, RunnableT::idx);
-  vt_debug_print(
-    handler, node,
-    "makeAutoHandlerFunctorMap: handler={}\n", han
-  );
+
+  constexpr bool is_auto = true;
+  constexpr bool is_functor = true;
+  auto const han =
+    HandlerManagerType::makeHandler(is_auto, is_functor, RunnableT::idx);
+  vt_debug_print(handler, node, "makeAutoHandlerFunctorMap: handler={}\n", han);
   return han;
 }
 
@@ -110,12 +111,12 @@ inline HandlerType makeAutoHandlerMap() {
   using ContainerType = AutoActiveMapContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveMapType>;
   using FuncType = ActiveMapFnPtrType;
+
+  constexpr bool is_auto = true;
+  constexpr bool is_functor = false;
   auto id = RunnableGen<FunctorType, ContainerType, RegInfoType, FuncType>::idx;
-  auto const& han = HandlerManagerType::makeHandler(true,false,id);
-  vt_debug_print(
-    handler, node,
-    "makeAutoHandlerMap: id={}, han={}\n", id, han
-  );
+  auto const han = HandlerManagerType::makeHandler(is_auto, is_functor, id);
+  vt_debug_print(handler, node, "makeAutoHandlerMap: id={}, han={}\n", id, han);
   return han;
 }
 
@@ -135,13 +136,13 @@ inline HandlerType makeAutoHandlerSeedMap() {
   using ContainerType = AutoActiveSeedMapContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveSeedMapType>;
   using FuncType = ActiveSeedMapFnPtrType;
+
+  constexpr bool is_auto = true;
+  constexpr bool is_functor = false;
   auto id = RunnableGen<FunctorType, ContainerType, RegInfoType, FuncType>::idx;
-  auto const& han = HandlerManagerType::makeHandler(true,false,id);
-  vt_debug_print(
-    handler, node,
-    "makeAutoHandlerMap: id={}, han={}\n", id, han
-  );
-  return id;
+  auto const han = HandlerManagerType::makeHandler(is_auto, is_functor, id);
+  vt_debug_print(handler, node, "makeAutoHandlerMap: id={}, han={}\n", id, han);
+  return han;
 }
 
 // Registration for seed mapping singletons

--- a/src/vt/registry/auto/rdma/auto_registry_rdma.h
+++ b/src/vt/registry/auto/rdma/auto_registry_rdma.h
@@ -54,8 +54,8 @@
 
 namespace vt { namespace auto_registry {
 
-AutoActiveRDMAGetType getAutoHandlerRDMAGet(HandlerType const& handler);
-AutoActiveRDMAPutType getAutoHandlerRDMAPut(HandlerType const& handler);
+AutoActiveRDMAGetType getAutoHandlerRDMAGet(HandlerType const handler);
+AutoActiveRDMAPutType getAutoHandlerRDMAPut(HandlerType const handler);
 
 template <typename MsgT, ActiveTypedRDMAPutFnType<MsgT>* f>
 HandlerType makeAutoHandlerRDMAPut();

--- a/src/vt/registry/auto/rdma/auto_registry_rdma.impl.h
+++ b/src/vt/registry/auto/rdma/auto_registry_rdma.impl.h
@@ -54,7 +54,9 @@ namespace vt { namespace auto_registry {
 
 inline AutoActiveRDMAPutType getAutoHandlerRDMAPut(HandlerType const& handler) {
   using ContainerType = AutoActiveRDMAPutContainerType;
-  return getAutoRegistryGen<ContainerType>().at(handler).getFun();
+
+  auto const han_id = HandlerManager::getHandlerIdentifier(handler);
+  return getAutoRegistryGen<ContainerType>().at(han_id).getFun();
 }
 
 template <typename MsgT, ActiveTypedRDMAPutFnType<MsgT>* f>
@@ -63,12 +65,17 @@ inline HandlerType makeAutoHandlerRDMAPut() {
   using ContainerType = AutoActiveRDMAPutContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveRDMAPutType>;
   using FuncType = ActiveRDMAPutFnPtrType;
-  return RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+
+  auto const id =
+    RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+  return HandlerManager::makeHandler(false, false, id);
 }
 
 inline AutoActiveRDMAGetType getAutoHandlerRDMAGet(HandlerType const& handler) {
   using ContainerType = AutoActiveRDMAGetContainerType;
-  return getAutoRegistryGen<ContainerType>().at(handler).getFun();
+
+  auto const han_id = HandlerManager::getHandlerIdentifier(handler);
+  return getAutoRegistryGen<ContainerType>().at(han_id).getFun();
 }
 
 template <typename MsgT, ActiveTypedRDMAGetFnType<MsgT>* f>
@@ -77,9 +84,11 @@ inline HandlerType makeAutoHandlerRDMAGet() {
   using ContainerType = AutoActiveRDMAGetContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveRDMAGetType>;
   using FuncType = ActiveRDMAGetFnPtrType;
-  return RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
-}
 
+  auto const id =
+    RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+  return HandlerManager::makeHandler(false, false, id);
+}
 
 }} /* end namespace vt::auto_registry */
 

--- a/src/vt/registry/auto/rdma/auto_registry_rdma.impl.h
+++ b/src/vt/registry/auto/rdma/auto_registry_rdma.impl.h
@@ -52,7 +52,7 @@
 
 namespace vt { namespace auto_registry {
 
-inline AutoActiveRDMAPutType getAutoHandlerRDMAPut(HandlerType const& handler) {
+inline AutoActiveRDMAPutType getAutoHandlerRDMAPut(HandlerType const handler) {
   using ContainerType = AutoActiveRDMAPutContainerType;
 
   auto const han_id = HandlerManager::getHandlerIdentifier(handler);
@@ -71,7 +71,7 @@ inline HandlerType makeAutoHandlerRDMAPut() {
   return HandlerManager::makeHandler(false, false, id);
 }
 
-inline AutoActiveRDMAGetType getAutoHandlerRDMAGet(HandlerType const& handler) {
+inline AutoActiveRDMAGetType getAutoHandlerRDMAGet(HandlerType const handler) {
   using ContainerType = AutoActiveRDMAGetContainerType;
 
   auto const han_id = HandlerManager::getHandlerIdentifier(handler);

--- a/src/vt/registry/auto/vc/auto_registry_vc.h
+++ b/src/vt/registry/auto/vc/auto_registry_vc.h
@@ -56,7 +56,7 @@ namespace vt { namespace auto_registry {
 
 using namespace vrt;
 
-AutoActiveVCType getAutoHandlerVC(HandlerType const& handler);
+AutoActiveVCType getAutoHandlerVC(HandlerType const handler);
 
 template <typename VrtT, typename MsgT, ActiveVrtTypedFnType<MsgT, VrtT>* f>
 HandlerType makeAutoHandlerVC();

--- a/src/vt/registry/auto/vc/auto_registry_vc_impl.h
+++ b/src/vt/registry/auto/vc/auto_registry_vc_impl.h
@@ -61,12 +61,17 @@ inline HandlerType makeAutoHandlerVC() {
   using ContainerType = AutoActiveVCContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveVCType>;
   using FuncType = ActiveVirtualFnPtrType;
-  return RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+
+  auto const id =
+    RunnableGen<FunctorT, ContainerType, RegInfoType, FuncType>::idx;
+  return HandlerManager::makeHandler(false, false, id);
 }
 
 inline AutoActiveVCType getAutoHandlerVC(HandlerType const& handler) {
   using ContainerType = AutoActiveVCContainerType;
-  return getAutoRegistryGen<ContainerType>().at(handler).getFun();
+
+  auto const han_id = HandlerManager::getHandlerIdentifier(handler);
+  return getAutoRegistryGen<ContainerType>().at(han_id).getFun();
 }
 
 }} // end namespace vt::auto_registry

--- a/src/vt/registry/auto/vc/auto_registry_vc_impl.h
+++ b/src/vt/registry/auto/vc/auto_registry_vc_impl.h
@@ -67,7 +67,7 @@ inline HandlerType makeAutoHandlerVC() {
   return HandlerManager::makeHandler(false, false, id);
 }
 
-inline AutoActiveVCType getAutoHandlerVC(HandlerType const& handler) {
+inline AutoActiveVCType getAutoHandlerVC(HandlerType const handler) {
   using ContainerType = AutoActiveVCContainerType;
 
   auto const han_id = HandlerManager::getHandlerIdentifier(handler);

--- a/src/vt/registry/registry.cc
+++ b/src/vt/registry/registry.cc
@@ -66,7 +66,7 @@ HandlerType Registry::registerNewHandler(
 }
 
 void Registry::swapHandler(
-  HandlerType const& han, ActiveClosureFnType fn, TagType const& tag
+  HandlerType const han, ActiveClosureFnType fn, TagType const& tag
 ) {
   if (tag == no_tag) {
     auto iter = registered_.find(han);
@@ -90,7 +90,7 @@ void Registry::swapHandler(
 }
 
 void Registry::unregisterHandlerFn(
-  HandlerType const& han, TagType const& tag
+  HandlerType const han, TagType const& tag
 ) {
   swapHandler(han, nullptr, tag);
 }
@@ -101,7 +101,7 @@ HandlerType Registry::registerActiveHandler(
   return registerNewHandler(fn, tag, true);
 }
 
-ActiveClosureFnType Registry::getHandlerNoTag(HandlerType const& han) {
+ActiveClosureFnType Registry::getHandlerNoTag(HandlerType const han) {
   auto iter = registered_.find(han);
   if (iter != registered_.end()) {
     return iter->second;
@@ -111,7 +111,7 @@ ActiveClosureFnType Registry::getHandlerNoTag(HandlerType const& han) {
 }
 
 ActiveClosureFnType Registry::getHandler(
-  HandlerType const& han, TagType const& tag
+  HandlerType const han, TagType const& tag
 ) {
   if (tag == no_tag) {
     return getHandlerNoTag(han);

--- a/src/vt/registry/registry.h
+++ b/src/vt/registry/registry.h
@@ -97,7 +97,7 @@ struct Registry : runtime::component::Component<Registry> {
    * \param[in] tag relevant message tag for delivery
    */
   void unregisterHandlerFn(
-    HandlerType const& han, TagType const& tag = no_tag
+    HandlerType const han, TagType const& tag = no_tag
   );
 
   /**
@@ -108,7 +108,7 @@ struct Registry : runtime::component::Component<Registry> {
    * \param[in] tag tag to associate
    */
   void swapHandler(
-    HandlerType const& han, ActiveClosureFnType fn, TagType const& tag = no_tag
+    HandlerType const han, ActiveClosureFnType fn, TagType const& tag = no_tag
   );
 
   /**
@@ -132,7 +132,7 @@ struct Registry : runtime::component::Component<Registry> {
    * \return the active function
    */
   ActiveClosureFnType getHandler(
-    HandlerType const& han, TagType const& tag = no_tag
+    HandlerType const han, TagType const& tag = no_tag
   );
 
   /**
@@ -142,7 +142,7 @@ struct Registry : runtime::component::Component<Registry> {
    *
    * \return the active function
    */
-  ActiveClosureFnType getHandlerNoTag(HandlerType const& han);
+  ActiveClosureFnType getHandlerNoTag(HandlerType const han);
 
 private:
   ContainerType registered_;

--- a/src/vt/runnable/collection.h
+++ b/src/vt/runnable/collection.h
@@ -53,7 +53,6 @@ template <typename MsgT, typename ElementT>
 struct RunnableCollection {
   static void run(
     HandlerType handler, MsgT* msg, ElementT* elm, NodeType from_node,
-    bool member,
     uint64_t idx1 = 0, uint64_t idx2 = 0, uint64_t idx3 = 0, uint64_t idx4 = 0,
     trace::TraceEventIDType in_trace_event = trace::no_trace_event
   );

--- a/src/vt/topos/location/message/msg.h
+++ b/src/vt/topos/location/message/msg.h
@@ -103,7 +103,7 @@ struct EntityMsg : ActiveMessageT {
   void setLocInst(LocInstType const& inst) { loc_man_inst_ = inst; }
   LocInstType getLocInst() const { return loc_man_inst_;  }
   bool hasHandler() const { return handler_ != uninitialized_handler; }
-  void setHandler(HandlerType const& han) { handler_ = han; }
+  void setHandler(HandlerType const han) { handler_ = han; }
   HandlerType getHandler() const { return handler_; }
   void setSerialize(bool const is_serialize) { serialize_ = is_serialize; }
   bool getSerialize() const { return serialize_; }

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -178,12 +178,9 @@ protected:
   void runLB(LBProxyType base_proxy, PhaseType phase);
 
 private:
-  std::size_t num_invocations_             = 0;
-  std::size_t num_release_                 = 0;
   PhaseType cached_phase_                  = no_lb_phase;
   LBType cached_lb_                        = LBType::NoLB;
   std::function<void()> destroy_lb_        = nullptr;
-  bool synced_in_lb_                       = true;
   objgroup::proxy::Proxy<LBManager> proxy_;
   std::shared_ptr<LoadModel> base_model_;
   std::shared_ptr<LoadModel> model_;

--- a/src/vt/vrt/collection/dispatch/dispatch.h
+++ b/src/vt/vrt/collection/dispatch/dispatch.h
@@ -61,12 +61,10 @@ struct DispatchCollectionBase {
   DispatchCollectionBase() = default;
   virtual ~DispatchCollectionBase() {}
 
-  virtual void broadcast(
-    VirtualProxyType proxy, void* msg, HandlerType han, bool member
-  ) = 0;
-  virtual void send(
-    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
-  ) = 0;
+  virtual void
+  broadcast(VirtualProxyType proxy, void* msg, HandlerType han) = 0;
+  virtual void
+  send(VirtualProxyType proxy, void* idx, void* msg, HandlerType han) = 0;
 
   template <typename=void>
   VirtualProxyType getDefaultProxy() const;
@@ -81,11 +79,9 @@ private:
 template <typename ColT, typename MsgT>
 struct DispatchCollection final : DispatchCollectionBase {
 private:
-  void broadcast(
-    VirtualProxyType proxy, void* msg, HandlerType han, bool member
-  ) override;
+  void broadcast(VirtualProxyType proxy, void* msg, HandlerType han) override;
   void send(
-    VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
+    VirtualProxyType proxy, void* idx, void* msg, HandlerType han
   ) override;
 };
 

--- a/src/vt/vrt/collection/dispatch/dispatch.impl.h
+++ b/src/vt/vrt/collection/dispatch/dispatch.impl.h
@@ -56,29 +56,27 @@
 namespace vt { namespace vrt { namespace collection {
 
 template <typename ColT, typename MsgT>
-void DispatchCollection<ColT,MsgT>::broadcast(
-  VirtualProxyType proxy, void* msg, HandlerType han, bool member
+void DispatchCollection<ColT, MsgT>::broadcast(
+  VirtualProxyType proxy, void* msg, HandlerType han
 ) {
   using IdxT = typename ColT::IndexType;
   auto const msg_typed = reinterpret_cast<MsgT*>(msg);
-  CollectionProxy<ColT,IdxT> typed_proxy{proxy};
-  theCollection()->broadcastMsgWithHan<MsgT,ColT>(
-    typed_proxy,msg_typed,han,member,true
+  CollectionProxy<ColT, IdxT> typed_proxy{proxy};
+  theCollection()->broadcastMsgWithHan<MsgT, ColT>(
+    typed_proxy, msg_typed, han, true
   );
 }
 
 template <typename ColT, typename MsgT>
-void DispatchCollection<ColT,MsgT>::send(
-  VirtualProxyType proxy, void* idx, void* msg, HandlerType han, bool member
+void DispatchCollection<ColT, MsgT>::send(
+  VirtualProxyType proxy, void* idx, void* msg, HandlerType han
 ) {
   using IdxT = typename ColT::IndexType;
   auto const msg_typed = reinterpret_cast<MsgT*>(msg);
   auto const idx_typed = reinterpret_cast<IdxT*>(idx);
   auto const& idx_typed_ref = *idx_typed;
-  VrtElmProxy<ColT,IdxT> typed_proxy{proxy,idx_typed_ref};
-  theCollection()->sendMsgWithHan<MsgT,ColT>(
-    typed_proxy,msg_typed,han,member
-  );
+  VrtElmProxy<ColT, IdxT> typed_proxy{proxy, idx_typed_ref};
+  theCollection()->sendMsgWithHan<MsgT, ColT>(typed_proxy, msg_typed, han);
 }
 
 template <typename always_void_>

--- a/src/vt/vrt/collection/dispatch/registry.h
+++ b/src/vt/vrt/collection/dispatch/registry.h
@@ -81,7 +81,7 @@ struct VrtDispatchHolder {
 template <typename MsgT, typename ColT>
 inline AutoHandlerType registerVrtDispatch();
 
-inline DispatchBasePtrType getDispatch(AutoHandlerType const& han);
+inline DispatchBasePtrType getDispatch(AutoHandlerType const han);
 
 template <typename MsgT, typename ColT>
 inline AutoHandlerType makeVrtDispatch(

--- a/src/vt/vrt/collection/dispatch/registry.impl.h
+++ b/src/vt/vrt/collection/dispatch/registry.impl.h
@@ -75,7 +75,7 @@ template <typename MsgT, typename ColT>
 AutoHandlerType const VrtDispatchHolder<MsgT,ColT>::idx =
   registerVrtDispatch<MsgT,ColT>();
 
-inline DispatchBasePtrType getDispatch(AutoHandlerType const& han) {
+inline DispatchBasePtrType getDispatch(AutoHandlerType const han) {
   return getTLRegistry().at(han).get();
 }
 

--- a/src/vt/vrt/collection/holders/col_holder.h
+++ b/src/vt/vrt/collection/holders/col_holder.h
@@ -73,7 +73,7 @@ public:
    * \param[in] in_is_static whether the collection is static
    */
   CollectionHolder(
-    HandlerType const& in_map_fn, IndexT const& idx, bool const in_is_static
+    HandlerType const in_map_fn, IndexT const& idx, bool const in_is_static
   );
   virtual ~CollectionHolder() {}
 

--- a/src/vt/vrt/collection/holders/col_holder.impl.h
+++ b/src/vt/vrt/collection/holders/col_holder.impl.h
@@ -52,7 +52,7 @@ namespace vt { namespace vrt { namespace collection {
 
 template <typename ColT, typename IndexT>
 CollectionHolder<ColT, IndexT>::CollectionHolder(
-  HandlerType const& in_map_fn, IndexT const& idx, bool const in_is_static
+  HandlerType const in_map_fn, IndexT const& idx, bool const in_is_static
 ) : is_static_(in_is_static), map_fn(in_map_fn), max_idx(idx)
 { }
 

--- a/src/vt/vrt/collection/holders/elm_holder.h
+++ b/src/vt/vrt/collection/holders/elm_holder.h
@@ -59,7 +59,7 @@ struct ElementHolder {
   using VirtualPtrType = std::unique_ptr<CollectionBase<ColT,IndexT>>;
 
   ElementHolder(
-    VirtualPtrType in_vc_ptr_, HandlerType const& in_han, IndexT const& idx
+    VirtualPtrType in_vc_ptr_, HandlerType const in_han, IndexT const& idx
   );
   ElementHolder(ElementHolder&&) = default;
 

--- a/src/vt/vrt/collection/holders/elm_holder.impl.h
+++ b/src/vt/vrt/collection/holders/elm_holder.impl.h
@@ -58,7 +58,7 @@ namespace vt { namespace vrt { namespace collection {
 
 template <typename ColT, typename IndexT>
 ElementHolder<ColT, IndexT>::ElementHolder(
-  VirtualPtrType in_vc_ptr_, HandlerType const& in_han, IndexT const& idx
+  VirtualPtrType in_vc_ptr_, HandlerType const in_han, IndexT const& idx
 ) : vc_ptr_(std::move(in_vc_ptr_)), map_fn(in_han), max_idx(idx)
 { }
 

--- a/src/vt/vrt/collection/holders/entire_holder.h
+++ b/src/vt/vrt/collection/holders/entire_holder.h
@@ -60,7 +60,7 @@ struct UniversalIndexHolder {
   static void destroyAllLive();
   static void destroyCollection(VirtualProxyType const proxy);
   static void insertMap(
-    VirtualProxyType const proxy, HandlerType const& han,
+    VirtualProxyType const proxy, HandlerType const han,
     EpochType const& insert_epoch = no_epoch
   );
   static HandlerType getMap(VirtualProxyType const proxy);

--- a/src/vt/vrt/collection/holders/entire_holder.impl.h
+++ b/src/vt/vrt/collection/holders/entire_holder.impl.h
@@ -76,7 +76,7 @@ template <typename always_void_>
 
 template <typename always_void_>
 /*static*/ void UniversalIndexHolder<always_void_>::insertMap(
-  VirtualProxyType const proxy, HandlerType const& han,
+  VirtualProxyType const proxy, HandlerType const han,
   EpochType const& insert_epoch
 ) {
   live_collections_map_.emplace(

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -80,7 +80,7 @@ void CollectionManager::startup() {
 }
 
 DispatchBasePtrType
-getDispatcher(auto_registry::AutoHandlerType const& han) {
+getDispatcher(auto_registry::AutoHandlerType const han) {
   return theCollection()->getDispatcher(han);
 }
 

--- a/src/vt/vrt/collection/manager.fwd.h
+++ b/src/vt/vrt/collection/manager.fwd.h
@@ -53,7 +53,7 @@ namespace vt { namespace vrt { namespace collection {
 
 struct CollectionManager;
 
-DispatchBasePtrType getDispatcher(auto_registry::AutoHandlerType const& han);
+DispatchBasePtrType getDispatcher(auto_registry::AutoHandlerType const han);
 
 }}} /* end namespace vt::vrt::collection */
 

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -192,7 +192,7 @@ struct CollectionManager
   template <typename ColT, typename... Args>
   CollectionProxyWrapType<ColT, typename ColT::IndexType>
   constructMap(
-    typename ColT::IndexType range, HandlerType const& map,
+    typename ColT::IndexType range, HandlerType const map,
     Args&&... args
   );
 
@@ -332,7 +332,7 @@ struct CollectionManager
   template <typename ColT>
   CollectionProxyWrapType<ColT> constructCollectiveMap(
     typename ColT::IndexType range, DistribConstructFn<ColT> cons_fn,
-    HandlerType const& map_han, TagType const& tag
+    HandlerType const map_han, TagType const& tag
   );
 
 private:
@@ -420,7 +420,7 @@ public:
    */
   template <typename ColT>
   InsertToken<ColT> constructInsertMap(
-    typename ColT::IndexType range, HandlerType const& map_han, TagType const& tag
+    typename ColT::IndexType range, HandlerType const map_han, TagType const& tag
   );
 
   /**
@@ -553,7 +553,7 @@ public:
   >
   messaging::PendingSend sendMsgUntypedHandler(
     VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
-    HandlerType const& handler, bool imm_context = true
+    HandlerType const handler, bool imm_context = true
   );
 
   /**
@@ -570,7 +570,7 @@ public:
   template <typename MsgT, typename ColT>
   IsNotColMsgType<MsgT> sendMsgWithHan(
     VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
-    HandlerType const& handler
+    HandlerType const handler
   );
 
   /**
@@ -586,7 +586,7 @@ public:
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> sendMsgWithHan(
     VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
-    HandlerType const& handler
+    HandlerType const handler
   );
 
   /**
@@ -602,7 +602,7 @@ public:
   template <typename MsgT, typename ColT>
   messaging::PendingSend sendNormalMsg(
     VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
-    HandlerType const& handler
+    HandlerType const handler
   );
 
   /**
@@ -881,7 +881,7 @@ public:
   template <typename MsgT, typename ColT>
   IsNotColMsgType<MsgT> broadcastMsgWithHan(
     CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
-    HandlerType const& handler, bool instrument = true
+    HandlerType const handler, bool instrument = true
   );
 
   /**
@@ -896,7 +896,7 @@ public:
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> broadcastMsgWithHan(
     CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
-    HandlerType const& handler, bool instrument = true
+    HandlerType const handler, bool instrument = true
   );
 
   /**
@@ -913,7 +913,7 @@ public:
   template <typename MsgT, typename ColT>
   messaging::PendingSend broadcastNormalMsg(
     CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
-    HandlerType const& handler, bool instrument = true
+    HandlerType const handler, bool instrument = true
   );
 
   /**
@@ -930,7 +930,7 @@ public:
   template <typename MsgT, typename ColT, typename IdxT>
   messaging::PendingSend broadcastMsgUntypedHandler(
     CollectionProxyWrapType<ColT, IdxT> const& proxy, MsgT* msg,
-    HandlerType const& handler, bool instrument
+    HandlerType const handler, bool instrument
   );
 
   /**
@@ -1358,7 +1358,7 @@ public:
   template <typename ColT, typename IndexT = typename ColT::IndexType>
   bool insertCollectionElement(
     VirtualPtrType<ColT, IndexT> vc, IndexT const& idx, IndexT const& max_idx,
-    HandlerType const& map_han, VirtualProxyType const& proxy,
+    HandlerType const map_han, VirtualProxyType const& proxy,
     bool const is_static, NodeType const& home_node,
     bool const& is_migrated_in = false,
     NodeType const& migrated_from = uninitialized_destination
@@ -1438,7 +1438,7 @@ protected:
    * \param[in] insert_epoch insert epoch for dynamic insertions
    */
   void insertCollectionInfo(
-    VirtualProxyType const& proxy, HandlerType const& map,
+    VirtualProxyType const& proxy, HandlerType const map,
     EpochType const& insert_epoch = no_epoch
   );
 
@@ -1662,7 +1662,7 @@ private:
   MigrateStatus migrateIn(
     VirtualProxyType const& proxy, IndexT const& idx, NodeType const& from,
     VirtualPtrType<ColT, IndexT> vrt_elm_ptr, IndexT const& range,
-    HandlerType const& map_han
+    HandlerType const map_han
   );
 
 public:

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -540,7 +540,6 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    * \param[in] imm_context whether in an immediate context (running a
    * collection element handler vs. directly in the scheduler)--- if in a
    * handler, local delivery must be postponed
@@ -553,9 +552,8 @@ public:
     typename IdxT = typename ColT::IndexType
   >
   messaging::PendingSend sendMsgUntypedHandler(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool imm_context = true
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool imm_context = true
   );
 
   /**
@@ -568,12 +566,11 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    */
   template <typename MsgT, typename ColT>
   IsNotColMsgType<MsgT> sendMsgWithHan(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler
   );
 
   /**
@@ -585,12 +582,11 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    */
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> sendMsgWithHan(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler
   );
 
   /**
@@ -600,14 +596,13 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to run
-   * \param[in] member whether it's a member handler (or active function)
    *
    * \return the pending send
    */
   template <typename MsgT, typename ColT>
   messaging::PendingSend sendNormalMsg(
-    VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member
+    VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler
   );
 
   /**
@@ -744,12 +739,11 @@ public:
    * \param[in] msg the message
    * \param[in] col pointer to collection element
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from node that sent the message
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsWrapType<ColT,UserMsgT,MsgT> collectionMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+  static IsWrapType<ColT, UserMsgT, MsgT> collectionMsgDeliver(
+    MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from
   );
 
@@ -760,12 +754,11 @@ public:
    * \param[in] msg the message
    * \param[in] col pointer to collection element
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from node that sent the message
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsNotWrapType<ColT,UserMsgT,MsgT> collectionMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+  static IsNotWrapType<ColT, UserMsgT, MsgT> collectionMsgDeliver(
+    MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from
   );
 
@@ -882,15 +875,13 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    */
   template <typename MsgT, typename ColT>
   IsNotColMsgType<MsgT> broadcastMsgWithHan(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument = true
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument = true
   );
 
   /**
@@ -899,15 +890,13 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    */
   template <typename MsgT, typename ColT>
   IsColMsgType<MsgT> broadcastMsgWithHan(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument = true
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument = true
   );
 
   /**
@@ -916,7 +905,6 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    *
@@ -924,9 +912,8 @@ public:
    */
   template <typename MsgT, typename ColT>
   messaging::PendingSend broadcastNormalMsg(
-    CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument = true
+    CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument = true
   );
 
   /**
@@ -935,7 +922,6 @@ public:
    * \param[in] proxy the collection proxy
    * \param[in] msg the message
    * \param[in] handler the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] instrument whether to instrument the broadcast for load
    * balancing (some system calls use this to disable instrumentation)
    *
@@ -943,9 +929,8 @@ public:
    */
   template <typename MsgT, typename ColT, typename IdxT>
   messaging::PendingSend broadcastMsgUntypedHandler(
-    CollectionProxyWrapType<ColT,IdxT> const& proxy, MsgT *msg,
-    HandlerType const& handler, bool const member,
-    bool instrument
+    CollectionProxyWrapType<ColT, IdxT> const& proxy, MsgT* msg,
+    HandlerType const& handler, bool instrument
   );
 
   /**
@@ -1233,13 +1218,12 @@ public:
    * \param[in] msg the message
    * \param[in] col the collection element pointer
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from the node that sent it
    * \param[in] event the associated trace event
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsWrapType<ColT,UserMsgT,MsgT> collectionAutoMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+    static IsWrapType<ColT, UserMsgT, MsgT> collectionAutoMsgDeliver(
+      MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from, trace::TraceEventIDType event
   );
 
@@ -1250,13 +1234,12 @@ public:
    * \param[in] msg the message
    * \param[in] col the collection element pointer
    * \param[in] han the handler to invoke
-   * \param[in] member whether it's a member handler
    * \param[in] from the node that sent it
    * \param[in] event the associated trace event
    */
   template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-  static IsNotWrapType<ColT,UserMsgT,MsgT> collectionAutoMsgDeliver(
-    MsgT* msg, CollectionBase<ColT,IndexT>* col, HandlerType han, bool member,
+    static IsNotWrapType<ColT, UserMsgT, MsgT> collectionAutoMsgDeliver(
+      MsgT* msg, CollectionBase<ColT, IndexT>* col, HandlerType han,
     NodeType from, trace::TraceEventIDType event
   );
 

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1009,7 +1009,7 @@ messaging::PendingSend CollectionManager::broadcastMsgImpl(
 
 template <typename MsgT, typename ColT>
 CollectionManager::IsColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const& h,
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const h,
   bool inst
 ) {
   using IdxT = typename ColT::IndexType;
@@ -1018,7 +1018,7 @@ CollectionManager::IsColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
 
 template <typename MsgT, typename ColT>
 CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const& h,
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const h,
   bool inst
 ) {
   return broadcastNormalMsg<MsgT, ColT>(proxy, msg, h, inst);
@@ -1027,7 +1027,7 @@ CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
 template <typename MsgT, typename ColT>
 messaging::PendingSend CollectionManager::broadcastNormalMsg(
   CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
-  HandlerType const& handler, bool instrument
+  HandlerType const handler, bool instrument
 ) {
   auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
   return broadcastMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
@@ -1038,7 +1038,7 @@ messaging::PendingSend CollectionManager::broadcastNormalMsg(
 template <typename MsgT, typename ColT, typename IdxT>
 messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
   CollectionProxyWrapType<ColT, IdxT> const& toProxy, MsgT* raw_msg,
-  HandlerType const& handler, bool instrument
+  HandlerType const handler, bool instrument
 ) {
   auto const idx = makeVrtDispatch<MsgT,ColT>();
   auto const col_proxy = toProxy.getProxy();
@@ -1263,7 +1263,7 @@ messaging::PendingSend CollectionManager::reduceMsgExpr(
 template <typename MsgT, typename ColT>
 CollectionManager::IsNotColMsgType<MsgT> CollectionManager::sendMsgWithHan(
   VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
-  HandlerType const& handler
+  HandlerType const handler
 ) {
   return sendNormalMsg<MsgT, ColT>(proxy, msg, handler);
 }
@@ -1271,7 +1271,7 @@ CollectionManager::IsNotColMsgType<MsgT> CollectionManager::sendMsgWithHan(
 template <typename MsgT, typename ColT>
 CollectionManager::IsColMsgType<MsgT> CollectionManager::sendMsgWithHan(
   VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
-  HandlerType const& handler
+  HandlerType const handler
 ) {
   using IdxT = typename ColT::IndexType;
   return sendMsgUntypedHandler<MsgT, ColT, IdxT>(proxy, msg, handler);
@@ -1280,7 +1280,7 @@ CollectionManager::IsColMsgType<MsgT> CollectionManager::sendMsgWithHan(
 template <typename MsgT, typename ColT>
 messaging::PendingSend CollectionManager::sendNormalMsg(
   VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
-  HandlerType const& handler
+  HandlerType const handler
 ) {
   auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
   return sendMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
@@ -1367,7 +1367,7 @@ messaging::PendingSend CollectionManager::sendMsgImpl(
 template <typename MsgT, typename ColT, typename IdxT>
 messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   VirtualElmProxyType<ColT> const& toProxy, MsgT* raw_msg,
-  HandlerType const& handler, bool imm_context
+  HandlerType const handler, bool imm_context
 ) {
   auto const& col_proxy = toProxy.getCollectionProxy();
   auto const& elm_proxy = toProxy.getElementProxy();
@@ -1448,7 +1448,7 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
 template <typename ColT, typename IndexT>
 bool CollectionManager::insertCollectionElement(
   VirtualPtrType<ColT, IndexT> vc, IndexT const& idx, IndexT const& max_idx,
-  HandlerType const& map_han, VirtualProxyType const& proxy,
+  HandlerType const map_han, VirtualProxyType const& proxy,
   bool const is_static, NodeType const& home_node, bool const& is_migrated_in,
   NodeType const& migrated_from
 ) {
@@ -1569,7 +1569,7 @@ template <typename ColT>
 CollectionManager::CollectionProxyWrapType<ColT>
 CollectionManager::constructCollectiveMap(
   typename ColT::IndexType range, DistribConstructFn<ColT> user_construct_fn,
-  HandlerType const& map_han, TagType const& tag
+  HandlerType const map_han, TagType const& tag
 ) {
   using IndexT         = typename ColT::IndexType;
   using TypedProxyType = CollectionProxyWrapType<ColT>;
@@ -1854,7 +1854,7 @@ InsertToken<ColT> CollectionManager::constructInsert(
 
 template <typename ColT>
 InsertToken<ColT> CollectionManager::constructInsertMap(
-  typename ColT::IndexType range, HandlerType const& map_han, TagType const& tag
+  typename ColT::IndexType range, HandlerType const map_han, TagType const& tag
 ) {
   using IndexT         = typename ColT::IndexType;
 
@@ -2063,7 +2063,7 @@ CollectionManager::construct(
 template <typename ColT, typename... Args>
 CollectionManager::CollectionProxyWrapType<ColT, typename ColT::IndexType>
 CollectionManager::constructMap(
-  typename ColT::IndexType range, HandlerType const& map_handler,
+  typename ColT::IndexType range, HandlerType const map_handler,
   Args&&... args
 ) {
   using IndexT = typename ColT::IndexType;
@@ -2111,7 +2111,7 @@ CollectionManager::constructMap(
 }
 
 inline void CollectionManager::insertCollectionInfo(
-  VirtualProxyType const& proxy, HandlerType const& map_han,
+  VirtualProxyType const& proxy, HandlerType const map_han,
   EpochType const& insert_epoch
 ) {
   UniversalIndexHolder<>::insertMap(proxy,map_han,insert_epoch);
@@ -2713,7 +2713,7 @@ template <typename ColT, typename IndexT>
 MigrateStatus CollectionManager::migrateIn(
   VirtualProxyType const& proxy, IndexT const& idx, NodeType const& from,
   VirtualPtrType<ColT, IndexT> vrt_elm_ptr, IndexT const& max,
-  HandlerType const& map_han
+  HandlerType const map_han
 ) {
   vt_debug_print(
     vrt_coll, node,

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -350,10 +350,10 @@ GroupType CollectionManager::createGroupCollection(
 }
 
 template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-/*static*/ CollectionManager::IsWrapType<ColT,UserMsgT,MsgT>
+/*static*/ CollectionManager::IsWrapType<ColT, UserMsgT, MsgT>
 CollectionManager::collectionAutoMsgDeliver(
-  MsgT* msg, CollectionBase<ColT,IndexT>* base, HandlerType han, bool member,
-  NodeType from, trace::TraceEventIDType event
+  MsgT* msg, CollectionBase<ColT, IndexT>* base, HandlerType han, NodeType from,
+  trace::TraceEventIDType event
 ) {
   using IdxContextHolder = InsertContextHolder<IndexT>;
 
@@ -379,7 +379,7 @@ CollectionManager::collectionAutoMsgDeliver(
   IdxContextHolder::set(&idx,proxy);
 
   runnable::RunnableCollection<UserMsgT,UntypedCollection>::run(
-    han, user_msg_ptr, ptr, from, member, idx1, idx2, idx3, idx4
+    han, user_msg_ptr, ptr, from, idx1, idx2, idx3, idx4
   );
 
   // Clear the current index context
@@ -387,10 +387,10 @@ CollectionManager::collectionAutoMsgDeliver(
 }
 
 template <typename ColT, typename IndexT, typename MsgT, typename UserMsgT>
-/*static*/ CollectionManager::IsNotWrapType<ColT,UserMsgT,MsgT>
+/*static*/ CollectionManager::IsNotWrapType<ColT, UserMsgT, MsgT>
 CollectionManager::collectionAutoMsgDeliver(
-  MsgT* msg, CollectionBase<ColT,IndexT>* base, HandlerType han, bool member,
-  NodeType from, trace::TraceEventIDType event
+  MsgT* msg, CollectionBase<ColT, IndexT>* base, HandlerType han, NodeType from,
+  trace::TraceEventIDType event
 ) {
   using IdxContextHolder = InsertContextHolder<IndexT>;
 
@@ -414,7 +414,7 @@ CollectionManager::collectionAutoMsgDeliver(
   IdxContextHolder::set(&idx,proxy);
 
   runnable::RunnableCollection<MsgT,UntypedCollection>::run(
-    han, msg, ptr, from, member, idx1, idx2, idx3, idx4, event
+    han, msg, ptr, from, idx1, idx2, idx3, idx4, event
   );
 
   // Clear the current index context
@@ -440,12 +440,11 @@ template <typename ColT, typename IndexT, typename MsgT>
   auto elm_holder = theCollection()->findElmHolder<ColT,IndexT>(bcast_proxy);
   if (elm_holder) {
     auto const handler = col_msg->getVrtHandler();
-    auto const member = col_msg->getMember();
     vt_debug_print(
       vrt_coll, node,
       "broadcast apply: size={}\n", elm_holder->numElements()
     );
-    elm_holder->foreach([col_msg,msg,handler,member](
+    elm_holder->foreach([col_msg, msg, handler](
       IndexT const& idx, CollectionBase<ColT,IndexT>* base
     ) {
       vt_debug_print(
@@ -502,7 +501,7 @@ template <typename ColT, typename IndexT, typename MsgT>
         trace_event = col_msg->getFromTraceEvent();
       #endif
       collectionAutoMsgDeliver<ColT,IndexT,MsgT,typename MsgT::UserMsgType>(
-        msg,base,handler,member,from,trace_event
+        msg, base, handler, from, trace_event
       );
 
       #if vt_check_enabled(lblite)
@@ -668,7 +667,6 @@ template <typename ColT, typename IndexT, typename MsgT>
   auto& inner_holder = elm_holder->lookup(idx);
 
   auto const sub_handler = col_msg->getVrtHandler();
-  auto const member = col_msg->getMember();
   auto const col_ptr = inner_holder.getCollection();
 
   vt_debug_print(
@@ -678,7 +676,7 @@ template <typename ColT, typename IndexT, typename MsgT>
 
   vtAssertInfo(
     col_ptr != nullptr, "Must be valid pointer",
-    sub_handler, member, cur_epoch, idx, exists
+    sub_handler, HandlerManager::isHandlerMember(sub_handler), cur_epoch, idx, exists
   );
 
 
@@ -729,7 +727,7 @@ template <typename ColT, typename IndexT, typename MsgT>
     trace_event = col_msg->getFromTraceEvent();
   #endif
   collectionAutoMsgDeliver<ColT,IndexT,MsgT,typename MsgT::UserMsgType>(
-    msg,col_ptr,sub_handler,member,from,trace_event
+    msg, col_ptr, sub_handler, from, trace_event
   );
   theMsg()->popEpoch(cur_epoch);
 
@@ -861,7 +859,6 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsg(
 
   auto& msgPtr = msg.msg_;
   msgPtr->setVrtHandler(auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>());
-  msgPtr->setMember(false);
 
   return broadcastCollectiveMsgImpl<MsgT, ColT>(proxy, msgPtr, instrument);
 }
@@ -880,7 +877,6 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsg(
   msgPtr->setVrtHandler(
     auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>()
   );
-  msgPtr->setMember(true);
 
   return broadcastCollectiveMsgImpl<MsgT, ColT>(proxy, msgPtr, instrument);
 }
@@ -897,12 +893,13 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
 #if vt_check_enabled(trace_enabled)
   // Create the trace creation event for the broadcast here to connect it a
   // higher semantic level
-  auto reg_type = msg->getMember() ?
+  auto const han = msg->getVrtHandler();
+  auto reg_type = HandlerManager::isHandlerMember(han) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
   auto event = theMsg()->makeTraceCreationSend(
-    msg, msg->getVrtHandler(), reg_type, msg_size, true
+    msg, han, reg_type, msg_size, true
   );
   msg->setFromTraceEvent(event);
 #endif
@@ -959,13 +956,12 @@ CollectionManager::broadcastMsg(
   return broadcastMsgImpl<MsgT,ColT,f>(proxy,msg,instrument);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, bool instrument
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsg(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, bool instrument
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,false,instrument);
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return broadcastNormalMsg<MsgT, ColT>(proxy, msg, h, instrument);
 }
 
 template <
@@ -982,75 +978,67 @@ CollectionManager::broadcastMsg(
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,ColT> f
+  typename MsgT, typename ColT, ActiveColMemberTypedFnType<MsgT, ColT> f
 >
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::broadcastMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg, bool instrument
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsg(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, bool instrument
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,true,instrument);
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return broadcastNormalMsg<MsgT, ColT>(proxy, msg, h, instrument);
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,ColT> f
+  typename MsgT, typename ColT, ActiveColMemberTypedFnType<MsgT, ColT> f
 >
 messaging::PendingSend CollectionManager::broadcastMsgImpl(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, bool inst
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* const msg, bool inst
 ) {
   // register the user's handler
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,true,inst);
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return broadcastMsgUntypedHandler<MsgT>(proxy, msg, h, inst);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
 messaging::PendingSend CollectionManager::broadcastMsgImpl(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *const msg, bool inst
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* const msg, bool inst
 ) {
   // register the user's handler
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return broadcastMsgUntypedHandler<MsgT>(proxy,msg,h,false,inst);
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return broadcastMsgUntypedHandler<MsgT>(proxy, msg, h, inst);
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsColMsgType<MsgT>
-CollectionManager::broadcastMsgWithHan(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& h, bool const mem, bool inst
+CollectionManager::IsColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const& h,
+  bool inst
 ) {
   using IdxT = typename ColT::IndexType;
-  return broadcastMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,h,mem,inst);
+  return broadcastMsgUntypedHandler<MsgT, ColT, IdxT>(proxy, msg, h, inst);
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::broadcastMsgWithHan(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& h, bool const mem, bool inst
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::broadcastMsgWithHan(
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg, HandlerType const& h,
+  bool inst
 ) {
-  return broadcastNormalMsg<MsgT,ColT>(proxy,msg,h,mem,inst);
+  return broadcastNormalMsg<MsgT, ColT>(proxy, msg, h, inst);
 }
 
 template <typename MsgT, typename ColT>
 messaging::PendingSend CollectionManager::broadcastNormalMsg(
-  CollectionProxyWrapType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member,
-  bool instrument
+  CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler, bool instrument
 ) {
-  auto wrap_msg = makeMessage<ColMsgWrap<ColT,MsgT>>(*msg);
-  return broadcastMsgUntypedHandler<ColMsgWrap<ColT,MsgT>,ColT>(
-    proxy, wrap_msg.get(), handler, member, instrument
+  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
+  return broadcastMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
+    proxy, wrap_msg.get(), handler, instrument
   );
 }
 
 template <typename MsgT, typename ColT, typename IdxT>
 messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
-  CollectionProxyWrapType<ColT, IdxT> const& toProxy, MsgT *raw_msg,
-  HandlerType const& handler, bool const member, bool instrument
+  CollectionProxyWrapType<ColT, IdxT> const& toProxy, MsgT* raw_msg,
+  HandlerType const& handler, bool instrument
 ) {
   auto const idx = makeVrtDispatch<MsgT,ColT>();
   auto const col_proxy = toProxy.getProxy();
@@ -1066,12 +1054,11 @@ messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
   msg->setFromNode(theContext()->getNode());
   msg->setVrtHandler(handler);
   msg->setBcastProxy(col_proxy);
-  msg->setMember(member);
 
 # if vt_check_enabled(trace_enabled)
   // Create the trace creation event for the broadcast here to connect it a
   // higher semantic level
-  auto reg_type = member ?
+  auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
@@ -1274,32 +1261,30 @@ messaging::PendingSend CollectionManager::reduceMsgExpr(
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::sendMsgWithHan(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member
+CollectionManager::IsNotColMsgType<MsgT> CollectionManager::sendMsgWithHan(
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler
 ) {
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,handler,member);
+  return sendNormalMsg<MsgT, ColT>(proxy, msg, handler);
 }
 
 template <typename MsgT, typename ColT>
-CollectionManager::IsColMsgType<MsgT>
-CollectionManager::sendMsgWithHan(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member
+CollectionManager::IsColMsgType<MsgT> CollectionManager::sendMsgWithHan(
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler
 ) {
   using IdxT = typename ColT::IndexType;
-  return sendMsgUntypedHandler<MsgT,ColT,IdxT>(proxy,msg,handler,member);
+  return sendMsgUntypedHandler<MsgT, ColT, IdxT>(proxy, msg, handler);
 }
 
 template <typename MsgT, typename ColT>
 messaging::PendingSend CollectionManager::sendNormalMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg,
-  HandlerType const& handler, bool const member
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
+  HandlerType const& handler
 ) {
-  auto wrap_msg = makeMessage<ColMsgWrap<ColT,MsgT>>(*msg);
-  return sendMsgUntypedHandler<ColMsgWrap<ColT,MsgT>,ColT>(
-    proxy, wrap_msg.get(), handler, member
+  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
+  return sendMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
+    proxy, wrap_msg.get(), handler
   );
 }
 
@@ -1332,13 +1317,11 @@ CollectionManager::sendMsg(
   return sendMsgImpl<MsgT,ColT,f>(proxy,msg);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
 CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
-) {
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,false);
+CollectionManager::sendMsg(VirtualElmProxyType<ColT> const& proxy, MsgT* msg) {
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return sendNormalMsg<MsgT, ColT>(proxy, msg, h);
 }
 
 template <
@@ -1354,43 +1337,37 @@ CollectionManager::sendMsg(
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,ColT> f
+  typename MsgT, typename ColT, ActiveColMemberTypedFnType<MsgT, ColT> f
 >
 CollectionManager::IsNotColMsgType<MsgT>
-CollectionManager::sendMsg(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
-) {
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return sendNormalMsg<MsgT,ColT>(proxy,msg,h,true);
+CollectionManager::sendMsg(VirtualElmProxyType<ColT> const& proxy, MsgT* msg) {
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return sendNormalMsg<MsgT, ColT>(proxy, msg, h);
 }
 
-template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT,ColT> *f>
+template <typename MsgT, typename ColT, ActiveColTypedFnType<MsgT, ColT>* f>
 messaging::PendingSend CollectionManager::sendMsgImpl(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,false);
+  auto const& h = auto_registry::makeAutoHandlerCollection<ColT, MsgT, f>();
+  return sendMsgUntypedHandler<MsgT>(proxy, msg, h);
 }
 
 template <
-  typename MsgT,
-  typename ColT,
-  ActiveColMemberTypedFnType<MsgT,typename MsgT::CollectionType> f
+  typename MsgT, typename ColT,
+  ActiveColMemberTypedFnType<MsgT, typename MsgT::CollectionType> f
 >
 messaging::PendingSend CollectionManager::sendMsgImpl(
-  VirtualElmProxyType<ColT> const& proxy, MsgT *msg
+  VirtualElmProxyType<ColT> const& proxy, MsgT* msg
 ) {
-  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  return sendMsgUntypedHandler<MsgT>(proxy,msg,h,true);
+  auto const& h = auto_registry::makeAutoHandlerCollectionMem<ColT, MsgT, f>();
+  return sendMsgUntypedHandler<MsgT>(proxy, msg, h);
 }
 
 template <typename MsgT, typename ColT, typename IdxT>
 messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
-  VirtualElmProxyType<ColT> const& toProxy, MsgT *raw_msg,
-  HandlerType const& handler, bool const member,
-  bool imm_context
+  VirtualElmProxyType<ColT> const& toProxy, MsgT* raw_msg,
+  HandlerType const& handler, bool imm_context
 ) {
   auto const& col_proxy = toProxy.getCollectionProxy();
   auto const& elm_proxy = toProxy.getElementProxy();
@@ -1422,7 +1399,7 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   // level. Do it in the imm_context so we see the send event when the user
   // actually invokes send on the proxy (not outside the event that actually
   // sent it)
-  auto reg_type = member ?
+  auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
@@ -1436,7 +1413,6 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   msg->setFromNode(theContext()->getNode());
   msg->setVrtHandler(handler);
   msg->setProxy(toProxy);
-  msg->setMember(member);
 
   auto idx = elm_proxy.getIndex();
   vt_debug_print(

--- a/src/vt/vrt/collection/messages/system_create.h
+++ b/src/vt/vrt/collection/messages/system_create.h
@@ -72,7 +72,7 @@ struct CollectionCreateMsg : ::vt::Message {
 
   CollectionCreateMsg() = default;
   CollectionCreateMsg(
-    HandlerType const& in_han, ArgsTuple&& in_tup
+    HandlerType const in_han, ArgsTuple&& in_tup
   ) : ::vt::Message(), tup(std::forward<ArgsTuple>(in_tup)), map(in_han)
   { }
 

--- a/src/vt/vrt/collection/messages/user.h
+++ b/src/vt/vrt/collection/messages/user.h
@@ -87,7 +87,7 @@ struct CollectionMessage : RoutedMessageType<BaseMsgT, ColT> {
     : is_wrap_(true)
   { }
 
-  void setVrtHandler(HandlerType const& in_handler);
+  void setVrtHandler(HandlerType const in_handler);
   HandlerType getVrtHandler() const;
 
   // The variable `to_proxy_' manages the intended target of the

--- a/src/vt/vrt/collection/messages/user.h
+++ b/src/vt/vrt/collection/messages/user.h
@@ -104,9 +104,6 @@ struct CollectionMessage : RoutedMessageType<BaseMsgT, ColT> {
   NodeType getFromNode() const;
   void setFromNode(NodeType const& node);
 
-  bool getMember() const;
-  void setMember(bool const& member);
-
   bool getWrap() const;
   void setWrap(bool const& wrap);
 
@@ -136,7 +133,6 @@ private:
   HandlerType vt_sub_handler_ = uninitialized_handler;
   EpochType bcast_epoch_ = no_epoch;
   NodeType from_node_ = uninitialized_destination;
-  bool member_ = false;
   bool is_wrap_ = false;
 
   #if vt_check_enabled(lblite)

--- a/src/vt/vrt/collection/messages/user.impl.h
+++ b/src/vt/vrt/collection/messages/user.impl.h
@@ -54,7 +54,7 @@ namespace vt { namespace vrt { namespace collection {
 
 template <typename ColT, typename BaseMsgT>
 void CollectionMessage<ColT, BaseMsgT>::setVrtHandler(
-  HandlerType const& in_handler
+  HandlerType const in_handler
 ) {
   vt_sub_handler_ = in_handler;
 }

--- a/src/vt/vrt/collection/messages/user.impl.h
+++ b/src/vt/vrt/collection/messages/user.impl.h
@@ -120,7 +120,6 @@ void CollectionMessage<ColT, BaseMsgT>::serialize(SerializerT& s) {
   s | to_proxy_;
   s | bcast_proxy_;
   s | bcast_epoch_;
-  s | member_;
   s | is_wrap_;
 
   #if vt_check_enabled(lblite)
@@ -133,16 +132,6 @@ void CollectionMessage<ColT, BaseMsgT>::serialize(SerializerT& s) {
   #if vt_check_enabled(trace_enabled)
     s | trace_event_;
   #endif
-}
-
-template <typename ColT, typename BaseMsgT>
-bool CollectionMessage<ColT,BaseMsgT>::getMember() const {
-  return member_;
-}
-
-template <typename ColT, typename BaseMsgT>
-void CollectionMessage<ColT,BaseMsgT>::setMember(bool const& member) {
-  member_ = member;
 }
 
 template <typename ColT, typename BaseMsgT>

--- a/src/vt/vrt/collection/migrate/manager_migrate_attorney.h
+++ b/src/vt/vrt/collection/migrate/manager_migrate_attorney.h
@@ -79,7 +79,7 @@ private:
 
   static MigrateStatus migrateIn(
     VirtualProxyType const& proxy, IndexT const& idx, NodeType const& from,
-    VirtualPtrType vc_elm, IndexT const& range, HandlerType const& map_han
+    VirtualPtrType vc_elm, IndexT const& range, HandlerType const map_han
   );
 };
 

--- a/src/vt/vrt/collection/migrate/manager_migrate_attorney.impl.h
+++ b/src/vt/vrt/collection/migrate/manager_migrate_attorney.impl.h
@@ -74,7 +74,7 @@ template <typename ColT, typename IndexT>
 template <typename ColT, typename IndexT>
 /*static*/ MigrateStatus CollectionElmAttorney<ColT, IndexT>::migrateIn(
   VirtualProxyType const& proxy, IndexT const& idx, NodeType const& from,
-  VirtualPtrType vc_elm, IndexT const& range, HandlerType const& map_han
+  VirtualPtrType vc_elm, IndexT const& range, HandlerType const map_han
 ) {
   return theCollection()->migrateIn<ColT,IndexT>(
     proxy, idx, from, std::move(vc_elm), range, map_han

--- a/src/vt/vrt/collection/migrate/migrate_msg.h
+++ b/src/vt/vrt/collection/migrate/migrate_msg.h
@@ -60,7 +60,7 @@ struct MigrateMsg final : ::vt::Message {
   MigrateMsg() = default;
   MigrateMsg(
     VrtElmProxy<ColT, IndexT> const& in_elm_proxy, NodeType const& in_from,
-    NodeType const& in_to, HandlerType const& in_map_fn, IndexT const& in_range,
+    NodeType const& in_to, HandlerType const in_map_fn, IndexT const& in_range,
     ColT* in_elm
   ) : elm_proxy_(in_elm_proxy), from_(in_from), to_(in_to), map_fn_(in_map_fn),
       range_(in_range), elm_(in_elm)

--- a/src/vt/vrt/context/context_vrtmanager.h
+++ b/src/vt/vrt/context/context_vrtmanager.h
@@ -124,12 +124,12 @@ private:
 
   void setupMappedVirutalContext(
     VirtualProxyType const& proxy, SeedType const& seed, CoreType const& core,
-    HandlerType const& map_handle
+    HandlerType const map_handle
   );
 
   template <typename VrtContextT, typename... Args>
   VirtualProxyType makeVirtualMapComm(
-    SeedType const& seed, HandlerType const& map_handle, Args&& ... args
+    SeedType const& seed, HandlerType const map_handle, Args&& ... args
   );
 
   template <typename VrtContextT, typename... Args>

--- a/src/vt/vrt/context/context_vrtmanager.impl.h
+++ b/src/vt/vrt/context/context_vrtmanager.impl.h
@@ -144,7 +144,7 @@ messaging::PendingSend VirtualContextManager::sendSerialMsg(
   if (theContext()->getWorker() == worker_id_comm_thread) {
     NodeType const& home_node = VirtualProxyBuilder::getVirtualNode(toProxy);
     // register the user's handler
-    HandlerType const& han = auto_registry::makeAutoHandlerVC<VcT,MsgT,f>();
+    HandlerType const han = auto_registry::makeAutoHandlerVC<VcT,MsgT,f>();
     // save the user's handler in the message
     msg->setVrtHandler(han);
     msg->setProxy(toProxy);
@@ -239,7 +239,7 @@ VirtualProxyType VirtualContextManager::makeVirtualRemote(
 
 inline void VirtualContextManager::setupMappedVirutalContext(
   VirtualProxyType const& proxy, SeedType const& seed, CoreType const& core,
-  HandlerType const& map_handle
+  HandlerType const map_handle
 ) {
   auto vrt_info = getVirtualInfoByProxy(proxy);
   vrt_info->setSeed(seed);
@@ -249,7 +249,7 @@ inline void VirtualContextManager::setupMappedVirutalContext(
 
 template <typename VrtContextT, typename... Args>
 VirtualProxyType VirtualContextManager::makeVirtualMapComm(
-  SeedType const& seed, HandlerType const& map_handle, Args&& ... args
+  SeedType const& seed, HandlerType const map_handle, Args&& ... args
 ) {
   auto const& proxy = makeVirtual<VrtContextT, Args...>(
     std::forward<Args>(args)...

--- a/src/vt/vrt/context/context_vrtmessage.h
+++ b/src/vt/vrt/context/context_vrtmessage.h
@@ -71,7 +71,7 @@ struct VirtualMessage : RoutedMessageType<vt::Message>
 
   // The variable `vc_sub_handler_' manages the intended user handler the
   // VirtualMessage should trigger
-  void setVrtHandler(HandlerType const& in_handler) {
+  void setVrtHandler(HandlerType const in_handler) {
     vt_sub_handler_ = in_handler;
   }
   HandlerType getVrtHandler() const {

--- a/tests/unit/collection/test_collection_group.extended.cc
+++ b/tests/unit/collection/test_collection_group.extended.cc
@@ -85,7 +85,7 @@ struct ColA : Collection<ColA,Index1D> {
     reduce_test = true;
   }
 
-  void memberHanlder(TestDataMsg* msg) {
+  void memberHandler(TestDataMsg* msg) {
     EXPECT_EQ(msg->value_, theContext()->getNode());
     --elem_counter;
     handler_executed = true;
@@ -146,7 +146,7 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
   // raw msg pointer case
   runBcastTestHelper([proxy, my_node]{
     auto msg = ::vt::makeMessage<ColA::TestDataMsg>(my_node);
-    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHanlder>(
+    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHandler>(
       msg.get()
     );
   });
@@ -156,7 +156,7 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
   // smart msg pointer case
   runBcastTestHelper([proxy, my_node]{
     auto msg = ::vt::makeMessage<ColA::TestDataMsg>(my_node);
-    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHanlder>(msg);
+    proxy.broadcastCollectiveMsg<ColA::TestDataMsg, &ColA::memberHandler>(msg);
   });
 
   EXPECT_EQ(elem_counter, -numElems);
@@ -164,7 +164,7 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
   // msg constructed on the fly case
   runBcastTestHelper([proxy, my_node] {
     proxy.broadcastCollective<
-      ColA::TestDataMsg, &ColA::memberHanlder, ColA::TestDataMsg>(my_node);
+      ColA::TestDataMsg, &ColA::memberHandler, ColA::TestDataMsg>(my_node);
   });
 
   EXPECT_EQ(elem_counter, -2 * numElems);

--- a/tests/unit/mapping/test_mapping_registry.cc
+++ b/tests/unit/mapping/test_mapping_registry.cc
@@ -58,7 +58,7 @@ namespace vt { namespace tests { namespace unit {
 struct TestMsg : vt::ShortMessage {
   bool is_block = false;
   HandlerType han;
-  TestMsg(HandlerType const& in_han) : ShortMessage(), han(in_han) { }
+  TestMsg(HandlerType const in_han) : ShortMessage(), han(in_han) { }
 };
 
 struct TestMappingRegistry : TestParallelHarness {

--- a/tutorial/tutorial_1a.h
+++ b/tutorial/tutorial_1a.h
@@ -66,7 +66,7 @@ static inline void context() {
 
   // The header-only library fmt is used for printing throughout VT. You can use
   // it because the headers are included by default
-  ::fmt::print("this_node={}, num_ndoes={}\n", this_node, num_nodes);
+  ::fmt::print("this_node={}, num_nodes={}\n", this_node, num_nodes);
 }
 /// [Tutorial1A]
 


### PR DESCRIPTION
* adds encoding member bit in handler field
* cleans up all the places that previously used `member` boolean
* fixes handlers' ID extraction
* standardizes making and getting handlers
* remove redundant const refs to HandlerType

Fixes #872 