### PR TITLE
1233: clang builds fail to compile with OpenMP

### DIFF
--- a/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -y -q && \
     valgrind \
     make-guile \
     libomp5 \
+    libomp-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -y -q && \
     valgrind \
     make-guile \
     libomp5 \
+    libomp-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
fixes #1233 