### PR TITLE
1122 elementstats is leaking

### DIFF
--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -113,17 +113,6 @@ void ElementStats::recvToNode(
   recvComm(key, bytes);
 }
 
-void ElementStats::setModelWeight(TimeType const& time) {
-  cur_time_started_ = false;
-  addTime(time);
-
-  vt_debug_print(
-    lb, node,
-    "ElementStats: setModelWeight: time={}, cur_load={}\n",
-    time, phase_timings_.at(cur_phase_)
-  );
-}
-
 void ElementStats::addTime(TimeType const& time) {
   phase_timings_.resize(cur_phase_ + 1);
   phase_timings_.at(cur_phase_) += time;

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -132,6 +132,13 @@ void ElementStats::updatePhase(PhaseType const& inc) {
   );
 
   cur_phase_ += inc;
+
+  // Access all table entries for current phase, to ensure presence even
+  // if they're left empty
+  phase_timings_[cur_phase_];
+  subphase_timings_[cur_phase_];
+  phase_comm_[cur_phase_];
+  subphase_comm_[cur_phase_];
 }
 
 PhaseType ElementStats::getPhase() const {

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -224,6 +224,22 @@ SubphaseType ElementStats::getSubPhase() const {
   return cur_subphase_;
 }
 
+std::size_t ElementStats::getLoadPhaseCount() const {
+  return phase_timings_.size();
+}
+
+std::size_t ElementStats::getCommPhaseCount() const {
+  return comm_.size();
+}
+
+std::size_t ElementStats::getSubphaseLoadPhaseCount() const {
+  return subphase_timings_.size();
+}
+
+std::size_t ElementStats::getSubphaseCommPhaseCount() const {
+  return subphase_comm_.size();
+}
+
 /*static*/
 void ElementStats::setFocusedSubPhase(VirtualProxyType collection, SubphaseType subphase) {
   focused_subphase_[collection] = subphase;

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -82,7 +82,7 @@ void ElementStats::stopTime() {
 void ElementStats::recvComm(
   LBCommKey key, double bytes
 ) {
-  comm_[cur_phase_][key].receiveMsg(bytes);
+  phase_comm_[cur_phase_][key].receiveMsg(bytes);
   subphase_comm_[cur_phase_].resize(cur_subphase_ + 1);
   subphase_comm_[cur_phase_].at(cur_subphase_)[key].receiveMsg(bytes);
 }
@@ -170,7 +170,7 @@ TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
 
 CommMapType const&
 ElementStats::getComm(PhaseType const& phase) {
-  auto const& phase_comm = comm_[phase];
+  auto const& phase_comm = phase_comm_[phase];
 
   vt_debug_print(
     lb, node,
@@ -206,7 +206,7 @@ void ElementStats::releaseStatsFromUnneededPhases(PhaseType phase, unsigned int 
   if (phase >= look_back) {
     phase_timings_.erase(phase - look_back);
     subphase_timings_.erase(phase - look_back);
-    comm_.erase(phase - look_back);
+    phase_comm_.erase(phase - look_back);
     subphase_comm_.erase(phase - look_back);
   }
 }
@@ -216,7 +216,7 @@ std::size_t ElementStats::getLoadPhaseCount() const {
 }
 
 std::size_t ElementStats::getCommPhaseCount() const {
-  return comm_.size();
+  return phase_comm_.size();
 }
 
 std::size_t ElementStats::getSubphaseLoadPhaseCount() const {

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -202,7 +202,7 @@ SubphaseType ElementStats::getSubPhase() const {
   return cur_subphase_;
 }
 
-void ElementStats::startIterCleanup(PhaseType phase, unsigned int look_back) {
+void ElementStats::releaseStatsFromUnneededPhases(PhaseType phase, unsigned int look_back) {
   if (phase >= look_back) {
     phase_timings_.erase(phase - look_back);
     subphase_timings_.erase(phase - look_back);

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -202,6 +202,15 @@ SubphaseType ElementStats::getSubPhase() const {
   return cur_subphase_;
 }
 
+void ElementStats::startIterCleanup(PhaseType phase, unsigned int look_back) {
+  if (phase >= look_back) {
+    phase_timings_.erase(phase - look_back);
+    subphase_timings_.erase(phase - look_back);
+    comm_.erase(phase - look_back);
+    subphase_comm_.erase(phase - look_back);
+  }
+}
+
 std::size_t ElementStats::getLoadPhaseCount() const {
   return phase_timings_.size();
 }

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -82,11 +82,9 @@ void ElementStats::stopTime() {
 void ElementStats::recvComm(
   LBCommKey key, double bytes
 ) {
-  comm_.resize(cur_phase_ + 1);
-  comm_.at(cur_phase_)[key].receiveMsg(bytes);
-  subphase_comm_.resize(cur_phase_ + 1);
-  subphase_comm_.at(cur_phase_).resize(cur_subphase_ + 1);
-  subphase_comm_.at(cur_phase_).at(cur_subphase_)[key].receiveMsg(bytes);
+  comm_[cur_phase_][key].receiveMsg(bytes);
+  subphase_comm_[cur_phase_].resize(cur_subphase_ + 1);
+  subphase_comm_[cur_phase_].at(cur_subphase_)[key].receiveMsg(bytes);
 }
 
 void ElementStats::recvObjData(
@@ -114,17 +112,15 @@ void ElementStats::recvToNode(
 }
 
 void ElementStats::addTime(TimeType const& time) {
-  phase_timings_.resize(cur_phase_ + 1);
-  phase_timings_.at(cur_phase_) += time;
+  phase_timings_[cur_phase_] += time;
 
-  subphase_timings_.resize(cur_phase_ + 1);
-  subphase_timings_.at(cur_phase_).resize(cur_subphase_ + 1);
-  subphase_timings_.at(cur_phase_).at(cur_subphase_) += time;
+  subphase_timings_[cur_phase_].resize(cur_subphase_ + 1);
+  subphase_timings_[cur_phase_].at(cur_subphase_) += time;
 
   vt_debug_print(
     lb, node,
     "ElementStats: addTime: time={}, cur_load={}\n",
-    time, phase_timings_.at(cur_phase_)
+    time, phase_timings_[cur_phase_]
   );
 }
 
@@ -136,8 +132,6 @@ void ElementStats::updatePhase(PhaseType const& inc) {
   );
 
   cur_phase_ += inc;
-  phase_timings_.resize(cur_phase_ + 1);
-  subphase_timings_.resize(cur_phase_ + 1);
 }
 
 PhaseType ElementStats::getPhase() const {
@@ -145,8 +139,6 @@ PhaseType ElementStats::getPhase() const {
 }
 
 TimeType ElementStats::getLoad(PhaseType const& phase) const {
-  vtAssert(phase_timings_.size() > phase, "Must have phase");
-
   auto const& total_load = phase_timings_.at(phase);
 
   vt_debug_print(
@@ -162,7 +154,6 @@ TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
   if (subphase == no_subphase)
     return getLoad(phase);
 
-  vtAssert(phase_timings_.size() > phase, "Must have phase");
   auto const& subphase_loads = subphase_timings_.at(phase);
 
   vtAssert(subphase_loads.size() > subphase, "Must have subphase");
@@ -179,7 +170,6 @@ TimeType ElementStats::getLoad(PhaseType phase, SubphaseType subphase) const {
 
 CommMapType const&
 ElementStats::getComm(PhaseType const& phase) {
-  comm_.resize(phase + 1);
   auto const& phase_comm = comm_[phase];
 
   vt_debug_print(
@@ -192,7 +182,6 @@ ElementStats::getComm(PhaseType const& phase) {
 }
 
 std::vector<CommMapType> const& ElementStats::getSubphaseComm(PhaseType phase) {
-  subphase_comm_.resize(phase + 1);
   auto const& subphase_comm = subphase_comm_[phase];
 
   vt_debug_print(

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -82,7 +82,6 @@ struct ElementStats {
     NodeType to, ElementIDType from_perm, ElementIDType from_temp,
     double bytes, bool bcast
   );
-  void setModelWeight(TimeType const& time);
   void updatePhase(PhaseType const& inc = 1);
   PhaseType getPhase() const;
   TimeType getLoad(PhaseType const& phase) const;

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -92,6 +92,11 @@ struct ElementStats {
   void setSubPhase(SubphaseType subphase);
   SubphaseType getSubPhase() const;
 
+  /**
+   * \internal \brief Cleanup after LB runs
+   */
+  void startIterCleanup(PhaseType phase, unsigned int look_back);
+
   // these are just for unit testing
   std::size_t getLoadPhaseCount() const;
   std::size_t getCommPhaseCount() const;

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -92,11 +92,6 @@ struct ElementStats {
   void setSubPhase(SubphaseType subphase);
   SubphaseType getSubPhase() const;
 
-  /**
-   * \internal \brief Cleanup after LB runs
-   */
-  void startIterCleanup(PhaseType phase, unsigned int look_back);
-
   // these are just for unit testing
   std::size_t getLoadPhaseCount() const;
   std::size_t getCommPhaseCount() const;
@@ -115,6 +110,12 @@ public:
   static void syncNextPhase(CollectStatsMsg<ColT>* msg, ColT* col);
 
   friend struct collection::Migratable;
+
+protected:
+  /**
+   * \internal \brief Release stats data from phases prior to lookback
+   */
+  void releaseStatsFromUnneededPhases(PhaseType phase, unsigned int look_back);
 
 protected:
   bool cur_time_started_ = false;

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -93,6 +93,12 @@ struct ElementStats {
   void setSubPhase(SubphaseType subphase);
   SubphaseType getSubPhase() const;
 
+  // these are just for unit testing
+  std::size_t getLoadPhaseCount() const;
+  std::size_t getCommPhaseCount() const;
+  std::size_t getSubphaseLoadPhaseCount() const;
+  std::size_t getSubphaseCommPhaseCount() const;
+
   static const constexpr SubphaseType no_subphase = std::numeric_limits<SubphaseType>::max();
   static void setFocusedSubPhase(VirtualProxyType collection, SubphaseType subphase);
   static SubphaseType getFocusedSubPhase(VirtualProxyType collection);

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -122,7 +122,7 @@ protected:
   TimeType cur_time_ = 0.0;
   PhaseType cur_phase_ = fst_lb_phase;
   std::unordered_map<PhaseType, TimeType> phase_timings_ = {};
-  std::unordered_map<PhaseType, CommMapType> comm_ = {};
+  std::unordered_map<PhaseType, CommMapType> phase_comm_ = {};
 
   SubphaseType cur_subphase_ = 0;
   std::unordered_map<PhaseType, std::vector<TimeType>> subphase_timings_ = {};

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -115,12 +115,12 @@ protected:
   bool cur_time_started_ = false;
   TimeType cur_time_ = 0.0;
   PhaseType cur_phase_ = fst_lb_phase;
-  std::vector<TimeType> phase_timings_ = {};
-  std::vector<CommMapType> comm_ = {};
+  std::unordered_map<PhaseType, TimeType> phase_timings_ = {};
+  std::unordered_map<PhaseType, CommMapType> comm_ = {};
 
   SubphaseType cur_subphase_ = 0;
-  std::vector<std::vector<TimeType>> subphase_timings_ = {};
-  std::vector<std::vector<CommMapType>> subphase_comm_ = {};
+  std::unordered_map<PhaseType, std::vector<TimeType>> subphase_timings_ = {};
+  std::unordered_map<PhaseType, std::vector<CommMapType>> subphase_comm_ = {};
 
   static std::unordered_map<VirtualProxyType, SubphaseType> focused_subphase_;
 };

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -65,7 +65,7 @@ void ElementStats::serialize(Serializer& s) {
   s | cur_time_;
   s | cur_phase_;
   s | phase_timings_;
-  s | comm_;
+  s | phase_comm_;
   s | cur_subphase_;
   s | subphase_timings_;
 }

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -95,6 +95,9 @@ void ElementStats::syncNextPhase(CollectStatsMsg<ColT>* msg, ColT* col) {
   theNodeStats()->addNodeStats(
     col, cur_phase, total_load, subphase_loads, comm, subphase_comm
   );
+
+  auto model = theLBManager()->getLoadModel();
+  stats.startIterCleanup(cur_phase, model->getNumPastPhasesNeeded());
 }
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/elm_stats.impl.h
+++ b/src/vt/vrt/collection/balance/elm_stats.impl.h
@@ -97,7 +97,7 @@ void ElementStats::syncNextPhase(CollectStatsMsg<ColT>* msg, ColT* col) {
   );
 
   auto model = theLBManager()->getLoadModel();
-  stats.startIterCleanup(cur_phase, model->getNumPastPhasesNeeded());
+  stats.releaseStatsFromUnneededPhases(cur_phase, model->getNumPastPhasesNeeded());
 }
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/tests/unit/collection/test_lbstats_retention.cc
+++ b/tests/unit/collection/test_lbstats_retention.cc
@@ -61,13 +61,7 @@ struct MyMsg : vt::CollectionMessage<ColT> { };
 struct TestCol : vt::Collection<TestCol,vt::Index1D> {
   unsigned int prev_calls_ = 0;
 
-  unsigned int prevCalls() {
-    fmt::print(
-      "{}: {}: prev_calls={}\n",
-      theContext()->getNode(), getIndex(), prev_calls_
-    );
-    return prev_calls_++;
-  }
+  unsigned int prevCalls() { return prev_calls_++; }
 
   static void colHandler(MyMsg<TestCol>* msg, TestCol* col) {
     auto phase = col->prevCalls();

--- a/tests/unit/collection/test_lbstats_retention.cc
+++ b/tests/unit/collection/test_lbstats_retention.cc
@@ -74,29 +74,37 @@ struct TestCol : vt::Collection<TestCol,vt::Index1D> {
     auto sp_load_phase_count = stats.getSubphaseLoadPhaseCount();
     auto sp_comm_phase_count = stats.getSubphaseCommPhaseCount();
 
-    if (phase > phases_needed) {
-      // syncNextPhase will have caused timings to be added for the
-      // next phase already
-      EXPECT_EQ(load_phase_count, phases_needed + 1);
-      EXPECT_EQ(sp_load_phase_count, phases_needed + 1);
+    #if vt_check_enabled(lblite)
+      if (phase > phases_needed) {
+        // syncNextPhase will have caused timings to be added for the
+        // next phase already
+        EXPECT_EQ(load_phase_count, phases_needed + 1);
+        EXPECT_EQ(sp_load_phase_count, phases_needed + 1);
 
-      EXPECT_EQ(comm_phase_count, phases_needed);
-      EXPECT_EQ(sp_comm_phase_count, phases_needed);
-    } else if (phase == 0) {
-      EXPECT_EQ(load_phase_count, phase);
-      EXPECT_EQ(sp_load_phase_count, phase);
+        EXPECT_EQ(comm_phase_count, phases_needed);
+        EXPECT_EQ(sp_comm_phase_count, phases_needed);
+      } else if (phase == 0) {
+        EXPECT_EQ(load_phase_count, phase);
+        EXPECT_EQ(sp_load_phase_count, phase);
 
-      EXPECT_EQ(comm_phase_count, phase);
-      EXPECT_EQ(sp_comm_phase_count, phase);
-    } else {
-      // syncNextPhase will have caused timings to be added for the
-      // next phase already
-      EXPECT_EQ(load_phase_count, phase + 1);
-      EXPECT_EQ(sp_load_phase_count, phase + 1);
+        EXPECT_EQ(comm_phase_count, phase);
+        EXPECT_EQ(sp_comm_phase_count, phase);
+      } else {
+        // syncNextPhase will have caused timings to be added for the
+        // next phase already
+        EXPECT_EQ(load_phase_count, phase + 1);
+        EXPECT_EQ(sp_load_phase_count, phase + 1);
 
-      EXPECT_EQ(comm_phase_count, phase);
-      EXPECT_EQ(sp_comm_phase_count, phase);
-    }
+        EXPECT_EQ(comm_phase_count, phase);
+        EXPECT_EQ(sp_comm_phase_count, phase);
+      }
+    #else
+      EXPECT_EQ(load_phase_count, 0);
+      EXPECT_EQ(sp_load_phase_count, 0);
+
+      EXPECT_EQ(comm_phase_count, 0);
+      EXPECT_EQ(sp_comm_phase_count, 0);
+    #endif
   }
 };
 

--- a/tests/unit/collection/test_lbstats_retention.cc
+++ b/tests/unit/collection/test_lbstats_retention.cc
@@ -76,33 +76,29 @@ struct TestCol : vt::Collection<TestCol,vt::Index1D> {
 
     #if vt_check_enabled(lblite)
       if (phase > phases_needed) {
-        // syncNextPhase will have caused timings to be added for the
+        // updatePhase will have caused entries to be added for the
         // next phase already
-        EXPECT_EQ(load_phase_count, phases_needed + 1);
+        EXPECT_EQ(load_phase_count,    phases_needed + 1);
         EXPECT_EQ(sp_load_phase_count, phases_needed + 1);
-
-        EXPECT_EQ(comm_phase_count, phases_needed);
-        EXPECT_EQ(sp_comm_phase_count, phases_needed);
+        EXPECT_EQ(comm_phase_count,    phases_needed + 1);
+        EXPECT_EQ(sp_comm_phase_count, phases_needed + 1);
       } else if (phase == 0) {
-        EXPECT_EQ(load_phase_count, phase);
+        EXPECT_EQ(load_phase_count,    phase);
         EXPECT_EQ(sp_load_phase_count, phase);
-
-        EXPECT_EQ(comm_phase_count, phase);
+        EXPECT_EQ(comm_phase_count,    phase);
         EXPECT_EQ(sp_comm_phase_count, phase);
       } else {
-        // syncNextPhase will have caused timings to be added for the
+        // updatePhase will have caused entries to be added for the
         // next phase already
-        EXPECT_EQ(load_phase_count, phase + 1);
+        EXPECT_EQ(load_phase_count,    phase + 1);
         EXPECT_EQ(sp_load_phase_count, phase + 1);
-
-        EXPECT_EQ(comm_phase_count, phase);
-        EXPECT_EQ(sp_comm_phase_count, phase);
+        EXPECT_EQ(comm_phase_count,    phase + 1);
+        EXPECT_EQ(sp_comm_phase_count, phase + 1);
       }
     #else
-      EXPECT_EQ(load_phase_count, 0);
+      EXPECT_EQ(load_phase_count,    0);
       EXPECT_EQ(sp_load_phase_count, 0);
-
-      EXPECT_EQ(comm_phase_count, 0);
+      EXPECT_EQ(comm_phase_count,    0);
       EXPECT_EQ(sp_comm_phase_count, 0);
     #endif
   }

--- a/tests/unit/collection/test_lbstats_retention.cc
+++ b/tests/unit/collection/test_lbstats_retention.cc
@@ -81,14 +81,26 @@ struct TestCol : vt::Collection<TestCol,vt::Index1D> {
     auto sp_comm_phase_count = stats.getSubphaseCommPhaseCount();
 
     if (phase > phases_needed) {
-      EXPECT_EQ(load_phase_count, phases_needed);
+      // syncNextPhase will have caused timings to be added for the
+      // next phase already
+      EXPECT_EQ(load_phase_count, phases_needed + 1);
+      EXPECT_EQ(sp_load_phase_count, phases_needed + 1);
+
       EXPECT_EQ(comm_phase_count, phases_needed);
-      EXPECT_EQ(sp_load_phase_count, phases_needed);
       EXPECT_EQ(sp_comm_phase_count, phases_needed);
-    } else {
+    } else if (phase == 0) {
       EXPECT_EQ(load_phase_count, phase);
-      EXPECT_EQ(comm_phase_count, phase);
       EXPECT_EQ(sp_load_phase_count, phase);
+
+      EXPECT_EQ(comm_phase_count, phase);
+      EXPECT_EQ(sp_comm_phase_count, phase);
+    } else {
+      // syncNextPhase will have caused timings to be added for the
+      // next phase already
+      EXPECT_EQ(load_phase_count, phase + 1);
+      EXPECT_EQ(sp_load_phase_count, phase + 1);
+
+      EXPECT_EQ(comm_phase_count, phase);
       EXPECT_EQ(sp_comm_phase_count, phase);
     }
   }

--- a/tests/unit/collection/test_lbstats_retention.cc
+++ b/tests/unit/collection/test_lbstats_retention.cc
@@ -1,0 +1,212 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                         test_lbstats_retention.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <vt/vrt/collection/balance/elm_stats.h>
+#include <vt/vrt/collection/balance/model/persistence_median_last_n.h>
+#include <vt/vrt/collection/balance/model/load_model.h>
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+
+#include <memory>
+
+namespace vt { namespace tests { namespace unit {
+
+template <typename ColT>
+struct MyMsg : vt::CollectionMessage<ColT> { };
+
+struct TestCol : vt::Collection<TestCol,vt::Index1D> {
+  unsigned int prev_calls_ = 0;
+
+  unsigned int prevCalls() {
+    fmt::print(
+      "{}: {}: prev_calls={}\n",
+      theContext()->getNode(), getIndex(), prev_calls_
+    );
+    return prev_calls_++;
+  }
+
+  static void colHandler(MyMsg<TestCol>* msg, TestCol* col) {
+    auto phase = col->prevCalls();
+    auto model = theLBManager()->getLoadModel();
+    auto phases_needed = model->getNumPastPhasesNeeded();
+
+    auto& stats = col->stats_;
+    auto load_phase_count = stats.getLoadPhaseCount();
+    auto comm_phase_count = stats.getCommPhaseCount();
+    auto sp_load_phase_count = stats.getSubphaseLoadPhaseCount();
+    auto sp_comm_phase_count = stats.getSubphaseCommPhaseCount();
+
+    if (phase > phases_needed) {
+      EXPECT_EQ(load_phase_count, phases_needed);
+      EXPECT_EQ(comm_phase_count, phases_needed);
+      EXPECT_EQ(sp_load_phase_count, phases_needed);
+      EXPECT_EQ(sp_comm_phase_count, phases_needed);
+    } else {
+      EXPECT_EQ(load_phase_count, phase);
+      EXPECT_EQ(comm_phase_count, phase);
+      EXPECT_EQ(sp_load_phase_count, phase);
+      EXPECT_EQ(sp_comm_phase_count, phase);
+    }
+  }
+};
+
+using TestLBstatsRetention = TestParallelHarness;
+
+using vt::vrt::collection::balance::LoadModel;
+using vt::vrt::collection::balance::PersistenceMedianLastN;
+
+static constexpr int32_t const num_elms = 16;
+
+TEST_F(TestLBstatsRetention, test_lbstats_retention_last1) {
+  static constexpr int const num_phases = 5;
+
+  // We must have more or equal number of elements than nodes for this test to
+  // work properly
+  EXPECT_GE(num_elms, vt::theContext()->getNumNodes());
+
+  auto range = vt::Index1D(num_elms);
+
+  vt::vrt::collection::CollectionProxy<TestCol> proxy;
+
+  // Construct two collections
+  runInEpochCollective([&]{
+    proxy = vt::theCollection()->constructCollective<TestCol>(range);
+  });
+
+  // Get the base model, assert it's valid
+  auto base = theLBManager()->getBaseLoadModel();
+  EXPECT_NE(base, nullptr);
+
+  // Create a new model
+  auto persist = std::make_shared<PersistenceMedianLastN>(base, 1U);
+
+  // Set the new model
+  theLBManager()->setLoadModel(persist);
+
+  for (int i=0; i<num_phases; ++i) {
+    runInEpochCollective([&]{
+      // Do some work.
+      proxy.broadcastCollective<MyMsg<TestCol>, TestCol::colHandler>();
+    });
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+  }
+}
+
+TEST_F(TestLBstatsRetention, test_lbstats_retention_last2) {
+  static constexpr int const num_phases = 6;
+
+  // We must have more or equal number of elements than nodes for this test to
+  // work properly
+  EXPECT_GE(num_elms, vt::theContext()->getNumNodes());
+
+  auto range = vt::Index1D(num_elms);
+
+  vt::vrt::collection::CollectionProxy<TestCol> proxy;
+
+  // Construct two collections
+  runInEpochCollective([&]{
+    proxy = vt::theCollection()->constructCollective<TestCol>(range);
+  });
+
+  // Get the base model, assert it's valid
+  auto base = theLBManager()->getBaseLoadModel();
+  EXPECT_NE(base, nullptr);
+
+  // Create a new model
+  auto persist = std::make_shared<PersistenceMedianLastN>(base, 2U);
+
+  // Set the new model
+  theLBManager()->setLoadModel(persist);
+
+  for (int i=0; i<num_phases; ++i) {
+    runInEpochCollective([&]{
+      // Do some work.
+      proxy.broadcastCollective<MyMsg<TestCol>, TestCol::colHandler>();
+    });
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+  }
+}
+
+TEST_F(TestLBstatsRetention, test_lbstats_retention_last4) {
+  static constexpr int const num_phases = 8;
+
+  // We must have more or equal number of elements than nodes for this test to
+  // work properly
+  EXPECT_GE(num_elms, vt::theContext()->getNumNodes());
+
+  auto range = vt::Index1D(num_elms);
+
+  vt::vrt::collection::CollectionProxy<TestCol> proxy;
+
+  // Construct two collections
+  runInEpochCollective([&]{
+    proxy = vt::theCollection()->constructCollective<TestCol>(range);
+  });
+
+  // Get the base model, assert it's valid
+  auto base = theLBManager()->getBaseLoadModel();
+  EXPECT_NE(base, nullptr);
+
+  // Create a new model
+  auto persist = std::make_shared<PersistenceMedianLastN>(base, 4U);
+
+  // Set the new model
+  theLBManager()->setLoadModel(persist);
+
+  for (int i=0; i<num_phases; ++i) {
+    runInEpochCollective([&]{
+      // Do some work.
+      proxy.broadcastCollective<MyMsg<TestCol>, TestCol::colHandler>();
+    });
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+  }
+}
+
+}}} // end namespace vt::tests::unit


### PR DESCRIPTION
The vectors holding stats in ElementStats grow without bound.  This PR erases stats data for phases older than the lookback.

Fixes #1122