### PR TITLE
1366 LB strategy name can skip validation

### DIFF
--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -116,12 +116,22 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
     auto interval = theConfig()->vt_lb_interval;
     vtAssert(interval != 0, "LB Interval must not be 0");
     if (interval == 1 || phase % interval == 1) {
+      bool name_match = false;
       for (auto&& elm : lb_names_) {
         if (elm.second == theConfig()->vt_lb_name) {
           the_lb = elm.first;
+          name_match = true;
           break;
         }
       }
+      vtAbortIf(
+        !name_match,
+        fmt::format(
+          "LB Name \"{}\" requested does not exist or was not enabled at "
+          "compile time",
+          theConfig()->vt_lb_name
+        )
+      );
     }
   }
 


### PR DESCRIPTION
Check for a failed attempt to match the LB name in `decideLBToRun` instead of defaulting to `NoLB`.

Fixes #1366.