### PR TITLE
1383: Add variants of runInEpoch* that take a string label as the first argument 

### DIFF
--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -69,7 +69,13 @@ template <typename Callable>
 void runInEpochRooted(Callable&& fn);
 
 template <typename Callable>
+void runInEpochRooted(std::string const& label, Callable&& fn);
+
+template <typename Callable>
 void runInEpochCollective(Callable&& fn);
+
+template <typename Callable>
+void runInEpochCollective(std::string const& label, Callable&& fn);
 
 namespace messaging {
 

--- a/src/vt/scheduler/scheduler.impl.h
+++ b/src/vt/scheduler/scheduler.impl.h
@@ -69,8 +69,20 @@ void runInEpochCollective(Callable&& fn) {
 }
 
 template <typename Callable>
+void runInEpochCollective(std::string const& label, Callable&& fn) {
+  auto ep = theTerm()->makeEpochCollective(label);
+  runInEpoch(ep, std::forward<Callable>(fn));
+}
+
+template <typename Callable>
 void runInEpochRooted(Callable&& fn) {
   auto ep = theTerm()->makeEpochRooted();
+  runInEpoch(ep, std::forward<Callable>(fn));
+}
+
+template <typename Callable>
+void runInEpochRooted(std::string const& label, Callable&& fn) {
+  auto ep = theTerm()->makeEpochRooted(label);
   runInEpoch(ep, std::forward<Callable>(fn));
 }
 

--- a/tests/unit/scheduler/test_high_level_calls.cc
+++ b/tests/unit/scheduler/test_high_level_calls.cc
@@ -70,8 +70,25 @@ TEST_F(TestHighLevelCalls, test_collective_std_function) {
   EXPECT_EQ(called, true);
 }
 
+TEST_F(TestHighLevelCalls, test_collective_std_function_labeled) {
+  std::function<void()> fn = [&]{
+    called = true;
+  };
+  runInEpochCollective("label", fn);
+
+  EXPECT_EQ(called, true);
+}
+
 TEST_F(TestHighLevelCalls, test_rooted_lambda) {
   runInEpochRooted([&]{
+    called = true;
+  });
+
+  EXPECT_EQ(called, true);
+}
+
+TEST_F(TestHighLevelCalls, test_rooted_lambda_labeled) {
+  runInEpochRooted("label", [&]{
     called = true;
   });
 


### PR DESCRIPTION
fixes #1383 