### PR TITLE
868 remove temporary ids

### DIFF
--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -108,9 +108,9 @@ void BaseLB::importProcessorData(
 
     vt_debug_print_verbose(
       lb, node,
-      "\t {}: importProcessorData: this_load={}, obj={}, load={}, "
+      "\t {}: importProcessorData: this_load={}, obj={}, home={}, load={}, "
       "load_milli={}, bin={}\n",
-      this_node, this_load, obj, load, load_milli, bin
+      this_node, this_load, obj.id, obj.home_node, load, load_milli, bin
     );
   }
 
@@ -191,8 +191,8 @@ void BaseLB::applyMigrations(TransferVecType const &transfers) {
 
       vt_debug_print(
         lb, node,
-        "migrateObjectTo, obj_id={}, from={}, to={}, found={}\n",
-        obj_id, from, to, has_object
+        "migrateObjectTo, obj_id={}, home={}, from={}, to={}, found={}\n",
+        obj_id.id, obj_id.home_node, from, to, has_object
       );
 
       local_migration_count_++;

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -64,7 +64,7 @@ namespace vt { namespace vrt { namespace collection { namespace lb {
 static constexpr int32_t const default_bin_size = 10;
 
 struct BaseLB {
-  using ObjIDType        = balance::ElementIDType;
+  using ObjIDType        = balance::ElementIDStruct;
   using ObjBinType       = int32_t;
   using ObjBinListType   = std::list<ObjIDType>;
   using ObjSampleType    = std::map<ObjBinType, ObjBinListType>;

--- a/src/vt/vrt/collection/balance/elm_stats.cc
+++ b/src/vt/vrt/collection/balance/elm_stats.cc
@@ -88,26 +88,26 @@ void ElementStats::recvComm(
 }
 
 void ElementStats::recvObjData(
-  ElementIDType pto, ElementIDType tto,
-  ElementIDType pfrom, ElementIDType tfrom, double bytes, bool bcast
+  ElementIDStruct pto,
+  ElementIDStruct pfrom, double bytes, bool bcast
 ) {
-  LBCommKey key(LBCommKey::CollectionTag{}, pfrom, tfrom, pto, tto, bcast);
+  LBCommKey key(LBCommKey::CollectionTag{}, pfrom, pto, bcast);
   recvComm(key, bytes);
 }
 
 void ElementStats::recvFromNode(
-  ElementIDType pto, ElementIDType tto, NodeType from,
+  ElementIDStruct pto, NodeType from,
   double bytes, bool bcast
 ) {
-  LBCommKey key(LBCommKey::NodeToCollectionTag{}, from, pto, tto, bcast);
+  LBCommKey key(LBCommKey::NodeToCollectionTag{}, from, pto, bcast);
   recvComm(key, bytes);
 }
 
 void ElementStats::recvToNode(
-  NodeType to, ElementIDType pfrom, ElementIDType tfrom,
+  NodeType to, ElementIDStruct pfrom,
   double bytes, bool bcast
 ) {
-  LBCommKey key(LBCommKey::CollectionToNodeTag{}, pfrom, tfrom, to, bcast);
+  LBCommKey key(LBCommKey::CollectionToNodeTag{}, pfrom, to, bcast);
   recvComm(key, bytes);
 }
 

--- a/src/vt/vrt/collection/balance/elm_stats.h
+++ b/src/vt/vrt/collection/balance/elm_stats.h
@@ -71,15 +71,15 @@ struct ElementStats {
   void addTime(TimeType const& time);
   void recvComm(LBCommKey key, double bytes);
   void recvObjData(
-    ElementIDType to_perm, ElementIDType to_temp,
-    ElementIDType from_perm, ElementIDType from_temp, double bytes, bool bcast
+    ElementIDStruct to_perm,
+    ElementIDStruct from_perm, double bytes, bool bcast
   );
   void recvFromNode(
-    ElementIDType to_perm, ElementIDType to_temp, NodeType from,
+    ElementIDStruct to_perm, NodeType from,
     double bytes, bool bcast
   );
   void recvToNode(
-    NodeType to, ElementIDType from_perm, ElementIDType from_temp,
+    NodeType to, ElementIDStruct from_perm,
     double bytes, bool bcast
   );
   void updatePhase(PhaseType const& inc = 1);

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -420,12 +420,13 @@ void GossipLB::decide() {
         vt_debug_print(
           gossiplb, node,
           "GossipLB::decide: under.size()={}, selected_node={}, selected_load={},"
-          "obj_id={:x}, obj_load={}, avg={}, this_new_load_={}, "
+          "obj_id={:x}, home={}, obj_load={}, avg={}, this_new_load_={}, "
           "criterion={}\n",
           under.size(),
           selected_node,
           selected_load,
-          obj_id,
+          obj_id.id,
+          obj_id.home_node,
           obj_load,
           avg,
           this_new_load_,

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -210,8 +210,9 @@ void GreedyLB::runBalancer(
 GreedyLB::ObjIDType GreedyLB::objSetNode(
   NodeType const& node, ObjIDType const& id
 ) {
-  auto const new_id = id & 0xFFFFFFFF0000000;
-  return new_id | node;
+  auto new_id = id;
+  new_id.curr_node = node;
+  return new_id;
 }
 
 void GreedyLB::recvObjsDirect(GreedyLBTypes::ObjIDType* objs) {
@@ -223,7 +224,7 @@ void GreedyLB::recvObjsDirect(GreedyLBTypes::ObjIDType* objs) {
     "recvObjsDirect: num_recs={}\n", num_recs
   );
 
-  for (decltype(+num_recs) i = 0; i < num_recs; i++) {
+  for (decltype(+num_recs.id) i = 0; i < num_recs.id; i++) {
     auto const to_node = objGetNode(recs[i]);
     auto const new_obj_id = objSetNode(this_node,recs[i]);
     vt_debug_print(
@@ -274,7 +275,7 @@ void GreedyLB::transferObjs(std::vector<GreedyProc>&& in_load) {
       auto ptr_out = reinterpret_cast<GreedyLBTypes::ObjIDType*>(ptr);
       auto const& proc = node_transfer[node];
       auto const& rec_size = proc.size();
-      *ptr_out = rec_size;
+      ptr_out->id = rec_size;
       for (size_t i = 0; i < rec_size; i++) {
         *(ptr_out + i + 1) = proc[i];
       }

--- a/src/vt/vrt/collection/balance/greedylb/greedylb_types.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb_types.h
@@ -56,7 +56,7 @@
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
 struct GreedyLBTypes {
-  using ObjIDType = balance::ElementIDType;
+  using ObjIDType = balance::ElementIDStruct;
   using ObjBinType = int32_t;
   using ObjBinListType = std::list<ObjIDType>;
   using ObjSampleType = std::map<ObjBinType, ObjBinListType>;
@@ -76,7 +76,9 @@ struct GreedyRecord {
   ObjType getObj() const { return obj_; }
 
 private:
-  GreedyLBTypes::ObjIDType obj_ = 0;
+  GreedyLBTypes::ObjIDType obj_ = {
+    0, uninitialized_destination, uninitialized_destination
+  };
   LoadType load_ = 0.0f;
 };
 

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb_types.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb_types.h
@@ -56,7 +56,7 @@
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
 struct HierLBTypes {
-  using ObjIDType = balance::ElementIDType;
+  using ObjIDType = balance::ElementIDStruct;
   using ObjBinType = int32_t;
   using ObjBinListType = std::list<ObjIDType>;
   using ObjSampleType = std::map<ObjBinType, ObjBinListType>;

--- a/src/vt/vrt/collection/balance/lb_comm.h
+++ b/src/vt/vrt/collection/balance/lb_comm.h
@@ -188,7 +188,7 @@ template <>
 struct hash<LBCommKeyType> {
   size_t operator()(LBCommKeyType const& in) const {
     return std::hash<uint64_t>()(
-      std::hash<ElementIDStructType>()(in.from_) ^ 
+      std::hash<ElementIDStructType>()(in.from_) ^
       std::hash<ElementIDStructType>()(in.to_) ^ in.nfrom_ ^ in.nto_
     );
   }

--- a/src/vt/vrt/collection/balance/lb_comm.h
+++ b/src/vt/vrt/collection/balance/lb_comm.h
@@ -103,7 +103,7 @@ struct LBCommKey {
   ElementIDStruct from_ = { no_element_id, uninitialized_destination, uninitialized_destination };
   ElementIDStruct to_   = { no_element_id, uninitialized_destination, uninitialized_destination };
 
-  ElementIDType edge_id_   = no_element_id;
+  ElementIDStruct edge_id_ = { no_element_id, uninitialized_destination, uninitialized_destination };
   NodeType nfrom_          = uninitialized_destination;
   NodeType nto_            = uninitialized_destination;
   CommCategory  cat_       = CommCategory::SendRecv;
@@ -112,7 +112,7 @@ struct LBCommKey {
   ElementIDStruct toObj()      const { return to_; }
   ElementIDType fromNode()     const { return nfrom_; }
   ElementIDType toNode()       const { return nto_; }
-  ElementIDType edgeID()       const { return edge_id_; }
+  ElementIDStruct edgeID()     const { return edge_id_; }
 
   bool selfEdge() const { return cat_ == CommCategory::SendRecv and from_ == to_; }
   bool offNode() const {

--- a/src/vt/vrt/collection/balance/lb_common.cc
+++ b/src/vt/vrt/collection/balance/lb_common.cc
@@ -46,6 +46,7 @@
 #include "vt/vrt/collection/balance/lb_common.h"
 
 #include <ostream>
+#include <fmt/ostream.h>
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 

--- a/src/vt/vrt/collection/balance/lb_common.cc
+++ b/src/vt/vrt/collection/balance/lb_common.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                multiple_phases.h
+//                                 lb_common.cc
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //
@@ -42,50 +42,18 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_MODEL_MULTIPLE_PHASES_H
-#define INCLUDED_VT_VRT_COLLECTION_BALANCE_MODEL_MULTIPLE_PHASES_H
+#include "vt/config.h"
+#include "vt/vrt/collection/balance/lb_common.h"
 
-#include "vt/vrt/collection/balance/model/composed_model.h"
+#include <ostream>
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-/**
- * \struct MultiplePhases
- *
- * \brief Predict an object's load as a sum over blocks of N future phases
- *
- * Expected to be most useful either when queried by an explicitly
- * subphase-aware vector-optimizing load balancer, or when queried by
- * a whole-phase scalar-optimizing load balancer with a Norm model
- * composed on top of this.
- *
- * Multiple phase blocked predictions will only be meaningfully
- * different from single phase predictions when composed on top of a
- * Predictor model that is not constant across future
- * phases. I.e. `LinearModel` rather than `NaivePersistence` or
- * `PersistenceMedianLastN`.
- */
-struct MultiplePhases : ComposedModel {
-  /**
-   * \brief Constructor
-   *
-   * \param[in] base the base model
-   *
-   * \param[in] in_future_phase_block_size how many phases to predict
-   * as each single queried phase
-   */
-  explicit MultiplePhases(
-    std::shared_ptr<balance::LoadModel> base, int in_future_phase_block_size)
-    : ComposedModel(base)
-    , future_phase_block_size_(in_future_phase_block_size)
-  { }
-
-  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
-
-private:
-  int future_phase_block_size_ = 0;
-};
+std::ostream& operator<<(
+  std::ostream& os, const ::vt::vrt::collection::balance::ElementIDStruct& id
+) {
+  os << "(" << id.id << "," << id.home_node << "," << id.curr_node << ")";
+  return os;
+}
 
 }}}} /* end namespace vt::vrt::collection::balance */
-
-#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_MODEL_MULTIPLE_PHASES_H*/

--- a/src/vt/vrt/collection/balance/lb_common.h
+++ b/src/vt/vrt/collection/balance/lb_common.h
@@ -56,6 +56,26 @@ namespace balance {
 
 using ElementIDType = uint64_t;
 
+struct ElementIDStruct {
+  using isByteCopyable = std::true_type;
+
+  ElementIDType id = 0;
+  NodeType home_node = uninitialized_destination;
+  NodeType curr_node = uninitialized_destination;
+
+  bool operator==(const ElementIDStruct& rhs) const {
+    return id == rhs.id and home_node == rhs.home_node;
+  }
+
+  bool operator<(const ElementIDStruct& rhs) const {
+    return id < rhs.id;
+  }
+};
+
+std::ostream& operator<<(
+  std::ostream& os, const ::vt::vrt::collection::balance::ElementIDStruct& id
+);
+
 static constexpr ElementIDType const no_element_id = 0;
 
 using LoadMapType         = std::unordered_map<ElementIDType,TimeType>;
@@ -106,5 +126,19 @@ namespace vt { namespace vrt { namespace collection { namespace lb {
 extern std::unordered_map<Statistic,std::string> lb_stat_name_;
 
 }}}} /* end namespace vt::vrt::collection::lb */
+
+namespace std {
+
+using ElementIDStructType = vt::vrt::collection::balance::ElementIDStruct;
+using ElementIDMemberType = vt::vrt::collection::balance::ElementIDType;
+
+template <>
+struct hash<ElementIDStructType> {
+  size_t operator()(ElementIDStructType const& in) const {
+    return std::hash<ElementIDMemberType>()(in.id);
+  }
+};
+
+} /* end namespace std */
 
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_LB_COMMON_H*/

--- a/src/vt/vrt/collection/balance/lb_common.h
+++ b/src/vt/vrt/collection/balance/lb_common.h
@@ -52,6 +52,8 @@
 #include <unordered_map>
 #include <ostream>
 
+#include <fmt/ostream.h>
+
 namespace vt { namespace vrt { namespace collection {
 namespace balance {
 

--- a/src/vt/vrt/collection/balance/lb_common.h
+++ b/src/vt/vrt/collection/balance/lb_common.h
@@ -50,6 +50,7 @@
 
 #include <cstdlib>
 #include <unordered_map>
+#include <ostream>
 
 namespace vt { namespace vrt { namespace collection {
 namespace balance {
@@ -78,8 +79,8 @@ std::ostream& operator<<(
 
 static constexpr ElementIDType const no_element_id = 0;
 
-using LoadMapType         = std::unordered_map<ElementIDType,TimeType>;
-using SubphaseLoadMapType = std::unordered_map<ElementIDType, std::vector<TimeType>>;
+using LoadMapType         = std::unordered_map<ElementIDStruct,TimeType>;
+using SubphaseLoadMapType = std::unordered_map<ElementIDStruct, std::vector<TimeType>>;
 } /* end namespace balance */
 
 namespace lb {

--- a/src/vt/vrt/collection/balance/lb_common.h
+++ b/src/vt/vrt/collection/balance/lb_common.h
@@ -60,12 +60,13 @@ using ElementIDType = uint64_t;
 struct ElementIDStruct {
   using isByteCopyable = std::true_type;
 
+  // id must be unique across nodes
   ElementIDType id = 0;
   NodeType home_node = uninitialized_destination;
   NodeType curr_node = uninitialized_destination;
 
   bool operator==(const ElementIDStruct& rhs) const {
-    return id == rhs.id and home_node == rhs.home_node;
+    return id == rhs.id;
   }
 
   bool operator<(const ElementIDStruct& rhs) const {

--- a/src/vt/vrt/collection/balance/model/comm_overhead.cc
+++ b/src/vt/vrt/collection/balance/model/comm_overhead.cc
@@ -62,7 +62,7 @@ void CommOverhead::setLoads(std::unordered_map<PhaseType, LoadMapType> const* pr
   ComposedModel::setLoads(proc_load, proc_subphase_load, proc_comm);
 }
 
-TimeType CommOverhead::getWork(ElementIDType object, PhaseOffset offset) {
+TimeType CommOverhead::getWork(ElementIDStruct object, PhaseOffset offset) {
   auto work = ComposedModel::getWork(object, offset);
 
   auto phase = getNumCompletedPhases() + offset.phases;
@@ -71,7 +71,7 @@ TimeType CommOverhead::getWork(ElementIDType object, PhaseOffset offset) {
   TimeType overhead = 0.;
   for (auto&& c : comm) {
     // find messages that go off-node and are sent to this object
-    if (c.first.offNode() and c.first.toObjTemp() == object) {
+    if (c.first.offNode() and c.first.toObj() == object) {
       overhead += per_msg_weight_ * c.second.messages;
       overhead += per_byte_weight_ * c.second.bytes;
     }

--- a/src/vt/vrt/collection/balance/model/comm_overhead.h
+++ b/src/vt/vrt/collection/balance/model/comm_overhead.h
@@ -70,7 +70,7 @@ struct CommOverhead : public ComposedModel {
                 std::unordered_map<PhaseType, SubphaseLoadMapType> const* proc_subphase_load,
                 std::unordered_map<PhaseType, CommMapType> const* proc_comm) override;
 
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
 
 private:
   std::unordered_map<PhaseType, CommMapType> const* proc_comm_; /**< Underlying comm data */

--- a/src/vt/vrt/collection/balance/model/composed_model.cc
+++ b/src/vt/vrt/collection/balance/model/composed_model.cc
@@ -56,7 +56,7 @@ void ComposedModel::updateLoads(PhaseType last_completed_phase) {
   base_->updateLoads(last_completed_phase);
 }
 
-TimeType ComposedModel::getWork(ElementIDType object, PhaseOffset when) {
+TimeType ComposedModel::getWork(ElementIDStruct object, PhaseOffset when) {
   return base_->getWork(object, when);
 }
 

--- a/src/vt/vrt/collection/balance/model/composed_model.h
+++ b/src/vt/vrt/collection/balance/model/composed_model.h
@@ -71,7 +71,7 @@ public:
 
   void updateLoads(PhaseType last_completed_phase) override;
 
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) override;
 
   ObjectIterator begin() override;

--- a/src/vt/vrt/collection/balance/model/linear_model.cc
+++ b/src/vt/vrt/collection/balance/model/linear_model.cc
@@ -49,7 +49,7 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-TimeType LinearModel::getWork(ElementIDType object, PhaseOffset when) {
+TimeType LinearModel::getWork(ElementIDStruct object, PhaseOffset when) {
   using util::stats::LinearRegression;
 
   // Retrospective queries don't call for a prediction

--- a/src/vt/vrt/collection/balance/model/linear_model.h
+++ b/src/vt/vrt/collection/balance/model/linear_model.h
@@ -70,7 +70,7 @@ struct LinearModel : ComposedModel {
       past_len_(in_past_len)
   { }
 
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) override;
 
 private:

--- a/src/vt/vrt/collection/balance/model/load_model.h
+++ b/src/vt/vrt/collection/balance/model/load_model.h
@@ -134,7 +134,7 @@ public:
    * The `updateLoads` method must have been called before any call to
    * this.
    */
-  virtual TimeType getWork(ElementIDType object, PhaseOffset when) = 0;
+  virtual TimeType getWork(ElementIDStruct object, PhaseOffset when) = 0;
 
   /**
    * \brief Compute how many phases of past load statistics need to be

--- a/src/vt/vrt/collection/balance/model/multiple_phases.cc
+++ b/src/vt/vrt/collection/balance/model/multiple_phases.cc
@@ -46,7 +46,7 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-TimeType MultiplePhases::getWork(ElementIDType object, PhaseOffset when) {
+TimeType MultiplePhases::getWork(ElementIDStruct object, PhaseOffset when) {
   // Retrospective queries don't call for a prediction
   if (when.phases < 0)
     return ComposedModel::getWork(object, when);

--- a/src/vt/vrt/collection/balance/model/naive_persistence.cc
+++ b/src/vt/vrt/collection/balance/model/naive_persistence.cc
@@ -51,7 +51,7 @@ NaivePersistence::NaivePersistence(std::shared_ptr<balance::LoadModel> base)
   : ComposedModel(base)
 { }
 
-TimeType NaivePersistence::getWork(ElementIDType object, PhaseOffset offset)
+TimeType NaivePersistence::getWork(ElementIDStruct object, PhaseOffset offset)
 {
   if (offset.phases >= 0)
     offset.phases = -1;

--- a/src/vt/vrt/collection/balance/model/naive_persistence.h
+++ b/src/vt/vrt/collection/balance/model/naive_persistence.h
@@ -61,7 +61,7 @@ struct NaivePersistence : public ComposedModel {
    * \param[in] base: The source of underlying load numbers to return; must not be null
    */
   explicit NaivePersistence(std::shared_ptr<balance::LoadModel> base);
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) override;
 }; // class NaivePersistence
 

--- a/src/vt/vrt/collection/balance/model/norm.cc
+++ b/src/vt/vrt/collection/balance/model/norm.cc
@@ -56,7 +56,7 @@ Norm::Norm(std::shared_ptr<balance::LoadModel> base, double power)
   vtAssert(power >= 0.0, "Reciprocal loads make no sense");
 }
 
-TimeType Norm::getWork(ElementIDType object, PhaseOffset offset)
+TimeType Norm::getWork(ElementIDStruct object, PhaseOffset offset)
 {
   if (offset.subphase != PhaseOffset::WHOLE_PHASE)
     return ComposedModel::getWork(object, offset);

--- a/src/vt/vrt/collection/balance/model/norm.h
+++ b/src/vt/vrt/collection/balance/model/norm.h
@@ -65,7 +65,7 @@ public:
    */
   Norm(std::shared_ptr<balance::LoadModel> base, double power);
 
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
 
 private:
   const double power_;

--- a/src/vt/vrt/collection/balance/model/per_collection.cc
+++ b/src/vt/vrt/collection/balance/model/per_collection.cc
@@ -70,7 +70,7 @@ void PerCollection::updateLoads(PhaseType last_completed_phase) {
   ComposedModel::updateLoads(last_completed_phase);
 }
 
-TimeType PerCollection::getWork(ElementIDType object, PhaseOffset when) {
+TimeType PerCollection::getWork(ElementIDStruct object, PhaseOffset when) {
   // See if some specific model has been given for the object in question
   auto mi = models_.find(theNodeStats()->getCollectionProxyForElement(object));
   if (mi != models_.end())

--- a/src/vt/vrt/collection/balance/model/per_collection.h
+++ b/src/vt/vrt/collection/balance/model/per_collection.h
@@ -80,7 +80,7 @@ struct PerCollection : public ComposedModel
 
   void updateLoads(PhaseType last_completed_phase) override;
 
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) override;
 
 private:

--- a/src/vt/vrt/collection/balance/model/persistence_median_last_n.cc
+++ b/src/vt/vrt/collection/balance/model/persistence_median_last_n.cc
@@ -55,7 +55,7 @@ PersistenceMedianLastN::PersistenceMedianLastN(std::shared_ptr<LoadModel> base, 
   vtAssert(n > 0, "Cannot take a median over no phases");
 }
 
-TimeType PersistenceMedianLastN::getWork(ElementIDType object, PhaseOffset when)
+TimeType PersistenceMedianLastN::getWork(ElementIDStruct object, PhaseOffset when)
 {
   // Retrospective queries don't call for a prospective calculation
   if (when.phases < 0)

--- a/src/vt/vrt/collection/balance/model/persistence_median_last_n.h
+++ b/src/vt/vrt/collection/balance/model/persistence_median_last_n.h
@@ -66,7 +66,7 @@ struct PersistenceMedianLastN : public ComposedModel
    */
   PersistenceMedianLastN(std::shared_ptr<LoadModel> base, unsigned int n);
 
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) override;
 
 private:

--- a/src/vt/vrt/collection/balance/model/raw_data.cc
+++ b/src/vt/vrt/collection/balance/model/raw_data.cc
@@ -83,7 +83,7 @@ int RawData::getNumSubphases() {
   return subphases.size();
 }
 
-TimeType RawData::getWork(ElementIDType object, PhaseOffset offset)
+TimeType RawData::getWork(ElementIDStruct object, PhaseOffset offset)
 {
   vtAssert(offset.phases < 0,
 	   "RawData makes no predictions. Compose with NaivePersistence or some longer-range forecasting model as needed");

--- a/src/vt/vrt/collection/balance/model/raw_data.h
+++ b/src/vt/vrt/collection/balance/model/raw_data.h
@@ -60,7 +60,7 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 struct RawData : public LoadModel {
   RawData() = default;
   void updateLoads(PhaseType last_completed_phase) override;
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
 
   void setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
                 std::unordered_map<PhaseType, SubphaseLoadMapType> const* proc_subphase_load,

--- a/src/vt/vrt/collection/balance/model/select_subphases.cc
+++ b/src/vt/vrt/collection/balance/model/select_subphases.cc
@@ -59,7 +59,7 @@ SelectSubphases::SelectSubphases(std::shared_ptr<LoadModel> base, std::vector<un
   //vtAssert(subphases_.size() < base_subphases, "...");
 }
 
-TimeType SelectSubphases::getWork(ElementIDType object, PhaseOffset when) {
+TimeType SelectSubphases::getWork(ElementIDStruct object, PhaseOffset when) {
   if (when.subphase == PhaseOffset::WHOLE_PHASE) {
     // Sum up the selected subphases as if they represent the entire phase
     TimeType sum = 0.0;

--- a/src/vt/vrt/collection/balance/model/select_subphases.h
+++ b/src/vt/vrt/collection/balance/model/select_subphases.h
@@ -69,7 +69,7 @@ public:
    */
   SelectSubphases(std::shared_ptr<LoadModel> base, std::vector<unsigned int> subphases);
 
-  TimeType getWork(ElementIDType object, PhaseOffset when) override;
+  TimeType getWork(ElementIDStruct object, PhaseOffset when) override;
   int getNumSubphases() override;
 
   std::vector<unsigned int> subphases_;

--- a/src/vt/vrt/collection/balance/node_stats.h
+++ b/src/vt/vrt/collection/balance/node_stats.h
@@ -109,9 +109,9 @@ public:
    * \param[in] time the time the object took
    * \param[in] comm the comm graph for the object
    *
-   * \return the temporary ID for the object assigned for this phase
+   * \return the ID struct for the object assigned for this phase
    */
-  ElementIDType addNodeStats(
+  ElementIDStruct addNodeStats(
     Migratable* col_elm,
     PhaseType const& phase, TimeType const& time,
     std::vector<TimeType> const& subphase_time,
@@ -124,7 +124,7 @@ public:
   void clearStats();
 
   /**
-   * \internal \brief Cleanup after LB runs; convert temporary to permanent IDs
+   * \internal \brief Cleanup after LB runs
    */
   void startIterCleanup(PhaseType phase, unsigned int look_back);
 
@@ -162,7 +162,7 @@ public:
   /**
    * \internal \brief Generate the next object element ID for LB
    */
-  ElementIDType getNextElm();
+  ElementIDStruct getNextElm();
 
   /**
    * \internal \brief Get stored object loads
@@ -195,50 +195,31 @@ public:
   /**
    * \internal \brief Test if this node has an object to migrate
    *
-   * \param[in] obj_id the object temporary ID
+   * \param[in] obj_id the object ID struct
    *
    * \return whether this node has the object
    */
-  bool hasObjectToMigrate(ElementIDType obj_id) const;
+  bool hasObjectToMigrate(ElementIDStruct obj_id) const;
 
   /**
    * \internal \brief Migrate an local object to another node
    *
-   * \param[in] obj_id the object temporary ID
+   * \param[in] obj_id the object ID struct
    * \param[in] to_node the node to migrate to
    *
    * \return whether this node has the object
    */
-  bool migrateObjTo(ElementIDType obj_id, NodeType to_node);
-
-  /**
-   * \internal \brief Convert temporary element ID to permanent Returns
-   * \c no_element_id if not found.
-   * \param[in] temp_id temporary ID
-   *
-   * \return permanent ID
-   */
-  ElementIDType tempToPerm(ElementIDType temp_id) const;
-
-  /**
-   * \internal \brief Convert permanent element ID to temporary. Returns
-   * \c no_element_id if not found.
-   *
-   * \param[in] perm_id permanent ID
-   *
-   * \return temporary ID
-   */
-  ElementIDType permToTemp(ElementIDType perm_id) const;
+  bool migrateObjTo(ElementIDStruct obj_id, NodeType to_node);
 
   /**
    * \internal \brief Get the collection proxy for a given element ID
    *
-   * \param[in] temp_id the temporary ID for the element for a given phase
+   * \param[in] obj_id the ID struct for the element
    *
    * \return the virtual proxy if the element is part of the collection;
    * otherwise \c no_vrt_proxy
    */
-  VirtualProxyType getCollectionProxyForElement(ElementIDType temp_id) const;
+  VirtualProxyType getCollectionProxyForElement(ElementIDStruct obj_id) const;
 
   void initialize() override;
   void finalize() override;
@@ -249,8 +230,6 @@ public:
       | node_data_
       | node_subphase_data_
       | node_migrate_
-      | node_temp_to_perm_
-      | node_perm_to_temp_
       | node_collection_lookup_
       | node_comm_
       | next_elm_
@@ -278,13 +257,9 @@ private:
   /// Node subphase timings for each local object
   std::unordered_map<PhaseType, SubphaseLoadMapType> node_subphase_data_;
   /// Local migration type-free lambdas for each object
-  std::unordered_map<ElementIDType,MigrateFnType> node_migrate_;
-  /// Map of temporary ID to permanent ID
-  std::unordered_map<ElementIDType,ElementIDType> node_temp_to_perm_;
-  /// Map of permanent ID to temporary ID
-  std::unordered_map<ElementIDType,ElementIDType> node_perm_to_temp_;
-  /// Map from element temporary ID to the collection's virtual proxy (untyped)
-  std::unordered_map<ElementIDType,VirtualProxyType> node_collection_lookup_;
+  std::unordered_map<ElementIDStruct,MigrateFnType> node_migrate_;
+  /// Map from element ID to the collection's virtual proxy (untyped)
+  std::unordered_map<ElementIDStruct,VirtualProxyType> node_collection_lookup_;
   /// Node communication graph for each local object
   std::unordered_map<PhaseType, CommMapType> node_comm_;
   /// Node communication graph for each subphase

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.cc
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.cc
@@ -95,8 +95,8 @@ void RandomLB::runLB() {
     if (to_node != this_node) {
       vt_debug_print(
         lb, node,
-        "RandomLB: migrating obj={:x} from={} to={}\n",
-        *it, this_node, to_node
+        "RandomLB: migrating obj={:x} home={} from={} to={}\n",
+        it->id, it->home_node, this_node, to_node
       );
       migrateObjectTo(*it, to_node);
     }

--- a/src/vt/vrt/collection/balance/statsmaplb/statsmaplb.cc
+++ b/src/vt/vrt/collection/balance/statsmaplb/statsmaplb.cc
@@ -58,11 +58,9 @@ void StatsMapLB::init(objgroup::proxy::Proxy<StatsMapLB> in_proxy) {
 void StatsMapLB::runLB() {
   auto const& myNewList = theStatsReader()->getMoveList(phase_);
   for (size_t in = 0; in < myNewList.size(); in += 2) {
-    auto temp_id = theNodeStats()->permToTemp(myNewList[in]);
-
-    vtAssert(temp_id != balance::no_element_id, "Must have valid ID here");
-
-    migrateObjectTo(temp_id, myNewList[in+1]);
+    auto this_node = theContext()->getNode();
+    ObjIDType id{myNewList[in], this_node, this_node};
+    migrateObjectTo(id, myNewList[in+1]);
   }
 
   theStatsReader()->clearMoveList(phase_);

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
@@ -120,7 +120,6 @@ private:
   };
 
   void recvSharedEdges(CommMsg* msg);
-  void recvEdgeGID(CommMsg* msg);
 
 private:
   static int getNumberOfVertices(void *data, int *ierr);
@@ -146,7 +145,6 @@ private:
   objgroup::proxy::Proxy<ZoltanLB> proxy = {};
   Zoltan_Struct* zoltan_ = nullptr;
   bool do_edges_ = false;
-  bool use_shared_edges_ = false;
   std::unordered_map<std::string, std::string> zoltan_config_;
   ElementCommType load_comm_symm;
   ElementCommType load_comm_edge_id;

--- a/src/vt/vrt/collection/manager.cc
+++ b/src/vt/vrt/collection/manager.cc
@@ -84,19 +84,14 @@ getDispatcher(auto_registry::AutoHandlerType const han) {
   return theCollection()->getDispatcher(han);
 }
 
-balance::ElementIDType CollectionManager::getCurrentContextPerm() const {
-  return cur_context_perm_elm_id_;
-}
-
-balance::ElementIDType CollectionManager::getCurrentContextTemp() const {
-  return cur_context_temp_elm_id_;
+balance::ElementIDStruct CollectionManager::getCurrentContext() const {
+  return cur_context_elm_id_;
 }
 
 void CollectionManager::setCurrentContext(
-  balance::ElementIDType perm, balance::ElementIDType temp
+  balance::ElementIDStruct elm
 ) {
-  cur_context_perm_elm_id_ = perm;
-  cur_context_temp_elm_id_ = temp;
+  cur_context_elm_id_ = elm;
 }
 
 void CollectionManager::schedule(ActionType action) {

--- a/src/vt/vrt/collection/manager.h
+++ b/src/vt/vrt/collection/manager.h
@@ -1870,8 +1870,7 @@ public:
       | user_insert_action_
       | dist_tag_id_
       | release_lb_
-      | cur_context_temp_elm_id_
-      | cur_context_perm_elm_id_
+      | cur_context_elm_id_
       | collect_stats_for_lb_;
   }
 
@@ -1889,29 +1888,20 @@ private:
   static BcastBufferType<ColT> broadcasts_;
 
   /**
-   * \internal \brief Get the current LB temporary element ID based on handler
+   * \internal \brief Get the current LB element ID struct based on handler
    * context
    *
    * \return the element ID
    */
-  balance::ElementIDType getCurrentContextTemp() const;
-
-  /**
-   * \internal \brief Get the current LB permanent element ID based on handler
-   * context
-   *
-   * \return the element ID
-   */
-  balance::ElementIDType getCurrentContextPerm() const;
+  balance::ElementIDStruct getCurrentContext() const;
 
   /**
    * \internal \brief Set the current LB element ID
    *
-   * \param[in] elm_perm permanent ID
-   * \param[in] elm_temp temporary ID
+   * \param[in] elm ID struct
    */
   void setCurrentContext(
-    balance::ElementIDType elm_perm, balance::ElementIDType elm_temp
+    balance::ElementIDStruct elm
   );
 
   /**
@@ -2071,8 +2061,9 @@ private:
   std::unordered_map<VirtualProxyType,ActionVecType> user_insert_action_ = {};
   std::unordered_map<TagType,VirtualIDType> dist_tag_id_ = {};
   std::unordered_map<VirtualProxyType,ActionType> release_lb_ = {};
-  balance::ElementIDType cur_context_temp_elm_id_ = balance::no_element_id;
-  balance::ElementIDType cur_context_perm_elm_id_ = balance::no_element_id;
+  balance::ElementIDStruct cur_context_elm_id_ = {
+    balance::no_element_id, uninitialized_destination, uninitialized_destination
+  };
 };
 
 // These are static variables in class templates because Intel 18

--- a/src/vt/vrt/collection/messages/user.h
+++ b/src/vt/vrt/collection/messages/user.h
@@ -115,9 +115,8 @@ struct CollectionMessage : RoutedMessageType<BaseMsgT, ColT> {
   #if vt_check_enabled(lblite)
     bool lbLiteInstrument() const;
     void setLBLiteInstrument(bool const& val);
-    balance::ElementIDType getElm() const;
-    balance::ElementIDType getElmTemp() const;
-    void setElm(balance::ElementIDType perm, balance::ElementIDType temp);
+    balance::ElementIDStruct getElm() const;
+    void setElm(balance::ElementIDStruct elm);
     balance::CommCategory getCat() const;
     void setCat(balance::CommCategory cat);
   #endif
@@ -142,8 +141,9 @@ private:
      * (sendMsg,broadcastMsg) they are automatically instrumented
      */
     bool lb_lite_instrument_ = false;
-    balance::ElementIDType elm_perm_ = 0;
-    balance::ElementIDType elm_temp_ = 0;
+    balance::ElementIDStruct elm_ = {
+      0, uninitialized_destination, uninitialized_destination
+    };
     balance::CommCategory cat_ = balance::CommCategory::SendRecv;
   #endif
 

--- a/src/vt/vrt/collection/messages/user.impl.h
+++ b/src/vt/vrt/collection/messages/user.impl.h
@@ -125,8 +125,7 @@ void CollectionMessage<ColT, BaseMsgT>::serialize(SerializerT& s) {
 
   #if vt_check_enabled(lblite)
     s | lb_lite_instrument_;
-    s | elm_perm_;
-    s | elm_temp_;
+    s | elm_;
     s | cat_;
   #endif
 
@@ -157,21 +156,15 @@ void CollectionMessage<ColT, BaseMsgT>::setLBLiteInstrument(bool const& val) {
 }
 
 template <typename ColT, typename BaseMsgT>
-balance::ElementIDType CollectionMessage<ColT, BaseMsgT>::getElm() const {
-  return elm_perm_;
+balance::ElementIDStruct CollectionMessage<ColT, BaseMsgT>::getElm() const {
+  return elm_;
 }
 
 template <typename ColT, typename BaseMsgT>
 void CollectionMessage<ColT, BaseMsgT>::setElm(
-  balance::ElementIDType perm, balance::ElementIDType temp
+  balance::ElementIDStruct elm
 ) {
-  elm_perm_ = perm;
-  elm_temp_ = temp;
-}
-
-template <typename ColT, typename BaseMsgT>
-balance::ElementIDType CollectionMessage<ColT, BaseMsgT>::getElmTemp() const {
-  return elm_temp_;
+  elm_ = elm;
 }
 
 template <typename ColT, typename BaseMsgT>

--- a/src/vt/vrt/collection/types/migratable.cc
+++ b/src/vt/vrt/collection/types/migratable.cc
@@ -50,8 +50,7 @@
 namespace vt { namespace vrt { namespace collection {
 
 Migratable::Migratable()
-  : stats_elm_id_(theNodeStats()->getNextElm()),
-    temp_elm_id_(theNodeStats()->getNextElm())
+  : elm_id_(theNodeStats()->getNextElm())
 { }
 
 /*virtual*/ void Migratable::destroy() {

--- a/src/vt/vrt/collection/types/migratable.h
+++ b/src/vt/vrt/collection/types/migratable.h
@@ -100,8 +100,7 @@ struct Migratable : MigrateHookBase, storage::Storable {
    */
   virtual void destroy();
 
-  balance::ElementIDType getElmID() const { return stats_elm_id_; }
-  balance::ElementIDType getTempID() const { return temp_elm_id_; }
+  balance::ElementIDStruct getElmID() const { return elm_id_; }
 
 protected:
   template <typename Serializer>
@@ -114,8 +113,7 @@ protected:
 public:
   balance::ElementStats& getStats() { return stats_; }
 protected:
-  balance::ElementIDType stats_elm_id_ = 0;
-  balance::ElementIDType temp_elm_id_ = 0;
+  balance::ElementIDStruct elm_id_ = {0, uninitialized_destination, uninitialized_destination};
 };
 
 }}} /* end namespace vt::vrt::collection */

--- a/src/vt/vrt/collection/types/migratable.impl.h
+++ b/src/vt/vrt/collection/types/migratable.impl.h
@@ -55,8 +55,7 @@ void Migratable::serialize(Serializer& s) {
   MigrateHookBase::serialize(s);
   storage::Storable::serialize(s);
   s | stats_;
-  s | stats_elm_id_;
-  s | temp_elm_id_;
+  s | elm_id_;
 }
 
 }}} /* end namespace vt::vrt::collection */

--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -116,68 +116,75 @@ private:
 };
 
 TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
-  ProcLoadMap proc_load = {
-    {0,
-     LoadMapType{
-       {ElementIDType{1}, TimeType{60}},
-       {ElementIDType{2}, TimeType{150}},
-       {ElementIDType{3}, TimeType{75}}}}};
+
+  // For simplicity's sake both temp and perm IDs are the same
+  // Element 1 (home node == 1)
+  auto const elem1_permID = ElementIDType{1};
+  auto const elem1_tempID = ElementIDType{1};
+
+  // Element 2 (home node == 2)
+  auto const elem2_permID = ElementIDType{2};
+  auto const elem2_tempID = ElementIDType{2};
+
+  // Element 3 (home node == 3)
+  auto const elem3_permID = ElementIDType{3};
+  auto const elem3_tempID = ElementIDType{3};
+
+  ProcLoadMap proc_load = {{0, LoadMapType{{elem2_tempID, TimeType{150}}}}};
 
   ProcCommMap proc_comm = {
     {0,
      CommMapType{// Node 1 -> Node 2
-                 {{CommKeyType::CollectionTag{}, ElementIDType{1},
-                   ElementIDType{1}, ElementIDType{2}, ElementIDType{2}, false},
+                 {{CommKeyType::CollectionTag{}, elem1_permID,
+                   elem1_tempID, elem2_permID, elem2_tempID, false},
                   CommVolume{20.0, 2}},
 
                  // Node 3 -> Node 2
-                 {{CommKeyType::CollectionTag{}, ElementIDType{3},
-                   ElementIDType{3}, ElementIDType{2}, ElementIDType{2}, false},
-                  CommVolume{5.0, 5}},
-
-                 // Node 1 -> Node 3
-                 {{CommKeyType::CollectionTag{}, ElementIDType{1},
-                   ElementIDType{1}, ElementIDType{3}, ElementIDType{3}, false},
-                  CommVolume{100.0, 1}}}},
+                 {{CommKeyType::CollectionTag{}, elem3_permID,
+                   elem3_tempID, elem2_permID, elem2_tempID, false},
+                  CommVolume{5.0, 5}}}
+    },
     {1,
-     CommMapType{// Node 3 -> Node 1 (current phase) -> Node 2
-                 {{CommKeyType::CollectionTag{}, ElementIDType{3},
-                   ElementIDType{3}, ElementIDType{2}, ElementIDType{1}, false},
-                  CommVolume{20.0, 2}},
-
-                 // Node 3 -> Node 2 (current phase) -> Node 1
-                 {{CommKeyType::CollectionTag{}, ElementIDType{3},
-                   ElementIDType{3}, ElementIDType{1}, ElementIDType{2}, false},
+     CommMapType{
+                 // Node 3 -> Node 2
+                 {{CommKeyType::CollectionTag{}, elem3_permID,
+                   elem3_tempID, elem2_permID, elem2_tempID, false},
                   CommVolume{500.0, 50}},
 
-                 // Node 1 -> Node 3 (current phase) -> Node 2
-                 {{CommKeyType::CollectionTag{}, ElementIDType{1},
-                   ElementIDType{1}, ElementIDType{2}, ElementIDType{3}, false},
-                  CommVolume{25.0, 10}}}}};
+                 // Node 1 -> Node 2
+                 {{CommKeyType::CollectionTag{}, elem1_permID,
+                   elem1_tempID, elem2_permID, elem2_tempID, false},
+                  CommVolume{25.0, 10}}}
+    }
+  };
 
-  auto test_model =
-    std::make_shared<CommOverhead>(std::make_shared<StubModel>(), 3.0, 5.0);
+  constexpr auto per_msg_weight = 3.0;
+  constexpr auto per_byte_weight = 5.0;
+
+  auto test_model = std::make_shared<CommOverhead>(
+    std::make_shared<StubModel>(), per_msg_weight, per_byte_weight
+  );
   test_model->setLoads(&proc_load, nullptr, &proc_comm);
 
-  std::unordered_map<PhaseType, std::vector<TimeType>> expected_work = {
-    {0, {TimeType{60}, TimeType{296}, TimeType{578}}},
-    {1, {TimeType{16.6}, TimeType{280}, TimeType{23}}}};
+  std::unordered_map<PhaseType, TimeType> expected_work = {
+    {0, TimeType{296}}, {1, TimeType{295.5}}
+  };
 
   for (; num_phases < 2; ++num_phases) {
     test_model->updateLoads(num_phases);
     int objects_seen = 0;
 
     for (auto&& obj : *test_model) {
-      EXPECT_TRUE(obj == 1 || obj == 2 || obj == 3);
+      EXPECT_TRUE(obj == 2);
       ++objects_seen;
 
       const auto subphase = num_phases == 0 ? PhaseOffset::WHOLE_PHASE : 1;
       auto work_val = test_model->getWork(obj, PhaseOffset{0, subphase});
-      EXPECT_EQ(work_val, expected_work[num_phases][obj - 1])
+      EXPECT_EQ(work_val, expected_work[num_phases])
         << fmt::format("For element={} on phase={}\n", obj, num_phases);
     }
 
-    EXPECT_EQ(objects_seen, 3);
+    EXPECT_EQ(objects_seen, 1);
   }
 }
 

--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -61,7 +61,7 @@ using vt::vrt::collection::balance::CommKeyType;
 using vt::vrt::collection::balance::CommMapType;
 using vt::vrt::collection::balance::CommOverhead;
 using vt::vrt::collection::balance::CommVolume;
-using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::ElementIDStruct;
 using vt::vrt::collection::balance::LoadMapType;
 using vt::vrt::collection::balance::LoadModel;
 using vt::vrt::collection::balance::ObjectIterator;
@@ -87,7 +87,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getWork(ElementIDType id, PhaseOffset phase) override {
+  TimeType getWork(ElementIDStruct id, PhaseOffset phase) override {
     const auto work = proc_load_->at(0).at(id);
 
     if (phase.subphase == PhaseOffset::WHOLE_PHASE) {
@@ -117,43 +117,36 @@ private:
 
 TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
 
-  // For simplicity's sake both temp and perm IDs are the same
+  // For simplicity's sake, the elements are on the home node
   // Element 1 (home node == 1)
-  auto const elem1_permID = ElementIDType{1};
-  auto const elem1_tempID = ElementIDType{1};
+  ElementIDStruct const elem1 = {1, 1, 1};
 
   // Element 2 (home node == 2)
-  auto const elem2_permID = ElementIDType{2};
-  auto const elem2_tempID = ElementIDType{2};
+  ElementIDStruct const elem2 = {2, 2, 2};
 
   // Element 3 (home node == 3)
-  auto const elem3_permID = ElementIDType{3};
-  auto const elem3_tempID = ElementIDType{3};
+  ElementIDStruct const elem3 = {3, 3, 3};
 
-  ProcLoadMap proc_load = {{0, LoadMapType{{elem2_tempID, TimeType{150}}}}};
+  ProcLoadMap proc_load = {{0, LoadMapType{{elem2, TimeType{150}}}}};
 
   ProcCommMap proc_comm = {
     {0,
      CommMapType{// Node 1 -> Node 2
-                 {{CommKeyType::CollectionTag{}, elem1_permID,
-                   elem1_tempID, elem2_permID, elem2_tempID, false},
+                 {{CommKeyType::CollectionTag{}, elem1, elem2, false},
                   CommVolume{20.0, 2}},
 
                  // Node 3 -> Node 2
-                 {{CommKeyType::CollectionTag{}, elem3_permID,
-                   elem3_tempID, elem2_permID, elem2_tempID, false},
+                 {{CommKeyType::CollectionTag{}, elem3, elem2, false},
                   CommVolume{5.0, 5}}}
     },
     {1,
      CommMapType{
                  // Node 3 -> Node 2
-                 {{CommKeyType::CollectionTag{}, elem3_permID,
-                   elem3_tempID, elem2_permID, elem2_tempID, false},
+                 {{CommKeyType::CollectionTag{}, elem3, elem2, false},
                   CommVolume{500.0, 50}},
 
                  // Node 1 -> Node 2
-                 {{CommKeyType::CollectionTag{}, elem1_permID,
-                   elem1_tempID, elem2_permID, elem2_tempID, false},
+                 {{CommKeyType::CollectionTag{}, elem1, elem2, false},
                   CommVolume{25.0, 10}}}
     }
   };
@@ -175,7 +168,7 @@ TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
     int objects_seen = 0;
 
     for (auto&& obj : *test_model) {
-      EXPECT_TRUE(obj == 2);
+      EXPECT_TRUE(obj.id == 2);
       ++objects_seen;
 
       const auto subphase = num_phases == 0 ? PhaseOffset::WHOLE_PHASE : 1;

--- a/tests/unit/collection/test_model_naive_persistence.nompi.cc
+++ b/tests/unit/collection/test_model_naive_persistence.nompi.cc
@@ -56,7 +56,7 @@ namespace vt { namespace tests { namespace unit { namespace naive {
 
 using TestModelNaivePersistence = TestHarness;
 
-using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::ElementIDStruct;
 using vt::vrt::collection::balance::LoadModel;
 using vt::vrt::collection::balance::NaivePersistence;
 using vt::vrt::collection::balance::PhaseOffset;
@@ -83,7 +83,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getWork(ElementIDType id, PhaseOffset phase) override {
+  TimeType getWork(ElementIDStruct id, PhaseOffset phase) override {
     EXPECT_LE(phase.phases, -1);
     return proc_load_->at(getIndexFromPhase(phase.phases)).at(id);
   }
@@ -106,15 +106,20 @@ private:
 };
 
 TEST_F(TestModelNaivePersistence, test_model_naive_persistence_1) {
-    std::unordered_map<PhaseType, LoadMapType> proc_loads = {
+  NodeType this_node = 0;
+  std::unordered_map<PhaseType, LoadMapType> proc_loads = {
     {0, LoadMapType{
-      {ElementIDType{1}, TimeType{10}}, {ElementIDType{2}, TimeType{40}}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{10}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{40}}}},
     {1, LoadMapType{
-      {ElementIDType{1}, TimeType{4}}, {ElementIDType{2}, TimeType{10}}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{4}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{10}}}},
     {2, LoadMapType{
-      {ElementIDType{1}, TimeType{20}}, {ElementIDType{2}, TimeType{50}}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{20}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{50}}}},
     {3, LoadMapType{
-      {ElementIDType{1}, TimeType{40}}, {ElementIDType{2}, TimeType{100}}}}};
+      {ElementIDStruct{1,this_node,this_node}, TimeType{40}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{100}}}}};
 
   auto test_model =
     std::make_shared<NaivePersistence>(std::make_shared<StubModel>());

--- a/tests/unit/collection/test_model_per_collection.extended.cc
+++ b/tests/unit/collection/test_model_per_collection.extended.cc
@@ -64,7 +64,7 @@ static constexpr int32_t const num_elms = 64;
 
 using vt::vrt::collection::balance::ComposedModel;
 using vt::vrt::collection::balance::LoadModel;
-using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::ElementIDStruct;
 using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::PerCollection;
 
@@ -75,7 +75,7 @@ struct ConstantTestModel : ComposedModel {
       proxy_(in_proxy)
   { }
 
-  TimeType getWork(ElementIDType, PhaseOffset) override {
+  TimeType getWork(ElementIDStruct, PhaseOffset) override {
     return static_cast<TimeType>(proxy_);
   }
 
@@ -86,13 +86,13 @@ private:
 template <typename ColT>
 struct MyMsg : vt::CollectionMessage<ColT> { };
 
-std::unordered_map<ElementIDType, VirtualProxyType> id_proxy_map;
+std::unordered_map<ElementIDStruct, VirtualProxyType> id_proxy_map;
 
 template <typename ColT>
 void colHandler(MyMsg<ColT>*, ColT* col) {
   // do nothing, except setting up our map using the temp ID, which will hit
   // every node
-  id_proxy_map[col->getTempID()] = col->getProxy();
+  id_proxy_map[col->getElmID()] = col->getProxy();
 }
 
 TEST_F(TestModelPerCollection, test_model_per_collection_1) {

--- a/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
+++ b/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
@@ -58,7 +58,7 @@ using TestModelPersistenceMedianLastN = TestHarness;
 
 static int32_t num_phases = 0;
 
-using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::ElementIDStruct;
 using vt::vrt::collection::balance::LoadModel;
 using vt::vrt::collection::balance::PersistenceMedianLastN;
 using vt::vrt::collection::balance::PhaseOffset;
@@ -81,7 +81,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getWork(ElementIDType id, PhaseOffset phase) override {
+  TimeType getWork(ElementIDStruct id, PhaseOffset phase) override {
     // Most recent phase will be at the end of vector
     return proc_load_->at(num_phases + phase.phases).at(id);
   }
@@ -104,6 +104,7 @@ private:
 
 TEST_F(TestModelPersistenceMedianLastN, test_model_persistence_median_last_n_1) {
   constexpr int32_t num_total_phases = 7;
+  NodeType this_node = 0;
 
   auto test_model =
     std::make_shared<PersistenceMedianLastN>(std::make_shared<StubModel>(), 4);
@@ -115,19 +116,26 @@ TEST_F(TestModelPersistenceMedianLastN, test_model_persistence_median_last_n_1) 
   // Work loads to be added in each test iteration
   std::vector<LoadMapType> load_holder{
     LoadMapType{
-      {ElementIDType{1}, TimeType{10}}, {ElementIDType{2}, TimeType{40}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{10}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{40}}},
     LoadMapType{
-      {ElementIDType{1}, TimeType{4}}, {ElementIDType{2}, TimeType{10}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{4}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{10}}},
     LoadMapType{
-      {ElementIDType{1}, TimeType{20}}, {ElementIDType{2}, TimeType{100}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{20}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{100}}},
     LoadMapType{
-      {ElementIDType{1}, TimeType{50}}, {ElementIDType{2}, TimeType{40}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{50}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{40}}},
     LoadMapType{
-      {ElementIDType{1}, TimeType{2}}, {ElementIDType{2}, TimeType{50}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{2}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{50}}},
     LoadMapType{
-      {ElementIDType{1}, TimeType{60}}, {ElementIDType{2}, TimeType{20}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{60}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{20}}},
     LoadMapType{
-      {ElementIDType{1}, TimeType{100}}, {ElementIDType{2}, TimeType{10}}},
+      {ElementIDStruct{1,this_node,this_node}, TimeType{100}},
+      {ElementIDStruct{2,this_node,this_node}, TimeType{10}}},
   };
 
   std::array<std::pair<TimeType, TimeType>, num_total_phases> expected_medians{
@@ -149,7 +157,7 @@ TEST_F(TestModelPersistenceMedianLastN, test_model_persistence_median_last_n_1) 
       auto work_val = test_model->getWork(obj, {PhaseOffset::NEXT_PHASE, PhaseOffset::WHOLE_PHASE});
       EXPECT_EQ(
         work_val,
-        obj == 1 ? expected_medians[iter].first : expected_medians[iter].second)
+        obj.id == 1 ? expected_medians[iter].first : expected_medians[iter].second)
         << fmt::format("Test failed on iteration {}", iter);
     }
   }

--- a/tests/unit/collection/test_model_raw_data.nompi.cc
+++ b/tests/unit/collection/test_model_raw_data.nompi.cc
@@ -57,7 +57,7 @@ namespace vt { namespace tests { namespace unit { namespace raw {
 using TestRawData = TestHarness;
 
 using vt::vrt::collection::balance::CommMapType;
-using vt::vrt::collection::balance::ElementIDType;
+using vt::vrt::collection::balance::ElementIDStruct;
 using vt::vrt::collection::balance::RawData;
 using vt::vrt::collection::balance::LoadMapType;
 using vt::vrt::collection::balance::LoadModel;
@@ -66,6 +66,7 @@ using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::SubphaseLoadMapType;
 
 TEST_F(TestRawData, test_model_raw_data_scalar) {
+  NodeType this_node = 0;
   auto test_model =
     std::make_shared<RawData>();
 
@@ -73,26 +74,23 @@ TEST_F(TestRawData, test_model_raw_data_scalar) {
   std::unordered_map<PhaseType, SubphaseLoadMapType> subphase_loads;
   test_model->setLoads(&proc_loads, &subphase_loads, nullptr);
 
+  ElementIDStruct id1{1,this_node,this_node};
+  ElementIDStruct id2{2,this_node,this_node};
+
   // Work loads to be added in each test iteration
   std::vector<LoadMapType> load_holder{
-    LoadMapType{
-      {ElementIDType{1}, TimeType{5}}, {ElementIDType{2}, TimeType{10}}},
-    LoadMapType{
-      {ElementIDType{1}, TimeType{30}}, {ElementIDType{2}, TimeType{100}}},
-    LoadMapType{
-      {ElementIDType{1}, TimeType{50}}, {ElementIDType{2}, TimeType{40}}},
-    LoadMapType{
-      {ElementIDType{1}, TimeType{2}}, {ElementIDType{2}, TimeType{50}}},
-    LoadMapType{
-      {ElementIDType{1}, TimeType{60}}, {ElementIDType{2}, TimeType{20}}},
-    LoadMapType{
-      {ElementIDType{1}, TimeType{100}}, {ElementIDType{2}, TimeType{10}}},
+    LoadMapType{{id1, TimeType{5}},   {id2, TimeType{10}}},
+    LoadMapType{{id1, TimeType{30}},  {id2, TimeType{100}}},
+    LoadMapType{{id1, TimeType{50}},  {id2, TimeType{40}}},
+    LoadMapType{{id1, TimeType{2}},   {id2, TimeType{50}}},
+    LoadMapType{{id1, TimeType{60}},  {id2, TimeType{20}}},
+    LoadMapType{{id1, TimeType{100}}, {id2, TimeType{10}}},
   };
 
   for (size_t iter = 0; iter < load_holder.size(); ++iter) {
     proc_loads[iter] = load_holder[iter];
-    subphase_loads[iter][1] = {load_holder[iter][1]};
-    subphase_loads[iter][2] = {load_holder[iter][2]};
+    subphase_loads[iter][id1] = {load_holder[iter][id1]};
+    subphase_loads[iter][id2] = {load_holder[iter][id2]};
     test_model->updateLoads(iter);
 
     EXPECT_EQ(test_model->getNumObjects(), 2);
@@ -104,7 +102,7 @@ TEST_F(TestRawData, test_model_raw_data_scalar) {
 
     int objects_seen = 0;
     for (auto&& obj : *test_model) {
-      EXPECT_TRUE(obj == 1 || obj == 2);
+      EXPECT_TRUE(obj.id == 1 || obj.id == 2);
       objects_seen++;
 
       auto work_val = test_model->getWork(obj, PhaseOffset{-1, PhaseOffset::WHOLE_PHASE});


### PR DESCRIPTION
I replaced all instances of a collection element's permanent or temporary ID with a struct called `ElementIDStruct` containing an ID that is unique across ranks, the home rank, and the rank where the element currently resides.  I left the unique ID part of the struct the same as the old permanent ID, which had bits encoding the rank. There shouldn't be any logic remaining that depends on those bits, so any alternative means of making the IDs unique across ranks should work fine.

Closes #868 