### PR TITLE
1260: Fix active messaging functor inference using the FunctorExtractor

### DIFF
--- a/examples/collection/transpose.cc
+++ b/examples/collection/transpose.cc
@@ -176,7 +176,7 @@ struct Block : vt::Collection<Block, vt::Index1D> {
     if (getIndex().x() == 0) {
       auto proxy = this->getCollectionProxy();
       auto proxy_msg = vt::makeMessage<ProxyMsg>(proxy.getProxy());
-      vt::theMsg()->broadcastMsg<SetupGroup,ProxyMsg>(proxy_msg);
+      vt::theMsg()->broadcastMsg<SetupGroup>(proxy_msg);
     }
   }
 

--- a/examples/hello_world/hello_world_functor.cc
+++ b/examples/hello_world/hello_world_functor.cc
@@ -52,9 +52,21 @@ struct HelloMsg : vt::Message {
   { }
 };
 
+struct AnotherMsg : vt::Message{};
+
 struct HelloWorld {
   void operator()(HelloMsg* msg) const {
-    fmt::print("{}: Hello from node {}\n", vt::theContext()->getNode(), msg->from);
+    fmt::print("{}: HelloWorld -> Hello from node {}\n", vt::theContext()->getNode(), msg->from);
+  }
+};
+
+struct MultipleFunctions {
+  void operator()(HelloMsg* msg) const {
+    fmt::print("{}: MultipleFunctions -> Hello from node {}\n", vt::theContext()->getNode(), msg->from);
+  }
+
+  void operator()(AnotherMsg* msg) const {
+    fmt::print("{}: MultipleFunctions with AnotherMsg\n", vt::theContext()->getNode());
   }
 };
 
@@ -70,7 +82,21 @@ int main(int argc, char** argv) {
 
   if (this_node == 0) {
     auto msg = vt::makeMessage<HelloMsg>(this_node);
+
+    // 'HelloWorld' functor has only single 'operator()' declared
+    // so we can call send/braodcast without specyfing message type
     vt::theMsg()->broadcastMsg<HelloWorld>(msg);
+
+    msg = vt::makeMessage<HelloMsg>(this_node);
+    vt::theMsg()->sendMsg<HelloWorld>(1, msg);
+
+    // 'MultipleFunctions' functor declares more than one 'operator()'
+    // so we have to specify the type of the message, as it can't be deduced
+    auto new_msg = vt::makeMessage<AnotherMsg>();
+    vt::theMsg()->broadcastMsg<MultipleFunctions, AnotherMsg>(new_msg);
+
+    new_msg = vt::makeMessage<AnotherMsg>();
+    vt::theMsg()->sendMsg<MultipleFunctions, AnotherMsg>(1, new_msg);
   }
 
   vt::finalize();

--- a/examples/hello_world/hello_world_functor.cc
+++ b/examples/hello_world/hello_world_functor.cc
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
 
   if (this_node == 0) {
     auto msg = vt::makeMessage<HelloMsg>(this_node);
-    vt::theMsg()->broadcastMsg<HelloWorld,HelloMsg>(msg);
+    vt::theMsg()->broadcastMsg<HelloWorld>(msg);
   }
 
   vt::finalize();

--- a/examples/hello_world/hello_world_functor.cc
+++ b/examples/hello_world/hello_world_functor.cc
@@ -95,8 +95,8 @@ int main(int argc, char** argv) {
     auto new_msg = vt::makeMessage<AnotherMsg>();
     vt::theMsg()->broadcastMsg<MultipleFunctions, AnotherMsg>(new_msg);
 
-    new_msg = vt::makeMessage<AnotherMsg>();
-    vt::theMsg()->sendMsg<MultipleFunctions, AnotherMsg>(1, new_msg);
+    msg = vt::makeMessage<HelloMsg>(this_node);
+    vt::theMsg()->sendMsg<MultipleFunctions, HelloMsg>(1, msg);
   }
 
   vt::finalize();

--- a/examples/hello_world/hello_world_functor.cc
+++ b/examples/hello_world/hello_world_functor.cc
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
     auto msg = vt::makeMessage<HelloMsg>(this_node);
 
     // 'HelloWorld' functor has only single 'operator()' declared
-    // so we can call send/braodcast without specyfing message type
+    // so we can call send/broadcast without specifying message type
     vt::theMsg()->broadcastMsg<HelloWorld>(msg);
 
     msg = vt::makeMessage<HelloMsg>(this_node);

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -904,7 +904,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     typename MsgT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
   PendingSendType broadcastMsg(
-    MsgPtrThief<MsgT> msg,
+    MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
     bool deliver_to_sender = true,
     TagType tag = no_tag
   );
@@ -926,7 +926,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     typename MsgT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
   PendingSendType broadcastMsgAuto(
-    MsgPtrThief<MsgT> msg,
+    MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
     TagType tag = no_tag
   );
 
@@ -947,7 +947,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   >
   PendingSendType sendMsg(
     NodeType dest,
-    MsgPtrThief<MsgT> msg,
+    MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
     TagType tag = no_tag
   );
 
@@ -970,7 +970,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   >
   PendingSendType sendMsgAuto(
     NodeType dest,
-    MsgPtrThief<MsgT> msg,
+    MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
     TagType tag = no_tag
   );
 

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -901,8 +901,26 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    */
   template <
     typename FunctorT,
-    typename MsgT = typename util::FunctorExtractor<FunctorT>::MessageType
+    typename MsgT
   >
+  PendingSendType broadcastMsg(
+    MsgPtrThief<MsgT> msg,
+    bool deliver_to_sender = true,
+    TagType tag = no_tag
+  );
+
+  /**
+   * \brief Broadcast a message.
+   *
+   * \note Takes ownership of the supplied message.
+   *
+   * \param[in] msg the message to broadcast
+   * \param[in] deliver_to_sender whether msg should be delivered to sender
+   * \param[in] tag the optional tag to put on the message
+   *
+   * \return the \c PendingSend for the broadcast
+   */
+  template <typename FunctorT>
   PendingSendType broadcastMsg(
     MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
     bool deliver_to_sender = true,
@@ -926,7 +944,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     typename MsgT = typename util::FunctorExtractor<FunctorT>::MessageType
   >
   PendingSendType broadcastMsgAuto(
-    MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+    MsgPtrThief<MsgT> msg,
     TagType tag = no_tag
   );
 
@@ -941,10 +959,25 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    *
    * \return the \c PendingSend for the send
    */
-  template <
-    typename FunctorT,
-    typename MsgT = typename util::FunctorExtractor<FunctorT>::MessageType
-  >
+  template <typename FunctorT,typename MsgT>
+  PendingSendType sendMsg(
+    NodeType dest,
+    MsgPtrThief<MsgT> msg,
+    TagType tag = no_tag
+  );
+
+  /**
+   * \brief Send a message with a type-safe handler.
+   *
+   * \note Takes ownership of the supplied message.
+   *
+   * \param[in] dest the destination node to send the message to
+   * \param[in] msg the message to broadcast
+   * \param[in] tag the tag to put on the message
+   *
+   * \return the \c PendingSend for the send
+   */
+  template <typename FunctorT>
   PendingSendType sendMsg(
     NodeType dest,
     MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
@@ -970,7 +1003,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   >
   PendingSendType sendMsgAuto(
     NodeType dest,
-    MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+    MsgPtrThief<MsgT> msg,
     TagType tag = no_tag
   );
 

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -347,7 +347,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
 
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
-  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+  MsgPtrThief<MsgT> msg,
   bool deliver_to_sender,
   TagType tag
 ) {
@@ -359,10 +359,20 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
   );
 }
 
+template <typename FunctorT>
+ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
+  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+  bool deliver_to_sender,
+  TagType tag
+) {
+  using MsgT = typename util::FunctorExtractor<FunctorT>::MessageType;
+  return broadcastMsg<FunctorT, MsgT>(msg, deliver_to_sender, tag);
+}
+
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
   NodeType dest,
