### PR TITLE
1079: Rewrote sucessor to parent epoch in all associated files

### DIFF
--- a/src/vt/termination/epoch_tags.cc
+++ b/src/vt/termination/epoch_tags.cc
@@ -48,7 +48,7 @@
 
 namespace vt { namespace term {
 
-ChildEpochCapture::ChildEpochCapture()
+ParentEpochCapture::ParentEpochCapture()
   : epoch_(
       (theMsg()->getEpoch() != no_epoch and
        theMsg()->getEpoch() != term::any_epoch_sentinel) ?

--- a/src/vt/termination/epoch_tags.cc
+++ b/src/vt/termination/epoch_tags.cc
@@ -48,7 +48,7 @@
 
 namespace vt { namespace term {
 
-SuccessorEpochCapture::SuccessorEpochCapture()
+ChildEpochCapture::ChildEpochCapture()
   : epoch_(
       (theMsg()->getEpoch() != no_epoch and
        theMsg()->getEpoch() != term::any_epoch_sentinel) ?

--- a/src/vt/termination/epoch_tags.h
+++ b/src/vt/termination/epoch_tags.h
@@ -49,11 +49,11 @@
 
 namespace vt { namespace term {
 
-struct SuccessorEpochCapture {
-  explicit SuccessorEpochCapture(EpochType epoch)
+struct ChildEpochCapture {
+  explicit ChildEpochCapture(EpochType epoch)
     : epoch_(epoch)
   { }
-  SuccessorEpochCapture();
+  ChildEpochCapture();
 
   operator EpochType() const { return epoch_; }
 

--- a/src/vt/termination/epoch_tags.h
+++ b/src/vt/termination/epoch_tags.h
@@ -49,11 +49,11 @@
 
 namespace vt { namespace term {
 
-struct ChildEpochCapture {
-  explicit ChildEpochCapture(EpochType epoch)
+struct ParentEpochCapture {
+  explicit ParentEpochCapture(EpochType epoch)
     : epoch_(epoch)
   { }
-  ChildEpochCapture();
+  ParentEpochCapture();
 
   operator EpochType() const { return epoch_; }
 

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -982,7 +982,7 @@ void TerminationDetector::finishedEpoch(EpochType const& epoch) {
 }
 
 EpochType TerminationDetector::makeEpochRootedWave(
-  SuccessorEpochCapture successor, std::string const& label
+  ChildEpochCapture successor, std::string const& label
 ) {
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch();
 
@@ -1015,7 +1015,7 @@ EpochType TerminationDetector::makeEpochRootedWave(
 }
 
 EpochType TerminationDetector::makeEpochRootedDS(
-  SuccessorEpochCapture successor, std::string const& label
+  ChildEpochCapture successor, std::string const& label
 ) {
   auto const ds_cat = epoch::eEpochCategory::DijkstraScholtenEpoch;
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch(false, ds_cat);
@@ -1042,13 +1042,13 @@ EpochType TerminationDetector::makeEpochRootedDS(
 }
 
 EpochType TerminationDetector::makeEpochRooted(
-  UseDS use_ds, SuccessorEpochCapture successor
+  UseDS use_ds, ChildEpochCapture successor
 ) {
   return makeEpochRooted("", use_ds, successor);
 }
 
 EpochType TerminationDetector::makeEpochRooted(
-  std::string const& label, UseDS use_ds, SuccessorEpochCapture successor
+  std::string const& label, UseDS use_ds, ChildEpochCapture successor
 ) {
   /*
    *  This method should only be called by the root node for the rooted epoch
@@ -1076,7 +1076,7 @@ EpochType TerminationDetector::makeEpochRooted(
 }
 
 EpochType TerminationDetector::makeEpochCollective(
-  SuccessorEpochCapture successor
+  ChildEpochCapture successor
 ) {
   vt_debug_print(
     normal, term,
@@ -1087,7 +1087,7 @@ EpochType TerminationDetector::makeEpochCollective(
 }
 
 EpochType TerminationDetector::makeEpochCollective(
-  std::string const& label, SuccessorEpochCapture successor
+  std::string const& label, ChildEpochCapture successor
 ) {
   auto const epoch = epoch::EpochManip::makeNewEpoch();
 
@@ -1110,7 +1110,7 @@ EpochType TerminationDetector::makeEpochCollective(
 
 EpochType TerminationDetector::makeEpoch(
   std::string const& label, bool is_coll, UseDS use_ds,
-  SuccessorEpochCapture successor
+  ChildEpochCapture successor
 ) {
   return is_coll ?
     makeEpochCollective(label, successor) :

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -982,7 +982,7 @@ void TerminationDetector::finishedEpoch(EpochType const& epoch) {
 }
 
 EpochType TerminationDetector::makeEpochRootedWave(
-  ChildEpochCapture successor, std::string const& label
+  ParentEpochCapture successor, std::string const& label
 ) {
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch();
 
@@ -1015,7 +1015,7 @@ EpochType TerminationDetector::makeEpochRootedWave(
 }
 
 EpochType TerminationDetector::makeEpochRootedDS(
-  ChildEpochCapture successor, std::string const& label
+  ParentEpochCapture successor, std::string const& label
 ) {
   auto const ds_cat = epoch::eEpochCategory::DijkstraScholtenEpoch;
   auto const epoch = epoch::EpochManip::makeNewRootedEpoch(false, ds_cat);
@@ -1042,13 +1042,13 @@ EpochType TerminationDetector::makeEpochRootedDS(
 }
 
 EpochType TerminationDetector::makeEpochRooted(
-  UseDS use_ds, ChildEpochCapture successor
+  UseDS use_ds, ParentEpochCapture successor
 ) {
   return makeEpochRooted("", use_ds, successor);
 }
 
 EpochType TerminationDetector::makeEpochRooted(
-  std::string const& label, UseDS use_ds, ChildEpochCapture successor
+  std::string const& label, UseDS use_ds, ParentEpochCapture successor
 ) {
   /*
    *  This method should only be called by the root node for the rooted epoch
@@ -1076,7 +1076,7 @@ EpochType TerminationDetector::makeEpochRooted(
 }
 
 EpochType TerminationDetector::makeEpochCollective(
-  ChildEpochCapture successor
+  ParentEpochCapture successor
 ) {
   vt_debug_print(
     normal, term,
@@ -1087,7 +1087,7 @@ EpochType TerminationDetector::makeEpochCollective(
 }
 
 EpochType TerminationDetector::makeEpochCollective(
-  std::string const& label, ChildEpochCapture successor
+  std::string const& label, ParentEpochCapture successor
 ) {
   auto const epoch = epoch::EpochManip::makeNewEpoch();
 
@@ -1110,7 +1110,7 @@ EpochType TerminationDetector::makeEpochCollective(
 
 EpochType TerminationDetector::makeEpoch(
   std::string const& label, bool is_coll, UseDS use_ds,
-  ChildEpochCapture successor
+  ParentEpochCapture successor
 ) {
   return is_coll ?
     makeEpochCollective(label, successor) :

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -217,7 +217,7 @@ public:
    */
   EpochType makeEpochRooted(
     UseDS use_ds = UseDS{false},
-    SuccessorEpochCapture successor = SuccessorEpochCapture{}
+    ChildEpochCapture successor = ChildEpochCapture{}
   );
 
   /**
@@ -228,7 +228,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochCollective(
-    SuccessorEpochCapture successor = SuccessorEpochCapture{}
+    ChildEpochCapture successor = ChildEpochCapture{}
   );
 
   /**
@@ -243,7 +243,7 @@ public:
   EpochType makeEpochRooted(
     std::string const& label,
     UseDS use_ds = UseDS{false},
-    SuccessorEpochCapture successor = SuccessorEpochCapture{}
+    ChildEpochCapture successor = ChildEpochCapture{}
   );
 
   /**
@@ -256,7 +256,7 @@ public:
    */
   EpochType makeEpochCollective(
     std::string const& label,
-    SuccessorEpochCapture successor = SuccessorEpochCapture{}
+    ChildEpochCapture successor = ChildEpochCapture{}
   );
 
   /**
@@ -273,7 +273,7 @@ public:
     std::string const& label,
     bool is_coll,
     UseDS use_ds = UseDS{false},
-    SuccessorEpochCapture successor = SuccessorEpochCapture{}
+    ChildEpochCapture successor = ChildEpochCapture{}
   );
 
   /**
@@ -313,7 +313,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochRootedWave(
-    SuccessorEpochCapture successor, std::string const& label = ""
+    ChildEpochCapture successor, std::string const& label = ""
   );
 
   /**
@@ -325,7 +325,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochRootedDS(
-    SuccessorEpochCapture successor, std::string const& label = ""
+    ChildEpochCapture successor, std::string const& label = ""
   );
 
 private:

--- a/src/vt/termination/termination.h
+++ b/src/vt/termination/termination.h
@@ -217,7 +217,7 @@ public:
    */
   EpochType makeEpochRooted(
     UseDS use_ds = UseDS{false},
-    ChildEpochCapture successor = ChildEpochCapture{}
+    ParentEpochCapture successor = ParentEpochCapture{}
   );
 
   /**
@@ -228,7 +228,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochCollective(
-    ChildEpochCapture successor = ChildEpochCapture{}
+    ParentEpochCapture successor = ParentEpochCapture{}
   );
 
   /**
@@ -243,7 +243,7 @@ public:
   EpochType makeEpochRooted(
     std::string const& label,
     UseDS use_ds = UseDS{false},
-    ChildEpochCapture successor = ChildEpochCapture{}
+    ParentEpochCapture successor = ParentEpochCapture{}
   );
 
   /**
@@ -256,7 +256,7 @@ public:
    */
   EpochType makeEpochCollective(
     std::string const& label,
-    ChildEpochCapture successor = ChildEpochCapture{}
+    ParentEpochCapture successor = ParentEpochCapture{}
   );
 
   /**
@@ -273,7 +273,7 @@ public:
     std::string const& label,
     bool is_coll,
     UseDS use_ds = UseDS{false},
-    ChildEpochCapture successor = ChildEpochCapture{}
+    ParentEpochCapture successor = ParentEpochCapture{}
   );
 
   /**
@@ -313,7 +313,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochRootedWave(
-    ChildEpochCapture successor, std::string const& label = ""
+    ParentEpochCapture successor, std::string const& label = ""
   );
 
   /**
@@ -325,7 +325,7 @@ public:
    * \return the new epoch
    */
   EpochType makeEpochRootedDS(
-    ChildEpochCapture successor, std::string const& label = ""
+    ParentEpochCapture successor, std::string const& label = ""
   );
 
 private:

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2141,7 +2141,7 @@ CollectionManager::constructMap(
 
   if (!is_static) {
     auto const& insert_epoch = theTerm()->makeEpochRootedWave(
-      term::SuccessorEpochCapture{no_epoch}
+      term::ChildEpochCapture{no_epoch}
     );
     theTerm()->finishNoActivateEpoch(insert_epoch);
     info.setInsertEpoch(insert_epoch);
@@ -2356,7 +2356,7 @@ void CollectionManager::finishedInsertEpoch(
    *  Add trigger for the next insertion phase/epoch finishing
    */
   auto const& next_insert_epoch = theTerm()->makeEpochRootedWave(
-    term::SuccessorEpochCapture{no_epoch}
+    term::ChildEpochCapture{no_epoch}
   );
   theTerm()->finishNoActivateEpoch(next_insert_epoch);
   UniversalIndexHolder<>::insertSetEpoch(untyped_proxy,next_insert_epoch);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2141,7 +2141,7 @@ CollectionManager::constructMap(
 
   if (!is_static) {
     auto const& insert_epoch = theTerm()->makeEpochRootedWave(
-      term::ChildEpochCapture{no_epoch}
+      term::ParentEpochCapture{no_epoch}
     );
     theTerm()->finishNoActivateEpoch(insert_epoch);
     info.setInsertEpoch(insert_epoch);
@@ -2356,7 +2356,7 @@ void CollectionManager::finishedInsertEpoch(
    *  Add trigger for the next insertion phase/epoch finishing
    */
   auto const& next_insert_epoch = theTerm()->makeEpochRootedWave(
-    term::ChildEpochCapture{no_epoch}
+    term::ParentEpochCapture{no_epoch}
   );
   theTerm()->finishNoActivateEpoch(next_insert_epoch);
   UniversalIndexHolder<>::insertSetEpoch(untyped_proxy,next_insert_epoch);

--- a/tests/unit/termination/test_term_cleanup.cc
+++ b/tests/unit/termination/test_term_cleanup.cc
@@ -112,10 +112,10 @@ TEST_F(TestTermCleanup, test_termination_cleanup_2) {
   for (int i = 0; i < num_epochs; i++) {
     EpochType const coll_epoch = theTerm()->makeEpochCollective();
     EpochType const root_epoch = theTerm()->makeEpochRootedDS(
-      term::SuccessorEpochCapture{no_epoch}
+      term::ChildEpochCapture{no_epoch}
     );
     EpochType const wave_epoch = theTerm()->makeEpochRootedWave(
-      term::SuccessorEpochCapture{no_epoch}
+      term::ChildEpochCapture{no_epoch}
     );
     //fmt::print("global collective epoch {:x}\n", epoch);
 

--- a/tests/unit/termination/test_term_cleanup.cc
+++ b/tests/unit/termination/test_term_cleanup.cc
@@ -112,10 +112,10 @@ TEST_F(TestTermCleanup, test_termination_cleanup_2) {
   for (int i = 0; i < num_epochs; i++) {
     EpochType const coll_epoch = theTerm()->makeEpochCollective();
     EpochType const root_epoch = theTerm()->makeEpochRootedDS(
-      term::ChildEpochCapture{no_epoch}
+      term::ParentEpochCapture{no_epoch}
     );
     EpochType const wave_epoch = theTerm()->makeEpochRootedWave(
-      term::ChildEpochCapture{no_epoch}
+      term::ParentEpochCapture{no_epoch}
     );
     //fmt::print("global collective epoch {:x}\n", epoch);
 

--- a/tests/unit/termination/test_termination_action_nested_collect.cc
+++ b/tests/unit/termination/test_termination_action_nested_collect.cc
@@ -50,7 +50,7 @@ struct TestTermNestedCollect : action::BaseFixture {
   void kernel(int depth, EpochType parent) {
     vtAssert(depth > 0, "Wrong depth");
     auto epoch = vt::theTerm()->makeEpochCollective(
-      term::SuccessorEpochCapture{parent}
+      term::ChildEpochCapture{parent}
     );
 
     // all ranks should have the same depth

--- a/tests/unit/termination/test_termination_action_nested_collect.cc
+++ b/tests/unit/termination/test_termination_action_nested_collect.cc
@@ -50,7 +50,7 @@ struct TestTermNestedCollect : action::BaseFixture {
   void kernel(int depth, EpochType parent) {
     vtAssert(depth > 0, "Wrong depth");
     auto epoch = vt::theTerm()->makeEpochCollective(
-      term::ChildEpochCapture{parent}
+      term::ParentEpochCapture{parent}
     );
 
     // all ranks should have the same depth

--- a/tests/unit/termination/test_termination_action_nested_rooted.cc
+++ b/tests/unit/termination/test_termination_action_nested_rooted.cc
@@ -56,7 +56,7 @@ struct TestTermNestedRooted : action::BaseFixture {
     if (channel::node == channel::root) {
       epoch = vt::theTerm()->makeEpochRooted(
         term::UseDS{useDS_},
-        term::SuccessorEpochCapture{parent}
+        term::ChildEpochCapture{parent}
       );
       // check that epoch is effectively rooted
       vtAssert(channel::root == epoch_manip::node(epoch), "Node should be root");

--- a/tests/unit/termination/test_termination_action_nested_rooted.cc
+++ b/tests/unit/termination/test_termination_action_nested_rooted.cc
@@ -56,7 +56,7 @@ struct TestTermNestedRooted : action::BaseFixture {
     if (channel::node == channel::root) {
       epoch = vt::theTerm()->makeEpochRooted(
         term::UseDS{useDS_},
-        term::ChildEpochCapture{parent}
+        term::ParentEpochCapture{parent}
       );
       // check that epoch is effectively rooted
       vtAssert(channel::root == epoch_manip::node(epoch), "Node should be root");


### PR DESCRIPTION
fixes #1079.