### PR TITLE
456: Fix intel compile warnings

### DIFF
--- a/examples/collection/transpose.cc
+++ b/examples/collection/transpose.cc
@@ -121,7 +121,7 @@ struct SubSolveInfo {
   static void solveDataIncoming(DataMsg* msg);
   static void subSolveHandler(SubSolveMsg* msg);
 
-  MPI_Comm sub_comm = MPI_COMM_WORLD;
+  MPI_Comm sub_comm_ = MPI_COMM_WORLD;
   int32_t sub_rank_ = -1;
   int32_t sub_size_ = -1;
   int32_t needed_blocks_ = 0;
@@ -232,7 +232,7 @@ vt::NodeType my_map(IndexT* idx, IndexT* max_idx, vt::NodeType num_nodes) {
   // Do a simple "blocked" map from collection pieces to node
   auto const blocks_to_node = num_pieces / sub_size;
   auto const solver_local_elms = blocks_to_node * block_size;
-  solver_info.sub_comm = sub_comm;
+  solver_info.sub_comm_ = sub_comm;
   solver_info.sub_rank_ = sub_rank;
   solver_info.sub_size_ = sub_size;
   solver_info.needed_blocks_ = blocks_to_node;
@@ -305,7 +305,7 @@ static void solveGroupSetup(vt::NodeType this_node, vt::VirtualProxyType coll_pr
   // auto const& the_comm = vt::theContext()->getComm();
   // MPI_Comm manual_sub_comm;
   // MPI_Comm_split(the_comm, is_even_node, this_node, &manual_sub_comm);
-  // solver_info.sub_comm = manual_sub_comm;
+  // solver_info.sub_comm_ = manual_sub_comm;
 
   fmt::print(
     "solveGroupSetup: node={}, is_even_node={}\n",

--- a/lib/libfort/CMakeLists.txt
+++ b/lib/libfort/CMakeLists.txt
@@ -62,6 +62,13 @@ else()
         -Wfloat-equal \
         -Wwrite-strings \
         ")
+    #Supress
+    if("${FORT_COMPILER}" STREQUAL "Intel")
+    set(ADDITIONAL_WARNINGS "${ADDITIONAL_WARNINGS} \
+        -wd279 \
+        -wd2192 \
+        -wd2102")
+    endif()
     if("${FORT_COMPILER}" STREQUAL "GNU")
         set(ADDITIONAL_WARNINGS "${ADDITIONAL_WARNINGS} \
             -Wtrampolines \

--- a/src/vt/runtime/runtime_get.cc
+++ b/src/vt/runtime/runtime_get.cc
@@ -165,11 +165,11 @@ static arguments::AppConfig preInitAppConfig{};
  * \return A configuration; possible a default configuration.
  */
 arguments::AppConfig const* preConfig() {
-  auto const rt = curRT;
-  if (not rt)
+  auto const runtime = curRT;
+  if (not runtime)
     return &preInitAppConfig;
-  auto const* config = rt->theArgConfig;
-  return config not_eq nullptr ? &config->config_ : rt->getAppConfig();
+  auto const* config = runtime->theArgConfig;
+  return config not_eq nullptr ? &config->config_ : runtime->getAppConfig();
 }
 
 }} /* end namespace vt::debug */

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -338,7 +338,7 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
 
 void Scheduler::triggerEvent(SchedulerEventType const& event) {
   vtAssert(
-    event_triggers.size() >= event, "Must be large enough to hold this event"
+    event_triggers.size() >= static_cast<size_t>(event), "Must be large enough to hold this event"
   );
 
   for (auto& t : event_triggers[event]) {
@@ -355,7 +355,7 @@ void Scheduler::registerTrigger(
   SchedulerEventType const& event, TriggerType trigger
 ) {
   vtAssert(
-    event_triggers.size() >= event, "Must be large enough to hold this event"
+    event_triggers.size() >= static_cast<size_t>(event), "Must be large enough to hold this event"
   );
   event_triggers[event].push_back(trigger);
 }
@@ -364,7 +364,7 @@ void Scheduler::registerTriggerOnce(
   SchedulerEventType const& event, TriggerType trigger
 ) {
   vtAssert(
-    event_triggers.size() >= event, "Must be large enough to hold this event"
+    event_triggers.size() >= static_cast<size_t>(event), "Must be large enough to hold this event"
   );
   event_triggers_once[event].push_back(trigger);
 }

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -524,8 +524,8 @@ struct MergeCol : vt::Collection<MergeCol,vt::Index2D> {
 
   struct GhostMsg : vt::CollectionMessage<MergeCol > {
     GhostMsg() = default;
-    explicit GhostMsg(vt::CollectionProxy<MergeCol, vt::Index2D> proxy_)
-      : proxy(proxy_)
+    explicit GhostMsg(vt::CollectionProxy<MergeCol, vt::Index2D> in_proxy_)
+      : proxy(in_proxy_)
     {}
     vt::CollectionProxy<MergeCol, vt::Index2D> proxy;
   };


### PR DESCRIPTION
Fixes #456

Current warnings: 

- /vt/src/vt/scheduler/scheduler.cc(340): warning #2557: comparison between signed and unsigned operands
- /vt/src/vt/scheduler/scheduler.cc(357): warning #2557: comparison between signed and unsigned operands
- /vt/src/vt/scheduler/scheduler.cc(366): warning #2557: comparison between signed and unsigned operands
- /vt/src/vt/runtime/runtime_get.cc(168): warning #3280: declaration hides variable "vt::rt" (declared at line 72 of "/vt/src/vt/runtime/runtime_inst.h")
- /vt/examples/collection/transpose.cc(213): warning #3868: declaration hides member "SubSolveInfo::sub_comm" (declared at line 124) in same scope
- /vt/tests/unit/termination/test_term_dep_send_chain.cc(527): warning #3280: declaration hides member "vt::vrt::VrtBase::proxy_" (declared at line 73 of "/vt/src/vt/vrt/base/base.h")
