### PR TITLE
1387 GossipLB fanout type is too small

### DIFF
--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.cc
@@ -116,6 +116,19 @@ void GossipLB::inputParams(balance::SpecEntry* spec) {
     obj_ordering_ == ObjectOrderEnum::Arbitrary && deterministic_,
     "Arbitrary object ordering is not deterministic"
   );
+
+  if (theContext()->getNode() == 0) {
+    vt_debug_print(
+      terse, gossiplb,
+      "GossipLB::inputParams: using f={}, k={}, i={}, c={}, trials={}, "
+      "deterministic={}, inform={}, ordering={}, cmf={}, rollback={}, "
+      "targetpole={}\n",
+      f_, k_max_, num_iters_, static_cast<int32_t>(criterion_), num_trials_,
+      deterministic_, static_cast<int32_t>(inform_type_),
+      static_cast<int32_t>(obj_ordering_), static_cast<int32_t>(cmf_type_),
+      rollback_, target_pole_
+    );
+  }
 }
 
 void GossipLB::runLB() {
@@ -359,7 +372,7 @@ void GossipLB::informAsync() {
 
   if (is_overloaded_) {
     vt_debug_print(
-      verbose, gossiplb,
+      terse, gossiplb,
       "GossipLB::informAsync: trial={}, iter={}, known underloaded={}\n",
       trial_, iter_, underloaded_.size()
     );

--- a/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
+++ b/src/vt/vrt/collection/balance/gossiplb/gossiplb.h
@@ -195,7 +195,7 @@ protected:
   void setupDone(ReduceMsgType* msg);
 
 private:
-  uint8_t f_                                        = 4;
+  uint16_t f_                                       = 4;
   uint8_t k_max_                                    = 4;
   uint8_t k_cur_                                    = 0;
   uint16_t iter_                                    = 0;


### PR DESCRIPTION
Changed the fanout type from uint8_t to uint16_t so that fanouts of 1 less than the number of processors can be used for "full information" with GossipLB.

Fixes #1387.