### PR TITLE
1331: Optimize build times for assertions by removing templates

### DIFF
--- a/src/vt/collective/basic.cc
+++ b/src/vt/collective/basic.cc
@@ -56,8 +56,8 @@ void abort(std::string const str, int32_t const code) {
 }
 
 void output(
-  std::string const str, int32_t const code, bool error, bool formatted,
-  bool decorate, bool abort_out
+  std::string const str, int32_t const code, bool error, bool decorate,
+  bool formatted, bool abort_out
 ) {
 #if !vt_check_enabled(trace_only)
   return CollectiveOps::output(str,code,error,decorate,formatted,abort_out);

--- a/src/vt/configs/error/assert_out.h
+++ b/src/vt/configs/error/assert_out.h
@@ -53,28 +53,10 @@
 
 namespace vt { namespace debug { namespace assert {
 
-template <typename=void>
-inline void assertOutExpr(
-  bool fail, std::string const cond, std::string const& file, int const line,
-  std::string const& func, ErrorCodeType error
-);
-
-template <typename... Args>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value == 0>
-assertOut(
+inline void assertOut(
   bool fail, std::string const cond, std::string const& str,
   std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, std::tuple<Args...>&& args
-);
-
-template <typename... Args>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value != 0>
-assertOut(
-  bool fail, std::string const cond, std::string const& str,
-  std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, std::tuple<Args...>&& args
+  ErrorCodeType error
 );
 
 }}} /* end namespace vt::debug::assert */

--- a/src/vt/configs/error/assert_out.impl.h
+++ b/src/vt/configs/error/assert_out.impl.h
@@ -60,27 +60,10 @@
 
 namespace vt { namespace debug { namespace assert {
 
-template <typename>
-inline void assertOutExpr(
-  bool fail, std::string const cond, std::string const& file, int const line,
-  std::string const& func, ErrorCodeType error
-) {
-  auto msg = "Assertion failed:";
-  auto reason = "";
-  auto assert_fail_str = stringizeMessage(msg,reason,cond,file,line,func,error);
-  ::vt::output(assert_fail_str,error,true,true,true,fail);
-  if (fail) {
-    vtAbort("Assertion failed");
-  }
-}
-
-template <typename... Args>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value == 0>
-assertOut(
+inline void assertOut(
   bool fail, std::string const cond, std::string const& str,
   std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, std::tuple<Args...>&& tup
+  ErrorCodeType error
 ) {
   auto msg = "Assertion failed:";
   auto assert_fail_str = stringizeMessage(msg,str,cond,file,line,func,error);
@@ -88,51 +71,6 @@ assertOut(
   if (fail) {
     vtAbort("Assertion failed");
   }
-}
-
-template <typename... Args>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value != 0>
-assertOutImpl(
-  bool fail, std::string const cond, std::string const& str,
-  std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, Args&&... args
-) {
-  auto const arg_str = ::fmt::format(str,std::forward<Args>(args)...);
-  assertOut(false,cond,arg_str,file,line,func,error,std::make_tuple());
-  if (fail) {
-    vtAbort("Assertion failed");
-  }
-}
-
-template <typename Tuple, size_t... I>
-inline void assertOutImplTup(
-  bool fail, std::string const cond, std::string const& str,
-  std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, Tuple&& tup, std::index_sequence<I...>
-) {
-  assertOutImpl(
-    fail,cond,str,file,line,func,error,
-    std::forward<typename std::tuple_element<I,Tuple>::type>(
-      std::get<I>(tup)
-    )...
-  );
-}
-
-template <typename... Args>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value != 0>
-assertOut(
-  bool fail, std::string const cond, std::string const& str,
-  std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, std::tuple<Args...>&& tup
-) {
-  static constexpr auto size = std::tuple_size<std::tuple<Args...>>::value;
-  assertOutImplTup(
-    fail,cond,str,file,line,func,error,
-    std::forward<std::tuple<Args...>>(tup),
-    std::make_index_sequence<size>{}
-  );
 }
 
 }}} /* end namespace vt::debug::assert */

--- a/src/vt/configs/error/assert_out_info.h
+++ b/src/vt/configs/error/assert_out_info.h
@@ -53,18 +53,7 @@
 namespace vt { namespace debug { namespace assert {
 
 template <typename... Args, typename... Args2>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value == 0>
-assertOutInfo(
-  bool fail, std::string const cond, std::string const& str,
-  std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, std::tuple<Args2...>&& tup, std::tuple<Args...>&& args
-);
-
-template <typename... Args, typename... Args2>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value != 0>
-assertOutInfo(
+inline void assertOutInfo(
   bool fail, std::string const cond, std::string const& str,
   std::string const& file, int const line, std::string const& func,
   ErrorCodeType error, std::tuple<Args2...>&& t1, std::tuple<Args...>&& args

--- a/src/vt/configs/error/assert_out_info.impl.h
+++ b/src/vt/configs/error/assert_out_info.impl.h
@@ -62,20 +62,7 @@
 namespace vt { namespace debug { namespace assert {
 
 template <typename... Args, typename... Args2>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value == 0>
-assertOutInfo(
-  bool fail, std::string const cond, std::string const& str,
-  std::string const& file, int const line, std::string const& func,
-  ErrorCodeType error, std::tuple<Args2...>&& tup, std::tuple<Args...>&& t2
-) {
-  return assertOut(fail,cond,str,file,line,func,error);
-}
-
-template <typename... Args, typename... Args2>
-inline
-std::enable_if_t<std::tuple_size<std::tuple<Args...>>::value != 0>
-assertOutInfo(
+inline void assertOutInfo(
   bool fail, std::string const cond, std::string const& str,
   std::string const& file, int const line, std::string const& func,
   ErrorCodeType error, std::tuple<Args2...>&& t1, std::tuple<Args...>&& t2

--- a/src/vt/configs/error/assert_out_info.impl.h
+++ b/src/vt/configs/error/assert_out_info.impl.h
@@ -70,7 +70,7 @@ inline void assertOutInfo(
   using KeyType = std::tuple<Args2...>;
   using ValueType = std::tuple<Args...>;
   static constexpr auto size = std::tuple_size<KeyType>::value;
-  using PrinterType = util::error::PrinterNameValue<size-1,KeyType,ValueType>;
+  using PrinterType = util::error::PrinterNameValue<size-2,KeyType,ValueType>;
 
   // Output the standard assert message
   assertOut(false,cond,str,file,line,func,error);

--- a/src/vt/configs/error/assert_out_info.impl.h
+++ b/src/vt/configs/error/assert_out_info.impl.h
@@ -69,9 +69,7 @@ assertOutInfo(
   std::string const& file, int const line, std::string const& func,
   ErrorCodeType error, std::tuple<Args2...>&& tup, std::tuple<Args...>&& t2
 ) {
-  return assertOut(
-    fail,cond,str,file,line,func,error,std::forward<std::tuple<Args...>>(t2)
-  );
+  return assertOut(fail,cond,str,file,line,func,error);
 }
 
 template <typename... Args, typename... Args2>
@@ -88,7 +86,7 @@ assertOutInfo(
   using PrinterType = util::error::PrinterNameValue<size-1,KeyType,ValueType>;
 
   // Output the standard assert message
-  assertOut(false,cond,str,file,line,func,error,std::make_tuple());
+  assertOut(false,cond,str,file,line,func,error);
 
   // Output each expression computed passed to the function along with the
   // computed value of that passed expression

--- a/src/vt/configs/error/config_assert.h
+++ b/src/vt/configs/error/config_assert.h
@@ -121,15 +121,15 @@
     do {                                                                \
       if (!(cond)) {                                                    \
         ::vt::debug::assert::assertOut(                                 \
-          fail,#cond,str,DEBUG_LOCATION,1,std::make_tuple()             \
+          fail,#cond,str,DEBUG_LOCATION,1                               \
         );                                                              \
       }                                                                 \
     } while (false)
   #define vtAssertExprImpl(fail,cond)                                   \
     do {                                                                \
       if (!(cond)) {                                                    \
-        ::vt::debug::assert::assertOutExpr(                             \
-          fail,#cond,DEBUG_LOCATION,1                                   \
+        ::vt::debug::assert::assertOut(                                 \
+          fail,#cond,"",DEBUG_LOCATION,1                                \
         );                                                              \
       }                                                                 \
     } while (false)


### PR DESCRIPTION
Fixes #1331
Fixes #1553 

TODO:
- [x] Optimize basic assertions
- [x] Optimize assertions with info?
  - [x] Get rid of info assertions without any actual info
  - [x] Optimize printer?
