### PR TITLE
1204 Documentation building: use latest version and remove assertion from m.css

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -134,8 +134,10 @@ then
     git clone "https://${token}@github.com/DARMA-tasking/DARMA-tasking.github.io"
     git clone https://github.com/mosra/m.css
     cd m.css
-    git checkout 6eefd92c2aa3e0a257503d31b1a469867dfff8b6
+    git checkout master
     cd ../
+
+    sed -i 's/assert len(self.children) < 16 and len(self.results) < 2048/\#removed assertion/' ./m.css/documentation/_search.py
 
     "$MCSS/documentation/doxygen.py" Doxyfile-mcss
     cp -R docs "$GHPAGE"


### PR DESCRIPTION
Fixes #1204

m.css has an assertion that limits the number of serialized children
and results used to build search strings by organizing them in a trie.
Commit 3fb8439 in VT introduced a new `serialize` method for
`LBManager`, which caused the number of children to exceed the amount
of storage allocated (4 bits or 16 children) due to the number of
related `serialize` methods. This commit updates VT to use the latest
version of m.css and removes the assertion during trie building for
search strings. This might cause strange behavior in searching, but
won't affect the rest of the documentation generation. A bug has been
submitted so we can hopefully remove this once they fix the bug:

https://github.com/mosra/m.css/issues/190