### PR TITLE
1369 implement additional gossiplb ordering

### DIFF
--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -77,7 +77,8 @@ void BaseLB::startLB(
   runInEpochCollective([this] { finishedStats();     });
 }
 
-BaseLB::LoadType BaseLB::loadMilli(LoadType const& load) const {
+/*static*/
+BaseLB::LoadType BaseLB::loadMilli(LoadType const& load) {
   // Convert `load` in seconds to milliseconds, typically for binning purposes
   return load * 1000;
 }

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -113,7 +113,7 @@ struct BaseLB {
   void finishedStats();
 
   ObjBinType histogramSample(LoadType const& load) const;
-  LoadType loadMilli(LoadType const& load) const;
+  static LoadType loadMilli(LoadType const& load);
   int32_t getBinSize() const { return bin_size_; }
   NodeType objGetNode(ObjIDType const id) const;
 

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -692,16 +692,21 @@ GossipLB::selectObject(
   }
 }
 
-std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
+/*static*/
+std::vector<GossipLB::ObjIDType> GossipLB::orderObjects(
+  ObjectOrderEnum obj_ordering,
+  std::unordered_map<ObjIDType, TimeType> cur_objs,
+  LoadType this_new_load, TimeType target_max_load
+) {
   // define the iteration order
-  std::vector<ObjIDType> ordered_obj_ids(cur_objs_.size());
+  std::vector<ObjIDType> ordered_obj_ids(cur_objs.size());
 
   int i = 0;
-  for (auto &obj : cur_objs_) {
+  for (auto &obj : cur_objs) {
     ordered_obj_ids[i++] = obj.first;
   }
 
-  switch (obj_ordering_) {
+  switch (obj_ordering) {
   case ObjectOrderEnum::ElmID:
     std::sort(
       ordered_obj_ids.begin(), ordered_obj_ids.end(), std::less<ObjIDType>()
@@ -711,11 +716,11 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
     {
       // first find the load of the smallest single object that, if migrated
       // away, could bring this processor's load below the target load
-      auto over_avg = this_new_load_ - target_max_load_;
+      auto over_avg = this_new_load - target_max_load;
       // if no objects are larger than over_avg, then single_obj_load will still
       // (incorrectly) reflect the total load, which will not be a problem
-      auto single_obj_load = this_new_load_;
-      for (auto &obj : cur_objs_) {
+      auto single_obj_load = this_new_load;
+      for (auto &obj : cur_objs) {
         // the object stats are in seconds but the processor stats are in
         // milliseconds; for now, convert the object loads to milliseconds
         auto obj_load_ms = loadMilli(obj.second);
@@ -727,9 +732,11 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
       // sort smallest to largest if > single_obj_load
       std::sort(
         ordered_obj_ids.begin(), ordered_obj_ids.end(),
-        [=](const ObjIDType &left, const ObjIDType &right) {
-          auto left_load = loadMilli(this->cur_objs_[left]);
-          auto right_load = loadMilli(this->cur_objs_[right]);
+        [&cur_objs, single_obj_load](
+          const ObjIDType &left, const ObjIDType &right
+        ) {
+          auto left_load = loadMilli(cur_objs[left]);
+          auto right_load = loadMilli(cur_objs[right]);
           if (left_load <= single_obj_load && right_load <= single_obj_load) {
             // we're in the sort load descending regime (first section)
             return left_load > right_load;
@@ -748,7 +755,7 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
       vt_debug_print(
         normal, gossiplb,
         "GossipLB::decide: over_avg={}, single_obj_load={}\n",
-        over_avg, loadMilli(cur_objs_[ordered_obj_ids[0]])
+        over_avg, loadMilli(cur_objs[ordered_obj_ids[0]])
       );
     }
     break;
@@ -757,21 +764,21 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
       // first find the smallest object that, if migrated away along with all
       // smaller objects, could bring this processor's load below the target
       // load
-      auto over_avg = this_new_load_ - target_max_load_;
+      auto over_avg = this_new_load - target_max_load;
       std::sort(
         ordered_obj_ids.begin(), ordered_obj_ids.end(),
-        [=](const ObjIDType &left, const ObjIDType &right) {
+        [&cur_objs](const ObjIDType &left, const ObjIDType &right) {
           // skipping the conversion to milliseconds here
-          auto left_load = this->cur_objs_[left];
-          auto right_load = this->cur_objs_[right];
+          auto left_load = cur_objs[left];
+          auto right_load = cur_objs[right];
           // sort load descending
           return left_load > right_load;
         }
       );
-      auto cum_obj_load = this_new_load_;
-      auto single_obj_load = loadMilli(cur_objs_[ordered_obj_ids[0]]);
+      auto cum_obj_load = this_new_load;
+      auto single_obj_load = loadMilli(cur_objs[ordered_obj_ids[0]]);
       for (auto obj_id : ordered_obj_ids) {
-        auto this_obj_load = loadMilli(cur_objs_[obj_id]);
+        auto this_obj_load = loadMilli(cur_objs[obj_id]);
         if (cum_obj_load - this_obj_load < over_avg) {
           single_obj_load = this_obj_load;
           break;
@@ -784,9 +791,11 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
       // sort smallest to largest if > single_obj_load
       std::sort(
         ordered_obj_ids.begin(), ordered_obj_ids.end(),
-        [=](const ObjIDType &left, const ObjIDType &right) {
-          auto left_load = loadMilli(this->cur_objs_[left]);
-          auto right_load = loadMilli(this->cur_objs_[right]);
+        [&cur_objs, single_obj_load](
+          const ObjIDType &left, const ObjIDType &right
+        ) {
+          auto left_load = loadMilli(cur_objs[left]);
+          auto right_load = loadMilli(cur_objs[right]);
           if (left_load <= single_obj_load && right_load <= single_obj_load) {
             // we're in the sort load descending regime (first section)
             return left_load > right_load;
@@ -805,7 +814,7 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects() {
       vt_debug_print(
         normal, gossiplb,
         "GossipLB::decide: over_avg={}, marginal_obj_load={}\n",
-        over_avg, loadMilli(cur_objs_[ordered_obj_ids[0]])
+        over_avg, loadMilli(cur_objs[ordered_obj_ids[0]])
       );
     }
     break;
@@ -829,7 +838,9 @@ void GossipLB::decide() {
     std::unordered_map<NodeType, ObjsType> migrate_objs;
 
     if (under.size() > 0) {
-      std::vector<ObjIDType> ordered_obj_ids = orderObjects();
+      std::vector<ObjIDType> ordered_obj_ids = orderObjects(
+        obj_ordering_, cur_objs_, this_new_load_, target_max_load_
+      );
 
       // Iterate through all the objects
       for (auto iter = ordered_obj_ids.begin(); iter != ordered_obj_ids.end(); ) {

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -759,7 +759,7 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects(
       );
     }
     break;
-  case ObjectOrderEnum::SmallestObjects:
+  case ObjectOrderEnum::SmallObjects:
     {
       // first find the smallest object that, if migrated away along with all
       // smaller objects, could bring this processor's load below the target

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -712,7 +712,7 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects(
       ordered_obj_ids.begin(), ordered_obj_ids.end(), std::less<ObjIDType>()
     );
     break;
-  case ObjectOrderEnum::LeastMigrations:
+  case ObjectOrderEnum::FewestMigrations:
     {
       // first find the load of the smallest single object that, if migrated
       // away, could bring this processor's load below the target load

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -818,6 +818,21 @@ std::vector<GossipLB::ObjIDType> GossipLB::orderObjects(
       );
     }
     break;
+  case ObjectOrderEnum::LargestObjects:
+    {
+      // sort by descending load
+      std::sort(
+        ordered_obj_ids.begin(), ordered_obj_ids.end(),
+        [&cur_objs](const ObjIDType &left, const ObjIDType &right) {
+          // skipping the conversion to milliseconds here
+          auto left_load = cur_objs[left];
+          auto right_load = cur_objs[right];
+          // sort load descending
+          return left_load > right_load;
+        }
+      );
+    }
+    break;
   case ObjectOrderEnum::Arbitrary:
     break;
   default:

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -155,6 +155,12 @@ public:
   void runLB() override;
   void inputParams(balance::SpecEntry* spec) override;
 
+  static std::vector<ObjIDType> orderObjects(
+    ObjectOrderEnum obj_ordering,
+    std::unordered_map<ObjIDType, TimeType> cur_objs,
+    LoadType this_new_load, TimeType target_max_load
+  );
+
 protected:
   void doLBStages(TimeType start_imb);
   void informAsync();
@@ -172,11 +178,6 @@ protected:
   std::vector<double> createCMF(NodeSetType const& under);
   NodeType sampleFromCMF(NodeSetType const& under, std::vector<double> const& cmf);
   std::vector<NodeType> makeUnderloaded() const;
-  static std::vector<ObjIDType> orderObjects(
-    ObjectOrderEnum obj_ordering,
-    std::unordered_map<ObjIDType, TimeType> cur_objs,
-    LoadType this_new_load, TimeType target_max_load
-  );
   ElementLoadType::iterator selectObject(
     LoadType size, ElementLoadType& load, std::set<ObjIDType> const& available
   );

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -99,7 +99,7 @@ enum struct ObjectOrderEnum : uint8_t {
    */
   LeastMigrations = 2,
   /**
-   * \brief Order for migrating the smallest objects
+   * \brief Order for migrating the objects with the smallest loads
    *
    * Find the object with the smallest load where the sum of its own load and
    * all smaller loads meets or exceeds the amount by which this processor's
@@ -107,7 +107,7 @@ enum struct ObjectOrderEnum : uint8_t {
    * descending load for objects with smaller loads, and finally by ascending
    * load for objects with larger loads.
    */
-  SmallestObjects = 3
+  SmallObjects = 3
 };
 
 /// Enum for how the CMF is computed

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -172,7 +172,11 @@ protected:
   std::vector<double> createCMF(NodeSetType const& under);
   NodeType sampleFromCMF(NodeSetType const& under, std::vector<double> const& cmf);
   std::vector<NodeType> makeUnderloaded() const;
-  std::vector<ObjIDType> orderObjects();
+  static std::vector<ObjIDType> orderObjects(
+    ObjectOrderEnum obj_ordering,
+    std::unordered_map<ObjIDType, TimeType> cur_objs,
+    LoadType this_new_load, TimeType target_max_load
+  );
   ElementLoadType::iterator selectObject(
     LoadType size, ElementLoadType& load, std::set<ObjIDType> const& available
   );

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -107,7 +107,11 @@ enum struct ObjectOrderEnum : uint8_t {
    * descending load for objects with smaller loads, and finally by ascending
    * load for objects with larger loads.
    */
-  SmallObjects = 3
+  SmallObjects = 3,
+  /**
+   * \brief Order by descending load
+   */
+  LargestObjects = 4
 };
 
 /// Enum for how the CMF is computed

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -92,11 +92,12 @@ enum struct ObjectOrderEnum : uint8_t {
   /**
    * \brief Order for the least migrations
    *
-   * Order by load, starting with the smallest object that can be transferred
-   * to drop the processor load below the average, then descending for objects
-   * with smaller loads, and finally ascending for objects with larger loads.
+   * Order starting with the smallest object that can be transferred to drop
+   * the processor load below the average, then by descending load for objects
+   * with smaller loads, and finally by ascending load for objects with larger
+   * loads.
    */
-  Marginal  = 2
+  LeastMigrations = 2
 };
 
 /// Enum for how the CMF is computed
@@ -226,7 +227,7 @@ private:
   TimeType target_max_load_                         = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
-  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::Marginal;
+  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::LeastMigrations;
   CMFTypeEnum cmf_type_                             = CMFTypeEnum::NormByMax;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -90,14 +90,14 @@ enum struct ObjectOrderEnum : uint8_t {
    */
   ElmID     = 1,
   /**
-   * \brief Order for the least migrations
+   * \brief Order for the fewest migrations
    *
-   * Order starting with the smallest object that can be transferred to drop
-   * the processor load below the average, then by descending load for objects
-   * with smaller loads, and finally by ascending load for objects with larger
-   * loads.
+   * Order starting with the object with the smallest load that can be
+   * transferred to drop the processor load below the average, then by
+   * descending load for objects with smaller loads, and finally by ascending
+   * load for objects with larger loads.
    */
-  LeastMigrations = 2,
+  FewestMigrations = 2,
   /**
    * \brief Order for migrating the objects with the smallest loads
    *
@@ -242,7 +242,7 @@ private:
   TimeType target_max_load_                         = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::SyncInform;
-  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::LeastMigrations;
+  ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::FewestMigrations;
   CMFTypeEnum cmf_type_                             = CMFTypeEnum::NormByMax;
   bool setup_done_                                  = false;
   bool propagate_next_round_                        = false;

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -97,7 +97,17 @@ enum struct ObjectOrderEnum : uint8_t {
    * with smaller loads, and finally by ascending load for objects with larger
    * loads.
    */
-  LeastMigrations = 2
+  LeastMigrations = 2,
+  /**
+   * \brief Order for migrating the smallest objects
+   *
+   * Find the object with the smallest load where the sum of its own load and
+   * all smaller loads meets or exceeds the amount by which this processor's
+   * load exceeds the target load. Order starting with that object, then by
+   * descending load for objects with smaller loads, and finally by ascending
+   * load for objects with larger loads.
+   */
+  SmallestObjects = 3
 };
 
 /// Enum for how the CMF is computed

--- a/tests/unit/lb/test_gossiplb.nompi.cc
+++ b/tests/unit/lb/test_gossiplb.nompi.cc
@@ -171,8 +171,8 @@ TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_smallest) {
 
 ///////////////////////////////////////////////////////////////////////////
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_intermediate) {
-  ObjectOrdering order = ObjectOrdering::SmallestObjects;
+TEST_F(TestGossipLB, test_gossiplb_ordering_smallobjects_intermediate) {
+  ObjectOrdering order = ObjectOrdering::SmallObjects;
   TimeType over_avg = 4.5;
   // marginal_obj_load will be 3.0
   // load order will be 3.0, 2.0, 4.0, 5.0, 6.0, 9.0
@@ -181,8 +181,8 @@ TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_intermediate) {
   orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_largest) {
-  ObjectOrdering order = ObjectOrdering::SmallestObjects;
+TEST_F(TestGossipLB, test_gossiplb_ordering_smallobjects_largest) {
+  ObjectOrdering order = ObjectOrdering::SmallObjects;
   TimeType target_load = 0.5;
   // marginal_obj_load will be 9.0
   // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
@@ -191,8 +191,8 @@ TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_largest) {
   orderUsingTargetLoadAndVerify(order, target_load, soln);
 }
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_smallest) {
-  ObjectOrdering order = ObjectOrdering::SmallestObjects;
+TEST_F(TestGossipLB, test_gossiplb_ordering_smallobjects_smallest) {
+  ObjectOrdering order = ObjectOrdering::SmallObjects;
   TimeType over_avg = 1.5;
   // marginal_obj_load will be 2.0
   // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0

--- a/tests/unit/lb/test_gossiplb.nompi.cc
+++ b/tests/unit/lb/test_gossiplb.nompi.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                              test_lb_reader.cc
+//                           test_gossiplb.nompi.cc
 //                           DARMA Toolkit v. 1.0.0
 //                       DARMA/vt => Virtual Transport
 //

--- a/tests/unit/lb/test_gossiplb.nompi.cc
+++ b/tests/unit/lb/test_gossiplb.nompi.cc
@@ -56,10 +56,10 @@ using ElementIDStruct = vt::vrt::collection::balance::ElementIDStruct;
 using ElementIDType = vt::vrt::collection::balance::ElementIDType;
 using ObjectOrdering = vt::vrt::collection::lb::ObjectOrderEnum;
 
-void setupProblem(
-  std::unordered_map<ElementIDStruct, TimeType> &cur_objs,
-  TimeType &my_load
+TimeType setupProblem(
+  std::unordered_map<ElementIDStruct, TimeType> &cur_objs
 ) {
+  // total load of 29 seconds
   cur_objs.emplace(ElementIDStruct{3,0,0}, 4.0);
   cur_objs.emplace(ElementIDStruct{5,0,0}, 5.0);
   cur_objs.emplace(ElementIDStruct{2,0,0}, 9.0);
@@ -67,161 +67,138 @@ void setupProblem(
   cur_objs.emplace(ElementIDStruct{1,0,0}, 6.0);
   cur_objs.emplace(ElementIDStruct{4,0,0}, 3.0);
 
-  my_load = 0;
+  // compute the load for this processor
+  TimeType my_load = 0;
   for (auto &obj : cur_objs) {
-    my_load += vt::vrt::collection::lb::BaseLB::loadMilli(obj.second);
+    my_load += obj.second;
   }
+  return my_load;
 }
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_elmid) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = 0;
-  setupProblem(cur_objs, my_load);
-
-  ObjectOrdering order = ObjectOrdering::ElmID;
-  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(4.5);
-  TimeType target_load = my_load - over_avg;
-  std::vector<ElementIDType> soln = {0, 1, 2, 3, 4, 5};
-
+void orderAndVerify(
+  ObjectOrdering order,
+  const std::unordered_map<ElementIDStruct, TimeType> &cur_objs,
+  TimeType my_load_ms, TimeType target_load_ms,
+  const std::vector<ElementIDType> &soln
+) {
+  // have GossipLB order the objects
   auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
-    order, cur_objs, my_load, target_load
+    order, cur_objs, my_load_ms, target_load_ms
   );
 
+  // verify correctness of the returned ordering
   int i = 0;
   for (auto obj_id : ordered_objs) {
     EXPECT_EQ(obj_id.id, soln[i++]);
   }
 }
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations) {
+void orderUsingOverloadAndVerify(
+  ObjectOrdering order, TimeType over_avg_sec /* my_load-target_load */,
+  const std::vector<ElementIDType> &soln
+) {
   std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = 0;
-  setupProblem(cur_objs, my_load);
+  TimeType my_load_ms = vt::vrt::collection::lb::BaseLB::loadMilli(
+    setupProblem(cur_objs)
+  );
 
+  // we know how overloaded we are and need to compute the target load
+  TimeType target_load_ms = my_load_ms -
+    vt::vrt::collection::lb::BaseLB::loadMilli(over_avg_sec);
+
+  orderAndVerify(order, cur_objs, my_load_ms, target_load_ms, soln);
+}
+
+void orderUsingTargetLoadAndVerify(
+  ObjectOrdering order, TimeType target_load_sec,
+  const std::vector<ElementIDType> &soln
+) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load_ms = vt::vrt::collection::lb::BaseLB::loadMilli(
+    setupProblem(cur_objs)
+  );
+
+  // we were given the target load directly but need to convert units
+  TimeType target_load_ms = vt::vrt::collection::lb::BaseLB::loadMilli(
+    target_load_sec
+  );
+
+  orderAndVerify(order, cur_objs, my_load_ms, target_load_ms, soln);
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_elmid) {
+  ObjectOrdering order = ObjectOrdering::ElmID;
+  TimeType over_avg = 4.5;
+  // result will be independent of over_avg
+  std::vector<ElementIDType> soln = {0, 1, 2, 3, 4, 5};
+
+  orderUsingOverloadAndVerify(order, over_avg, soln);
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_intermediate) {
   ObjectOrdering order = ObjectOrdering::LeastMigrations;
-  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(4.5);
-  TimeType target_load = my_load - over_avg;
+  TimeType over_avg = 4.5;
   // single_obj_load will be 5.0
   // load order will be 5.0, 4.0, 3.0, 2.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {5, 3, 4, 0, 1, 2};
 
-  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
-    order, cur_objs, my_load, target_load
-  );
-
-  int i = 0;
-  for (auto obj_id : ordered_objs) {
-    EXPECT_EQ(obj_id.id, soln[i++]);
-  }
+  orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
 TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_largest) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = 0;
-  setupProblem(cur_objs, my_load);
-
   ObjectOrdering order = ObjectOrdering::LeastMigrations;
-  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(12.5);
-  TimeType target_load = my_load - over_avg;
+  TimeType over_avg = 12.5;
   // single_obj_load will be 9.0
   // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
   std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
 
-  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
-    order, cur_objs, my_load, target_load
-  );
-
-  int i = 0;
-  for (auto obj_id : ordered_objs) {
-    EXPECT_EQ(obj_id.id, soln[i++]);
-  }
+  orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
 TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_smallest) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = 0;
-  setupProblem(cur_objs, my_load);
-
   ObjectOrdering order = ObjectOrdering::LeastMigrations;
-  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(1.5);
-  TimeType target_load = my_load - over_avg;
+  TimeType over_avg = 1.5;
   // single_obj_load will be 2.0
   // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {0, 4, 3, 5, 1, 2};
 
-  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
-    order, cur_objs, my_load, target_load
-  );
-
-  int i = 0;
-  for (auto obj_id : ordered_objs) {
-    EXPECT_EQ(obj_id.id, soln[i++]);
-  }
+  orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = 0;
-  setupProblem(cur_objs, my_load);
+///////////////////////////////////////////////////////////////////////////
 
+TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_intermediate) {
   ObjectOrdering order = ObjectOrdering::SmallestObjects;
-  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(4.5);
-  TimeType target_load = my_load - over_avg;
+  TimeType over_avg = 4.5;
   // marginal_obj_load will be 3.0
   // load order will be 3.0, 2.0, 4.0, 5.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {4, 0, 3, 5, 1, 2};
 
-  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
-    order, cur_objs, my_load, target_load
-  );
-
-  int i = 0;
-  for (auto obj_id : ordered_objs) {
-    EXPECT_EQ(obj_id.id, soln[i++]);
-  }
+  orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
 TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_largest) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = 0;
-  setupProblem(cur_objs, my_load);
-
   ObjectOrdering order = ObjectOrdering::SmallestObjects;
-  TimeType target_load = vt::vrt::collection::lb::BaseLB::loadMilli(0.5);
+  TimeType target_load = 0.5;
   // marginal_obj_load will be 9.0
   // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
   std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
 
-  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
-    order, cur_objs, my_load, target_load
-  );
-
-  int i = 0;
-  for (auto obj_id : ordered_objs) {
-    EXPECT_EQ(obj_id.id, soln[i++]);
-  }
+  orderUsingTargetLoadAndVerify(order, target_load, soln);
 }
 
 TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_smallest) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = 0;
-  setupProblem(cur_objs, my_load);
-
   ObjectOrdering order = ObjectOrdering::SmallestObjects;
-  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(1.5);
-  TimeType target_load = my_load - over_avg;
+  TimeType over_avg = 1.5;
   // marginal_obj_load will be 2.0
   // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {0, 4, 3, 5, 1, 2};
 
-  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
-    order, cur_objs, my_load, target_load
-  );
-
-  int i = 0;
-  for (auto obj_id : ordered_objs) {
-    EXPECT_EQ(obj_id.id, soln[i++]);
-  }
+  orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/lb/test_gossiplb.nompi.cc
+++ b/tests/unit/lb/test_gossiplb.nompi.cc
@@ -1,0 +1,227 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                              test_lb_reader.cc
+//                           DARMA Toolkit v. 1.0.0
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <vt/transport.h>
+#include <vt/vrt/collection/balance/lb_common.h>
+#include <vt/vrt/collection/balance/baselb/baselb.h>
+#include <vt/vrt/collection/balance/gossiplb/gossiplb.h>
+
+#include "test_harness.h"
+
+namespace vt { namespace tests { namespace unit {
+
+using TestGossipLB = TestHarness;
+using ElementIDStruct = vt::vrt::collection::balance::ElementIDStruct;
+using ElementIDType = vt::vrt::collection::balance::ElementIDType;
+using ObjectOrdering = vt::vrt::collection::lb::ObjectOrderEnum;
+
+void setupProblem(
+  std::unordered_map<ElementIDStruct, TimeType> &cur_objs,
+  TimeType &my_load
+) {
+  cur_objs.emplace(ElementIDStruct{3,0,0}, 4.0);
+  cur_objs.emplace(ElementIDStruct{5,0,0}, 5.0);
+  cur_objs.emplace(ElementIDStruct{2,0,0}, 9.0);
+  cur_objs.emplace(ElementIDStruct{0,0,0}, 2.0);
+  cur_objs.emplace(ElementIDStruct{1,0,0}, 6.0);
+  cur_objs.emplace(ElementIDStruct{4,0,0}, 3.0);
+
+  my_load = 0;
+  for (auto &obj : cur_objs) {
+    my_load += vt::vrt::collection::lb::BaseLB::loadMilli(obj.second);
+  }
+}
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_elmid) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load = 0;
+  setupProblem(cur_objs, my_load);
+
+  ObjectOrdering order = ObjectOrdering::ElmID;
+  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(4.5);
+  TimeType target_load = my_load - over_avg;
+  std::vector<ElementIDType> soln = {0, 1, 2, 3, 4, 5};
+
+  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
+    order, cur_objs, my_load, target_load
+  );
+
+  int i = 0;
+  for (auto obj_id : ordered_objs) {
+    EXPECT_EQ(obj_id.id, soln[i++]);
+  }
+}
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load = 0;
+  setupProblem(cur_objs, my_load);
+
+  ObjectOrdering order = ObjectOrdering::LeastMigrations;
+  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(4.5);
+  TimeType target_load = my_load - over_avg;
+  // single_obj_load will be 5.0
+  // load order will be 5.0, 4.0, 3.0, 2.0, 6.0, 9.0
+  std::vector<ElementIDType> soln = {5, 3, 4, 0, 1, 2};
+
+  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
+    order, cur_objs, my_load, target_load
+  );
+
+  int i = 0;
+  for (auto obj_id : ordered_objs) {
+    EXPECT_EQ(obj_id.id, soln[i++]);
+  }
+}
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_largest) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load = 0;
+  setupProblem(cur_objs, my_load);
+
+  ObjectOrdering order = ObjectOrdering::LeastMigrations;
+  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(12.5);
+  TimeType target_load = my_load - over_avg;
+  // single_obj_load will be 9.0
+  // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
+  std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
+
+  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
+    order, cur_objs, my_load, target_load
+  );
+
+  int i = 0;
+  for (auto obj_id : ordered_objs) {
+    EXPECT_EQ(obj_id.id, soln[i++]);
+  }
+}
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_smallest) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load = 0;
+  setupProblem(cur_objs, my_load);
+
+  ObjectOrdering order = ObjectOrdering::LeastMigrations;
+  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(1.5);
+  TimeType target_load = my_load - over_avg;
+  // single_obj_load will be 2.0
+  // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0
+  std::vector<ElementIDType> soln = {0, 4, 3, 5, 1, 2};
+
+  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
+    order, cur_objs, my_load, target_load
+  );
+
+  int i = 0;
+  for (auto obj_id : ordered_objs) {
+    EXPECT_EQ(obj_id.id, soln[i++]);
+  }
+}
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load = 0;
+  setupProblem(cur_objs, my_load);
+
+  ObjectOrdering order = ObjectOrdering::SmallestObjects;
+  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(4.5);
+  TimeType target_load = my_load - over_avg;
+  // marginal_obj_load will be 3.0
+  // load order will be 3.0, 2.0, 4.0, 5.0, 6.0, 9.0
+  std::vector<ElementIDType> soln = {4, 0, 3, 5, 1, 2};
+
+  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
+    order, cur_objs, my_load, target_load
+  );
+
+  int i = 0;
+  for (auto obj_id : ordered_objs) {
+    EXPECT_EQ(obj_id.id, soln[i++]);
+  }
+}
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_largest) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load = 0;
+  setupProblem(cur_objs, my_load);
+
+  ObjectOrdering order = ObjectOrdering::SmallestObjects;
+  TimeType target_load = vt::vrt::collection::lb::BaseLB::loadMilli(0.5);
+  // marginal_obj_load will be 9.0
+  // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
+  std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
+
+  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
+    order, cur_objs, my_load, target_load
+  );
+
+  int i = 0;
+  for (auto obj_id : ordered_objs) {
+    EXPECT_EQ(obj_id.id, soln[i++]);
+  }
+}
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_smallestobjects_smallest) {
+  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
+  TimeType my_load = 0;
+  setupProblem(cur_objs, my_load);
+
+  ObjectOrdering order = ObjectOrdering::SmallestObjects;
+  TimeType over_avg = vt::vrt::collection::lb::BaseLB::loadMilli(1.5);
+  TimeType target_load = my_load - over_avg;
+  // marginal_obj_load will be 2.0
+  // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0
+  std::vector<ElementIDType> soln = {0, 4, 3, 5, 1, 2};
+
+  auto ordered_objs = vt::vrt::collection::lb::GossipLB::orderObjects(
+    order, cur_objs, my_load, target_load
+  );
+
+  int i = 0;
+  for (auto obj_id : ordered_objs) {
+    EXPECT_EQ(obj_id.id, soln[i++]);
+  }
+}
+
+}}} // end namespace vt::tests::unit

