### PR TITLE
1277: Stats output mixes perm and temp IDs

### DIFF
--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -273,7 +273,6 @@ void BaseLB::finalize(CountMsg* msg) {
     );
     fflush(stdout);
   }
-  balance::ProcStats::startIterCleanup();
   balance::LBManager::finishedRunningLB(phase_);
 }
 

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -224,6 +224,7 @@ void LBManager::releaseNow(PhaseType phase) {
     );
   }
 
+  balance::ProcStats::startIterCleanup();
   balance::ProcStats::clearStats();
 
   auto msg = makeMessage<CollectionPhaseMsg>();

--- a/src/vt/vrt/collection/balance/proc_stats.cc
+++ b/src/vt/vrt/collection/balance/proc_stats.cc
@@ -118,7 +118,6 @@ ProcStats::getProcSubphaseLoad(PhaseType phase) {
   ProcStats::proc_migrate_.clear();
   ProcStats::proc_temp_to_perm_.clear();
   ProcStats::proc_perm_to_temp_.clear();
-  clearStats();
 }
 
 /*static*/ ElementIDType ProcStats::getNextElm() {


### PR DESCRIPTION
Call `startIterCleanup` where it will happen on every phase, not just ones where LB happens, so that stats output will consistently contain permanent IDs.

Fixes #1277 