### PR TITLE
1183 reset the phase when restoring from file

### DIFF
--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -141,6 +141,10 @@ void ElementStats::updatePhase(PhaseType const& inc) {
   subphase_comm_[cur_phase_];
 }
 
+void ElementStats::resetPhase() {
+  cur_phase_ = fst_lb_phase;
+}
+
 PhaseType ElementStats::getPhase() const {
   return cur_phase_;
 }

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -83,6 +83,7 @@ struct ElementStats {
     double bytes, bool bcast
   );
   void updatePhase(PhaseType const& inc = 1);
+  void resetPhase();
   PhaseType getPhase() const;
   TimeType getLoad(PhaseType const& phase) const;
   TimeType getLoad(PhaseType phase, SubphaseType subphase) const;

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -1836,6 +1836,8 @@ public:
   /**
    * \brief Restore the collection (collective) from file.
    *
+   * \note Resets the phase to 0 for every element.
+   *
    * \param[in] range the range of the collection to restart
    * \param[in] file_base the base file name for the files to read
    *

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -3223,6 +3223,7 @@ CollectionManager::restoreFromFile(
     // @todo: error check the file read with bytes in directory
 
     auto col_ptr = checkpoint::deserializeFromFile<ColT>(file_name);
+    col_ptr->stats_.resetPhase();
     token[idx].insertPtr(std::move(col_ptr));
   }
 

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -189,6 +189,8 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
       }
     });
 
+    vt::thePhase()->nextPhaseCollective();
+
     // Destroy the collection
     vt::runInEpochCollective([&]{
       if (this_node == 0) {


### PR DESCRIPTION
fixes #1183 

from discussion with Jonathan:

> If we assume that `theCollection()->restoreFromFile()` always is after a reinitialization of VT we can just set the phase in every element to 0 instead of deserializing it from file and getting the old phase (a true restart)

> The phase in `ElementStats` (embedded in the collection) needs to align with the user’s call to `theCollection()->nextPhase(proxy, phase)` so I think resetting it to zero is fine. Even if a full restart isn’t done, the user should just pass 0 to `nextPhase` since it was restored