### PR TITLE
1279 gossiplb inform and decide have bugs

### DIFF
--- a/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
@@ -85,6 +85,31 @@ private:
   NodeLoadType node_load_ = {};
 };
 
+struct GossipMsgAsync : GossipMsg {
+  using MessageParentType = GossipMsg;
+  vt_msg_serialize_if_needed_by_parent();
+
+  GossipMsgAsync() = default;
+  GossipMsgAsync(
+    NodeType in_from_node, NodeLoadType const& in_node_load, int round
+  )
+    : GossipMsg(in_from_node, in_node_load), round_(round)
+  { }
+
+  uint8_t getRound() const {
+    return round_;
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    MessageParentType::serialize(s);
+    s | round_;
+  }
+
+private:
+  int round_;
+};
+
 struct LazyMigrationMsg : SerializeRequired<
   vt::Message,
   LazyMigrationMsg

--- a/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
@@ -143,6 +143,32 @@ private:
   ObjsType objs_  = {};
 };
 
+struct RejectionStats {
+  RejectionStats() = default;
+  RejectionStats(int n_rejected, int n_transfers)
+    : n_rejected_(n_rejected), n_transfers_(n_transfers) { }
+
+  friend RejectionStats operator+(RejectionStats a1, RejectionStats const& a2) {
+    a1.n_rejected_ += a2.n_rejected_;
+    a1.n_transfers_ += a2.n_transfers_;
+
+    return a1;
+  }
+
+  int n_rejected_ = 0;
+  int n_transfers_ = 0;
+};
+
+struct GossipRejectionStatsMsg : collective::ReduceTMsg<RejectionStats> {
+  GossipRejectionStatsMsg() = default;
+  GossipRejectionStatsMsg(int n_rejected, int n_transfers)
+    : ReduceTMsg<RejectionStats>(RejectionStats(n_rejected, n_transfers))
+  { }
+  GossipRejectionStatsMsg(RejectionStats&& rs)
+    : ReduceTMsg<RejectionStats>(std::move(rs))
+  { }
+};
+
 }}}} /* end namespace vt::vrt::collection::balance */
 
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_GOSSIPLB_GOSSIP_MSG_H*/

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -78,7 +78,7 @@ bool GossipLB::isOverloaded(LoadType load) const {
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
   std::vector<std::string> allowed{
-    "f", "k", "i", "c", "trials", "deterministic", "ordering", "cmf"
+    "f", "k", "i", "c", "trials", "deterministic", "inform", "ordering", "cmf"
   };
   spec->checkAllowedKeys(allowed);
 
@@ -97,8 +97,8 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   num_iters_     = spec->getOrDefault<int32_t>("i", num_iters_);
   num_trials_    = spec->getOrDefault<int32_t>("trials", num_trials_);
   deterministic_ = spec->getOrDefault<int32_t>("deterministic", deterministic_);
-  int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
 
+  int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
   criterion_     = static_cast<CriterionEnum>(c);
   int32_t inf    = spec->getOrDefault<int32_t>("inform", default_inform);
   inform_type_   = static_cast<InformTypeEnum>(inf);

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -219,7 +219,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
       if (this_node == 0) {
         vt_print(
           gossiplb,
-          "GossipLB::doLBStages: trial={} iter={} imb={:0.2f}\n",
+          "GossipLB::doLBStages: trial={} iter={} imb={:0.4f}\n",
           trial_, iter_, new_imbalance_
         );
       }
@@ -228,7 +228,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
     if (this_node == 0) {
       vt_print(
         gossiplb,
-        "GossipLB::doLBStages: trial={} imb={:0.2f}\n",
+        "GossipLB::doLBStages: trial={} imb={:0.4f}\n",
         trial_, new_imbalance_
       );
     }
@@ -254,7 +254,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
     if (this_node == 0) {
       vt_print(
         gossiplb,
-        "GossipLB::doLBStages: chose trial={} with imb={:0.2f}\n",
+        "GossipLB::doLBStages: chose trial={} with imb={:0.4f}\n",
         best_trial, new_imbalance_
       );
     }
@@ -278,7 +278,7 @@ void GossipLB::gossipStatsHandler(StatsMsgType* msg) {
   if (this_node == 0) {
     vt_print(
       gossiplb,
-      "GossipLB::gossipStatsHandler: max={:0.2f} min={:0.2f} avg={:0.2f} imb={:0.2f}\n",
+      "GossipLB::gossipStatsHandler: max={:0.2f} min={:0.2f} avg={:0.2f} imb={:0.4f}\n",
       in.max(), in.min(), in.avg(), in.I()
     );
   }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -224,7 +224,6 @@ void GossipLB::doLBStages(TimeType start_imb) {
 
       if (rollback_ || theConfig()->vt_debug_gossiplb || (iter_ == num_iters_ - 1)) {
         runInEpochCollective([=] {
-          using StatsMsgType = balance::NodeStatsMsg;
           using ReduceOp = collective::PlusOp<balance::LoadData>;
           auto cb = vt::theCB()->makeBcast<
             GossipLB, StatsMsgType, &GossipLB::gossipStatsHandler

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -405,7 +405,8 @@ void GossipLB::informSync() {
   theSched()->runSchedulerWhile([this]{ return not setup_done_; });
 
   for (; k_cur_ < k_max_; ++k_cur_) {
-    vt::theCollective()->barrier();
+    auto kbarr = theCollective()->newNamedCollectiveBarrier();
+    theCollective()->barrier(nullptr, kbarr);
 
     auto name = fmt::format("GossipLB: informSync k_cur={}", k_cur_);
     auto propagate_epoch = theTerm()->makeEpochCollective(name);

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -352,6 +352,9 @@ void GossipLB::propagateRound(EpochType epoch) {
 
   auto& selected = selected_;
   selected = underloaded_;
+  if (selected.find(this_node) == selected.end()) {
+    selected.insert(this_node);
+  }
 
   auto const fanout = std::min(f_, static_cast<decltype(f_)>(num_nodes - 1));
 
@@ -363,7 +366,7 @@ void GossipLB::propagateRound(EpochType epoch) {
 
   for (int i = 0; i < fanout; i++) {
     // This implies full knowledge of all processors
-    if (selected.size() >= static_cast<size_t>(num_nodes - 1)) {
+    if (selected.size() >= static_cast<size_t>(num_nodes)) {
       return;
     }
 
@@ -374,9 +377,9 @@ void GossipLB::propagateRound(EpochType epoch) {
     do {
       random_node = dist(gen);
     } while (
-      selected.find(random_node) != selected.end() or
-      random_node == this_node
+      selected.find(random_node) != selected.end()
     );
+    selected.insert(random_node);
 
     vt_debug_print(
       verbose, gossiplb,

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -77,13 +77,18 @@ bool GossipLB::isOverloaded(LoadType load) const {
 }
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
-  std::vector<std::string> allowed{"f", "k", "i", "c", "trials", "deterministic"};
+  std::vector<std::string> allowed{
+    "f", "k", "i", "c", "trials", "deterministic", "ordering"
+  };
   spec->checkAllowedKeys(allowed);
-  using CriterionEnumUnder = typename std::underlying_type<CriterionEnum>::type;
-  using InformTypeEnumUnder = typename std::underlying_type<InformTypeEnum>::type;
 
-  auto default_c = static_cast<CriterionEnumUnder>(criterion_);
+  using CriterionEnumUnder   = typename std::underlying_type<CriterionEnum>::type;
+  using InformTypeEnumUnder  = typename std::underlying_type<InformTypeEnum>::type;
+  using ObjectOrderEnumUnder = typename std::underlying_type<ObjectOrderEnum>::type;
+
+  auto default_c      = static_cast<CriterionEnumUnder>(criterion_);
   auto default_inform = static_cast<InformTypeEnumUnder>(inform_type_);
+  auto default_order  = static_cast<ObjectOrderEnumUnder>(obj_ordering_);
 
   f_             = spec->getOrDefault<int32_t>("f", f_);
   k_max_         = spec->getOrDefault<int32_t>("k", k_max_);
@@ -91,13 +96,20 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   num_trials_    = spec->getOrDefault<int32_t>("trials", num_trials_);
   deterministic_ = spec->getOrDefault<int32_t>("deterministic", deterministic_);
   int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
+
   criterion_     = static_cast<CriterionEnum>(c);
   int32_t inf    = spec->getOrDefault<int32_t>("inform", default_inform);
   inform_type_   = static_cast<InformTypeEnum>(inf);
+  int32_t ord    = spec->getOrDefault<int32_t>("ordering", default_order);
+  obj_ordering_  = static_cast<ObjectOrderEnum>(ord);
 
   vtAbortIf(
     inform_type_ == InformTypeEnum::AsyncInform && deterministic_,
     "Asynchronous informs allow race conditions and thus are not deterministic"
+  );
+  vtAbortIf(
+    obj_ordering_ == ObjectOrderEnum::Arbitrary && deterministic_,
+    "Arbitrary object ordering is not deterministic"
   );
 }
 
@@ -692,9 +704,71 @@ void GossipLB::decide() {
     std::unordered_map<NodeType, ObjsType> migrate_objs;
 
     if (under.size() > 0) {
+      std::vector<ObjIDType> ordered_obj_ids(cur_objs_.size());
+
+      // define the iteration order
+      int i = 0;
+      for (auto &obj : cur_objs_) {
+        ordered_obj_ids[i++] = obj.first;
+      }
+      switch (obj_ordering_) {
+      case ObjectOrderEnum::ElmID:
+        std::sort(
+          ordered_obj_ids.begin(), ordered_obj_ids.end(), std::less<ObjIDType>()
+        );
+        break;
+      case ObjectOrderEnum::Marginal:
+        {
+          // first find marginal object's load
+          auto over_avg = this_new_load_ - avg;
+          // if no objects are larger than over_avg, then marginal will still
+          // (incorrectly) reflect the total load, which will not be a problem
+          auto marginal = this_new_load_;
+          for (auto &obj : cur_objs_) {
+            // the object stats are in seconds but the processor stats are in
+            // milliseconds; for now, convert the object loads to milliseconds
+            auto obj_load_ms = loadMilli(obj.second);
+            if (obj_load_ms > over_avg && obj_load_ms < marginal) {
+              marginal = obj_load_ms;
+            }
+          }
+          // sort largest to smallest if <= marginal
+          // sort smallest to largest if > marginal
+          std::sort(
+            ordered_obj_ids.begin(), ordered_obj_ids.end(),
+            [=](const ObjIDType &left, const ObjIDType &right) {
+              auto left_load = loadMilli(this->cur_objs_[left]);
+              auto right_load = loadMilli(this->cur_objs_[right]);
+              if (left_load <= marginal && right_load <= marginal) {
+                // we're in the sort load descending regime (first section)
+                return left_load > right_load;
+              }
+              // else
+              // EITHER
+              // a) both are above the cut, and we're in the sort ascending
+              //    regime (second section), so return left < right
+              // OR
+              // b) one is above the cut and one is at or below, and the one
+              //    that is at or below the cut needs to come first, so
+              //    also return left < right
+              return left_load < right_load;
+            }
+          );
+          vt_debug_print(
+            normal, gossiplb,
+            "GossipLB::decide: over_avg={}, marginal={}\n",
+            over_avg, loadMilli(cur_objs_[ordered_obj_ids[0]])
+          );
+        }
+        break;
+      default:
+        break;
+      }
+
       // Iterate through all the objects
-      for (auto iter = cur_objs_.begin(); iter != cur_objs_.end(); ) {
-        auto obj_load = cur_objs_[iter->first];
+      for (auto iter = ordered_obj_ids.begin(); iter != ordered_obj_ids.end(); ) {
+        auto obj_id = *iter;
+        auto obj_load = cur_objs_[obj_id];
 
         // the object stats are in seconds but the processor stats are in
         // milliseconds; for now, convert the object loads to milliseconds
@@ -712,7 +786,7 @@ void GossipLB::decide() {
 
         vt_debug_print(
           verbose, gossiplb,
-          "GossipLB::decide: selected_node={}, load_info_.size()\n",
+          "GossipLB::decide: selected_node={}, load_info_.size()={}\n",
           selected_node, load_info_.size()
         );
 
@@ -723,7 +797,6 @@ void GossipLB::decide() {
         auto& selected_load = load_iter->second;
 
         //auto max_obj_size = avg - selected_load;
-        auto obj_id = iter->first;
 
         bool eval = Criterion(criterion_)(this_new_load_, selected_load, obj_load_ms, avg);
 
@@ -754,7 +827,8 @@ void GossipLB::decide() {
           this_new_load_ -= obj_load_ms;
           selected_load += obj_load_ms;
 
-          iter = cur_objs_.erase(iter);
+          iter = ordered_obj_ids.erase(iter);
+          cur_objs_.erase(obj_id);
         } else {
           ++n_rejected;
           iter++;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -557,9 +557,18 @@ void GossipLB::propagateIncomingSync(GossipMsgSync* msg) {
 }
 
 std::vector<double> GossipLB::createCMF(NodeSetType const& under) {
+  // Build the CMF
+  std::vector<double> cmf = {};
+
+  if (under.size() == 1) {
+    // trying to compute the cmf for only a single object can result
+    // in nan for some cmf types below, so do it the easy way instead
+    cmf.push_back(1.0);
+    return cmf;
+  }
+
   double const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
 
-  // Build the CMF
   double sum_p = 0.0;
   double factor = 1.0;
 
@@ -588,7 +597,6 @@ std::vector<double> GossipLB::createCMF(NodeSetType const& under) {
     vtAbort("This CMF type is not supported");
   }
 
-  std::vector<double> cmf = {};
   for (auto&& pe : under) {
     auto iter = load_info_.find(pe);
     vtAssert(iter != load_info_.end(), "Node must be in load_info_");

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -384,6 +384,8 @@ void GossipLB::informSync() {
   theSched()->runSchedulerWhile([this]{ return not setup_done_; });
 
   for (; k_cur_ < k_max_; ++k_cur_) {
+    vt::theCollective()->barrier();
+
     auto name = fmt::format("GossipLB: informSync k_cur={}", k_cur_);
     auto propagate_epoch = theTerm()->makeEpochCollective(name);
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -263,11 +263,11 @@ void GossipLB::doLBStages(TimeType start_imb) {
   }
 
   if (best_imb <= start_imb) {
+    // load the configuration with the best imbalance
     cur_objs_ = best_objs;
     this_load = this_new_load_ = best_load;
     new_imbalance_ = best_imb;
 
-    // Update the load based on new object assignments
     if (this_node == 0) {
       vt_print(
         gossiplb,
@@ -695,6 +695,75 @@ GossipLB::selectObject(
   }
 }
 
+std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
+  // define the iteration order
+  std::vector<ObjIDType> ordered_obj_ids(cur_objs_.size());
+
+  int i = 0;
+  for (auto &obj : cur_objs_) {
+    ordered_obj_ids[i++] = obj.first;
+  }
+
+  switch (obj_ordering_) {
+  case ObjectOrderEnum::ElmID:
+    std::sort(
+      ordered_obj_ids.begin(), ordered_obj_ids.end(), std::less<ObjIDType>()
+    );
+    break;
+  case ObjectOrderEnum::Marginal:
+    {
+      // first find marginal object's load
+      auto over_avg = this_new_load_ - target_max_load_;
+      // if no objects are larger than over_avg, then marginal will still
+      // (incorrectly) reflect the total load, which will not be a problem
+      auto marginal = this_new_load_;
+      for (auto &obj : cur_objs_) {
+        // the object stats are in seconds but the processor stats are in
+        // milliseconds; for now, convert the object loads to milliseconds
+        auto obj_load_ms = loadMilli(obj.second);
+        if (obj_load_ms > over_avg && obj_load_ms < marginal) {
+          marginal = obj_load_ms;
+        }
+      }
+      // sort largest to smallest if <= marginal
+      // sort smallest to largest if > marginal
+      std::sort(
+        ordered_obj_ids.begin(), ordered_obj_ids.end(),
+        [=](const ObjIDType &left, const ObjIDType &right) {
+          auto left_load = loadMilli(this->cur_objs_[left]);
+          auto right_load = loadMilli(this->cur_objs_[right]);
+          if (left_load <= marginal && right_load <= marginal) {
+            // we're in the sort load descending regime (first section)
+            return left_load > right_load;
+          }
+          // else
+          // EITHER
+          // a) both are above the cut, and we're in the sort ascending
+          //    regime (second section), so return left < right
+          // OR
+          // b) one is above the cut and one is at or below, and the one
+          //    that is at or below the cut needs to come first, so
+          //    also return left < right
+          return left_load < right_load;
+        }
+      );
+      vt_debug_print(
+        normal, gossiplb,
+        "GossipLB::decide: over_avg={}, marginal={}\n",
+        over_avg, loadMilli(cur_objs_[ordered_obj_ids[0]])
+      );
+    }
+    break;
+  case ObjectOrderEnum::Arbitrary:
+    break;
+  default:
+    vtAbort("GossipLB::orderObjects: ordering not supported");
+    break;
+  }
+
+  return ordered_obj_ids;
+}
+
 void GossipLB::decide() {
   auto lazy_epoch = theTerm()->makeEpochCollective("GossipLB: decide");
 
@@ -705,66 +774,7 @@ void GossipLB::decide() {
     std::unordered_map<NodeType, ObjsType> migrate_objs;
 
     if (under.size() > 0) {
-      std::vector<ObjIDType> ordered_obj_ids(cur_objs_.size());
-
-      // define the iteration order
-      int i = 0;
-      for (auto &obj : cur_objs_) {
-        ordered_obj_ids[i++] = obj.first;
-      }
-      switch (obj_ordering_) {
-      case ObjectOrderEnum::ElmID:
-        std::sort(
-          ordered_obj_ids.begin(), ordered_obj_ids.end(), std::less<ObjIDType>()
-        );
-        break;
-      case ObjectOrderEnum::Marginal:
-        {
-          // first find marginal object's load
-          auto over_avg = this_new_load_ - target_max_load_;
-          // if no objects are larger than over_avg, then marginal will still
-          // (incorrectly) reflect the total load, which will not be a problem
-          auto marginal = this_new_load_;
-          for (auto &obj : cur_objs_) {
-            // the object stats are in seconds but the processor stats are in
-            // milliseconds; for now, convert the object loads to milliseconds
-            auto obj_load_ms = loadMilli(obj.second);
-            if (obj_load_ms > over_avg && obj_load_ms < marginal) {
-              marginal = obj_load_ms;
-            }
-          }
-          // sort largest to smallest if <= marginal
-          // sort smallest to largest if > marginal
-          std::sort(
-            ordered_obj_ids.begin(), ordered_obj_ids.end(),
-            [=](const ObjIDType &left, const ObjIDType &right) {
-              auto left_load = loadMilli(this->cur_objs_[left]);
-              auto right_load = loadMilli(this->cur_objs_[right]);
-              if (left_load <= marginal && right_load <= marginal) {
-                // we're in the sort load descending regime (first section)
-                return left_load > right_load;
-              }
-              // else
-              // EITHER
-              // a) both are above the cut, and we're in the sort ascending
-              //    regime (second section), so return left < right
-              // OR
-              // b) one is above the cut and one is at or below, and the one
-              //    that is at or below the cut needs to come first, so
-              //    also return left < right
-              return left_load < right_load;
-            }
-          );
-          vt_debug_print(
-            verbose, gossiplb,
-            "GossipLB::decide: over_avg={}, marginal={}\n",
-            over_avg, loadMilli(cur_objs_[ordered_obj_ids[0]])
-          );
-        }
-        break;
-      default:
-        break;
-      }
+      std::vector<ObjIDType> ordered_obj_ids = orderObjects();
 
       // Iterate through all the objects
       for (auto iter = ordered_obj_ids.begin(); iter != ordered_obj_ids.end(); ) {

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -166,7 +166,6 @@ void GossipLB::doLBStages(TimeType start_imb) {
     selected_.clear();
     underloaded_.clear();
     load_info_.clear();
-    k_cur_ = 0;
     is_overloaded_ = is_underloaded_ = false;
 
     TimeType best_imb_this_trial = start_imb + 10;
@@ -192,7 +191,6 @@ void GossipLB::doLBStages(TimeType start_imb) {
         selected_.clear();
         underloaded_.clear();
         load_info_.clear();
-        k_cur_ = 0;
         is_overloaded_ = is_underloaded_ = false;
       }
 
@@ -324,13 +322,12 @@ void GossipLB::gossipRejectionStatsHandler(GossipRejectionMsgType* msg) {
 
 void GossipLB::informAsync() {
   propagated_k_.assign(k_max_, false);
-  uint8_t k_cur_async = 0;
 
   vt_debug_print(
     normal, gossiplb,
     "GossipLB::informAsync: starting inform phase: trial={}, iter={}, "
-    "k_max={}, k_cur={}, is_underloaded={}, is_overloaded={}, load={}\n",
-    trial_, iter_, k_max_, k_cur_, is_underloaded_, is_overloaded_, this_new_load_
+    "k_max={}, is_underloaded={}, is_overloaded={}, load={}\n",
+    trial_, iter_, k_max_, is_underloaded_, is_overloaded_, this_new_load_
   );
 
   vtAssert(k_max_ > 0, "Number of rounds (k) must be greater than zero");
@@ -352,6 +349,7 @@ void GossipLB::informAsync() {
 
   // Underloaded start the round
   if (is_underloaded_) {
+    uint8_t k_cur_async = 0;
     propagateRound(k_cur_async, false, propagate_epoch);
   }
 
@@ -370,8 +368,8 @@ void GossipLB::informAsync() {
   vt_debug_print(
     verbose, gossiplb,
     "GossipLB::informAsync: finished inform phase: trial={}, iter={}, "
-    "k_max={}, k_cur={}\n",
-    trial_, iter_, k_max_, k_cur_
+    "k_max={}\n",
+    trial_, iter_, k_max_
   );
 }
 
@@ -379,8 +377,8 @@ void GossipLB::informSync() {
   vt_debug_print(
     normal, gossiplb,
     "GossipLB::informSync: starting inform phase: trial={}, iter={}, "
-    "k_max={}, k_cur={}, is_underloaded={}, is_overloaded={}, load={}\n",
-    trial_, iter_, k_max_, k_cur_, is_underloaded_, is_overloaded_, this_new_load_
+    "k_max={}, is_underloaded={}, is_overloaded={}, load={}\n",
+    trial_, iter_, k_max_, is_underloaded_, is_overloaded_, this_new_load_
   );
 
   vtAssert(k_max_ > 0, "Number of rounds (k) must be greater than zero");
@@ -403,7 +401,7 @@ void GossipLB::informSync() {
 
   theSched()->runSchedulerWhile([this]{ return not setup_done_; });
 
-  for (; k_cur_ < k_max_; ++k_cur_) {
+  for (k_cur_ = 0; k_cur_ < k_max_; ++k_cur_) {
     auto kbarr = theCollective()->newNamedCollectiveBarrier();
     theCollective()->barrier(nullptr, kbarr);
 
@@ -531,7 +529,7 @@ void GossipLB::propagateIncomingAsync(GossipMsgAsync* msg) {
     normal, gossiplb,
     "GossipLB::propagateIncomingAsync: trial={}, iter={}, k_max={}, "
     "k_cur={}, from_node={}, load info size={}\n",
-    trial_, iter_, k_max_, k_cur_, from_node, msg->getNodeLoad().size()
+    trial_, iter_, k_max_, k_cur_async, from_node, msg->getNodeLoad().size()
   );
 
   for (auto&& elm : msg->getNodeLoad()) {

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -694,6 +694,12 @@ void GossipLB::decide() {
     if (under.size() > 0) {
       // Iterate through all the objects
       for (auto iter = cur_objs_.begin(); iter != cur_objs_.end(); ) {
+        auto obj_load = cur_objs_[iter->first];
+
+        // the object stats are in seconds but the processor stats are in
+        // milliseconds; for now, convert the object loads to milliseconds
+        auto obj_load_ms = loadMilli(obj_load);
+
         // Rebuild the relaxed underloaded set based on updated load of this node
         under = makeUnderloaded();
         if (under.size() == 0) {
@@ -719,18 +725,13 @@ void GossipLB::decide() {
         //auto max_obj_size = avg - selected_load;
         auto obj_id = iter->first;
 
-        // @todo: for now, convert to milliseconds due to the stats framework all
-        // computing in milliseconds; should be converted to seconds along with
-        // the rest of the stats framework
-        auto obj_load = loadMilli(iter->second);
-
-        bool eval = Criterion(criterion_)(this_new_load_, selected_load, obj_load, avg);
+        bool eval = Criterion(criterion_)(this_new_load_, selected_load, obj_load_ms, avg);
 
         vt_debug_print(
           verbose, gossiplb,
           "GossipLB::decide: trial={}, iter={}, under.size()={}, "
           "selected_node={}, selected_load={:e}, obj_id={:x}, home={}, "
-          "obj_load={:e}, avg={:e}, this_new_load_={:e}, criterion={}\n",
+          "obj_load_ms={:e}, avg={:e}, this_new_load_={:e}, criterion={}\n",
           trial_,
           iter_,
           under.size(),
@@ -738,7 +739,7 @@ void GossipLB::decide() {
           selected_load,
           obj_id.id,
           obj_id.home_node,
-          obj_load,
+          obj_load_ms,
           avg,
           this_new_load_,
           eval
@@ -746,10 +747,12 @@ void GossipLB::decide() {
 
         if (eval) {
           ++n_transfers;
+          // transfer the object load in seconds, not milliseconds,
+          // to match the object load units on the receiving end
           migrate_objs[selected_node][obj_id] = obj_load;
 
-          this_new_load_ -= obj_load;
-          selected_load += obj_load;
+          this_new_load_ -= obj_load_ms;
+          selected_load += obj_load_ms;
 
           iter = cur_objs_.erase(iter);
         } else {
@@ -808,7 +811,8 @@ void GossipLB::inLazyMigrations(balance::LazyMigrationMsg* msg) {
     auto iter = cur_objs_.find(obj.first);
     vtAssert(iter == cur_objs_.end(), "Incoming object should not exist");
     cur_objs_.insert(obj);
-    this_new_load_ += obj.second;
+    // need to convert to milliseconds because we received seconds
+    this_new_load_ += loadMilli(obj.second);
   }
 }
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -114,7 +114,7 @@ void GossipLB::runLB() {
 
 void GossipLB::doLBStages(TimeType start_imb) {
   std::unordered_map<ObjIDType, TimeType> best_objs;
-  LoadType best_load;
+  LoadType best_load = 0;
   TimeType best_imb = start_imb+1;
   uint16_t best_trial = 0;
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -119,7 +119,7 @@ void GossipLB::runLB() {
 }
 
 void GossipLB::doLBStages(TimeType start_imb) {
-  std::unordered_map<ObjIDType, TimeType> best_objs;
+  decltype(this->cur_objs_) best_objs;
   LoadType best_load = 0;
   TimeType best_imb = start_imb+1;
   uint16_t best_trial = 0;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -128,9 +128,8 @@ void GossipLB::runLB() {
   if (theContext()->getNode() == 0) {
     vt_print(
       gossiplb,
-      "GossipLB::runLB: avg={}, max={}, load={},"
-      " overloaded_={}, underloaded_={}, should_lb={}\n",
-      avg, max, load, is_overloaded_, is_underloaded_, should_lb
+      "GossipLB::runLB: avg={}, max={}, load={}, should_lb={}\n",
+      avg, max, load, should_lb
     );
   }
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -411,7 +411,7 @@ void GossipLB::propagateIncoming(GossipMsg* msg) {
     if (load_info_.find(elm.first) == load_info_.end()) {
       load_info_[elm.first] = elm.second;
 
-      if (isUnderloaded(elm.first)) {
+      if (isUnderloaded(elm.second)) {
         underloaded_.insert(elm.first);
       }
     }
@@ -479,7 +479,7 @@ NodeType GossipLB::sampleFromCMF(
 std::vector<NodeType> GossipLB::makeUnderloaded() const {
   std::vector<NodeType> under = {};
   for (auto&& elm : load_info_) {
-    if (isUnderloaded(elm.first)) {
+    if (isUnderloaded(elm.second)) {
       under.push_back(elm.first);
     }
   }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -264,7 +264,7 @@ void GossipLB::gossipStatsHandler(StatsMsgType* msg) {
   }
 }
 
-void GossipLB::gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg) {
+void GossipLB::gossipRejectionStatsHandler(GossipRejectionMsgType* msg) {
   auto in = msg->getConstVal();
 
   auto n_rejected = in.n_rejected_;
@@ -758,11 +758,11 @@ void GossipLB::decide() {
   vt::runSchedulerThrough(lazy_epoch);
 
   runInEpochCollective([=] {
-    using ReduceOp = collective::PlusOp<RejectionStats>;
+    using ReduceOp = collective::PlusOp<balance::RejectionStats>;
     auto cb = vt::theCB()->makeBcast<
-      GossipLB, GossipRejectionStatsMsg, &GossipLB::gossipRejectionStatsHandler
+      GossipLB, GossipRejectionMsgType, &GossipLB::gossipRejectionStatsHandler
     >(this->proxy_);
-    auto msg = makeMessage<GossipRejectionStatsMsg>(n_rejected, n_transfers);
+    auto msg = makeMessage<GossipRejectionMsgType>(n_rejected, n_transfers);
     this->proxy_.template reduce<ReduceOp>(msg,cb);
   });
 }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -84,10 +84,10 @@ struct GossipRejectionStatsMsg : collective::ReduceTMsg<RejectionStats> {
 };
 
 struct GossipLB : BaseLB {
-  using GossipMsg     = balance::GossipMsg;
-  using NodeSetType   = std::vector<NodeType>;
-  using ObjsType      = std::unordered_map<ObjIDType, LoadType>;
-  using ReduceMsgType = vt::collective::ReduceNoneMsg;
+  using GossipMsgAsync = balance::GossipMsgAsync;
+  using NodeSetType    = std::vector<NodeType>;
+  using ObjsType       = std::unordered_map<ObjIDType, LoadType>;
+  using ReduceMsgType  = vt::collective::ReduceNoneMsg;
 
   GossipLB() = default;
   GossipLB(GossipLB const&) = delete;
@@ -101,12 +101,12 @@ public:
 
 protected:
   void doLBStages(TimeType start_imb);
-  void inform();
+  void informAsync();
   void decide();
   void migrate();
 
-  void propagateRound(EpochType epoch = no_epoch);
-  void propagateIncoming(GossipMsg* msg);
+  void propagateRoundAsync(uint8_t k_cur_async, EpochType epoch = no_epoch);
+  void propagateIncomingAsync(GossipMsgAsync* msg);
   bool isUnderloaded(LoadType load) const;
   bool isUnderloadedRelaxed(LoadType over, LoadType under) const;
   bool isOverloaded(LoadType load) const;
@@ -146,6 +146,7 @@ private:
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   bool setup_done_                                  = false;
+  std::vector<bool> propagated_k_;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -147,8 +147,8 @@ private:
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
-  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Arbitrary;
-  CMFTypeEnum cmf_type_                             = CMFTypeEnum::Original;
+  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Marginal;
+  CMFTypeEnum cmf_type_                             = CMFTypeEnum::NormByMax;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -133,6 +133,7 @@ private:
   uint16_t num_iters_                               = 4;
   uint16_t num_trials_                              = 3;
   bool deterministic_                               = false;
+  bool rollback_                                    = true;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
   std::unordered_map<NodeType, LoadType> new_load_info_ = {};

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -112,6 +112,7 @@ protected:
   std::vector<double> createCMF(NodeSetType const& under);
   NodeType sampleFromCMF(NodeSetType const& under, std::vector<double> const& cmf);
   std::vector<NodeType> makeUnderloaded() const;
+  std::vector<ObjIDType> orderObjects();
   ElementLoadType::iterator selectObject(
     LoadType size, ElementLoadType& load, std::set<ObjIDType> const& available
   );

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -102,8 +102,7 @@ protected:
   void decide();
   void migrate();
 
-  void propagateRoundAsync(uint8_t k_cur_async, EpochType epoch = no_epoch);
-  void propagateRoundSync(EpochType epoch = no_epoch);
+  void propagateRound(uint8_t k_cur_async, bool sync, EpochType epoch = no_epoch);
   void propagateIncomingAsync(GossipMsgAsync* msg);
   void propagateIncomingSync(GossipMsgSync* msg);
   bool isUnderloaded(LoadType load) const;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -129,7 +129,7 @@ private:
   std::unordered_set<NodeType> selected_            = {};
   std::unordered_set<NodeType> underloaded_         = {};
   std::unordered_set<NodeType> new_underloaded_     = {};
-  std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
+  std::map<ObjIDType, TimeType> cur_objs_           = {};
   LoadType this_new_load_                           = 0.0;
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -134,6 +134,7 @@ private:
   uint16_t num_trials_                              = 3;
   bool deterministic_                               = false;
   bool rollback_                                    = true;
+  bool target_pole_                                 = false;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
   std::unordered_map<NodeType, LoadType> new_load_info_ = {};
@@ -146,6 +147,7 @@ private:
   std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
   LoadType this_new_load_                           = 0.0;
   TimeType new_imbalance_                           = 0.0;
+  TimeType target_max_load_                         = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
   ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Marginal;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -71,6 +71,12 @@ enum struct ObjectOrderEnum : uint8_t {
   Marginal  = 2
 };
 
+enum struct CMFTypeEnum : uint8_t {
+  Original   = 0,
+  NormByMax  = 1,
+  NormBySelf = 2
+};
+
 struct GossipLB : BaseLB {
   using GossipMsgAsync = balance::GossipMsgAsync;
   using GossipMsgSync  = balance::GossipMsg;
@@ -143,6 +149,7 @@ private:
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
   ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Arbitrary;
+  CMFTypeEnum cmf_type_                             = CMFTypeEnum::Original;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -52,6 +52,7 @@
 
 #include <random>
 #include <unordered_map>
+#include <map>
 #include <unordered_set>
 #include <vector>
 
@@ -120,6 +121,7 @@ private:
   uint16_t trial_                                   = 0;
   uint16_t num_iters_                               = 4;
   uint16_t num_trials_                              = 3;
+  bool deterministic_                               = false;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
   std::unordered_map<NodeType, LoadType> new_load_info_ = {};
@@ -137,6 +139,8 @@ private:
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;
+  std::mt19937 gen_propagate_;
+  std::mt19937 gen_sample_;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -65,6 +65,12 @@ enum struct InformTypeEnum : uint8_t {
   AsyncInform = 1
 };
 
+enum struct ObjectOrderEnum : uint8_t {
+  Arbitrary = 0,
+  ElmID     = 1,
+  Marginal  = 2
+};
+
 struct GossipLB : BaseLB {
   using GossipMsgAsync = balance::GossipMsgAsync;
   using GossipMsgSync  = balance::GossipMsg;
@@ -131,11 +137,12 @@ private:
   std::unordered_set<NodeType> selected_            = {};
   std::unordered_set<NodeType> underloaded_         = {};
   std::unordered_set<NodeType> new_underloaded_     = {};
-  std::map<ObjIDType, TimeType> cur_objs_           = {};
+  std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
   LoadType this_new_load_                           = 0.0;
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
+  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Arbitrary;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -83,8 +83,16 @@ struct GossipRejectionStatsMsg : collective::ReduceTMsg<RejectionStats> {
   { }
 };
 
+enum struct InformTypeEnum : uint8_t {
+  // synchronized rounds propagate info faster but have sync cost
+  SyncInform  = 0,
+  // async rounds propagate before round has completed, omitting some info
+  AsyncInform = 1
+};
+
 struct GossipLB : BaseLB {
   using GossipMsgAsync = balance::GossipMsgAsync;
+  using GossipMsgSync  =  balance::GossipMsg;
   using NodeSetType    = std::vector<NodeType>;
   using ObjsType       = std::unordered_map<ObjIDType, LoadType>;
   using ReduceMsgType  = vt::collective::ReduceNoneMsg;
@@ -102,11 +110,14 @@ public:
 protected:
   void doLBStages(TimeType start_imb);
   void informAsync();
+  void informSync();
   void decide();
   void migrate();
 
   void propagateRoundAsync(uint8_t k_cur_async, EpochType epoch = no_epoch);
+  void propagateRoundSync(EpochType epoch = no_epoch);
   void propagateIncomingAsync(GossipMsgAsync* msg);
+  void propagateIncomingSync(GossipMsgSync* msg);
   bool isUnderloaded(LoadType load) const;
   bool isUnderloadedRelaxed(LoadType over, LoadType under) const;
   bool isOverloaded(LoadType load) const;
@@ -136,16 +147,20 @@ private:
   uint16_t num_trials_                              = 3;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
+  std::unordered_map<NodeType, LoadType> new_load_info_ = {};
   objgroup::proxy::Proxy<GossipLB> proxy_           = {};
   bool is_overloaded_                               = false;
   bool is_underloaded_                              = false;
   std::unordered_set<NodeType> selected_            = {};
   std::unordered_set<NodeType> underloaded_         = {};
+  std::unordered_set<NodeType> new_underloaded_     = {};
   std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
   LoadType this_new_load_                           = 0.0;
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
+  InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
   bool setup_done_                                  = false;
+  bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;
 };
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -57,32 +57,6 @@
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
-struct RejectionStats {
-  RejectionStats() = default;
-  RejectionStats(int n_rejected, int n_transfers)
-    : n_rejected_(n_rejected), n_transfers_(n_transfers) { }
-
-  friend RejectionStats operator+(RejectionStats a1, RejectionStats const& a2) {
-    a1.n_rejected_ += a2.n_rejected_;
-    a1.n_transfers_ += a2.n_transfers_;
-
-    return a1;
-  }
-
-  int n_rejected_ = 0;
-  int n_transfers_ = 0;
-};
-
-struct GossipRejectionStatsMsg : collective::ReduceTMsg<RejectionStats> {
-  GossipRejectionStatsMsg() = default;
-  GossipRejectionStatsMsg(int n_rejected, int n_transfers)
-    : ReduceTMsg<RejectionStats>(RejectionStats(n_rejected, n_transfers))
-  { }
-  GossipRejectionStatsMsg(RejectionStats&& rs)
-    : ReduceTMsg<RejectionStats>(std::move(rs))
-  { }
-};
-
 enum struct InformTypeEnum : uint8_t {
   // synchronized rounds propagate info faster but have sync cost
   SyncInform  = 0,
@@ -92,10 +66,11 @@ enum struct InformTypeEnum : uint8_t {
 
 struct GossipLB : BaseLB {
   using GossipMsgAsync = balance::GossipMsgAsync;
-  using GossipMsgSync  =  balance::GossipMsg;
+  using GossipMsgSync  = balance::GossipMsg;
   using NodeSetType    = std::vector<NodeType>;
   using ObjsType       = std::unordered_map<ObjIDType, LoadType>;
   using ReduceMsgType  = vt::collective::ReduceNoneMsg;
+  using GossipRejectionMsgType = balance::GossipRejectionStatsMsg;
 
   GossipLB() = default;
   GossipLB(GossipLB const&) = delete;
@@ -132,7 +107,7 @@ protected:
   void lazyMigrateObjsTo(EpochType epoch, NodeType node, ObjsType const& objs);
   void inLazyMigrations(balance::LazyMigrationMsg* msg);
   void gossipStatsHandler(StatsMsgType* msg);
-  void gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg);
+  void gossipRejectionStatsHandler(GossipRejectionMsgType* msg);
   void thunkMigrations();
 
   void setupDone(ReduceMsgType* msg);

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -58,22 +58,43 @@
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
+// gossiping approach
 enum struct InformTypeEnum : uint8_t {
-  // synchronized rounds propagate info faster but have sync cost
+  // synchronous: round number defined at the processor level;  propagates
+  // after all messages for a round are received, but has sync cost
   SyncInform  = 0,
-  // async rounds propagate before round has completed, omitting some info
+  // asynchronous: round number defined at the message level; propagates
+  // when the first message for a round is received, so has no sync cost
   AsyncInform = 1
 };
 
+// order in which local objects are considered for transfer
 enum struct ObjectOrderEnum : uint8_t {
+  // abitrary: use the unordered_map order
   Arbitrary = 0,
+  // element id: ascending by id member of ElementIDStruct
   ElmID     = 1,
+  // marginal: order by load, starting with the object of marginal load
+  // (the smallest object that can be transferred to drop the processor
+  // load below the average), then descending for objects with loads less
+  // than the marginal load, and finally ascending for objects with loads
+  // greater than the marginal load
   Marginal  = 2
 };
 
+// how the cmf is computed
 enum struct CMFTypeEnum : uint8_t {
+  // original: remove processors from the CMF as soon as they exceed the
+  // target (e.g., processor-avg) load; use a CMF factor of 1.0/x, where x
+  // is the target load
   Original   = 0,
+  // normalize by max: do not remove processors from the CMF that exceed the
+  // target load until the next iteration; use a CMF factor of 1.0/x, where x
+  // is the maximum of the target load and the most loaded processor in the CMF
   NormByMax  = 1,
+  // normalize by self: do not remove processors from the CMF that exceed the
+  // target load until the next iteration; use a CMF factor of 1.0/x, where x
+  // is the load of the processor that is computing the CMF
   NormBySelf = 2
 };
 
@@ -132,9 +153,18 @@ private:
   uint16_t iter_                                    = 0;
   uint16_t trial_                                   = 0;
   uint16_t num_iters_                               = 4;
+  // how many times to repeat the requested number of iterations, hoping to
+  // find a better imbalance (helps if it's easy to get stuck in a local
+  // minimum)
   uint16_t num_trials_                              = 3;
+  // whether to make migration choices deterministic, assuming we're operating
+  // on deterministic loads
   bool deterministic_                               = false;
+  // whether to roll back to the state from a previous iteration if that
+  // iteration had a better imbalance than the final one
   bool rollback_                                    = true;
+  // whether to use a target load equal to the maximum object load (the
+  // "longest pole") when that load exceeds the processor-average load
   bool target_pole_                                 = false;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -131,6 +131,7 @@ private:
   uint8_t k_max_                                    = 4;
   uint8_t k_cur_                                    = 0;
   uint16_t iter_                                    = 0;
+  uint16_t trial_                                   = 0;
   uint16_t num_iters_                               = 4;
   uint16_t num_trials_                              = 3;
   std::random_device seed_;


### PR DESCRIPTION
Includes many bug fixes and improvements to GossipLB.  The following LB args were added:

- `trials` (default `3`): how many times to repeat the requested number of iterations, hoping to find a better imbalance; helps if it’s easy to get stuck in a local minimum
- `deterministic` (default false): for debugging purposes, make the migration decision deterministic assuming deterministic loads (for testing on deterministic loads, consider using the driver in development under #1265)
- `inform` (default SyncInform): choice of gossiping approach
  - SyncInform (`0`): synchronous propagates after all recvs for a round, but has sync cost (matches LBAF approach)
  - AsyncInform (`1`): asynchronous propagates after the first recv for a round, but avoids sync cost
- `ordering` (default Marginal): order in which to evaluate local objects for migration
  - Arbitrary (`0`): use the unordered_map iteration order
  - ElmID (`1`): order by ascending element ID
  - Marginal (`2`): order by descending load starting with the object of marginal load, then order ascending for larger loads
- `cmf` (default NormByMax): the algorithm used for computing the CMF
  - Original (`0`): remove processors from the CMF as soon as they exceed the target (e.g., processor-average) load; use a CMF factor of 1.0/x, where x is the target load
  - NormByMax (`1`): do not remove processors from the CMF that exceed the target load until the next iteration; use a CMF factor of 1.0x, where x is the maximum of the target load and the most loaded processor in the CMF
  - NormBySelf (`2`): do not remove processors from the CMF that exceed the target load until the next iteration; use a CMF factor of 1.0x, where x is the load of the processor that is computing the CMF
- `rollback` (default true): whether to roll back to an earlier iteration if it had the best imbalance
- `targetpole` (default false): whether to replace the processor-average load with the max of that and the maximum object load, effectively redefining overloaded/underloaded based on the longest pole load when it exceeds the processor-average load

Note that I have a both a develop-based branch (this PR; `1279-gossiplb-inform-and-decide-have-bugs`) and a release-based branch (`1279-gossiplb-inform-and-decide-have-bugs-release`).

Closes #1279