### PR TITLE
1279 gossiplb inform and decide have bugs - release branch

### DIFF
--- a/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
@@ -81,6 +81,30 @@ private:
   NodeLoadType node_load_ = {};
 };
 
+struct GossipMsgAsync : GossipMsg {
+  using MessageParentType = GossipMsg;
+
+  GossipMsgAsync() = default;
+  GossipMsgAsync(
+    NodeType in_from_node, NodeLoadType const& in_node_load, int round
+  )
+    : GossipMsg(in_from_node, in_node_load), round_(round)
+  { }
+
+  uint8_t getRound() const {
+    return round_;
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    MessageParentType::serialize(s);
+    s | round_;
+  }
+
+private:
+  int round_;
+};
+
 struct LazyMigrationMsg : vt::Message {
   using ObjsType = std::unordered_map<lb::BaseLB::ObjIDType, lb::BaseLB::LoadType>;
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossip_msg.h
@@ -130,6 +130,32 @@ private:
   ObjsType objs_  = {};
 };
 
+struct RejectionStats {
+  RejectionStats() = default;
+  RejectionStats(int n_rejected, int n_transfers)
+    : n_rejected_(n_rejected), n_transfers_(n_transfers) { }
+
+  friend RejectionStats operator+(RejectionStats a1, RejectionStats const& a2) {
+    a1.n_rejected_ += a2.n_rejected_;
+    a1.n_transfers_ += a2.n_transfers_;
+
+    return a1;
+  }
+
+  int n_rejected_ = 0;
+  int n_transfers_ = 0;
+};
+
+struct GossipRejectionStatsMsg : collective::ReduceTMsg<RejectionStats> {
+  GossipRejectionStatsMsg() = default;
+  GossipRejectionStatsMsg(int n_rejected, int n_transfers)
+    : ReduceTMsg<RejectionStats>(RejectionStats(n_rejected, n_transfers))
+  { }
+  GossipRejectionStatsMsg(RejectionStats&& rs)
+    : ReduceTMsg<RejectionStats>(std::move(rs))
+  { }
+};
+
 }}}} /* end namespace vt::vrt::collection::balance */
 
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_GOSSIPLB_GOSSIP_MSG_H*/

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -414,7 +414,7 @@ void GossipLB::propagateIncoming(GossipMsg* msg) {
     if (load_info_.find(elm.first) == load_info_.end()) {
       load_info_[elm.first] = elm.second;
 
-      if (isUnderloaded(elm.first)) {
+      if (isUnderloaded(elm.second)) {
         underloaded_.insert(elm.first);
       }
     }
@@ -482,7 +482,7 @@ NodeType GossipLB::sampleFromCMF(
 std::vector<NodeType> GossipLB::makeUnderloaded() const {
   std::vector<NodeType> under = {};
   for (auto&& elm : load_info_) {
-    if (isUnderloaded(elm.first)) {
+    if (isUnderloaded(elm.second)) {
       under.push_back(elm.first);
     }
   }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -355,6 +355,9 @@ void GossipLB::propagateRound(EpochType epoch) {
 
   auto& selected = selected_;
   selected = underloaded_;
+  if (selected.find(this_node) == selected.end()) {
+    selected.insert(this_node);
+  }
 
   auto const fanout = std::min(f_, static_cast<decltype(f_)>(num_nodes - 1));
 
@@ -366,7 +369,7 @@ void GossipLB::propagateRound(EpochType epoch) {
 
   for (int i = 0; i < fanout; i++) {
     // This implies full knowledge of all processors
-    if (selected.size() >= static_cast<size_t>(num_nodes - 1)) {
+    if (selected.size() >= static_cast<size_t>(num_nodes)) {
       return;
     }
 
@@ -377,9 +380,9 @@ void GossipLB::propagateRound(EpochType epoch) {
     do {
       random_node = dist(gen);
     } while (
-      selected.find(random_node) != selected.end() or
-      random_node == this_node
+      selected.find(random_node) != selected.end()
     );
+    selected.insert(random_node);
 
     debug_print(
       gossiplb, node,

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -79,7 +79,7 @@ bool GossipLB::isOverloaded(LoadType load) const {
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
   std::vector<std::string> allowed{
-    "f", "k", "i", "c", "trials", "deterministic", "ordering", "cmf"
+    "f", "k", "i", "c", "trials", "deterministic", "inform", "ordering", "cmf"
   };
   spec->checkAllowedKeys(allowed);
 
@@ -98,8 +98,8 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   num_iters_     = spec->getOrDefault<int32_t>("i", num_iters_);
   num_trials_    = spec->getOrDefault<int32_t>("trials", num_trials_);
   deterministic_ = spec->getOrDefault<int32_t>("deterministic", deterministic_);
-  int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
 
+  int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
   criterion_     = static_cast<CriterionEnum>(c);
   int32_t inf    = spec->getOrDefault<int32_t>("inform", default_inform);
   inform_type_   = static_cast<InformTypeEnum>(inf);

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -265,7 +265,7 @@ void GossipLB::gossipStatsHandler(StatsMsgType* msg) {
   }
 }
 
-void GossipLB::gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg) {
+void GossipLB::gossipRejectionStatsHandler(GossipRejectionMsgType* msg) {
   auto in = msg->getConstVal();
 
   auto n_rejected = in.n_rejected_;
@@ -762,11 +762,11 @@ void GossipLB::decide() {
   theSched()->runSchedulerWhile([&decide_done]{ return not decide_done; });
 
   runInEpochCollective([=] {
-    using ReduceOp = collective::PlusOp<RejectionStats>;
+    using ReduceOp = collective::PlusOp<balance::RejectionStats>;
     auto cb = vt::theCB()->makeBcast<
-      GossipLB, GossipRejectionStatsMsg, &GossipLB::gossipRejectionStatsHandler
+      GossipLB, GossipRejectionMsgType, &GossipLB::gossipRejectionStatsHandler
     >(this->proxy_);
-    auto msg = makeMessage<GossipRejectionStatsMsg>(n_rejected, n_transfers);
+    auto msg = makeMessage<GossipRejectionMsgType>(n_rejected, n_transfers);
     this->proxy_.template reduce<ReduceOp>(msg,cb);
   });
 }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -62,6 +62,9 @@ namespace vt { namespace vrt { namespace collection { namespace lb {
 
 void GossipLB::init(objgroup::proxy::Proxy<GossipLB> in_proxy) {
   proxy_ = in_proxy;
+  auto const this_node = theContext()->getNode();
+  gen_propagate_.seed(this_node + 12345);
+  gen_sample_.seed(this_node + 54321);
 }
 
 bool GossipLB::isUnderloaded(LoadType load) const {
@@ -75,7 +78,7 @@ bool GossipLB::isOverloaded(LoadType load) const {
 }
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
-  std::vector<std::string> allowed{"f", "k", "i", "c", "trials"};
+  std::vector<std::string> allowed{"f", "k", "i", "c", "trials", "deterministic"};
   spec->checkAllowedKeys(allowed);
   using CriterionEnumUnder = typename std::underlying_type<CriterionEnum>::type;
   using InformTypeEnumUnder = typename std::underlying_type<InformTypeEnum>::type;
@@ -83,14 +86,20 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   auto default_c = static_cast<CriterionEnumUnder>(criterion_);
   auto default_inform = static_cast<InformTypeEnumUnder>(inform_type_);
 
-  f_           = spec->getOrDefault<int32_t>("f", f_);
-  k_max_       = spec->getOrDefault<int32_t>("k", k_max_);
-  num_iters_   = spec->getOrDefault<int32_t>("i", num_iters_);
-  num_trials_  = spec->getOrDefault<int32_t>("trials", num_trials_);
-  int32_t c    = spec->getOrDefault<int32_t>("c", default_c);
-  criterion_   = static_cast<CriterionEnum>(c);
-  int32_t inf  = spec->getOrDefault<int32_t>("inform", default_inform);
-  inform_type_ = static_cast<InformTypeEnum>(inf);
+  f_             = spec->getOrDefault<int32_t>("f", f_);
+  k_max_         = spec->getOrDefault<int32_t>("k", k_max_);
+  num_iters_     = spec->getOrDefault<int32_t>("i", num_iters_);
+  num_trials_    = spec->getOrDefault<int32_t>("trials", num_trials_);
+  deterministic_ = spec->getOrDefault<int32_t>("deterministic", deterministic_);
+  int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
+  criterion_     = static_cast<CriterionEnum>(c);
+  int32_t inf    = spec->getOrDefault<int32_t>("inform", default_inform);
+  inform_type_   = static_cast<InformTypeEnum>(inf);
+
+  vtAbortIf(
+    inform_type_ == InformTypeEnum::AsyncInform && deterministic_,
+    "Asynchronous informs allow race conditions and thus are not deterministic"
+  );
 }
 
 void GossipLB::runLB() {
@@ -418,7 +427,10 @@ void GossipLB::propagateRoundAsync(uint8_t k_cur_async, EpochType epoch) {
   auto const this_node = theContext()->getNode();
   auto const num_nodes = theContext()->getNumNodes();
   std::uniform_int_distribution<NodeType> dist(0, num_nodes - 1);
-  std::mt19937 gen(seed_());
+
+  if (!deterministic_) {
+    gen_propagate_.seed(seed_());
+  }
 
   auto& selected = selected_;
   selected = underloaded_;
@@ -446,7 +458,7 @@ void GossipLB::propagateRoundAsync(uint8_t k_cur_async, EpochType epoch) {
 
     // Keep generating until we have a unique node for this round
     do {
-      random_node = dist(gen);
+      random_node = dist(gen_propagate_);
     } while (
       selected.find(random_node) != selected.end()
     );
@@ -481,7 +493,10 @@ void GossipLB::propagateRoundSync(EpochType epoch) {
   auto const this_node = theContext()->getNode();
   auto const num_nodes = theContext()->getNumNodes();
   std::uniform_int_distribution<NodeType> dist(0, num_nodes - 1);
-  std::mt19937 gen(seed_());
+
+  if (!deterministic_) {
+    gen_propagate_.seed(seed_());
+  }
 
   auto& selected = selected_;
   selected = underloaded_;
@@ -509,7 +524,7 @@ void GossipLB::propagateRoundSync(EpochType epoch) {
 
     // Keep generating until we have a unique node for this round
     do {
-      random_node = dist(gen);
+      random_node = dist(gen_propagate_);
     } while (
       selected.find(random_node) != selected.end()
     );
@@ -619,12 +634,15 @@ NodeType GossipLB::sampleFromCMF(
 ) {
   // Create the distribution
   std::uniform_real_distribution<double> dist(0.0, 1.0);
-  std::mt19937 gen(seed_());
+
+  if (!deterministic_) {
+    gen_sample_.seed(seed_());
+  }
 
   NodeType selected_node = uninitialized_destination;
 
   // Pick from the CMF
-  auto const u = dist(gen);
+  auto const u = dist(gen_sample_);
   std::size_t i = 0;
   for (auto&& x : cmf) {
     if (x >= u) {
@@ -643,6 +661,9 @@ std::vector<NodeType> GossipLB::makeUnderloaded() const {
     if (isUnderloaded(elm.second)) {
       under.push_back(elm.first);
     }
+  }
+  if (deterministic_) {
+    std::sort(under.begin(), under.end());
   }
   return under;
 }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -123,7 +123,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
 
   auto this_node = theContext()->getNode();
 
-  for (uint16_t trial = 0; trial < num_trials_; ++trial) {
+  for (trial_ = 0; trial_ < num_trials_; ++trial_) {
     // Clear out data structures
     selected_.clear();
     underloaded_.clear();
@@ -136,8 +136,9 @@ void GossipLB::doLBStages(TimeType start_imb) {
 
       debug_print(
         gossiplb, node,
-        "GossipLB::doLBStages: (before) running iter_={}, num_iters_={}, load={}, new_load={}\n",
-        iter_, num_iters_, this_load, this_new_load_
+        "GossipLB::doLBStages: (before) running trial={}, iter={}, "
+        "num_iters={}, load={}, new_load={}\n",
+        trial_, iter_, num_iters_, this_load, this_new_load_
       );
 
       if (first_iter) {
@@ -164,8 +165,9 @@ void GossipLB::doLBStages(TimeType start_imb) {
 
       debug_print(
         gossiplb, node,
-        "GossipLB::doLBStages: (after) running iter_={}, num_iters_={}, load={}, new_load={}\n",
-        iter_, num_iters_, this_load, this_new_load_
+        "GossipLB::doLBStages: (after) running trial={}, iter={}, "
+        "num_iters={}, load={}, new_load={}\n",
+        trial_, iter_, num_iters_, this_load, this_new_load_
       );
 
       runInEpochCollective([=] {
@@ -183,7 +185,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
         vt_print(
           gossiplb,
           "GossipLB::doLBStages: trial={} iter={} imb={:0.2f}\n",
-          trial, iter_, new_imbalance_
+          trial_, iter_, new_imbalance_
         );
       }
     }
@@ -192,15 +194,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
       vt_print(
         gossiplb,
         "GossipLB::doLBStages: trial={} imb={:0.2f}\n",
-        trial, new_imbalance_
-      );
-    }
-
-    if (cur_objs_.size() == 0) {
-      vt_print(
-        gossiplb,
-        "GossipLB::doLBStages: trial={} local_objs={}\n",
-        trial, cur_objs_.size()
+        trial_, new_imbalance_
       );
     }
 
@@ -208,7 +202,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
       best_load = this_new_load_;
       best_objs = cur_objs_;
       best_imb = new_imbalance_;
-      best_trial = trial;
+      best_trial = trial_;
     }
 
     // Clear out for next try or for not migrating by default
@@ -253,22 +247,6 @@ void GossipLB::gossipStatsHandler(StatsMsgType* msg) {
       in.max(), in.min(), in.avg(), in.I()
     );
   }
-/*
-  if (this_new_load_ <= in.min() * 1.01) {
-    vt_print(
-      gossiplb,
-      "GossipLB::gossipStatsHandler: new_load={:0.2f} min={:0.2f} count={}\n",
-      this_new_load_, in.min(), cur_objs_.size()
-    );
-  }
-  if (this_new_load_ >= in.max() * 0.99) {
-    vt_print(
-      gossiplb,
-      "GossipLB::gossipStatsHandler: new_load={:0.2f} max={:0.2f} count={}\n",
-      this_new_load_, in.max(), cur_objs_.size()
-    );
-  }
-*/
 }
 
 void GossipLB::gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg) {
@@ -291,8 +269,9 @@ void GossipLB::gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg) {
 void GossipLB::inform() {
   debug_print(
     gossiplb, node,
-    "GossipLB::inform: starting inform phase: k_max_={}, k_cur_={}\n",
-    k_max_, k_cur_
+    "GossipLB::inform: starting inform phase: trial={}, iter={}, k_max={}, "
+    "k_cur={}, is_underloaded={}, is_overloaded={}, load={}\n",
+    trial_, iter_, k_max_, k_cur_, is_underloaded_, is_overloaded_, this_new_load_
   );
 
   vtAssert(k_max_ > 0, "Number of rounds (k) must be greater than zero");
@@ -301,13 +280,6 @@ void GossipLB::inform() {
   if (is_underloaded_) {
     underloaded_.insert(this_node);
   }
-
-  debug_print(
-    gossiplb, node,
-    "GossipLB::inform: starting inform phase: k_max_={}, k_cur_={}, "
-    "is_underloaded={}, is_overloaded={}, load={}\n",
-    k_max_, k_cur_, is_underloaded_, is_overloaded_, this_new_load_
-  );
 
   setup_done_ = false;
 
@@ -330,10 +302,19 @@ void GossipLB::inform() {
 
   theSched()->runSchedulerWhile([&inform_done]{ return not inform_done; });
 
+  if (is_overloaded_) {
+    vt_print(
+      gossiplb,
+      "GossipLB::inform: trial={}, iter={}, known underloaded={}\n",
+      trial_, iter_, underloaded_.size()
+    );
+  }
+
   debug_print(
     gossiplb, node,
-    "GossipLB::inform: finished inform phase: k_max_={}, k_cur_={}\n",
-    k_max_, k_cur_
+    "GossipLB::inform: finished inform phase: trial={}, iter={}, "
+    "k_max={}, k_cur={}\n",
+    trial_, iter_, k_max_, k_cur_
   );
 }
 
@@ -344,8 +325,8 @@ void GossipLB::setupDone(ReduceMsgType* msg) {
 void GossipLB::propagateRound(EpochType epoch) {
   debug_print(
     gossiplb, node,
-    "GossipLB::propagateRound: k_max_={}, k_cur_={}\n",
-    k_max_, k_cur_
+    "GossipLB::propagateRound: trial={}, iter={}, k_max={}, k_cur={}\n",
+    trial_, iter_, k_max_, k_cur_
   );
 
   auto const this_node = theContext()->getNode();
@@ -363,8 +344,9 @@ void GossipLB::propagateRound(EpochType epoch) {
 
   debug_print(
     gossiplb, node,
-    "GossipLB::propagateRound: k_max_={}, k_cur_={}, selected.size()={}, fanout={}\n",
-    k_max_, k_cur_, selected.size(), fanout
+    "GossipLB::propagateRound: trial={}, iter={}, k_max={}, k_cur={}, "
+    "selected.size()={}, fanout={}\n",
+    trial_, iter_, k_max_, k_cur_, selected.size(), fanout
   );
 
   for (int i = 0; i < fanout; i++) {
@@ -386,8 +368,9 @@ void GossipLB::propagateRound(EpochType epoch) {
 
     debug_print(
       gossiplb, node,
-      "GossipLB::propagateRound: k_max_={}, k_cur_={}, sending={}\n",
-      k_max_, k_cur_, random_node
+      "GossipLB::propagateRound: trial={}, iter={}, k_max={}, k_cur={}, "
+      "sending={}\n",
+      trial_, iter_, k_max_, k_cur_, random_node
     );
 
     // Send message with load
@@ -405,9 +388,9 @@ void GossipLB::propagateIncoming(GossipMsg* msg) {
 
   debug_print(
     gossiplb, node,
-    "GossipLB::propagateIncoming: k_max_={}, k_cur_={}, from_node={}, "
-    "load info size={}\n",
-    k_max_, k_cur_, from_node, msg->getNodeLoad().size()
+    "GossipLB::propagateIncoming: trial={}, iter={}, k_max={}, k_cur={}, "
+    "from_node={}, load info size={}\n",
+    trial_, iter_, k_max_, k_cur_, from_node, msg->getNodeLoad().size()
   );
 
   for (auto&& elm : msg->getNodeLoad()) {
@@ -557,9 +540,11 @@ void GossipLB::decide() {
 
         debug_print(
           gossiplb, node,
-          "GossipLB::decide: under.size()={}, selected_node={}, selected_load={},"
-          "obj_id={:x}, obj_load={}, avg={}, this_new_load_={}, "
-          "criterion={}\n",
+          "GossipLB::decide: trial={}, iter={}, under.size()={}, "
+          "selected_node={}, selected_load={:e}, obj_id={:x}, obj_load={:e}, "
+          "avg={:e}, this_new_load_={:e}, criterion={}\n",
+          trial_,
+          iter_,
           under.size(),
           selected_node,
           selected_load,

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -129,9 +129,8 @@ void GossipLB::runLB() {
   if (theContext()->getNode() == 0) {
     vt_print(
       gossiplb,
-      "GossipLB::runLB: avg={}, max={}, load={},"
-      " overloaded_={}, underloaded_={}, should_lb={}\n",
-      avg, max, load, is_overloaded_, is_underloaded_, should_lb
+      "GossipLB::runLB: avg={}, max={}, load={}, should_lb={}\n",
+      avg, max, load, should_lb
     );
   }
 
@@ -170,10 +169,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
 
       if (first_iter) {
         // Copy this node's object assignments to a local, mutable copy
-        cur_objs_.clear();
-        for (auto obj : *load_data) {
-          cur_objs_[obj.first] = obj.second;
-        }
+        cur_objs_ = *load_data;
         this_new_load_ = this_load;
       } else {
         // Clear out data structures from previous iteration

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -160,7 +160,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
         is_underloaded_ = true;
       }
 
-      inform();
+      informAsync();
       decide();
 
       debug_print(
@@ -266,11 +266,14 @@ void GossipLB::gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg) {
   }
 }
 
-void GossipLB::inform() {
+void GossipLB::informAsync() {
+  propagated_k_.assign(k_max_, false);
+  uint8_t k_cur_async = 0;
+
   debug_print(
     gossiplb, node,
-    "GossipLB::inform: starting inform phase: trial={}, iter={}, k_max={}, "
-    "k_cur={}, is_underloaded={}, is_overloaded={}, load={}\n",
+    "GossipLB::informAsync: starting inform phase: trial={}, iter={}, "
+    "k_max={}, k_cur={}, is_underloaded={}, is_overloaded={}, load={}\n",
     trial_, iter_, k_max_, k_cur_, is_underloaded_, is_overloaded_, this_new_load_
   );
 
@@ -290,12 +293,12 @@ void GossipLB::inform() {
   theSched()->runSchedulerWhile([this]{ return not setup_done_; });
 
   bool inform_done = false;
-  auto propagate_epoch = theTerm()->makeEpochCollective("GossipLB: inform");
+  auto propagate_epoch = theTerm()->makeEpochCollective("GossipLB: informAsync");
   theTerm()->addAction(propagate_epoch, [&inform_done] { inform_done = true; });
 
   // Underloaded start the round
   if (is_underloaded_) {
-    propagateRound(propagate_epoch);
+    propagateRoundAsync(k_cur_async, propagate_epoch);
   }
 
   theTerm()->finishedEpoch(propagate_epoch);
@@ -305,14 +308,14 @@ void GossipLB::inform() {
   if (is_overloaded_) {
     vt_print(
       gossiplb,
-      "GossipLB::inform: trial={}, iter={}, known underloaded={}\n",
+      "GossipLB::informAsync: trial={}, iter={}, known underloaded={}\n",
       trial_, iter_, underloaded_.size()
     );
   }
 
   debug_print(
     gossiplb, node,
-    "GossipLB::inform: finished inform phase: trial={}, iter={}, "
+    "GossipLB::informAsync: finished inform phase: trial={}, iter={}, "
     "k_max={}, k_cur={}\n",
     trial_, iter_, k_max_, k_cur_
   );
@@ -322,10 +325,10 @@ void GossipLB::setupDone(ReduceMsgType* msg) {
   setup_done_ = true;
 }
 
-void GossipLB::propagateRound(EpochType epoch) {
+void GossipLB::propagateRoundAsync(uint8_t k_cur_async, EpochType epoch) {
   debug_print(
     gossiplb, node,
-    "GossipLB::propagateRound: trial={}, iter={}, k_max={}, k_cur={}\n",
+    "GossipLB::propagateRoundAsync: trial={}, iter={}, k_max={}, k_cur={}\n",
     trial_, iter_, k_max_, k_cur_
   );
 
@@ -344,7 +347,7 @@ void GossipLB::propagateRound(EpochType epoch) {
 
   debug_print(
     gossiplb, node,
-    "GossipLB::propagateRound: trial={}, iter={}, k_max={}, k_cur={}, "
+    "GossipLB::propagateRoundAsync: trial={}, iter={}, k_max={}, k_cur={}, "
     "selected.size()={}, fanout={}\n",
     trial_, iter_, k_max_, k_cur_, selected.size(), fanout
   );
@@ -368,28 +371,31 @@ void GossipLB::propagateRound(EpochType epoch) {
 
     debug_print(
       gossiplb, node,
-      "GossipLB::propagateRound: trial={}, iter={}, k_max={}, k_cur={}, "
-      "sending={}\n",
+      "GossipLB::propagateRoundAsync: trial={}, iter={}, k_max={}, "
+      "k_cur={}, sending={}\n",
       trial_, iter_, k_max_, k_cur_, random_node
     );
 
     // Send message with load
-    auto msg = makeMessage<GossipMsg>(this_node, load_info_);
+    auto msg = makeMessage<GossipMsgAsync>(this_node, load_info_, k_cur_async);
     if (epoch != no_epoch) {
       envelopeSetEpoch(msg->env, epoch);
     }
     msg->addNodeLoad(this_node, this_new_load_);
-    proxy_[random_node].send<GossipMsg, &GossipLB::propagateIncoming>(msg.get());
+    proxy_[random_node].send<
+      GossipMsgAsync, &GossipLB::propagateIncomingAsync
+    >(msg.get());
   }
 }
 
-void GossipLB::propagateIncoming(GossipMsg* msg) {
+void GossipLB::propagateIncomingAsync(GossipMsgAsync* msg) {
   auto const from_node = msg->getFromNode();
+  auto k_cur_async = msg->getRound();
 
   debug_print(
     gossiplb, node,
-    "GossipLB::propagateIncoming: trial={}, iter={}, k_max={}, k_cur={}, "
-    "from_node={}, load info size={}\n",
+    "GossipLB::propagateIncomingAsync: trial={}, iter={}, k_max={}, "
+    "k_cur={}, from_node={}, load info size={}\n",
     trial_, iter_, k_max_, k_cur_, from_node, msg->getNodeLoad().size()
   );
 
@@ -403,12 +409,14 @@ void GossipLB::propagateIncoming(GossipMsg* msg) {
     }
   }
 
-  if (k_cur_ == k_max_ - 1) {
+  if (k_cur_async == k_max_ - 1) {
     // nothing to do but wait for termination to be detected
+  } else if (propagated_k_[k_cur_async]) {
+    // we already propagated this round before receiving this message
   } else {
     // send out another round
-    propagateRound();
-    k_cur_++;
+    propagated_k_[k_cur_async] = true;
+    propagateRoundAsync(k_cur_async + 1);
   }
 }
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -122,7 +122,7 @@ void GossipLB::runLB() {
 }
 
 void GossipLB::doLBStages(TimeType start_imb) {
-  std::unordered_map<ObjIDType, TimeType> best_objs;
+  decltype(this->cur_objs_) best_objs;
   LoadType best_load = 0;
   TimeType best_imb = start_imb+1;
   uint16_t best_trial = 0;
@@ -149,7 +149,10 @@ void GossipLB::doLBStages(TimeType start_imb) {
 
       if (first_iter) {
         // Copy this node's object assignments to a local, mutable copy
-        cur_objs_ = *load_data;
+        cur_objs_.clear();
+        for (auto obj : *load_data) {
+          cur_objs_[obj.first] = obj.second;
+        }
         this_new_load_ = this_load;
       } else {
         // Clear out data structures from previous iteration

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -117,7 +117,7 @@ void GossipLB::runLB() {
 
 void GossipLB::doLBStages(TimeType start_imb) {
   std::unordered_map<ObjIDType, TimeType> best_objs;
-  LoadType best_load;
+  LoadType best_load = 0;
   TimeType best_imb = start_imb+1;
   uint16_t best_trial = 0;
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -387,6 +387,8 @@ void GossipLB::informSync() {
   theSched()->runSchedulerWhile([this]{ return not setup_done_; });
 
   for (; k_cur_ < k_max_; ++k_cur_) {
+    vt::theCollective()->barrier();
+
     auto name = fmt::format("GossipLB: informSync k_cur={}", k_cur_);
     auto propagate_epoch = theTerm()->makeEpochCollective(name);
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -75,15 +75,16 @@ bool GossipLB::isOverloaded(LoadType load) const {
 }
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
-  std::vector<std::string> allowed{"f", "k", "i", "c"};
+  std::vector<std::string> allowed{"f", "k", "i", "c", "trials"};
   spec->checkAllowedKeys(allowed);
   using CriterionEnumUnder = typename std::underlying_type<CriterionEnum>::type;
   auto default_c = static_cast<CriterionEnumUnder>(criterion_);
-  f_         = spec->getOrDefault<int32_t>("f", f_);
-  k_max_     = spec->getOrDefault<int32_t>("k", k_max_);
-  num_iters_ = spec->getOrDefault<int32_t>("i", num_iters_);
-  int32_t c  = spec->getOrDefault<int32_t>("c", default_c);
-  criterion_ = static_cast<CriterionEnum>(c);
+  f_          = spec->getOrDefault<int32_t>("f", f_);
+  k_max_      = spec->getOrDefault<int32_t>("k", k_max_);
+  num_iters_  = spec->getOrDefault<int32_t>("i", num_iters_);
+  num_trials_ = spec->getOrDefault<int32_t>("trials", num_trials_);
+  int32_t c   = spec->getOrDefault<int32_t>("c", default_c);
+  criterion_  = static_cast<CriterionEnum>(c);
 }
 
 void GossipLB::runLB() {
@@ -91,6 +92,7 @@ void GossipLB::runLB() {
 
   auto const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
   auto const max  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::max);
+  auto const imb  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::imb);
   auto const load = this_load;
 
   if (avg > 0.0000000001) {
@@ -107,57 +109,183 @@ void GossipLB::runLB() {
   }
 
   if (should_lb) {
-    doLBStages();
+    doLBStages(imb);
   } else {
     migrationDone();
   }
 }
 
-void GossipLB::doLBStages() {
-  for (iter_ = 0; iter_ < num_iters_; iter_++) {
-    bool first_iter = iter_ == 0;
+void GossipLB::doLBStages(TimeType start_imb) {
+  std::unordered_map<ObjIDType, TimeType> best_objs;
+  LoadType best_load;
+  TimeType best_imb = start_imb+1;
+  uint16_t best_trial = 0;
 
-    debug_print(
-      gossiplb, node,
-      "GossipLB::doLBStages: (before) running iter_={}, num_iters_={}, load={}, new_load={}\n",
-      iter_, num_iters_, this_load, this_new_load_
-    );
+  auto this_node = theContext()->getNode();
 
-    if (first_iter) {
-      // Copy this node's object assignments to a local, mutable copy
-      cur_objs_ = *load_data;
-      this_new_load_ = this_load;
-    } else {
-      // Clear out data structures from previous iteration
-      selected_.clear();
-      underloaded_.clear();
-      load_info_.clear();
-      k_cur_ = 0;
-      is_overloaded_ = is_underloaded_ = false;
+  for (uint16_t trial = 0; trial < num_trials_; ++trial) {
+    // Clear out data structures
+    selected_.clear();
+    underloaded_.clear();
+    load_info_.clear();
+    k_cur_ = 0;
+    is_overloaded_ = is_underloaded_ = false;
+
+    for (iter_ = 0; iter_ < num_iters_; iter_++) {
+      bool first_iter = iter_ == 0;
+
+      debug_print(
+        gossiplb, node,
+        "GossipLB::doLBStages: (before) running iter_={}, num_iters_={}, load={}, new_load={}\n",
+        iter_, num_iters_, this_load, this_new_load_
+      );
+
+      if (first_iter) {
+        // Copy this node's object assignments to a local, mutable copy
+        cur_objs_ = *load_data;
+        this_new_load_ = this_load;
+      } else {
+        // Clear out data structures from previous iteration
+        selected_.clear();
+        underloaded_.clear();
+        load_info_.clear();
+        k_cur_ = 0;
+        is_overloaded_ = is_underloaded_ = false;
+      }
+
+      if (isOverloaded(this_new_load_)) {
+        is_overloaded_ = true;
+      } else if (isUnderloaded(this_new_load_)) {
+        is_underloaded_ = true;
+      }
+
+      inform();
+      decide();
+
+      debug_print(
+        gossiplb, node,
+        "GossipLB::doLBStages: (after) running iter_={}, num_iters_={}, load={}, new_load={}\n",
+        iter_, num_iters_, this_load, this_new_load_
+      );
+
+      runInEpochCollective([=] {
+        using StatsMsgType = balance::ProcStatsMsg;
+        using ReduceOp = collective::PlusOp<balance::LoadData>;
+        auto cb = vt::theCB()->makeBcast<
+          GossipLB, StatsMsgType, &GossipLB::gossipStatsHandler
+        >(this->proxy_);
+        // Perform the reduction for P_l -> processor load only
+        auto msg = makeMessage<StatsMsgType>(Statistic::P_l, this_new_load_);
+        this->proxy_.template reduce<ReduceOp>(msg,cb);
+      });
+
+      if (this_node == 0) {
+        vt_print(
+          gossiplb,
+          "GossipLB::doLBStages: trial={} iter={} imb={:0.2f}\n",
+          trial, iter_, new_imbalance_
+        );
+      }
     }
 
-    if (isOverloaded(this_new_load_)) {
-      is_overloaded_ = true;
-    } else if (isUnderloaded(this_new_load_)) {
-      is_underloaded_ = true;
+    if (this_node == 0) {
+      vt_print(
+        gossiplb,
+        "GossipLB::doLBStages: trial={} imb={:0.2f}\n",
+        trial, new_imbalance_
+      );
     }
 
-    inform();
-    decide();
+    if (cur_objs_.size() == 0) {
+      vt_print(
+        gossiplb,
+        "GossipLB::doLBStages: trial={} local_objs={}\n",
+        trial, cur_objs_.size()
+      );
+    }
 
-    debug_print(
-      gossiplb, node,
-      "GossipLB::doLBStages: (after) running iter_={}, num_iters_={}, load={}, new_load={}\n",
-      iter_, num_iters_, this_load, this_new_load_
-    );
+    if (new_imbalance_ <= start_imb && new_imbalance_ < best_imb) {
+      best_load = this_new_load_;
+      best_objs = cur_objs_;
+      best_imb = new_imbalance_;
+      best_trial = trial;
+    }
+
+    // Clear out for next try or for not migrating by default
+    cur_objs_.clear();
+    this_new_load_ = this_load;
   }
 
-  // Update the load based on new object assignments
-  this_load = this_new_load_;
+  if (best_imb <= start_imb) {
+    cur_objs_ = best_objs;
+    this_load = this_new_load_ = best_load;
+    new_imbalance_ = best_imb;
+
+    // Update the load based on new object assignments
+    if (this_node == 0) {
+      vt_print(
+        gossiplb,
+        "GossipLB::doLBStages: chose trial={} with imb={:0.2f}\n",
+        best_trial, new_imbalance_
+      );
+    }
+  } else if (this_node == 0) {
+    vt_print(
+      gossiplb,
+      "GossipLB::doLBStages: rejected all trials because they would increase imbalance\n"
+    );
+  }
 
   // Concretize lazy migrations by invoking the BaseLB object migration on new
   // object node assignments
   thunkMigrations();
+}
+
+void GossipLB::gossipStatsHandler(StatsMsgType* msg) {
+  auto in = msg->getConstVal();
+  new_imbalance_ = in.I();
+
+  auto this_node = theContext()->getNode();
+  if (this_node == 0) {
+    vt_print(
+      gossiplb,
+      "GossipLB::gossipStatsHandler: max={:0.2f} min={:0.2f} avg={:0.2f} imb={:0.2f}\n",
+      in.max(), in.min(), in.avg(), in.I()
+    );
+  }
+/*
+  if (this_new_load_ <= in.min() * 1.01) {
+    vt_print(
+      gossiplb,
+      "GossipLB::gossipStatsHandler: new_load={:0.2f} min={:0.2f} count={}\n",
+      this_new_load_, in.min(), cur_objs_.size()
+    );
+  }
+  if (this_new_load_ >= in.max() * 0.99) {
+    vt_print(
+      gossiplb,
+      "GossipLB::gossipStatsHandler: new_load={:0.2f} max={:0.2f} count={}\n",
+      this_new_load_, in.max(), cur_objs_.size()
+    );
+  }
+*/
+}
+
+void GossipLB::gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg) {
+  auto in = msg->getConstVal();
+
+  auto n_rejected = in.n_rejected_;
+  auto n_transfers = in.n_transfers_;
+  double rej = static_cast<double>(n_rejected) / static_cast<double>(n_rejected + n_transfers) * 100.0;
+
+  auto this_node = theContext()->getNode();
+  if (this_node == 0) {
+    vt_print(
+      gossiplb,
+      "GossipLB::gossipRejectionStatsHandler: n_transfers={} n_rejected={} rejection_rate={:0.1f}%\n",
+      n_transfers, n_rejected, rej
+    );
+  }
 }
 
 void GossipLB::inform() {
@@ -383,6 +511,8 @@ void GossipLB::decide() {
   auto lazy_epoch = theTerm()->makeEpochCollective("GossipLB: decide");
   theTerm()->addAction(lazy_epoch, [&decide_done] { decide_done = true; });
 
+  int n_transfers = 0, n_rejected = 0;
+
   if (is_overloaded_) {
     std::vector<NodeType> under = makeUnderloaded();
     std::unordered_map<NodeType, ObjsType> migrate_objs;
@@ -438,6 +568,7 @@ void GossipLB::decide() {
         );
 
         if (eval) {
+          ++n_transfers;
           migrate_objs[selected_node][obj_id] = obj_load;
 
           this_new_load_ -= obj_load;
@@ -445,6 +576,7 @@ void GossipLB::decide() {
 
           iter = cur_objs_.erase(iter);
         } else {
+          ++n_rejected;
           iter++;
         }
 
@@ -468,6 +600,15 @@ void GossipLB::decide() {
   theTerm()->finishedEpoch(lazy_epoch);
 
   theSched()->runSchedulerWhile([&decide_done]{ return not decide_done; });
+
+  runInEpochCollective([=] {
+    using ReduceOp = collective::PlusOp<RejectionStats>;
+    auto cb = vt::theCB()->makeBcast<
+      GossipLB, GossipRejectionStatsMsg, &GossipLB::gossipRejectionStatsHandler
+    >(this->proxy_);
+    auto msg = makeMessage<GossipRejectionStatsMsg>(n_rejected, n_transfers);
+    this->proxy_.template reduce<ReduceOp>(msg,cb);
+  });
 }
 
 void GossipLB::thunkMigrations() {

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -220,7 +220,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
       if (this_node == 0) {
         vt_print(
           gossiplb,
-          "GossipLB::doLBStages: trial={} iter={} imb={:0.2f}\n",
+          "GossipLB::doLBStages: trial={} iter={} imb={:0.4f}\n",
           trial_, iter_, new_imbalance_
         );
       }
@@ -229,7 +229,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
     if (this_node == 0) {
       vt_print(
         gossiplb,
-        "GossipLB::doLBStages: trial={} imb={:0.2f}\n",
+        "GossipLB::doLBStages: trial={} imb={:0.4f}\n",
         trial_, new_imbalance_
       );
     }
@@ -255,7 +255,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
     if (this_node == 0) {
       vt_print(
         gossiplb,
-        "GossipLB::doLBStages: chose trial={} with imb={:0.2f}\n",
+        "GossipLB::doLBStages: chose trial={} with imb={:0.4f}\n",
         best_trial, new_imbalance_
       );
     }
@@ -279,7 +279,7 @@ void GossipLB::gossipStatsHandler(StatsMsgType* msg) {
   if (this_node == 0) {
     vt_print(
       gossiplb,
-      "GossipLB::gossipStatsHandler: max={:0.2f} min={:0.2f} avg={:0.2f} imb={:0.2f}\n",
+      "GossipLB::gossipStatsHandler: max={:0.2f} min={:0.2f} avg={:0.2f} imb={:0.4f}\n",
       in.max(), in.min(), in.avg(), in.I()
     );
   }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -79,17 +79,19 @@ bool GossipLB::isOverloaded(LoadType load) const {
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
   std::vector<std::string> allowed{
-    "f", "k", "i", "c", "trials", "deterministic", "ordering"
+    "f", "k", "i", "c", "trials", "deterministic", "ordering", "cmf"
   };
   spec->checkAllowedKeys(allowed);
 
   using CriterionEnumUnder   = typename std::underlying_type<CriterionEnum>::type;
   using InformTypeEnumUnder  = typename std::underlying_type<InformTypeEnum>::type;
   using ObjectOrderEnumUnder = typename std::underlying_type<ObjectOrderEnum>::type;
+  using CMFTypeEnumUnder     = typename std::underlying_type<CMFTypeEnum>::type;
 
   auto default_c      = static_cast<CriterionEnumUnder>(criterion_);
   auto default_inform = static_cast<InformTypeEnumUnder>(inform_type_);
   auto default_order  = static_cast<ObjectOrderEnumUnder>(obj_ordering_);
+  auto default_cmf    = static_cast<CMFTypeEnumUnder>(cmf_type_);
 
   f_             = spec->getOrDefault<int32_t>("f", f_);
   k_max_         = spec->getOrDefault<int32_t>("k", k_max_);
@@ -103,6 +105,8 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   inform_type_   = static_cast<InformTypeEnum>(inf);
   int32_t ord    = spec->getOrDefault<int32_t>("ordering", default_order);
   obj_ordering_  = static_cast<ObjectOrderEnum>(ord);
+  int32_t cmf    = spec->getOrDefault<int32_t>("cmf", default_cmf);
+  cmf_type_      = static_cast<CMFTypeEnum>(cmf);
 
   vtAbortIf(
     inform_type_ == InformTypeEnum::AsyncInform && deterministic_,
@@ -615,15 +619,40 @@ std::vector<double> GossipLB::createCMF(NodeSetType const& under) {
 
   // Build the CMF
   double sum_p = 0.0;
-  double inv_l_avg = 1.0 / avg;
-  std::vector<double> cmf = {};
+  double factor = 1.0;
 
+  switch (cmf_type_) {
+  case CMFTypeEnum::Original:
+    factor = 1.0 / avg;
+    break;
+  case CMFTypeEnum::NormBySelf:
+    factor = 1.0 / this_new_load_;
+    break;
+  case CMFTypeEnum::NormByMax:
+    {
+      double l_max = 0.0;
+      for (auto&& pe : under) {
+        auto iter = load_info_.find(pe);
+        vtAssert(iter != load_info_.end(), "Node must be in load_info_");
+        auto load = iter->second;
+        if (load > l_max) {
+          l_max = load;
+        }
+      }
+      factor = 1.0 / (l_max > avg ? l_max : avg);
+    }
+    break;
+  default:
+    vtAbort("This CMF type is not supported");
+  }
+
+  std::vector<double> cmf = {};
   for (auto&& pe : under) {
     auto iter = load_info_.find(pe);
     vtAssert(iter != load_info_.end(), "Node must be in load_info_");
 
     auto load = iter->second;
-    sum_p += 1. - inv_l_avg * load;
+    sum_p += 1. - factor * load;
     cmf.push_back(sum_p);
   }
 
@@ -778,8 +807,10 @@ void GossipLB::decide() {
         // milliseconds; for now, convert the object loads to milliseconds
         auto obj_load_ms = loadMilli(obj_load);
 
-        // Rebuild the relaxed underloaded set based on updated load of this node
-        under = makeUnderloaded();
+        if (cmf_type_ == CMFTypeEnum::Original) {
+          // Rebuild the relaxed underloaded set based on updated load of this node
+          under = makeUnderloaded();
+        }
         if (under.size() == 0) {
           break;
         }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -78,13 +78,19 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   std::vector<std::string> allowed{"f", "k", "i", "c", "trials"};
   spec->checkAllowedKeys(allowed);
   using CriterionEnumUnder = typename std::underlying_type<CriterionEnum>::type;
+  using InformTypeEnumUnder = typename std::underlying_type<InformTypeEnum>::type;
+
   auto default_c = static_cast<CriterionEnumUnder>(criterion_);
-  f_          = spec->getOrDefault<int32_t>("f", f_);
-  k_max_      = spec->getOrDefault<int32_t>("k", k_max_);
-  num_iters_  = spec->getOrDefault<int32_t>("i", num_iters_);
-  num_trials_ = spec->getOrDefault<int32_t>("trials", num_trials_);
-  int32_t c   = spec->getOrDefault<int32_t>("c", default_c);
-  criterion_  = static_cast<CriterionEnum>(c);
+  auto default_inform = static_cast<InformTypeEnumUnder>(inform_type_);
+
+  f_           = spec->getOrDefault<int32_t>("f", f_);
+  k_max_       = spec->getOrDefault<int32_t>("k", k_max_);
+  num_iters_   = spec->getOrDefault<int32_t>("i", num_iters_);
+  num_trials_  = spec->getOrDefault<int32_t>("trials", num_trials_);
+  int32_t c    = spec->getOrDefault<int32_t>("c", default_c);
+  criterion_   = static_cast<CriterionEnum>(c);
+  int32_t inf  = spec->getOrDefault<int32_t>("inform", default_inform);
+  inform_type_ = static_cast<InformTypeEnum>(inf);
 }
 
 void GossipLB::runLB() {
@@ -160,7 +166,17 @@ void GossipLB::doLBStages(TimeType start_imb) {
         is_underloaded_ = true;
       }
 
-      informAsync();
+      switch (inform_type_) {
+      case InformTypeEnum::SyncInform:
+        informSync();
+        break;
+      case InformTypeEnum::AsyncInform:
+        informAsync();
+        break;
+      default:
+        vtAbort("GossipLB:: Unsupported inform type");
+      }
+
       decide();
 
       debug_print(
@@ -321,6 +337,70 @@ void GossipLB::informAsync() {
   );
 }
 
+void GossipLB::informSync() {
+  debug_print(
+    gossiplb, node,
+    "GossipLB::informSync: starting inform phase: trial={}, iter={}, "
+    "k_max={}, k_cur={}, is_underloaded={}, is_overloaded={}, load={}\n",
+    trial_, iter_, k_max_, k_cur_, is_underloaded_, is_overloaded_, this_new_load_
+  );
+
+  vtAssert(k_max_ > 0, "Number of rounds (k) must be greater than zero");
+
+  auto const this_node = theContext()->getNode();
+  if (is_underloaded_) {
+    underloaded_.insert(this_node);
+  }
+
+  auto propagate_this_round = is_underloaded_;
+  propagate_next_round_ = false;
+  new_underloaded_ = underloaded_;
+  new_load_info_ = load_info_;
+
+  setup_done_ = false;
+
+  auto cb = theCB()->makeBcast<GossipLB, ReduceMsgType, &GossipLB::setupDone>(proxy_);
+  auto msg = makeMessage<ReduceMsgType>();
+  proxy_.reduce(msg.get(), cb);
+
+  theSched()->runSchedulerWhile([this]{ return not setup_done_; });
+
+  for (; k_cur_ < k_max_; ++k_cur_) {
+    auto name = fmt::format("GossipLB: informSync k_cur={}", k_cur_);
+    auto propagate_epoch = theTerm()->makeEpochCollective(name);
+
+    // Underloaded start the first round; ranks that received on some round
+    // start subsequent rounds
+    if (propagate_this_round) {
+      propagateRoundSync(propagate_epoch);
+    }
+
+    theTerm()->finishedEpoch(propagate_epoch);
+
+    vt::runSchedulerThrough(propagate_epoch);
+
+    propagate_this_round = propagate_next_round_;
+    propagate_next_round_ = false;
+    underloaded_ = new_underloaded_;
+    load_info_ = new_load_info_;
+  }
+
+  if (is_overloaded_) {
+    vt_print(
+      gossiplb,
+      "GossipLB::informSync: trial={}, iter={}, known underloaded={}\n",
+      trial_, iter_, underloaded_.size()
+    );
+  }
+
+  debug_print(
+    gossiplb, node,
+    "GossipLB::informSync: finished inform phase: trial={}, iter={}, "
+    "k_max={}, k_cur={}\n",
+    trial_, iter_, k_max_, k_cur_
+  );
+}
+
 void GossipLB::setupDone(ReduceMsgType* msg) {
   setup_done_ = true;
 }
@@ -388,6 +468,66 @@ void GossipLB::propagateRoundAsync(uint8_t k_cur_async, EpochType epoch) {
   }
 }
 
+void GossipLB::propagateRoundSync(EpochType epoch) {
+  debug_print(
+    gossiplb, node,
+    "GossipLB::propagateRoundSync: trial={}, iter={}, k_max={}, k_cur={}\n",
+    trial_, iter_, k_max_, k_cur_
+  );
+
+  auto const this_node = theContext()->getNode();
+  auto const num_nodes = theContext()->getNumNodes();
+  std::uniform_int_distribution<NodeType> dist(0, num_nodes - 1);
+  std::mt19937 gen(seed_());
+
+  auto& selected = selected_;
+  selected = underloaded_;
+  if (selected.find(this_node) == selected.end()) {
+    selected.insert(this_node);
+  }
+
+  auto const fanout = std::min(f_, static_cast<decltype(f_)>(num_nodes - 1));
+
+  debug_print(
+    gossiplb, node,
+    "GossipLB::propagateRoundSync: trial={}, iter={}, k_max={}, k_cur={}, "
+    "selected.size()={}, fanout={}\n",
+    trial_, iter_, k_max_, k_cur_, selected.size(), fanout
+  );
+
+  for (int i = 0; i < fanout; i++) {
+    // This implies full knowledge of all processors
+    if (selected.size() >= static_cast<size_t>(num_nodes)) {
+      return;
+    }
+
+    // First, randomly select a node
+    NodeType random_node = uninitialized_destination;
+
+    // Keep generating until we have a unique node for this round
+    do {
+      random_node = dist(gen);
+    } while (
+      selected.find(random_node) != selected.end()
+    );
+    selected.insert(random_node);
+
+    debug_print(
+      gossiplb, node,
+      "GossipLB::propagateRoundSync: k_max_={}, k_cur_={}, sending={}\n",
+      k_max_, k_cur_, random_node
+    );
+
+    // Send message with load
+    auto msg = makeMessage<GossipMsgSync>(this_node, load_info_);
+    if (epoch != no_epoch) {
+      envelopeSetEpoch(msg->env, epoch);
+    }
+    msg->addNodeLoad(this_node, this_new_load_);
+    proxy_[random_node].send<GossipMsgSync, &GossipLB::propagateIncomingSync>(msg.get());
+  }
+}
+
 void GossipLB::propagateIncomingAsync(GossipMsgAsync* msg) {
   auto const from_node = msg->getFromNode();
   auto k_cur_async = msg->getRound();
@@ -417,6 +557,30 @@ void GossipLB::propagateIncomingAsync(GossipMsgAsync* msg) {
     // send out another round
     propagated_k_[k_cur_async] = true;
     propagateRoundAsync(k_cur_async + 1);
+  }
+}
+
+void GossipLB::propagateIncomingSync(GossipMsgSync* msg) {
+  auto const from_node = msg->getFromNode();
+
+  // we collected more info that should be propagated on the next round
+  propagate_next_round_ = true;
+
+  debug_print(
+    gossiplb, node,
+    "GossipLB::propagateIncomingSync: trial={}, iter={}, k_max={}, "
+    "k_cur={}, from_node={}, load info size={}\n",
+    trial_, iter_, k_max_, k_cur_, from_node, msg->getNodeLoad().size()
+  );
+
+  for (auto&& elm : msg->getNodeLoad()) {
+    if (new_load_info_.find(elm.first) == new_load_info_.end()) {
+      new_load_info_[elm.first] = elm.second;
+
+      if (isUnderloaded(elm.second)) {
+        new_underloaded_.insert(elm.first);
+      }
+    }
   }
 }
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -68,19 +68,17 @@ void GossipLB::init(objgroup::proxy::Proxy<GossipLB> in_proxy) {
 }
 
 bool GossipLB::isUnderloaded(LoadType load) const {
-  auto const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
-  return load < avg * gossip_threshold;
+  return load < target_max_load_ * gossip_threshold;
 }
 
 bool GossipLB::isOverloaded(LoadType load) const {
-  auto const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
-  return load > avg * gossip_threshold;
+  return load > target_max_load_ * gossip_threshold;
 }
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
   std::vector<std::string> allowed{
     "f", "k", "i", "c", "trials", "deterministic", "inform", "ordering", "cmf",
-    "rollback"
+    "rollback", "targetpole"
   };
   spec->checkAllowedKeys(allowed);
 
@@ -100,6 +98,7 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   num_trials_    = spec->getOrDefault<int32_t>("trials", num_trials_);
   deterministic_ = spec->getOrDefault<int32_t>("deterministic", deterministic_);
   rollback_      = spec->getOrDefault<int32_t>("rollback", rollback_);
+  target_pole_   = spec->getOrDefault<int32_t>("targetpole", target_pole_);
 
   int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
   criterion_     = static_cast<CriterionEnum>(c);
@@ -125,18 +124,28 @@ void GossipLB::runLB() {
 
   auto const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
   auto const max  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::max);
+  auto const pole = stats.at(lb::Statistic::O_l).at(lb::StatisticQuantity::max) * 1000;
   auto const imb  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::imb);
   auto const load = this_load;
 
+  if (target_pole_) {
+    // we can't get the processor max lower than the max object load, so
+    // modify the algorithm to define overloaded as exceeding the max
+    // object load instead of the processor average load
+    target_max_load_ = (pole > avg ? pole : avg);
+  } else {
+    target_max_load_ = avg;
+  }
+
   if (avg > 0.0000000001) {
-    should_lb = max > gossip_tolerance * avg;
+    should_lb = max > gossip_tolerance * target_max_load_;
   }
 
   if (theContext()->getNode() == 0) {
     debug_print(
       gossiplb, node,
-      "GossipLB::runLB: avg={}, max={}, load={}, should_lb={}\n",
-      avg, max, load, should_lb
+      "GossipLB::runLB: avg={}, max={}, pole={}, imb={}, load={}, should_lb={}\n",
+      avg, max, pole, imb, load, should_lb
     );
   }
 
@@ -288,8 +297,10 @@ void GossipLB::gossipStatsHandler(StatsMsgType* msg) {
     debug_print(
       gossiplb, node,
       "GossipLB::gossipStatsHandler: trial={} iter={} max={:0.2f} min={:0.2f} "
-      "avg={:0.2f} imb={:0.4f}\n",
-      trial_, iter_, in.max(), in.min(), in.avg(), in.I()
+      "avg={:0.2f} pole={:0.2f} imb={:0.4f}\n",
+      trial_, iter_, in.max(), in.min(), in.avg(),
+      stats.at(lb::Statistic::O_l).at(lb::StatisticQuantity::max) * 1000,
+      in.I()
     );
   }
 }
@@ -582,14 +593,12 @@ std::vector<double> GossipLB::createCMF(NodeSetType const& under) {
     return cmf;
   }
 
-  double const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
-
   double sum_p = 0.0;
   double factor = 1.0;
 
   switch (cmf_type_) {
   case CMFTypeEnum::Original:
-    factor = 1.0 / avg;
+    factor = 1.0 / target_max_load_;
     break;
   case CMFTypeEnum::NormBySelf:
     factor = 1.0 / this_new_load_;
@@ -605,7 +614,7 @@ std::vector<double> GossipLB::createCMF(NodeSetType const& under) {
           l_max = load;
         }
       }
-      factor = 1.0 / (l_max > avg ? l_max : avg);
+      factor = 1.0 / (l_max > target_max_load_ ? l_max : target_max_load_);
     }
     break;
   default:
@@ -689,8 +698,6 @@ GossipLB::selectObject(
 }
 
 void GossipLB::decide() {
-  double const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
-
   bool decide_done = false;
   auto lazy_epoch = theTerm()->makeEpochCollective("GossipLB: decide");
   theTerm()->addAction(lazy_epoch, [&decide_done] { decide_done = true; });
@@ -718,7 +725,7 @@ void GossipLB::decide() {
       case ObjectOrderEnum::Marginal:
         {
           // first find marginal object's load
-          auto over_avg = this_new_load_ - avg;
+          auto over_avg = this_new_load_ - target_max_load_;
           // if no objects are larger than over_avg, then marginal will still
           // (incorrectly) reflect the total load, which will not be a problem
           auto marginal = this_new_load_;
@@ -796,15 +803,15 @@ void GossipLB::decide() {
         // The load of the node selected
         auto& selected_load = load_iter->second;
 
-        //auto max_obj_size = avg - selected_load;
-
-        bool eval = Criterion(criterion_)(this_new_load_, selected_load, obj_load_ms, avg);
+        bool eval = Criterion(criterion_)(
+          this_new_load_, selected_load, obj_load_ms, target_max_load_
+        );
 
         debug_print_verbose(
           gossiplb, node,
           "GossipLB::decide: trial={}, iter={}, under.size()={}, "
           "selected_node={}, selected_load={:e}, obj_id={:x}, obj_load_ms={:e}, "
-          "avg={:e}, this_new_load_={:e}, criterion={}\n",
+          "target_max_load={:e}, this_new_load_={:e}, criterion={}\n",
           trial_,
           iter_,
           under.size(),
@@ -812,7 +819,7 @@ void GossipLB::decide() {
           selected_load,
           obj_id,
           obj_load_ms,
-          avg,
+          target_max_load_,
           this_new_load_,
           eval
         );
@@ -833,7 +840,7 @@ void GossipLB::decide() {
           iter++;
         }
 
-        if (not (this_new_load_ > avg)) {
+        if (not (this_new_load_ > target_max_load_)) {
           break;
         }
       }

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -408,7 +408,8 @@ void GossipLB::informSync() {
   theSched()->runSchedulerWhile([this]{ return not setup_done_; });
 
   for (; k_cur_ < k_max_; ++k_cur_) {
-    vt::theCollective()->barrier();
+    auto kbarr = theCollective()->newNamedCollectiveBarrier();
+    theCollective()->barrier(nullptr, kbarr);
 
     auto name = fmt::format("GossipLB: informSync k_cur={}", k_cur_);
     auto propagate_epoch = theTerm()->makeEpochCollective(name);

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -210,16 +210,18 @@ void GossipLB::doLBStages(TimeType start_imb) {
         trial_, iter_, num_iters_, this_load, this_new_load_
       );
 
-      runInEpochCollective([=] {
-        using StatsMsgType = balance::ProcStatsMsg;
-        using ReduceOp = collective::PlusOp<balance::LoadData>;
-        auto cb = vt::theCB()->makeBcast<
-          GossipLB, StatsMsgType, &GossipLB::gossipStatsHandler
-        >(this->proxy_);
-        // Perform the reduction for P_l -> processor load only
-        auto msg = makeMessage<StatsMsgType>(Statistic::P_l, this_new_load_);
-        this->proxy_.template reduce<ReduceOp>(msg,cb);
-      });
+      if (ArgType::vt_debug_gossiplb || (iter_ == num_iters_ - 1)) {
+        runInEpochCollective([=] {
+          using StatsMsgType = balance::ProcStatsMsg;
+          using ReduceOp = collective::PlusOp<balance::LoadData>;
+          auto cb = vt::theCB()->makeBcast<
+            GossipLB, StatsMsgType, &GossipLB::gossipStatsHandler
+          >(this->proxy_);
+          // Perform the reduction for P_l -> processor load only
+          auto msg = makeMessage<StatsMsgType>(Statistic::P_l, this_new_load_);
+          this->proxy_.template reduce<ReduceOp>(msg,cb);
+        });
+      }
     }
 
     if (this_node == 0) {
@@ -832,14 +834,17 @@ void GossipLB::decide() {
 
   theSched()->runSchedulerWhile([&decide_done]{ return not decide_done; });
 
-  runInEpochCollective([=] {
-    using ReduceOp = collective::PlusOp<balance::RejectionStats>;
-    auto cb = vt::theCB()->makeBcast<
-      GossipLB, GossipRejectionMsgType, &GossipLB::gossipRejectionStatsHandler
-    >(this->proxy_);
-    auto msg = makeMessage<GossipRejectionMsgType>(n_rejected, n_transfers);
-    this->proxy_.template reduce<ReduceOp>(msg,cb);
-  });
+  if (ArgType::vt_debug_gossiplb) {
+    // compute rejection rate because it will be printed
+    runInEpochCollective([=] {
+      using ReduceOp = collective::PlusOp<balance::RejectionStats>;
+      auto cb = vt::theCB()->makeBcast<
+        GossipLB, GossipRejectionMsgType, &GossipLB::gossipRejectionStatsHandler
+      >(this->proxy_);
+      auto msg = makeMessage<GossipRejectionMsgType>(n_rejected, n_transfers);
+      this->proxy_.template reduce<ReduceOp>(msg,cb);
+    });
+  }
 }
 
 void GossipLB::thunkMigrations() {

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -560,9 +560,18 @@ void GossipLB::propagateIncomingSync(GossipMsgSync* msg) {
 }
 
 std::vector<double> GossipLB::createCMF(NodeSetType const& under) {
+  // Build the CMF
+  std::vector<double> cmf = {};
+
+  if (under.size() == 1) {
+    // trying to compute the cmf for only a single object can result
+    // in nan for some cmf types below, so do it the easy way instead
+    cmf.push_back(1.0);
+    return cmf;
+  }
+
   double const avg  = stats.at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
 
-  // Build the CMF
   double sum_p = 0.0;
   double factor = 1.0;
 
@@ -591,7 +600,6 @@ std::vector<double> GossipLB::createCMF(NodeSetType const& under) {
     vtAbort("This CMF type is not supported");
   }
 
-  std::vector<double> cmf = {};
   for (auto&& pe : under) {
     auto iter = load_info_.find(pe);
     vtAssert(iter != load_info_.end(), "Node must be in load_info_");

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -79,7 +79,8 @@ bool GossipLB::isOverloaded(LoadType load) const {
 
 void GossipLB::inputParams(balance::SpecEntry* spec) {
   std::vector<std::string> allowed{
-    "f", "k", "i", "c", "trials", "deterministic", "inform", "ordering", "cmf"
+    "f", "k", "i", "c", "trials", "deterministic", "inform", "ordering", "cmf",
+    "rollback"
   };
   spec->checkAllowedKeys(allowed);
 
@@ -98,6 +99,7 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
   num_iters_     = spec->getOrDefault<int32_t>("i", num_iters_);
   num_trials_    = spec->getOrDefault<int32_t>("trials", num_trials_);
   deterministic_ = spec->getOrDefault<int32_t>("deterministic", deterministic_);
+  rollback_      = spec->getOrDefault<int32_t>("rollback", rollback_);
 
   int32_t c      = spec->getOrDefault<int32_t>("c", default_c);
   criterion_     = static_cast<CriterionEnum>(c);
@@ -148,7 +150,7 @@ void GossipLB::runLB() {
 void GossipLB::doLBStages(TimeType start_imb) {
   decltype(this->cur_objs_) best_objs;
   LoadType best_load = 0;
-  TimeType best_imb = start_imb+1;
+  TimeType best_imb = start_imb + 10;
   uint16_t best_trial = 0;
 
   auto this_node = theContext()->getNode();
@@ -160,6 +162,8 @@ void GossipLB::doLBStages(TimeType start_imb) {
     load_info_.clear();
     k_cur_ = 0;
     is_overloaded_ = is_underloaded_ = false;
+
+    TimeType best_imb_this_trial = start_imb + 10;
 
     for (iter_ = 0; iter_ < num_iters_; iter_++) {
       bool first_iter = iter_ == 0;
@@ -210,7 +214,7 @@ void GossipLB::doLBStages(TimeType start_imb) {
         trial_, iter_, num_iters_, this_load, this_new_load_
       );
 
-      if (ArgType::vt_debug_gossiplb || (iter_ == num_iters_ - 1)) {
+      if (rollback_ || ArgType::vt_debug_gossiplb || (iter_ == num_iters_ - 1)) {
         runInEpochCollective([=] {
           using StatsMsgType = balance::ProcStatsMsg;
           using ReduceOp = collective::PlusOp<balance::LoadData>;
@@ -222,21 +226,27 @@ void GossipLB::doLBStages(TimeType start_imb) {
           this->proxy_.template reduce<ReduceOp>(msg,cb);
         });
       }
+
+      if (rollback_ || (iter_ == num_iters_ - 1)) {
+        // if known, save the best iteration within any trial so we can roll back
+        if (new_imbalance_ < best_imb && new_imbalance_ <= start_imb) {
+          best_load = this_new_load_;
+          best_objs = cur_objs_;
+          best_imb = new_imbalance_;
+          best_trial = trial_;
+        }
+        if (new_imbalance_ < best_imb_this_trial) {
+          best_imb_this_trial = new_imbalance_;
+        }
+      }
     }
 
     if (this_node == 0) {
       vt_print(
         gossiplb,
-        "GossipLB::doLBStages: trial={} final imb={:0.4f}\n",
-        trial_, new_imbalance_
+        "GossipLB::doLBStages: trial={} {} imb={:0.4f}\n",
+        trial_, rollback_ ? "best" : "final", best_imb_this_trial
       );
-    }
-
-    if (new_imbalance_ <= start_imb && new_imbalance_ < best_imb) {
-      best_load = this_new_load_;
-      best_objs = cur_objs_;
-      best_imb = new_imbalance_;
-      best_trial = trial_;
     }
 
     // Clear out for next try or for not migrating by default

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -134,6 +134,7 @@ private:
   uint16_t num_iters_                               = 4;
   uint16_t num_trials_                              = 3;
   bool deterministic_                               = false;
+  bool rollback_                                    = true;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
   std::unordered_map<NodeType, LoadType> new_load_info_ = {};

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -57,22 +57,43 @@
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
+// gossiping approach
 enum struct InformTypeEnum : uint8_t {
-  // synchronized rounds propagate info faster but have sync cost
+  // synchronous: round number defined at the processor level;  propagates
+  // after all messages for a round are received, but has sync cost
   SyncInform  = 0,
-  // async rounds propagate before round has completed, omitting some info
+  // asynchronous: round number defined at the message level; propagates
+  // when the first message for a round is received, so has no sync cost
   AsyncInform = 1
 };
 
+// order in which local objects are considered for transfer
 enum struct ObjectOrderEnum : uint8_t {
+  // abitrary: use the unordered_map order
   Arbitrary = 0,
+  // element id: ascending by object id
   ElmID     = 1,
+  // marginal: order by load, starting with the object of marginal load
+  // (the smallest object that can be transferred to drop the processor
+  // load below the average), then descending for objects with loads less
+  // than the marginal load, and finally ascending for objects with loads
+  // greater than the marginal load
   Marginal  = 2
 };
 
+// how the cmf is computed
 enum struct CMFTypeEnum : uint8_t {
+  // original: remove processors from the CMF as soon as they exceed the
+  // target (e.g., processor-avg) load; use a CMF factor of 1.0/x, where x
+  // is the target load
   Original   = 0,
+  // normalize by max: do not remove processors from the CMF that exceed the
+  // target load until the next iteration; use a CMF factor of 1.0/x, where x
+  // is the maximum of the target load and the most loaded processor in the CMF
   NormByMax  = 1,
+  // normalize by self: do not remove processors from the CMF that exceed the
+  // target load until the next iteration; use a CMF factor of 1.0/x, where x
+  // is the load of the processor that is computing the CMF
   NormBySelf = 2
 };
 
@@ -133,9 +154,18 @@ private:
   uint16_t iter_                                    = 0;
   uint16_t trial_                                   = 0;
   uint16_t num_iters_                               = 4;
+  // how many times to repeat the requested number of iterations, hoping to
+  // find a better imbalance (helps if it's easy to get stuck in a local
+  // minimum)
   uint16_t num_trials_                              = 3;
+  // whether to make migration choices deterministic, assuming we're operating
+  // on deterministic loads
   bool deterministic_                               = false;
+  // whether to roll back to the state from a previous iteration if that
+  // iteration had a better imbalance than the final one
   bool rollback_                                    = true;
+  // whether to use a target load equal to the maximum object load (the
+  // "longest pole") when that load exceeds the processor-average load
   bool target_pole_                                 = false;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -103,8 +103,7 @@ protected:
   void decide();
   void migrate();
 
-  void propagateRoundAsync(uint8_t k_cur_async, EpochType epoch = no_epoch);
-  void propagateRoundSync(EpochType epoch = no_epoch);
+  void propagateRound(uint8_t k_cur_async, bool sync, EpochType epoch = no_epoch);
   void propagateIncomingAsync(GossipMsgAsync* msg);
   void propagateIncomingSync(GossipMsgSync* msg);
   bool isUnderloaded(LoadType load) const;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -135,6 +135,7 @@ private:
   uint16_t num_trials_                              = 3;
   bool deterministic_                               = false;
   bool rollback_                                    = true;
+  bool target_pole_                                 = false;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
   std::unordered_map<NodeType, LoadType> new_load_info_ = {};
@@ -147,6 +148,7 @@ private:
   std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
   LoadType this_new_load_                           = 0.0;
   TimeType new_imbalance_                           = 0.0;
+  TimeType target_max_load_                         = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
   ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Marginal;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -71,6 +71,12 @@ enum struct ObjectOrderEnum : uint8_t {
   Marginal  = 2
 };
 
+enum struct CMFTypeEnum : uint8_t {
+  Original   = 0,
+  NormByMax  = 1,
+  NormBySelf = 2
+};
+
 struct GossipLB : BaseLB {
   using GossipMsgAsync = balance::GossipMsgAsync;
   using GossipMsgSync  = balance::GossipMsg;
@@ -144,6 +150,7 @@ private:
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
   ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Arbitrary;
+  CMFTypeEnum cmf_type_                             = CMFTypeEnum::Original;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -65,6 +65,12 @@ enum struct InformTypeEnum : uint8_t {
   AsyncInform = 1
 };
 
+enum struct ObjectOrderEnum : uint8_t {
+  Arbitrary = 0,
+  ElmID     = 1,
+  Marginal  = 2
+};
+
 struct GossipLB : BaseLB {
   using GossipMsgAsync = balance::GossipMsgAsync;
   using GossipMsgSync  = balance::GossipMsg;
@@ -132,11 +138,12 @@ private:
   std::unordered_set<NodeType> selected_            = {};
   std::unordered_set<NodeType> underloaded_         = {};
   std::unordered_set<NodeType> new_underloaded_     = {};
-  std::map<ObjIDType, TimeType> cur_objs_           = {};
+  std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
   LoadType this_new_load_                           = 0.0;
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
+  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Arbitrary;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -148,8 +148,8 @@ private:
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
-  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Arbitrary;
-  CMFTypeEnum cmf_type_                             = CMFTypeEnum::Original;
+  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Marginal;
+  CMFTypeEnum cmf_type_                             = CMFTypeEnum::NormByMax;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -57,6 +57,32 @@
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
+struct RejectionStats {
+  RejectionStats() = default;
+  RejectionStats(int n_rejected, int n_transfers)
+    : n_rejected_(n_rejected), n_transfers_(n_transfers) { }
+
+  friend RejectionStats operator+(RejectionStats a1, RejectionStats const& a2) {
+    a1.n_rejected_ += a2.n_rejected_;
+    a1.n_transfers_ += a2.n_transfers_;
+
+    return a1;
+  }
+
+  int n_rejected_ = 0;
+  int n_transfers_ = 0;
+};
+
+struct GossipRejectionStatsMsg : collective::ReduceTMsg<RejectionStats> {
+  GossipRejectionStatsMsg() = default;
+  GossipRejectionStatsMsg(int n_rejected, int n_transfers)
+    : ReduceTMsg<RejectionStats>(RejectionStats(n_rejected, n_transfers))
+  { }
+  GossipRejectionStatsMsg(RejectionStats&& rs)
+    : ReduceTMsg<RejectionStats>(std::move(rs))
+  { }
+};
+
 struct GossipLB : BaseLB {
   using GossipMsg     = balance::GossipMsg;
   using NodeSetType   = std::vector<NodeType>;
@@ -75,7 +101,7 @@ public:
   void inputParams(balance::SpecEntry* spec) override;
 
 protected:
-  void doLBStages();
+  void doLBStages(TimeType start_imb);
   void inform();
   void decide();
   void migrate();
@@ -95,6 +121,8 @@ protected:
 
   void lazyMigrateObjsTo(EpochType epoch, NodeType node, ObjsType const& objs);
   void inLazyMigrations(balance::LazyMigrationMsg* msg);
+  void gossipStatsHandler(StatsMsgType* msg);
+  void gossipRejectionStatsHandler(GossipRejectionStatsMsg* msg);
   void thunkMigrations();
 
   void setupDone(ReduceMsgType* msg);
@@ -105,6 +133,7 @@ private:
   uint8_t k_cur_                                    = 0;
   uint16_t iter_                                    = 0;
   uint16_t num_iters_                               = 4;
+  uint16_t num_trials_                              = 3;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
   objgroup::proxy::Proxy<GossipLB> proxy_           = {};
@@ -114,6 +143,7 @@ private:
   std::unordered_set<NodeType> underloaded_         = {};
   std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
   LoadType this_new_load_                           = 0.0;
+  TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   bool setup_done_                                  = false;
 };

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -130,7 +130,7 @@ private:
   std::unordered_set<NodeType> selected_            = {};
   std::unordered_set<NodeType> underloaded_         = {};
   std::unordered_set<NodeType> new_underloaded_     = {};
-  std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
+  std::map<ObjIDType, TimeType> cur_objs_           = {};
   LoadType this_new_load_                           = 0.0;
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -84,10 +84,10 @@ struct GossipRejectionStatsMsg : collective::ReduceTMsg<RejectionStats> {
 };
 
 struct GossipLB : BaseLB {
-  using GossipMsg     = balance::GossipMsg;
-  using NodeSetType   = std::vector<NodeType>;
-  using ObjsType      = std::unordered_map<ObjIDType, LoadType>;
-  using ReduceMsgType = vt::collective::ReduceNoneMsg;
+  using GossipMsgAsync = balance::GossipMsgAsync;
+  using NodeSetType    = std::vector<NodeType>;
+  using ObjsType       = std::unordered_map<ObjIDType, LoadType>;
+  using ReduceMsgType  = vt::collective::ReduceNoneMsg;
 
   GossipLB() = default;
 
@@ -102,12 +102,12 @@ public:
 
 protected:
   void doLBStages(TimeType start_imb);
-  void inform();
+  void informAsync();
   void decide();
   void migrate();
 
-  void propagateRound(EpochType epoch = no_epoch);
-  void propagateIncoming(GossipMsg* msg);
+  void propagateRoundAsync(uint8_t k_cur_async, EpochType epoch = no_epoch);
+  void propagateIncomingAsync(GossipMsgAsync* msg);
   bool isUnderloaded(LoadType load) const;
   bool isUnderloadedRelaxed(LoadType over, LoadType under) const;
   bool isOverloaded(LoadType load) const;
@@ -147,6 +147,7 @@ private:
   TimeType new_imbalance_                           = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   bool setup_done_                                  = false;
+  std::vector<bool> propagated_k_;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -113,6 +113,7 @@ protected:
   std::vector<double> createCMF(NodeSetType const& under);
   NodeType sampleFromCMF(NodeSetType const& under, std::vector<double> const& cmf);
   std::vector<NodeType> makeUnderloaded() const;
+  std::vector<ObjIDType> orderObjects();
   ElementLoadType::iterator selectObject(
     LoadType size, ElementLoadType& load, std::set<ObjIDType> const& available
   );

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -52,7 +52,6 @@
 
 #include <random>
 #include <unordered_map>
-#include <map>
 #include <unordered_set>
 #include <vector>
 
@@ -80,6 +79,7 @@ enum struct CMFTypeEnum : uint8_t {
 struct GossipLB : BaseLB {
   using GossipMsgAsync = balance::GossipMsgAsync;
   using GossipMsgSync  = balance::GossipMsg;
+  using ArgType        = vt::arguments::ArgConfig;
   using NodeSetType    = std::vector<NodeType>;
   using ObjsType       = std::unordered_map<ObjIDType, LoadType>;
   using ReduceMsgType  = vt::collective::ReduceNoneMsg;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -52,6 +52,7 @@
 
 #include <random>
 #include <unordered_map>
+#include <map>
 #include <unordered_set>
 #include <vector>
 
@@ -121,6 +122,7 @@ private:
   uint16_t trial_                                   = 0;
   uint16_t num_iters_                               = 4;
   uint16_t num_trials_                              = 3;
+  bool deterministic_                               = false;
   std::random_device seed_;
   std::unordered_map<NodeType, LoadType> load_info_ = {};
   std::unordered_map<NodeType, LoadType> new_load_info_ = {};
@@ -138,6 +140,8 @@ private:
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;
   std::vector<bool> propagated_k_;
+  std::mt19937 gen_propagate_;
+  std::mt19937 gen_sample_;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -132,6 +132,7 @@ private:
   uint8_t k_max_                                    = 4;
   uint8_t k_cur_                                    = 0;
   uint16_t iter_                                    = 0;
+  uint16_t trial_                                   = 0;
   uint16_t num_iters_                               = 4;
   uint16_t num_trials_                              = 3;
   std::random_device seed_;


### PR DESCRIPTION
**This PR is the release branch-based equivalent of #1348. Please post review comments on #1348.**

Includes many bug fixes and improvements to GossipLB.  The following LB args were added:

- `trials` (default `3`): how many times to repeat the requested number of iterations, hoping to find a better imbalance; helps if it’s easy to get stuck in a local minimum
- `deterministic` (default false): for debugging purposes, make the migration decision deterministic assuming deterministic loads (for testing on deterministic loads, consider using the driver in development under #1265)
- `inform` (default SyncInform): choice of gossiping approach
  - SyncInform (`0`): synchronous propagates after all recvs for a round, but has sync cost (matches LBAF approach)
  - AsyncInform (`1`): asynchronous propagates after the first recv for a round, but avoids sync cost
- `ordering` (default Marginal): order in which to evaluate local objects for migration
  - Arbitrary (`0`): use the unordered_map iteration order
  - ElmID (`1`): order by ascending element ID
  - Marginal (`2`): order by descending load starting with the object of marginal load, then order ascending for larger loads
- `cmf` (default NormByMax): the algorithm used for computing the CMF
  - Original (`0`): remove processors from the CMF as soon as they exceed the target (e.g., processor-average) load; use a CMF factor of 1.0/x, where x is the target load
  - NormByMax (`1`): do not remove processors from the CMF that exceed the target load until the next iteration; use a CMF factor of 1.0x, where x is the maximum of the target load and the most loaded processor in the CMF
  - NormBySelf (`2`): do not remove processors from the CMF that exceed the target load until the next iteration; use a CMF factor of 1.0x, where x is the load of the processor that is computing the CMF
- `rollback` (default true): whether to roll back to an earlier iteration if it had the best imbalance
- `targetpole` (default false): whether to replace the processor-average load with the max of that and the maximum object load, effectively redefining overloaded/underloaded based on the longest pole load when it exceeds the processor-average load

Closes #1279