### PR TITLE
1199: argv is missing nullptr at the end in TestParallelHarness

### DIFF
--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -101,8 +101,6 @@ void myHandler(MsgT* m) {
 
 template <typename T>
 struct TestActiveSendLarge : TestParallelHarness {
-  using TagType = typename std::tuple_element<1,T>::type;
-
   // Set max size to 16 KiB for testing
   void addAdditionalArgs() override {
     new_arg = fmt::format("--vt_max_mpi_send_size=16384");

--- a/tests/unit/test_harness.h
+++ b/tests/unit/test_harness.h
@@ -54,38 +54,13 @@
 
 namespace vt { namespace tests { namespace unit {
 
-extern int test_argc;
-extern char** test_argv;
-
 template <typename TestBase>
 struct TestHarnessAny : TestBase {
-  virtual void SetUp() {
-    argc_ = orig_args_.size();
-    argv_ = new char*[argc_];
-
-    for (int i = 0; i < argc_; i++) {
-      auto const len = orig_args_[i].size();
-      argv_[i] = new char[len + 1];
-      argv_[i][len] = 0;
-      orig_args_[i].copy(argv_[i], len);
-    }
-  }
-
-  virtual void TearDown() {
-    for (int i = 0; i < argc_; i++) {
-      delete [] argv_[i];
-    }
-    delete [] argv_;
-  }
-
   static void store_cmdline_args(int argc, char **argv) {
     orig_args_ = std::vector<std::string>(argv, argv + argc);
   }
 
   static std::vector<std::string> orig_args_;
-
-  int argc_ = 0;
-  char** argv_ = nullptr;
 };
 
 template <typename TestBase>

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -110,6 +110,10 @@ struct TestParallelHarnessAny : TestHarnessAny<TestBase> {
     auto const new_args = injectAdditionalArgs(test_argc, test_argv);
     auto custom_argc = new_args.first;
     auto custom_argv = new_args.second;
+    vtAssert(
+      custom_argv[custom_argc] == nullptr,
+      "The value of argv[argc] should always be 0"
+    );
     CollectiveOps::initialize(custom_argc, custom_argv, no_workers, true, &comm);
 
 #if DEBUG_TEST_HARNESS_PRINT
@@ -157,7 +161,8 @@ private:
 
     addAdditionalArgs();
 
-    int custom_argc = additional_args_.size();
+    additional_args_.emplace_back(nullptr);
+    int custom_argc = additional_args_.size() - 1;
     char** custom_argv = additional_args_.data();
 
     return std::make_pair(custom_argc, custom_argv);

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -99,9 +99,6 @@ struct TestParallelHarnessAny : TestHarnessAny<TestBase> {
 
 #if vt_feature_cmake_test_trace_on
     static char traceon[]{"--vt_trace=1"};
-#endif
-
-#if vt_feature_cmake_test_trace_on
     addArgs(traceon);
 #endif
 

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -58,6 +58,9 @@
 
 namespace vt { namespace tests { namespace unit {
 
+extern int test_argc;
+extern char** test_argv;
+
 /*
  *  gtest runs many tests in the same binary, but there is no way to know when
  *  to call MPI_Finalize, which can only be called once (when it's called


### PR DESCRIPTION
fixes #1199 