### PR TITLE
#1190: Add a web-updatable 'secret' to the cache key, to ease dropping a broken cache

### DIFF
--- a/.github/workflows/macosx-clang-mpich.yml
+++ b/.github/workflows/macosx-clang-mpich.yml
@@ -27,9 +27,9 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.ccache
-        key: ${{ runner.os }}-macosx-clang-8-ccache-${{ hashFiles('**/*') }}
+        key: ${{ runner.os }}-macosx-clang-8-ccache-${{ secrets.GH_ACTIONS_CACHE_VERSION }}-${{ hashFiles('**/*') }}
         restore-keys: |
-          ${{ runner.os }}-macosx-clang-8-ccache-
+          ${{ runner.os }}-macosx-clang-8-ccache-${{ secrets.GH_ACTIONS_CACHE_VERSION }}
     - name: Install Dependencies
       shell: bash
       run: brew update --preinstall && brew bundle --file=ci/Brewfile

--- a/.github/workflows/macosx-clang-mpich.yml
+++ b/.github/workflows/macosx-clang-mpich.yml
@@ -22,6 +22,7 @@ jobs:
       VT_LB_ENABLED: 1
       VT_TRACE_ENABLED: 1
       CMAKE_GENERATOR: "Unix Makefiles"
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macosx-clang-mpich.yml
+++ b/.github/workflows/macosx-clang-mpich.yml
@@ -21,6 +21,7 @@ jobs:
       CMAKE_BUILD_TYPE: release
       VT_LB_ENABLED: 1
       VT_TRACE_ENABLED: 1
+      CMAKE_GENERATOR: "Unix Makefiles"
 
     steps:
     - uses: actions/checkout@v2

--- a/ci/Brewfile
+++ b/ci/Brewfile
@@ -1,3 +1,2 @@
 brew "ccache"
-brew "ninja"
 brew "mpich"


### PR DESCRIPTION
Fixes #1190