### PR TITLE
1274: Release build system does not find deps in lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(vt)
 
+set(PROJECT_BIN_DIR     ${CMAKE_CURRENT_BINARY_DIR})
+set(PROJECT_BASE_DIR    ${CMAKE_CURRENT_SOURCE_DIR})
+set(PROJECT_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+set(PROJECT_EXAMPLE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/examples)
+
 if (POLICY CMP0082) # CMake 3.14
   # Prevent mixing install policies from add_subdirectory;
   # This suppresses a warning as the old behavior is deprecated-by-definition.
@@ -40,11 +45,6 @@ option(CODE_COVERAGE "Enable coverage reporting" OFF)
 # endif(CODE_COVERAGE_ENABLED)
 
 set(MPI_EXTRA_FLAGS "" CACHE STRING "Flags to pass to mpirun/mpiexec")
-
-set(PROJECT_BIN_DIR     ${CMAKE_CURRENT_BINARY_DIR})
-set(PROJECT_BASE_DIR    ${CMAKE_CURRENT_SOURCE_DIR})
-set(PROJECT_LIB_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-set(PROJECT_EXAMPLE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/examples)
 
 include(cmake/build_git_info.cmake)
 

--- a/cmake/load_local_packages.cmake
+++ b/cmake/load_local_packages.cmake
@@ -5,15 +5,26 @@
 
 include(cmake/local_package.cmake)
 
+if (EXISTS "${PROJECT_LIB_DIR}/detector")
+  add_subdirectory(${PROJECT_LIB_DIR}/detector)
+  set(vt_find_detector_dep 0)
+else()
+  # require directories for these packages
+  require_pkg_directory(detector "VT detector library")
+  # find these required packages locally
+  find_package_local(detector "${detector_DIR}" detector)
+  set(vt_find_detector_dep 1)
+endif()
 
-# require directories for these packages
-require_pkg_directory(detector "VT detector library")
-# find these required packages locally
-find_package_local(detector "${detector_DIR}" detector)
-
-# require directories for these packages
-require_pkg_directory(checkpoint "VT checkpoint library")
-# find these required packages locally
-find_package_local(checkpoint "${checkpoint_DIR}" checkpoint)
+if (EXISTS "${PROJECT_LIB_DIR}/checkpoint")
+  add_subdirectory(${PROJECT_LIB_DIR}/checkpoint)
+  set(vt_find_checkpoint_dep 0)
+else()
+  # require directories for these packages
+  require_pkg_directory(checkpoint "VT checkpoint library")
+  # find these required packages locally
+  find_package_local(checkpoint "${checkpoint_DIR}" checkpoint)
+  set(vt_find_checkpoint_dep 1)
+endif()
 
 set(CHECKPOINT_LIBRARY vt::lib::checkpoint)


### PR DESCRIPTION
Updated build system so that vt finds checkpoint and detector when dropped into the lib subdirectory, as it already does on develop.

Fixes #1274 