### PR TITLE
#1159: build: correct messages when package not found

### DIFF
--- a/cmake/local_package.cmake
+++ b/cmake/local_package.cmake
@@ -50,9 +50,8 @@ macro(find_package_local pkg_name pkg_directory pkg_other_name)
 
     foreach(prefix ${prefix_args})
       set(potential_path ${pkg_directory}/${prefix})
-      set(${pkg_name}_DIR ${potential_path})
       # message("prefix: ${potential_path}")
-      if (EXISTS "${${pkg_name}_DIR}${pkg_prefix}")
+      if (EXISTS "${potential_path}")
         # message(STATUS "find_package_local: trying path: ${potential_path}")
 
         # Search locally only for package based on the user's supplied path; if


### PR DESCRIPTION
Fixes #1159.

I made the same change here as in checkpoint.  This one doesn't get directly tested because vt is currently using checkpoint's `find_package_local`, as described in #1158.