### PR TITLE
1216: Add Github workflow that creates graph of VT build times and pushes it to wiki page

### DIFF
--- a/.github/workflows/graph-build-times.yml
+++ b/.github/workflows/graph-build-times.yml
@@ -2,16 +2,11 @@ name: Graph VT build times
 
 # Only trigger, when the Docker Image CI finishes
 # This ensures that the graph will actually include the most recent build
-# on:
-#   workflow_run:
-#     workflows: ["Docker Image CI"]
-#     types:
-#       - completed
-
 on:
-  push:
-    branches:
-      - 1216-graph-docker-build-times
+  workflow_run:
+    workflows: ["Docker Image CI"]
+    types:
+      - completed
 
 jobs:
   graph:

--- a/.github/workflows/graph-build-times.yml
+++ b/.github/workflows/graph-build-times.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - develop
-      # Remove later
-      - 1216-graph-docker-build-times
 
 jobs:
   graph:

--- a/.github/workflows/graph-build-times.yml
+++ b/.github/workflows/graph-build-times.yml
@@ -1,0 +1,26 @@
+name: Graph VT build times
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - develop
+      # Remove later
+      - 1216-graph-docker-build-times
+
+jobs:
+  graph:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Generate and push graph
+      uses: DARMA-tasking/graph-build-times@1-create-the-github-action
+      with:
+        github_personal_token: ${{ secrets.GH_PAT }}
+        github_token: ${{ github.token }}
+        workflow: pushdockerimage.yml
+        filename: build_times.png
+        num_last_build: 50
+        title: Last 50 builds of vt:develop docker image
+        graph_width: 19
+        graph_height: 8

--- a/.github/workflows/graph-build-times.yml
+++ b/.github/workflows/graph-build-times.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Generate and push graph
-      uses: DARMA-tasking/graph-build-times@1-create-the-github-action
+      uses: DARMA-tasking/graph-build-times@master
       with:
         github_personal_token: ${{ secrets.GH_PAT }}
         github_token: ${{ github.token }}

--- a/.github/workflows/graph-build-times.yml
+++ b/.github/workflows/graph-build-times.yml
@@ -1,23 +1,32 @@
 name: Graph VT build times
 
+# Only trigger, when the Docker Image CI finishes
+# This ensures that the graph will actually include the most recent build
+# on:
+#   workflow_run:
+#     workflows: ["Docker Image CI"]
+#     types:
+#       - completed
+
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
   push:
     branches:
-      - develop
+      - 1216-graph-docker-build-times
 
 jobs:
   graph:
     runs-on: ubuntu-latest
     steps:
     - name: Generate and push graph
-      uses: DARMA-tasking/graph-build-times@master
+      uses: DARMA-tasking/graph-build-times@3-generate-badge
       with:
         github_personal_token: ${{ secrets.GH_PAT }}
         github_token: ${{ github.token }}
         workflow: pushdockerimage.yml
-        filename: build_times.png
+        graph_filename: build_times.png
+        badge_filename: build_time_badge.svg
+        badge_title: vt:develop build time
+        badge_logo: Docker
         num_last_build: 50
         title: Last 50 builds of vt:develop docker image
         graph_width: 19

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 [![nvidia cuda 11.0, ubuntu, mpich](https://dev.azure.com/DARMA-tasking/DARMA/_apis/build/status/PR%20tests%20(nvidia%20cuda%2011.0%2C%20ubuntu%2C%20mpich)?branchName=develop&Label=(nvidia%20cuda%2011.0%2C%20ubuntu%2C%20mpich))](https://dev.azure.com/DARMA-tasking/DARMA/_build/latest?definitionId=12&branchName=develop)
 ![apple clang, macosx, mpich](https://github.com/DARMA-tasking/vt/workflows/PR%20tests%20(clang-8,%20macosx,%20mpich)/badge.svg?branch=develop)
 ![Build Documentation](https://github.com/DARMA-tasking/vt/workflows/Build%20Documentation/badge.svg?branch=develop)
-
-![](https://github.com/DARMA-tasking/vt/wiki/build_times.png)
+[![](https://github.com/DARMA-tasking/vt/wiki/build_time_badge.svg)](https://github.com/DARMA-tasking/vt/wiki/build_times.png)
 
 ## Introduction : What is *vt*?
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 ![apple clang, macosx, mpich](https://github.com/DARMA-tasking/vt/workflows/PR%20tests%20(clang-8,%20macosx,%20mpich)/badge.svg?branch=develop)
 ![Build Documentation](https://github.com/DARMA-tasking/vt/workflows/Build%20Documentation/badge.svg?branch=develop)
 
+![](https://github.com/DARMA-tasking/vt/wiki/build_times.png)
+
 ## Introduction : What is *vt*?
 
 *vt* is an active messaging layer that utilizes C++ object virtualization to


### PR DESCRIPTION
Fixes #1216 

What this workflow does:
- generate the graph of last 50 builds of pushdockerimage.yml workflow
- push the file of generated graph to our wiki repo

For now I've edited the [Build Requirements](https://github.com/DARMA-tasking/vt/wiki/Build-Requirements) page to use this graph. 
