### PR TITLE
1372 Still skip LB on first phase when interval is 1

### DIFF
--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -115,7 +115,7 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
   } else {
     auto interval = theConfig()->vt_lb_interval;
     vtAssert(interval != 0, "LB Interval must not be 0");
-    if (interval == 1 || phase % interval == 1) {
+    if (phase % interval == 1 || (interval == 1 && phase != 0)) {
       bool name_match = false;
       for (auto&& elm : lb_names_) {
         if (elm.second == theConfig()->vt_lb_name) {


### PR DESCRIPTION
Release 1.0.1 skips LB on the first phase when the interval is 1 but develop does not. Update develop to match the 1.0.1 release.

Closes #1372.