-  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+  MsgPtrThief<MsgT> msg,
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
@@ -370,9 +380,19 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
   return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
 }
 
+template <typename FunctorT>
+ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
+  NodeType dest,
+  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+  TagType tag
+) {
+  using MsgT = typename util::FunctorExtractor<FunctorT>::MessageType;
+  return sendMsg<FunctorT, MsgT>(dest, msg, tag);
+}
+
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
-  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+  MsgPtrThief<MsgT> msg,
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
@@ -385,7 +405,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::sendMsgAuto(
   NodeType dest,
-  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
+  MsgPtrThief<MsgT> msg,
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -347,7 +347,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
 
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
-  MsgPtrThief<MsgT> msg,
+  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
   bool deliver_to_sender,
   TagType tag
 ) {
@@ -362,7 +362,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
   NodeType dest,
-  MsgPtrThief<MsgT> msg,
+  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
@@ -372,7 +372,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
 
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
-  MsgPtrThief<MsgT> msg,
+  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
@@ -385,7 +385,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
 template <typename FunctorT, typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::sendMsgAuto(
   NodeType dest,
-  MsgPtrThief<MsgT> msg,
+  MsgPtrThief<typename util::FunctorExtractor<FunctorT>::MessageType> msg,
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();

--- a/src/vt/utils/static_checks/functor.h
+++ b/src/vt/utils/static_checks/functor.h
@@ -46,6 +46,8 @@
 #define INCLUDED_UTILS_STATIC_CHECKS_FUNCTOR_H
 
 #include "vt/config.h"
+#include <type_traits>
+
 
 namespace vt { namespace util {
 
@@ -54,6 +56,13 @@ struct FunctorTraits;
 
 template <typename FunctorT, typename ReturnT, typename MsgT>
 struct FunctorTraits<ReturnT(FunctorT::*)(MsgT*)> {
+  using FunctorType = FunctorT;
+  using MessageType = MsgT;
+  using ReturnType  = ReturnT;
+};
+
+template <typename FunctorT, typename ReturnT, typename MsgT>
+struct FunctorTraits<ReturnT(FunctorT::*)(MsgT*) const> {
   using FunctorType = FunctorT;
   using MessageType = MsgT;
   using ReturnType  = ReturnT;

--- a/src/vt/utils/static_checks/functor.h
+++ b/src/vt/utils/static_checks/functor.h
@@ -47,7 +47,6 @@
 
 #include "vt/config.h"
 
-
 namespace vt { namespace util {
 
 template <typename FunctorT>

--- a/src/vt/utils/static_checks/functor.h
+++ b/src/vt/utils/static_checks/functor.h
@@ -46,7 +46,6 @@
 #define INCLUDED_UTILS_STATIC_CHECKS_FUNCTOR_H
 
 #include "vt/config.h"
-#include <type_traits>
 
 
 namespace vt { namespace util {

--- a/tutorial/tutorial_1b.h
+++ b/tutorial/tutorial_1b.h
@@ -154,7 +154,7 @@ static void msgHandlerA(MyMsg* msg) {
   NodeType const to_node = 0;
   auto msg2 = ::vt::makeMessage<MyMsg>(10,20);
 
-  ::vt::theMsg()->sendMsg<MsgHandlerB, MyMsg>(to_node, msg2);
+  ::vt::theMsg()->sendMsg<MsgHandlerB>(to_node, msg2);
 
   // Alternate/equivalent form with explicit (and optional) std::move:
   //


### PR DESCRIPTION
Fixes #1260 