--- a/tests/unit/lb/test_gossiplb.nompi.cc
+++ b/tests/unit/lb/test_gossiplb.nompi.cc
@@ -139,8 +139,8 @@ TEST_F(TestGossipLB, test_gossiplb_ordering_elmid) {
 
 ///////////////////////////////////////////////////////////////////////////
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_intermediate) {
-  ObjectOrdering order = ObjectOrdering::LeastMigrations;
+TEST_F(TestGossipLB, test_gossiplb_ordering_fewestmigrations_intermediate) {
+  ObjectOrdering order = ObjectOrdering::FewestMigrations;
   TimeType over_avg = 4.5;
   // single_obj_load will be 5.0
   // load order will be 5.0, 4.0, 3.0, 2.0, 6.0, 9.0
@@ -149,8 +149,8 @@ TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_intermediate) {
   orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_largest) {
-  ObjectOrdering order = ObjectOrdering::LeastMigrations;
+TEST_F(TestGossipLB, test_gossiplb_ordering_fewestmigrations_largest) {
+  ObjectOrdering order = ObjectOrdering::FewestMigrations;
   TimeType over_avg = 12.5;
   // single_obj_load will be 9.0
   // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
@@ -159,8 +159,8 @@ TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_largest) {
   orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
-TEST_F(TestGossipLB, test_gossiplb_ordering_leastmigrations_smallest) {
-  ObjectOrdering order = ObjectOrdering::LeastMigrations;
+TEST_F(TestGossipLB, test_gossiplb_ordering_fewestmigrations_smallest) {
+  ObjectOrdering order = ObjectOrdering::FewestMigrations;
   TimeType over_avg = 1.5;
   // single_obj_load will be 2.0
   // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0

--- a/tests/unit/lb/test_gossiplb.nompi.cc
+++ b/tests/unit/lb/test_gossiplb.nompi.cc
@@ -201,4 +201,15 @@ TEST_F(TestGossipLB, test_gossiplb_ordering_smallobjects_smallest) {
   orderUsingOverloadAndVerify(order, over_avg, soln);
 }
 
+///////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestGossipLB, test_gossiplb_ordering_largestobjects) {
+  ObjectOrdering order = ObjectOrdering::LargestObjects;
+  TimeType over_avg = 4.5;
+  // result will be independent of over_avg
+  std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
+
+  orderUsingOverloadAndVerify(order, over_avg, soln);
+}
+
 }}} // end namespace vt::tests::unit


### PR DESCRIPTION
This renames the `Marginal` object ordering to `FewestMigrations` and adds @PhilMiller's `SmallObjects` ordering and the more naive `LargestObjects` ordering.  Tests for all three, along with ordering by element ID, are included.

Closes #1369 