### PR TITLE
1273: Fix runScheduler call in waitCollective

### DIFF
--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -104,9 +104,7 @@ bool CollectiveScope::isCollectiveDone(TagType tag) {
 }
 
 void CollectiveScope::waitCollective(TagType tag) {
-  while (not isCollectiveDone(tag)) {
-    runScheduler();
-  }
+  theSched()->runSchedulerWhile([this,tag]{ return not isCollectiveDone(tag); });
 }
 
 void CollectiveScope::mpiCollectiveWait(ActionType action) {


### PR DESCRIPTION
Switched `runScheduler` to `runSchedulerWhile` to make sure that the between schedulers event in the trace is closed, otherwise it asserts in debug builds.

Fixes #1273 