### PR TITLE
1272: Update the usage of scheduler in code

### DIFF
--- a/docs/md/scheduler.md
+++ b/docs/md/scheduler.md
@@ -8,23 +8,14 @@ scheduler allows registration of callbacks when the system is idle.
 
 \section calls-to-the-scheduler Calls to the scheduler
 
-To advance the scheduler, one can call it as follows:
-
-\code{.cpp}
-vt::theSched()->scheduler();
-\endcode
-
-This polls every component that might generate or complete work, and potentially
-runs one piece of available work.
-
-However, if the scheduler needs to be run until a condition (or set of
-conditions) is met, it is recommended that `runSchedulerWhile` be invoked:
+To advance the scheduler, one should use:
 
 \code{.cpp}
 vt::theSched()->runSchedulerWhile(/*std::function<bool()> cond*/);
 \endcode
 
-\copydetails vt::sched::Scheduler::runSchedulerWhile(std::function<bool()>)
+This function polls (while \c cond is true) every component that might generate or complete work, and potentially runs one piece of available work,
+while also ensuring proper event unwinding and idle time tracking.
 
 \section higher-level-calls Higher-level Calls to Wait for Completion
 
@@ -48,7 +39,7 @@ vt::runInEpochRooted([]{
 });
 \endcode
 
