### PR TITLE
1266: Use checkpoint::reconstructPointedToObjectIfNeeded for reconstructing migrated collection element

### DIFF
--- a/examples/collection/migrate_collection.cc
+++ b/examples/collection/migrate_collection.cc
@@ -48,13 +48,14 @@
 static constexpr int32_t const default_num_elms = 16;
 
 struct Hello : vt::Collection<Hello, vt::Index1D> {
-  Hello() = default;
 
   explicit Hello(vt::NodeType create) {
     vt::NodeType this_node = vt::theContext()->getNode();
     fmt::print("{}: Hello: create={}, index={}\n", this_node, create, getIndex());
     test_val = getIndex().x() * 29.3;
   }
+
+  explicit Hello(checkpoint::SERIALIZE_CONSTRUCT_TAG) {}
 
   template <typename Serializer>
   void serialize(Serializer& s) {

--- a/src/vt/vrt/collection/migrate/migrate_msg.h
+++ b/src/vt/vrt/collection/migrate/migrate_msg.h
@@ -75,12 +75,10 @@ struct MigrateMsg final : ::vt::Message {
   template <typename Serializer>
   void serialize(Serializer& s) {
     MessageParentType::serialize(s);
-    s | elm_proxy_ | from_ | to_ | map_fn_ | range_;
-    if (s.isUnpacking()) {
-      // handler always takes ownership of this by constructing a unique_ptr
-      elm_ = new ColT{};
-    }
-    s | *elm_;
+
+    checkpoint::reconstructPointedToObjectIfNeeded(s, elm_);
+
+    s | *elm_ | elm_proxy_ | from_ | to_ | map_fn_ | range_;
   }
 
 private:


### PR DESCRIPTION
Fixes #1266