### PR TITLE
1157: Use non deprecated send function for objgrp proxy in Zoltanlb

### DIFF
--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
@@ -218,8 +218,7 @@ void ZoltanLB::makeGraphSymmetric() {
   }
 
   for (auto&& elm : shared_edges) {
-    auto msg = makeMessage<CommMsg>(elm.second);
-    proxy[elm.first].send<CommMsg, &ZoltanLB::recvSharedEdges>(msg.get());
+    proxy[elm.first].send<CommMsg, &ZoltanLB::recvSharedEdges>(elm.second);
   }
 
 }
@@ -362,8 +361,7 @@ void ZoltanLB::allocateShareEdgeGIDs() {
 
   if (use_shared_edges_) {
     for (auto&& elm : shared_edges) {
-      auto msg = makeMessage<CommMsg>(elm.second);
-      proxy[elm.first].send<CommMsg, &ZoltanLB::recvEdgeGID>(msg.get());
+      proxy[elm.first].send<CommMsg, &ZoltanLB::recvEdgeGID>(elm.second);
     }
   }
 }


### PR DESCRIPTION
Fixes #1157 

![image](https://user-images.githubusercontent.com/9077677/102143217-ea636900-3e63-11eb-99fa-0ba1d44df9a3.png)
