### PR TITLE
#1217: Check for zero objects on a MPI rank/node case after LB runs

### DIFF
--- a/docs/md/collection.md
+++ b/docs/md/collection.md
@@ -11,9 +11,12 @@ location to manage the location of these elements to efficiently deliver
 messages. It also utilizes the \ref group to build a spanning tree across
 the nodes that the collection is currently mapped to. This group makes
 broadcasts efficient and allows reductions to make progress without waiting for
-nodes that do not have collection elements. The \ref proc-stats component
-stores the statistics for live collections that then passes the instrumented
-data to the \ref lb-manager component to apply load balancing strategies.
+nodes that do not have collection elements.
+
+The \ref proc-stats component stores the statistics for live collections that
+then passes the instrumented data to the \ref lb-manager component to apply load
+balancing strategies. You can use `--vt_lb_keep_last_elm` flag to prohibit load
+balancer from migrating last element in collection.
 
 \section rooted-hello-world-collection Hello World 1D Dense Collection (Rooted)
 \snippet  examples/hello_world/hello_world_collection.cc Hello world collection

--- a/src/vt/configs/arguments/app_config.h
+++ b/src/vt/configs/arguments/app_config.h
@@ -137,6 +137,7 @@ struct AppConfig {
   std::string vt_lb_name      = "NoLB";
   std::string vt_lb_args      = "";
   int32_t vt_lb_interval      = 1;
+  bool vt_lb_keep_last_elm    = false;
   bool vt_lb_stats            = false;
   std::string vt_lb_stats_dir     = "vt_lb_stats";
   std::string vt_lb_stats_file    = "stats";

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -336,6 +336,7 @@ void ArgConfig::addLbArgs(CLI::App& app) {
   auto lb_show_spec  = "Show LB specification during startup";
   auto lb_name       = "Name of the load balancer to use";
   auto lb_interval   = "Load balancing interval";
+  auto lb_keep_last_elm = "Do not migrate last element in collection";
   auto lb_stats      = "Enable load balancing statistics";
   auto lb_stats_dir  = "Load balancing statistics output directory";
   auto lb_stats_file = "Load balancing statistics output file name";
@@ -355,6 +356,7 @@ void ArgConfig::addLbArgs(CLI::App& app) {
   auto v  = app.add_option("--vt_lb_name",       config_.vt_lb_name,        lb_name,      lbn);
   auto v1 = app.add_option("--vt_lb_args",       config_.vt_lb_args,        lb_args,      lba);
   auto w  = app.add_option("--vt_lb_interval",   config_.vt_lb_interval,    lb_interval,  lbi);
+  auto wl = app.add_flag("--vt_lb_keep_last_elm", config_.vt_lb_keep_last_elm, lb_keep_last_elm);
   auto ww = app.add_flag("--vt_lb_stats",        config_.vt_lb_stats,       lb_stats);
   auto wx = app.add_option("--vt_lb_stats_dir",  config_.vt_lb_stats_dir,   lb_stats_dir, lbd);
   auto wy = app.add_option("--vt_lb_stats_file", config_.vt_lb_stats_file,  lb_stats_file,lbs);
@@ -369,6 +371,7 @@ void ArgConfig::addLbArgs(CLI::App& app) {
   v->group(debugLB);
   v1->group(debugLB);
   w->group(debugLB);
+  wl->group(debugLB);
   ww->group(debugLB);
   wx->group(debugLB);
   wy->group(debugLB);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2836,7 +2836,7 @@ MigrateStatus CollectionManager::migrateOut(
    if (elm_holder->numElements() == 1 and theConfig()->vt_lb_keep_last_elm) {
      vt_debug_print(
        vrt_coll, node,
-       "migrateOut: do not migrate last element\n",
+       "migrateOut: do not migrate last element\n"
      );
      return MigrateStatus::ElementNotLocal;
    }

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2833,6 +2833,14 @@ MigrateStatus CollectionManager::migrateOut(
      elm_holder->numElements()
    );
 
+   if (elm_holder->numElements() == 1 and theConfig()->vt_lb_keep_last_elm) {
+     vt_debug_print(
+       vrt_coll, node,
+       "migrateOut: do not migrate last element\n",
+     );
+     return MigrateStatus::ElementNotLocal;
+   }
+
    auto& coll_elm_info = elm_holder->lookup(idx);
    auto map_fn = coll_elm_info.map_fn;
    auto range = coll_elm_info.max_idx;

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -80,14 +80,15 @@ void colHandler(MyMsg*, MyCol* col) {
   }
 }
 
-struct TestLoadBalancer : TestParallelHarnessParam<std::string> { };
+struct TestLoadBalancer : TestParallelHarnessParam<std::string> {
+  void runTest();
+};
 
-TEST_P(TestLoadBalancer, test_load_balancer_1) {
+void TestLoadBalancer::runTest() {
   auto lb_name = GetParam();
 
   vt::theConfig()->vt_lb = true;
   vt::theConfig()->vt_lb_name = lb_name;
-  vt::theConfig()->vt_lb_keep_last_elm = true;
   if (vt::theContext()->getNode() == 0) {
     fmt::print("Testing lb {}\n", lb_name);
   }
@@ -112,6 +113,16 @@ TEST_P(TestLoadBalancer, test_load_balancer_1) {
     // Go to the next phase.
     vt::thePhase()->nextPhaseCollective();
   }
+  return;
+}
+
+TEST_P(TestLoadBalancer, test_load_balancer_1) {
+  runTest();
+}
+
+TEST_P(TestLoadBalancer, test_load_balancer_keep_last_elm) {
+  vt::theConfig()->vt_lb_keep_last_elm = true;
+  runTest();
 }
 
 auto balancers = ::testing::Values(

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -87,6 +87,7 @@ TEST_P(TestLoadBalancer, test_load_balancer_1) {
 
   vt::theConfig()->vt_lb = true;
   vt::theConfig()->vt_lb_name = lb_name;
+  vt::theConfig()->vt_lb_keep_last_elm = true;
   if (vt::theContext()->getNode() == 0) {
     fmt::print("Testing lb {}\n", lb_name);
   }


### PR DESCRIPTION
fixes #1217 