### PR TITLE
1296: Avoid running LB on warm-up phase

### DIFF
--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -89,7 +89,8 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
     }
   } else {
     vtAssert(ArgType::vt_lb_interval != 0, "LB Interval must not be 0");
-    if (phase % ArgType::vt_lb_interval == 0) {
+    // avoid running LB on warm-up phase unless we're running LB at every phase
+    if (phase % ArgType::vt_lb_interval == 1 || ArgType::vt_lb_interval == 1) {
       for (auto&& elm : lb_names_) {
         if (elm.second == ArgType::vt_lb_name) {
           the_lb = elm.first;

--- a/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/invoke.cc
@@ -90,7 +90,9 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
   } else {
     vtAssert(ArgType::vt_lb_interval != 0, "LB Interval must not be 0");
     // avoid running LB on warm-up phase unless we're running LB at every phase
-    if (phase % ArgType::vt_lb_interval == 1 || ArgType::vt_lb_interval == 1) {
+    if (phase % ArgType::vt_lb_interval == 1 || (
+      ArgType::vt_lb_interval == 1 && phase != 0
+    )) {
       for (auto&& elm : lb_names_) {
         if (elm.second == ArgType::vt_lb_name) {
           the_lb = elm.first;


### PR DESCRIPTION
Unless we're running LB every phase, skip running LB on phase 0, which is a warm-up/app initialization phase, unless an LB spec file is used.  Now LB at intervals happens on `phase % interval == 1`.  I made this PR directly on the release branch because we already have a very similar change on develop.

Closes #1296