### PR TITLE
1256:  Create vt_trace_only option before creating trace-only CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,11 @@ include(cmake/load_bundled_libraries.cmake)
 
 include(cmake/nvcc_no_deprecated_gpu_targets.cmake)
 
+option(vt_trace_only "Build VT with trace-only mode enabled" ON)
+if (vt_trace_only)
+  message(STATUS "Building additional target for VT in trace-only mode")
+endif()
+
 # Primary VT build
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ include(cmake/load_bundled_libraries.cmake)
 
 include(cmake/nvcc_no_deprecated_gpu_targets.cmake)
 
-option(vt_trace_only "Build VT with trace-only mode enabled" ON)
+option(vt_trace_only "Build VT with trace-only mode enabled" OFF)
 if (vt_trace_only)
   message(STATUS "Building additional target for VT in trace-only mode")
 endif()

--- a/cmake/define_build_types.cmake
+++ b/cmake/define_build_types.cmake
@@ -104,11 +104,6 @@ else()
   set(vt_feature_cmake_trace_enabled "0")
 endif()
 
-option(vt_trace_only "Build VT with trace-only mode enabled" ON)
-if (vt_trace_only)
-  message(STATUS "Building additional target for VT in trace-only mode")
-endif()
-
 # This will be set to 1 during generation of cmake config for vt-trace target
 set(vt_feature_cmake_trace_only "0")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,13 +252,12 @@ link_target_with_vt(
   DEFAULT_LINK_SET
 )
 
-# Define and set up the different build types of VT
-
 include(../cmake/trace_only_functions.cmake)
 if (vt_trace_only)
   create_trace_only_target()
 endif()
 
+# Define and set up the different build types of VT
 include(../cmake/define_build_types.cmake)
 
 target_include_directories(


### PR DESCRIPTION
Fixes #1256 

With this fix, it's no longer required to add -Dvt_trace_only