### PR TITLE
#1211: Fix warning about missing default ctor for member SendInfo

### DIFF
--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -178,7 +178,6 @@ EventType ActiveMessenger::sendMsgBytesWithPut(
 }
 
 struct MultiMsg : vt::Message {
-  MultiMsg() = default;
   MultiMsg(SendInfo in_info, NodeType in_from, MsgSizeType in_size)
     : info(in_info),
       from(in_from),


### PR DESCRIPTION
Fixes #1211