-If the work should be executed by all nodes, use a collective epoch::
+If the work should be executed by all nodes, use a collective epoch:
 
 \code{.cpp}
 vt::runInEpochCollective([]{

--- a/src/vt/group/global/group_default.cc
+++ b/src/vt/group/global/group_default.cc
@@ -69,7 +69,7 @@ namespace vt { namespace group { namespace global {
   // Wait for startup to complete all phases before initializing other
   // components, which may broadcast, requiring the spanning tree to be setup
   while (default_group_->cur_phase_ < num_phases) {
-    theSched()->scheduler(true);
+    theSched()->runSchedulerImpl(true);
   }
 }
 

--- a/src/vt/group/global/group_default.cc
+++ b/src/vt/group/global/group_default.cc
@@ -69,7 +69,7 @@ namespace vt { namespace group { namespace global {
   // Wait for startup to complete all phases before initializing other
   // components, which may broadcast, requiring the spanning tree to be setup
   while (default_group_->cur_phase_ < num_phases) {
-    theSched()->runSchedulerImpl(true);
+    theSched()->runSchedulerOnceImpl(true);
   }
 }
 

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -496,10 +496,6 @@ void Runtime::systemSync() {
   MPI_Barrier(comm);
 }
 
-void Runtime::runScheduler() {
-  theSched->scheduler();
-}
-
 void Runtime::reset() {
   MPI_Comm comm = theContext->getComm();
   MPI_Barrier(comm);

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -191,7 +191,7 @@ struct Runtime {
   void computeAndPrintDiagnostics();
 
   /**
-   * \brief Run the scheduler once
+   * \internal \brief Run the scheduler once
    */
   void runScheduler();
 

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -191,11 +191,6 @@ struct Runtime {
   void computeAndPrintDiagnostics();
 
   /**
-   * \internal \brief Run the scheduler once
-   */
-  void runScheduler();
-
-  /**
    * \brief Abort--die immediately after spitting out error message
    *
    * \param[in] abort_str the error message

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -253,7 +253,7 @@ void Scheduler::runProgress(bool msg_only) {
   last_progress_time_ = timing::Timing::getCurrentTime();
 }
 
-void Scheduler::scheduler(bool msg_only) {
+void Scheduler::runSchedulerImpl(bool msg_only) {
   using TimerType = timing::Timing;
 
   auto time_since_last_progress = TimerType::getCurrentTime() - last_progress_time_;
@@ -322,7 +322,7 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
   }
 
   while (cond()) {
-    scheduler();
+    runSchedulerImpl();
   }
 
   // After running the scheduler ensure to exit idle state.

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -373,10 +373,6 @@ void Scheduler::registerTriggerOnce(
 
 namespace vt {
 
-void runScheduler() {
-  theSched()->scheduler();
-}
-
 void runSchedulerThrough(EpochType epoch) {
   // WARNING: This is to prevent global termination from spuriously
   // thinking that the work done in this loop over the scheduler

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -253,7 +253,7 @@ void Scheduler::runProgress(bool msg_only) {
   last_progress_time_ = timing::Timing::getCurrentTime();
 }
 
-void Scheduler::runSchedulerImpl(bool msg_only) {
+void Scheduler::runSchedulerOnceImpl(bool msg_only) {
   using TimerType = timing::Timing;
 
   auto time_since_last_progress = TimerType::getCurrentTime() - last_progress_time_;
@@ -322,7 +322,7 @@ void Scheduler::runSchedulerWhile(std::function<bool()> cond) {
   }
 
   while (cond()) {
-    runSchedulerImpl();
+    runSchedulerOnceImpl();
   }
 
   // After running the scheduler ensure to exit idle state.

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -61,7 +61,6 @@
 #include <memory>
 
 namespace vt {
-  void runScheduler();
   void runSchedulerThrough(EpochType epoch);
 
   template <typename Callable>
@@ -154,7 +153,7 @@ struct Scheduler : runtime::component::Component<Scheduler> {
    * \brief Runs the scheduler until a condition is met.
    *
    * Runs the scheduler until a condition is met.
-   * This form SHOULD be used instead of "while (..) { runScheduler(..) }"
+   * This form SHOULD be used instead of "while (..) { vt::theSched()->scheduler(..) }"
    * in all cases of nested scheduler loops, such as during a barrier,
    * in order to ensure proper event unwinding and idle time tracking.
    *

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -143,7 +143,7 @@ struct Scheduler : runtime::component::Component<Scheduler> {
    * \param[in] msg_only whether to only make progress on the core active
    * messenger
    */
-  void runSchedulerImpl(bool msg_only = false);
+  void runSchedulerOnceImpl(bool msg_only = false);
 
   /**
    * \brief Run the progress function
@@ -157,7 +157,7 @@ struct Scheduler : runtime::component::Component<Scheduler> {
    * \brief Runs the scheduler until a condition is met.
    *
    * Runs the scheduler until a condition is met.
-   * This form SHOULD be used instead of "while (..) { runSchedulerImpl(..) }"
+   * This form SHOULD be used instead of "while (..) { runSchedulerOnceImpl(..) }"
    * in all cases of nested scheduler loops, such as during a barrier,
    * in order to ensure proper event unwinding and idle time tracking.
    *

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -131,15 +131,19 @@ struct Scheduler : runtime::component::Component<Scheduler> {
   ) const;
 
   /**
+   * \internal
    * \brief Turn the scheduler
    *
    * Polls every component that might generate or complete work, and
    * potentially runs one piece of available work.
    *
+   * \note This function should only be used internally by vt. For running scheduler
+   * in user code, one should use \c runSchedulerWhile
+   *
    * \param[in] msg_only whether to only make progress on the core active
    * messenger
    */
-  void scheduler(bool msg_only = false);
+  void runSchedulerImpl(bool msg_only = false);
 
   /**
    * \brief Run the progress function
@@ -153,7 +157,7 @@ struct Scheduler : runtime::component::Component<Scheduler> {
    * \brief Runs the scheduler until a condition is met.
    *
    * Runs the scheduler until a condition is met.
-   * This form SHOULD be used instead of "while (..) { vt::theSched()->scheduler(..) }"
+   * This form SHOULD be used instead of "while (..) { runSchedulerImpl(..) }"
    * in all cases of nested scheduler loops, such as during a barrier,
    * in order to ensure proper event unwinding and idle time tracking.
    *

--- a/src/vt/standalone/vt_main.h
+++ b/src/vt/standalone/vt_main.h
@@ -70,9 +70,7 @@ inline void vrLaunchMainContext() {
 inline void vtMainScheduler() {
   vt_debug_print(gen, node, "vtMainScheduler: running main scheduler\n");
 
-  while (!rt->isTerminated()) {
-    rt->runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated();});
 }
 
 template <typename VrtContextT>

--- a/tests/perf/comm_cost_curve.cc
+++ b/tests/perf/comm_cost_curve.cc
@@ -91,7 +91,9 @@ void sender() {
     auto msg = vt::makeMessage<PingMsg>(bytes);
     vt::theMsg()->sendMsg<PingMsg,handler>(1, msg);
   }
-  while (not is_done) vt::runScheduler();
+
+  runSchedulerWhile([]{return !is_done; });
+
   is_done = false;
   auto time = (vt::timing::Timing::getCurrentTime() - start) / pings;
   auto Mb = static_cast<double>(bytes) / 1024.0 / 1024.0;

--- a/tests/perf/memory_checker.cc
+++ b/tests/perf/memory_checker.cc
@@ -75,13 +75,13 @@ int main(int argc, char** argv) {
     for (int i = 0; i < 32; i++) {
       allocateAndTouch(1024 * 1024 * 64);
       fmt::print("After alloc {} MiB: {}\n", (i + 1) * 64, usage->getUsageAll());
-      vt::theSched()->scheduler();
+      vt::theSched()->runSchedulerImpl();
     }
 
     for (int i = 0; i < 32; i++) {
       deallocate();
       fmt::print("After de-alloc {} MiB: {}\n", (32 * 64) - (i + 1) * 64, usage->getUsageAll());
-      vt::theSched()->scheduler();
+      vt::theSched()->runSchedulerImpl();
     }
   }
 

--- a/tests/perf/memory_checker.cc
+++ b/tests/perf/memory_checker.cc
@@ -75,13 +75,13 @@ int main(int argc, char** argv) {
     for (int i = 0; i < 32; i++) {
       allocateAndTouch(1024 * 1024 * 64);
       fmt::print("After alloc {} MiB: {}\n", (i + 1) * 64, usage->getUsageAll());
-      vt::theSched()->runSchedulerImpl();
+      vt::theSched()->runSchedulerOnceImpl();
     }
 
     for (int i = 0; i < 32; i++) {
       deallocate();
       fmt::print("After de-alloc {} MiB: {}\n", (32 * 64) - (i + 1) * 64, usage->getUsageAll());
-      vt::theSched()->runSchedulerImpl();
+      vt::theSched()->runSchedulerOnceImpl();
     }
   }
 

--- a/tests/perf/memory_checker.cc
+++ b/tests/perf/memory_checker.cc
@@ -75,13 +75,13 @@ int main(int argc, char** argv) {
     for (int i = 0; i < 32; i++) {
       allocateAndTouch(1024 * 1024 * 64);
       fmt::print("After alloc {} MiB: {}\n", (i + 1) * 64, usage->getUsageAll());
-      vt::runScheduler();
+      vt::theSched()->scheduler();
     }
 
     for (int i = 0; i < 32; i++) {
       deallocate();
       fmt::print("After de-alloc {} MiB: {}\n", (32 * 64) - (i + 1) * 64, usage->getUsageAll());
-      vt::runScheduler();
+      vt::theSched()->scheduler();
     }
   }
 

--- a/tests/perf/memory_checker.cc
+++ b/tests/perf/memory_checker.cc
@@ -85,9 +85,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  while (!vt::rt->isTerminated()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !vt::rt->isTerminated(); });
 
   vt::finalize();
 

--- a/tests/perf/ping_pong.cc
+++ b/tests/perf/ping_pong.cc
@@ -172,9 +172,7 @@ int main(int argc, char** argv) {
     theMsg()->sendMsg<PingMsg<min_bytes>, pingPong<min_bytes>>(pong_node, m);
   }
 
-  while (!rt->isTerminated()) {
-    runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 
   CollectiveOps::finalize();
 

--- a/tests/unit/active/test_active_bcast_put.cc
+++ b/tests/unit/active/test_active_bcast_put.cc
@@ -135,9 +135,7 @@ TEST_P(TestActiveBroadcastPut, test_type_safe_active_fn_bcast2) {
   }
 
   // Spin here so test_vec does not go out of scope before the send completes
-  while (not vt::rt->isTerminated()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -155,9 +155,7 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send) {
   }
 
   // Spin here so test_vec does not go out of scope before the send completes
-  while (not vt::rt->isTerminated()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 }
 
 TEST_F(TestActiveSend, test_type_safe_active_fn_send_small_put) {
@@ -181,9 +179,7 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send_small_put) {
   }
 
   // Spin here so test_vec does not go out of scope before the send completes
-  while (not vt::rt->isTerminated()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 }
 
 TEST_F(TestActiveSend, test_type_safe_active_fn_send_large_put) {
@@ -207,9 +203,7 @@ TEST_F(TestActiveSend, test_type_safe_active_fn_send_large_put) {
   }
 
   // Spin here so test_vec does not go out of scope before the send completes
-  while (not vt::rt->isTerminated()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 }
 
 

--- a/tests/unit/active/test_active_send_put.cc
+++ b/tests/unit/active/test_active_send_put.cc
@@ -116,9 +116,7 @@ TEST_P(TestActiveSendPut, test_active_fn_send_put_param) {
   }
 
   // Spin here so test_vec does not go out of scope before the send completes
-  while (not vt::rt->isTerminated()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -98,8 +98,8 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   // break out
   int k = 0;
 
-  theSched()->runSchedulerWhile([&k, ep]() mutable {
-    return theTerm()->isEpochTerminated(ep) || (k++ > 10);
+  theSched()->runSchedulerWhile([&k, ep] {
+    return !theTerm()->isEpochTerminated(ep) && (++k <= 10);
   });
 
   // Epoch should not end with a valid pending send created in an live epoch

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -97,13 +97,10 @@ TEST_F(TestPendingSend, test_pending_send_hold) {
   // !theTerm()->isEpochTermianted(ep), thus `k` is used to
   // break out
   int k = 0;
-  while (!theTerm()->isEpochTerminated(ep)) {
-    k++;
-    vt::runScheduler();
-    if (k > 10) {
-      break;
-    }
-  }
+
+  theSched()->runSchedulerWhile([&k, ep]() mutable {
+    return theTerm()->isEpochTerminated(ep) || (k++ > 10);
+  });
 
   // Epoch should not end with a valid pending send created in an live epoch
   EXPECT_EQ(theTerm()->isEpochTerminated(ep), false);

--- a/tests/unit/lb/test_lb_stats_reader.cc
+++ b/tests/unit/lb/test_lb_stats_reader.cc
@@ -134,9 +134,7 @@ TEST_F(TestLBStatsReader, test_lb_stats_read_1) {
 
   //--- Spin here so the test does not end before the communications complete
 
-  while (not vt::rt->isTerminated()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 
   //--- Check the read values
 

--- a/tests/unit/location/test_location.cc
+++ b/tests/unit/location/test_location.cc
@@ -70,9 +70,7 @@ TEST_F(TestLocation, test_register_and_get_entity) /* NOLINT */ {
     }
   );
 
-  while (not success) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile([&success]{ return not success; });
 
   vt::theCollective()->barrier();
 
@@ -111,9 +109,7 @@ TEST_F(TestLocation, test_register_and_get_multiple_entities)  /* NOLINT */ {
       }
     );
 
-    while (not success) {
-      vt::runScheduler();
-    }
+    vt::theSched()->runSchedulerWhile([&success]{ return not success; });
 
     vt::theCollective()->barrier();
 
@@ -172,9 +168,7 @@ TEST_F(TestLocation, test_migrate_entity) /* NOLINT */ {
       }
     );
 
-    while (not done) {
-      vt::runScheduler();
-    }
+    vt::theSched()->runSchedulerWhile([&done]{ return !done; });
 
     vt::theCollective()->barrier();
 
@@ -242,9 +236,7 @@ TEST_F(TestLocation, test_migrate_entity_expire_cache) /* NOLINT */ {
       }
     );
 
-    while (not executed) {
-      vt::runScheduler();
-    }
+    vt::theSched()->runSchedulerWhile([&executed]{ return not executed; });
 
     vt::theCollective()->barrier();
 
@@ -305,9 +297,7 @@ TEST_F(TestLocation, test_migrate_multiple_entities) /* NOLINT */ {
         }
       );
 
-      while (not success) {
-        vt::runScheduler();
-      }
+      vt::theSched()->runSchedulerWhile([&success]{ return !success; });
 
       vt::theCollective()->barrier();
 

--- a/tests/unit/pipe/test_signal_cleanup.cc
+++ b/tests/unit/pipe/test_signal_cleanup.cc
@@ -88,7 +88,7 @@ TEST_F(TestSignalCleanup, test_signal_cleanup_3) {
   }
 
   // run until termination
-  do vt::runScheduler(); while (not vt::rt->isTerminated());
+  vt::theSched()->runSchedulerWhile([]{ return not vt::rt->isTerminated(); });
 
   // explicitly finalize runtime to destroy and reset components
   vt::rt->finalize(true, false);
@@ -115,7 +115,7 @@ TEST_F(TestSignalCleanup, test_signal_cleanup_3) {
   }
 
   // run until termination
-  do vt::runScheduler(); while (not vt::rt->isTerminated());
+  vt::theSched()->runSchedulerWhile([]{ return not vt::rt->isTerminated(); });
 
   // now, check if we only fired the callbacks exactly once!
   if (this_node == 0) {

--- a/tests/unit/rdma/test_rdma_handle.h
+++ b/tests/unit/rdma/test_rdma_handle.h
@@ -86,7 +86,7 @@ TYPED_TEST_P(TestRDMAHandle, test_rdma_handle_1) {
   auto proxy = TestObjGroup::construct();
   vt::HandleRDMA<T> handle = proxy.get()->makeHandle<T>(size, true);
 
-  do vt::runScheduler(); while (not handle.ready());
+  vt::theSched()->runSchedulerWhile([handle]{ return not handle.ready(); });
 
   auto rank = vt::theContext()->getNode();
   int space = 100;
@@ -127,7 +127,7 @@ TYPED_TEST_P(TestRDMAHandle, test_rdma_handle_2) {
   auto proxy = TestObjGroup::construct();
   vt::HandleRDMA<T> handle = proxy.get()->makeHandle<T>(size, true);
 
-  do vt::runScheduler(); while (not handle.ready());
+  vt::theSched()->runSchedulerWhile([handle]{ return not handle.ready(); });
 
   auto rank = vt::theContext()->getNode();
   int space = 100;
@@ -181,7 +181,7 @@ TYPED_TEST_P(TestRDMAHandle, test_rdma_handle_3) {
   auto proxy = TestObjGroup::construct();
   vt::HandleRDMA<T> handle = proxy.get()->makeHandle<T>(size, true);
 
-  do vt::runScheduler(); while (not handle.ready());
+  vt::theSched()->runSchedulerWhile([handle]{ return not handle.ready(); });
 
   int space = 100;
   UpdateData<T>::init(handle, space, size, 0);
@@ -224,7 +224,7 @@ TYPED_TEST_P(TestRDMAHandle, test_rdma_handle_4) {
   auto proxy = TestObjGroup::construct();
   vt::HandleRDMA<T> handle = proxy.get()->makeHandle<T>(size, false);
 
-  do vt::runScheduler(); while (not handle.ready());
+  vt::theSched()->runSchedulerWhile([handle]{ return not handle.ready(); });
 
   // Barrier to order following locks
   vt::theCollective()->barrier();
@@ -245,7 +245,7 @@ TYPED_TEST_P(TestRDMAHandle, test_rdma_handle_5) {
   auto proxy = TestObjGroup::construct();
   vt::HandleRDMA<T> handle = proxy.get()->makeHandle<T>(size, true);
 
-  do vt::runScheduler(); while (not handle.ready());
+  vt::theSched()->runSchedulerWhile([handle]{ return not handle.ready(); });
 
   int space = 100;
   UpdateData<T>::init(handle, space, size, 0);

--- a/tests/unit/scheduler/test_scheduler_loop.cc
+++ b/tests/unit/scheduler/test_scheduler_loop.cc
@@ -101,7 +101,7 @@ static void message_handler_with_nested_loop(TestMsg* msg) {
     // Original manual loops.
     // Not recommended as scheduler event generation is less consistent.
     while (not ack[next_depth]) {
-      theSched()->runSchedulerImpl();
+      theSched()->runSchedulerOnceImpl();
     }
   } else {
     vtAssertInfo(false, "Invalid action", action);

--- a/tests/unit/scheduler/test_scheduler_loop.cc
+++ b/tests/unit/scheduler/test_scheduler_loop.cc
@@ -101,7 +101,7 @@ static void message_handler_with_nested_loop(TestMsg* msg) {
     // Original manual loops.
     // Not recommended as scheduler event generation is less consistent.
     while (not ack[next_depth]) {
-      theSched()->scheduler();
+      theSched()->runSchedulerImpl();
     }
   } else {
     vtAssertInfo(false, "Invalid action", action);

--- a/tests/unit/scheduler/test_scheduler_loop.cc
+++ b/tests/unit/scheduler/test_scheduler_loop.cc
@@ -101,7 +101,7 @@ static void message_handler_with_nested_loop(TestMsg* msg) {
     // Original manual loops.
     // Not recommended as scheduler event generation is less consistent.
     while (not ack[next_depth]) {
-      vt::runScheduler();
+      theSched()->scheduler();
     }
   } else {
     vtAssertInfo(false, "Invalid action", action);

--- a/tests/unit/scheduler/test_scheduler_priorities.extended.cc
+++ b/tests/unit/scheduler/test_scheduler_priorities.extended.cc
@@ -80,9 +80,8 @@ TEST_F(TestSchedPriorities, test_scheduler_priorities_1) {
 
   total = testSched->workQueueSize();
 
-  do {
-    testSched->scheduler();
-  } while (total > 0);
+  testSched->runSchedulerWhile([&total]{ return total > 0; });
+
 # endif
 }
 
@@ -122,9 +121,8 @@ TEST_F(TestSchedPriorities, test_scheduler_priorities_2) {
 
   total = testSched->workQueueSize();
 
-  do {
-    testSched->scheduler();
-  } while (total > 0);
+  testSched->runSchedulerWhile([&total]{ return total > 0; });
+
 # endif
 }
 
@@ -167,9 +165,8 @@ TEST_F(TestSchedPriorities, test_scheduler_priorities_3) {
 
   total = testSched->workQueueSize();
 
-  do {
-    testSched->scheduler();
-  } while (total > 0);
+  testSched->runSchedulerWhile([&total]{ return total > 0; });
+
 # endif
 }
 

--- a/tests/unit/scheduler/test_scheduler_progress.extended.cc
+++ b/tests/unit/scheduler/test_scheduler_progress.extended.cc
@@ -81,7 +81,7 @@ TEST_F(TestSchedProgress, test_scheduler_progress_1) {
     testSched->enqueue([]{ sleep_for(50ms); });
   }
 
-  do testSched->scheduler(); while (not done);
+  testSched->runSchedulerWhile([&done]{return not done;});
 
   double const fudge = 0.8;
 
@@ -120,7 +120,7 @@ TEST_F(TestSchedProgress, test_scheduler_progress_2) {
     testSched->enqueue([]{ sleep_for(100ms); });
   }
 
-  do testSched->scheduler(); while (not done);
+  testSched->runSchedulerWhile([&done]{return not done;});
 
   double const fudge = 0.8;
 

--- a/tests/unit/termination/test_term_cleanup.cc
+++ b/tests/unit/termination/test_term_cleanup.cc
@@ -93,9 +93,9 @@ TEST_F(TestTermCleanup, test_termination_cleanup_1) {
     EXPECT_LT(theTerm()->getEpochReadySet().size(), std::size_t{2});
   }
 
-  while (not vt::rt->isTerminated() or not vt::theSched()->isIdle()) {
-    vt::runScheduler();
-  }
+  theSched()->runSchedulerWhile(
+    [] { return not vt::rt->isTerminated() or not vt::theSched()->isIdle();
+  });
 
   EXPECT_LT(theTerm()->getEpochState().size(), std::size_t{2});
   EXPECT_EQ(theTerm()->getEpochWaitSet().size(), std::size_t{0});
@@ -149,9 +149,9 @@ TEST_F(TestTermCleanup, test_termination_cleanup_2) {
     vt::runSchedulerThrough(wave_epoch);
   }
 
-  while (not vt::rt->isTerminated() or not vt::theSched()->isIdle()) {
-    vt::runScheduler();
-  }
+  vt::theSched()->runSchedulerWhile(
+    []{ return not vt::rt->isTerminated() or not vt::theSched()->isIdle();
+  });
 
   EXPECT_LT(theTerm()->getEpochState().size(), std::size_t{2});
   EXPECT_EQ(theTerm()->getEpochWaitSet().size(), std::size_t{0});

--- a/tests/unit/termination/test_termination_action_common.impl.h
+++ b/tests/unit/termination/test_termination_action_common.impl.h
@@ -142,7 +142,7 @@ inline void finalize(vt::EpochType const& epoch, int order) {
     finish(epoch);
     vt::theCollective()->barrier();
     // spin until termination of the epoch
-    while (not channel::ok) { vt::rt->runScheduler(); }
+    vt::theSched()->runSchedulerWhile([] { return not channel::ok; });
   }
 }
 

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -126,9 +126,7 @@ struct TestParallelHarnessAny : TestHarnessAny<TestBase> {
   virtual void TearDown() {
     using namespace vt;
 
-    while (!rt->isTerminated()) {
-      runScheduler();
-    }
+  vt::theSched()->runSchedulerWhile([]{ return !rt->isTerminated(); });
 
 #if DEBUG_TEST_HARNESS_PRINT
     auto const& my_node = theContext()->getNode();

--- a/tests/unit/trace/test_trace_spec_reader.cc
+++ b/tests/unit/trace/test_trace_spec_reader.cc
@@ -75,7 +75,7 @@ TEST_F(TestTraceSpec, test_trace_spec_1) {
     proxy.get()->parse();
     proxy.get()->broadcastSpec();
   }
-  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  vt::theSched()->runSchedulerWhile([proxy]{ return not proxy.get()->specReceived();});
   theTerm()->consume();
 
   for (typename Spec::SpecIndex i = 0; i < 1000; i++) {
@@ -109,7 +109,7 @@ TEST_F(TestTraceSpec, test_trace_spec_2) {
     proxy.get()->parse();
     proxy.get()->broadcastSpec();
   }
-  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  vt::theSched()->runSchedulerWhile([proxy]{ return not proxy.get()->specReceived();});
   theTerm()->consume();
 
   for (typename Spec::SpecIndex i = 0; i < 1000; i++) {
@@ -145,7 +145,10 @@ TEST_F(TestTraceSpec, test_trace_spec_3) {
     proxy.get()->parse();
     proxy.get()->broadcastSpec();
   }
-  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  vt::theSched()->runSchedulerWhile(
+    [proxy]{ return not proxy.get()->specReceived();
+  });
+
   theTerm()->consume();
 
   for (typename Spec::SpecIndex i = 0; i < 1000; i++) {
@@ -186,7 +189,7 @@ TEST_F(TestTraceSpec, test_trace_spec_4) {
     proxy.get()->parse();
     proxy.get()->broadcastSpec();
   }
-  do vt::runScheduler(); while (not proxy.get()->specReceived());
+  vt::theSched()->runSchedulerWhile([proxy]{ return not proxy.get()->specReceived();});
   theTerm()->consume();
 
   for (typename Spec::SpecIndex i = 0; i < 1000; i++) {

--- a/tutorial/tutorial_main.h
+++ b/tutorial/tutorial_main.h
@@ -126,9 +126,8 @@ int main(int argc, char** argv) {
    * all work in the system is finished and will not generate more work (via a
    * incomplete causal chain of events).
    */
-  while (!::vt::rt->isTerminated()) {
-    ::vt::runScheduler();
-  }
+
+  ::vt::theSched()->runSchedulerWhile([]{return !::vt::rt->isTerminated(); });
 
   /*
    * All node invoke finalize at the end of the program


### PR DESCRIPTION
Fixes #1272 

For the most part I've changed the uses of `while() runScheduler()` to `theSched()->runSchedulerWhile()`. The exceptions were:
https://github.com/DARMA-tasking/vt/blob/4a0f2cd17d11fc2099e93bbe850acf17f02eec3e/tests/perf/memory_checker.cc#L75-L86
https://github.com/DARMA-tasking/vt/blob/4a0f2cd17d11fc2099e93bbe850acf17f02eec3e/tests/unit/scheduler/test_scheduler_loop.cc#L100-L105

</br>
Since `runScheduler` was just a wrapper for `theSched()->scheduler()` and it's meant to be used only by our internal code, I think it's better to remove `runScheduler` altogether and use  `theSched()->scheduler()` instead. 