### PR TITLE
1006: GroupCollective setup races with continuation registration code

### DIFF
--- a/src/vt/configs/debug/debug_print.h
+++ b/src/vt/configs/debug/debug_print.h
@@ -130,7 +130,7 @@
 
 #define vt_config_print_force_impl(cftype, feature, ctx, ...)           \
   vt_debug_print_impl(                                                  \
-    true, vt_make_config(feature, cftype), normal, feature, ctx,        \
+    true, vt_make_config(feature, cftype), terse, feature, ctx,         \
     __VA_ARGS__                                                         \
   )
 

--- a/src/vt/group/collective/group_info_collective.cc
+++ b/src/vt/group/collective/group_info_collective.cc
@@ -152,7 +152,6 @@ void InfoColl::setupCollective() {
     );
   }
 
-  up_tree_cont_       = makeCollectiveContinuation(group_);
   down_tree_cont_     = theGroup()->nextCollectiveID();
   down_tree_fin_cont_ = theGroup()->nextCollectiveID();
   finalize_cont_      = theGroup()->nextCollectiveID();
@@ -200,6 +199,12 @@ void InfoColl::setupCollective() {
       iter->second->newRoot(msg.get());
     }
   );
+
+  // This must be *after* all the other continuation registrations because it
+  // triggers buffered work that is waiting on the meta-continuation to be
+  // registered which checks for message counts and then dispatches to the
+  // secondary continuation.
+  up_tree_cont_ = makeCollectiveContinuation(group_);
 
   vt_debug_print(
     normal, group,

--- a/tests/unit/group/test_group.extended.cc
+++ b/tests/unit/group/test_group.extended.cc
@@ -1,0 +1,100 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                           test_group.extended.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+
+#include "vt/transport.h"
+
+namespace vt { namespace tests { namespace unit {
+
+struct MySimpleMsg : ::vt::Message { };
+
+static void msgHandlerGroup(MySimpleMsg* msg) {
+  auto const cur_node = ::vt::theContext()->getNode();
+  vtAssert(cur_node % 2 == 0, "This handler should only execute on even nodes");
+
+  ::fmt::print("msgHandlerGroup: triggered on node={}\n", cur_node);
+}
+
+// demonstrate collective group creation and broadcast to that group
+static inline void activeMessageGroupCollective() {
+  NodeType const this_node = ::vt::theContext()->getNode();
+
+  auto const is_even_node = this_node % 2 == 0;
+
+  if (this_node == 0) {
+    int val = 10;
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    vt::theSched()->runSchedulerWhile(
+      [&val]{
+        return --val >= 0;
+      }
+    );
+  }
+
+  auto group = theGroup()->newGroupCollective(
+    is_even_node, [](GroupType group_id){
+      fmt::print("Group is created: id={:x}\n", group_id);
+
+      // node 1 broadcasts to the group of even nodes
+      auto const my_node = ::vt::theContext()->getNode();
+      if (my_node == 1) {
+        auto msg = makeMessage<MySimpleMsg>();
+        envelopeSetGroup(msg->env, group_id);
+        theMsg()->broadcastMsg<MySimpleMsg,msgHandlerGroup>(msg);
+      }
+    }
+  );
+  (void)group;
+}
+
+struct TestGroupExtended : TestParallelHarness {};
+
+TEST_F(TestGroupExtended, test_group_collective) {
+  vt::runInEpochCollective([] { activeMessageGroupCollective(); });
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -677,20 +677,17 @@ TEST_P(TestTermDepSendChain, test_term_dep_send_chain_merge) {
   vt::theConfig()->vt_term_rooted_use_ds = use_ds;
 
   auto obj_a = std::make_unique<MergeObjGroup>();
-  auto obj_b = std::make_unique<MergeObjGroup>();
-
   obj_a->startup();
   obj_a->makeVT();
+  obj_a->makeColl(num_nodes,k, 0.0);
 
+  auto obj_b = std::make_unique<MergeObjGroup>();
   obj_b->startup();
   obj_b->makeVT();
+  obj_b->makeColl(num_nodes,k, 1000.0);
 
-  vt::runInEpochCollective([&obj_a, num_nodes, k]() mutable {
-    obj_a->makeColl(num_nodes,k, 0.0);
-  });
-  vt::runInEpochCollective([&obj_b, num_nodes, k]() mutable {
-    obj_b->makeColl(num_nodes,k, 1000.0);
-  });
+  // Must have barrier here so op4Impl does not bounce early (invalid proxy)!
+  vt::theCollective()->barrier();
 
   for (int t = 0; t < iter; t++) {
     obj_a->startUpdate();


### PR DESCRIPTION
When a collective registration is delayed on one node and it starts sending messages before the continuations are registered, the continuation runs but doesn't have the proper state to make progress.

Solution:
Move `makeCollectiveContinuation` call after continuation registrations.
This must be *after* all the other continuation registrations because it triggers buffered work that is waiting on the meta-continuation to be registered which checks for message counts and then dispatches to the secondary continuation.

A few more details: The call`makeCollectiveContinuation(group)`  takes the new `group` ID that is mid-construction as an argument and creates the "meta-continuation" for it, which basically says that the message dispatchers are ready for that group so messages that are held back can not be delivered. If that happens before they are all actually registered (which was the ordering previously) we get bogus data for the registered handlers.

fixes #1006 