### PR TITLE
1195: passing argc and argv by value causes incorrect argument parsing

### DIFF
--- a/src/vt/collective/startup.cc
+++ b/src/vt/collective/startup.cc
@@ -52,16 +52,20 @@ namespace vt {
 
 // vt::{initialize,finalize} for main ::vt namespace
 RuntimePtrType initialize(
-  int argc, char** argv, WorkerCountType const num_workers,
-  bool is_interop /* = false */, MPI_Comm* comm /* = nullptr */
+  int& argc, char**& argv, WorkerCountType const num_workers,
+  bool is_interop, MPI_Comm* comm
 ) {
   return CollectiveOps::initialize(argc,argv,num_workers,is_interop,comm);
 }
 
-RuntimePtrType initialize(
-  int argc /* = 0 */, char** argv /* = nullptr */,
-  MPI_Comm* comm /* = nullptr */
-) {
+RuntimePtrType initialize(int& argc, char**& argv, MPI_Comm* comm) {
+  bool const is_interop = comm != nullptr;
+  return CollectiveOps::initialize(argc,argv,no_workers,is_interop,comm);
+}
+
+RuntimePtrType initialize(MPI_Comm* comm) {
+  int argc = 0;
+  char** argv = nullptr;
   bool const is_interop = comm != nullptr;
   return CollectiveOps::initialize(argc,argv,no_workers,is_interop,comm);
 }

--- a/src/vt/collective/startup.h
+++ b/src/vt/collective/startup.h
@@ -51,12 +51,11 @@
 namespace vt {
 
 RuntimePtrType initialize(
-  int argc, char** argv, WorkerCountType const num_workers,
+  int& argc, char**& argv, WorkerCountType const num_workers,
   bool is_interop = false, MPI_Comm* comm = nullptr
 );
-RuntimePtrType initialize(
-  int argc = 0, char** argv = nullptr, MPI_Comm* comm = nullptr
-);
+RuntimePtrType initialize(int& argc, char**& argv, MPI_Comm* comm = nullptr);
+RuntimePtrType initialize(MPI_Comm* comm = nullptr);
 
 void finalize(RuntimePtrType in_rt);
 void finalize();

--- a/tests/unit/runtime/test_initialization.cc
+++ b/tests/unit/runtime/test_initialization.cc
@@ -70,8 +70,9 @@ struct TestInitialization : TestParallelHarness {
     custom_args.emplace_back(&prog_name[0]);
     custom_args.emplace_back(&cli_argument[0]);
     custom_args.emplace_back(&vt_no_terminate[0]);
+    custom_args.emplace_back(nullptr);
 
-    custom_argc = custom_args.size();
+    custom_argc = custom_args.size() - 1;
     custom_argv = custom_args.data();
     EXPECT_EQ(custom_argc, 3);
 
@@ -90,6 +91,7 @@ TEST_F(TestInitialization, test_initialize_with_args) {
   EXPECT_EQ(custom_argc, 2);
   EXPECT_STREQ(custom_argv[0], "vt_program");
   EXPECT_STREQ(custom_argv[1], "--cli_argument=100");
+  EXPECT_EQ(custom_argv[2], nullptr);
 }
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/runtime/test_initialization.cc
+++ b/tests/unit/runtime/test_initialization.cc
@@ -1,0 +1,95 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                           test_initialization.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+
+#include <vt/transport.h>
+
+namespace vt { namespace tests { namespace unit {
+
+struct TestInitialization : TestParallelHarness {
+  void SetUp() override {
+    using namespace vt;
+
+    TestHarness::SetUp();
+
+    if (mpi_singleton == nullptr) {
+      mpi_singleton =
+        std::make_unique<MPISingletonMultiTest>(test_argc, test_argv);
+    }
+
+    // communicator is duplicated.
+    MPI_Comm comm = mpi_singleton->getComm();
+
+    static char prog_name[]{"vt_program"};
+    static char cli_argument[]{"--cli_argument=100"};
+    static char vt_no_terminate[]{"--vt_no_terminate"};
+    custom_args.emplace_back(&prog_name[0]);
+    custom_args.emplace_back(&cli_argument[0]);
+    custom_args.emplace_back(&vt_no_terminate[0]);
+
+    custom_argc = custom_args.size();
+    custom_argv = custom_args.data();
+    EXPECT_EQ(custom_argc, 3);
+
+    vt::initialize(custom_argc, custom_argv, no_workers, true, &comm);
+  }
+
+  std::vector<char*> custom_args;
+  int custom_argc;
+  char** custom_argv;
+};
+
+TEST_F(TestInitialization, test_initialize_with_args) {
+  EXPECT_EQ(theConfig()->prog_name, "vt_program");
+  EXPECT_EQ(theConfig()->vt_no_terminate, true);
+
+  EXPECT_EQ(custom_argc, 2);
+  EXPECT_STREQ(custom_argv[0], "vt_program");
+  EXPECT_STREQ(custom_argv[1], "--cli_argument=100");
+}
+
+}}} // end namespace vt::tests::unit


### PR DESCRIPTION
fixes #1195 