### PR TITLE
1154 NodeStats subphase comm data growth

### DIFF
--- a/src/vt/vrt/collection/balance/node_stats.cc
+++ b/src/vt/vrt/collection/balance/node_stats.cc
@@ -150,6 +150,7 @@ void NodeStats::startIterCleanup(PhaseType phase, unsigned int look_back) {
     node_data_.erase(phase - look_back);
     node_subphase_data_.erase(phase - look_back);
     node_comm_.erase(phase - look_back);
+    node_subphase_comm_.erase(phase - look_back);
   }
 
   // Create migrate lambdas and temp to perm map since LB is complete


### PR DESCRIPTION
Subphase comm data in NodeStats for phases earlier than the lookback was not being cleared out in startIterCleanup as it was for other data structures.  This PR adds it, preventing the memory use from growing without bound.

Fixes #1154 