### PR TITLE
1390: Remove unnecessary vt/transport.h includes from tests

### DIFF
--- a/src/vt/runtime/mpi_access.h
+++ b/src/vt/runtime/mpi_access.h
@@ -45,6 +45,8 @@
 #if !defined INCLUDED_RUNTIME_MPI_ACCESS_H
 #define INCLUDED_RUNTIME_MPI_ACCESS_H
 
+#include "vt/configs/features/features_enableif.h"
+
 #if vt_check_enabled(mpi_access_guards)
 #define VT_ALLOW_MPI_CALLS vt::runtime::ScopedMPIAccess _vt_allow_scoped_mpi{};
 #else

--- a/tests/unit/active/test_active_bcast_put.cc
+++ b/tests/unit/active/test_active_bcast_put.cc
@@ -44,11 +44,10 @@
 
 #include <gtest/gtest.h>
 
+#include "vt/messaging/active.h"
 #include "test_parallel_harness.h"
 #include "data_message.h"
 #include "test_helpers.h"
-
-#include "vt/transport.h"
 
 namespace vt { namespace tests { namespace unit { namespace bcast_put {
 

--- a/tests/unit/active/test_active_broadcast.cc
+++ b/tests/unit/active/test_active_broadcast.cc
@@ -44,11 +44,10 @@
 
 #include <gtest/gtest.h>
 
+#include "vt/messaging/active.h"
 #include "test_parallel_harness.h"
 #include "data_message.h"
 #include "test_helpers.h"
-
-#include "vt/transport.h"
 
 namespace vt { namespace tests { namespace unit { namespace bcast {
 

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -44,11 +44,10 @@
 
 #include <gtest/gtest.h>
 
+#include "vt/messaging/active.h"
 #include "test_parallel_harness.h"
 #include "data_message.h"
 #include "test_helpers.h"
-
-#include "vt/transport.h"
 
 namespace vt { namespace tests { namespace unit { namespace send {
 

--- a/tests/unit/active/test_active_send_large.cc
+++ b/tests/unit/active/test_active_send_large.cc
@@ -42,9 +42,12 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <gtest/gtest.h>
 
+#include "vt/messaging/active.h"
+#include "vt/pipe/callback/cb_union/cb_raw_base.h"
+#include "vt/pipe/pipe_lifetime.h"
+#include "vt/pipe/pipe_manager.h"
 #include "test_parallel_harness.h"
 #include "data_message.h"
 #include "test_helpers.h"

--- a/tests/unit/active/test_active_send_put.cc
+++ b/tests/unit/active/test_active_send_put.cc
@@ -44,11 +44,10 @@
 
 #include <gtest/gtest.h>
 
+#include "vt/messaging/active.h"
 #include "test_parallel_harness.h"
 #include "data_message.h"
 #include "test_helpers.h"
-
-#include "vt/transport.h"
 
 namespace vt { namespace tests { namespace unit { namespace send_put {
 

--- a/tests/unit/active/test_async_op.cc
+++ b/tests/unit/active/test_async_op.cc
@@ -42,12 +42,15 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
+#include <mpi.h>
+#include "test_parallel_harness.h"
+
 #include <vt/runtime/mpi_access.h>
 #include <vt/messaging/async_op_mpi.h>
+#include <vt/objgroup/manager.h>
 
 #include <gtest/gtest.h>
-#include "test_parallel_harness.h"
+
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/active/test_async_op_threads.cc
+++ b/tests/unit/active/test_async_op_threads.cc
@@ -41,13 +41,14 @@
 // *****************************************************************************
 //@HEADER
 */
+#include <mpi.h>
+#include "test_parallel_harness.h"
 
-#include <vt/transport.h>
-#include <vt/runtime/mpi_access.h>
 #include <vt/messaging/async_op_mpi.h>
+#include <vt/messaging/active.h>
 
 #include <gtest/gtest.h>
-#include "test_parallel_harness.h"
+
 
 #if vt_check_enabled(fcontext)
 

--- a/tests/unit/active/test_pending_send.cc
+++ b/tests/unit/active/test_pending_send.cc
@@ -44,10 +44,9 @@
 
 #include <gtest/gtest.h>
 
+#include "vt/termination/termination.h"
 #include "test_parallel_harness.h"
 #include "data_message.h"
-
-#include "vt/transport.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/atomic/test_atomic.cc
+++ b/tests/unit/atomic/test_atomic.cc
@@ -42,22 +42,18 @@
 //@HEADER
 */
 
-#include <cstring>
-#include <memory>
-
 #include <gtest/gtest.h>
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"
-
-#include "vt/transport.h"
+#include "vt/utils/atomic/atomic.h"
+#include "vt/utils/mutex/mutex.h"
 
 #if vt_check_enabled(openmp)
   #include <omp.h>
 #else
   #include <thread>
 #endif
-#include <thread>
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/collection/test_broadcast.cc
+++ b/tests/unit/collection/test_broadcast.cc
@@ -44,12 +44,9 @@
 
 #include <gtest/gtest.h>
 
-#include "test_parallel_harness.h"
 #include "test_collection_common.h"
 #include "data_message.h"
 #include "test_broadcast.h"
-
-#include "vt/transport.h"
 
 #include <cstdint>
 

--- a/tests/unit/collection/test_broadcast.extended.cc
+++ b/tests/unit/collection/test_broadcast.extended.cc
@@ -49,8 +49,6 @@
 #include "data_message.h"
 #include "test_broadcast.h"
 
-#include "vt/transport.h"
-
 #include <cstdint>
 
 namespace vt { namespace tests { namespace unit { namespace bcast {

--- a/tests/unit/collection/test_broadcast.h
+++ b/tests/unit/collection/test_broadcast.h
@@ -44,11 +44,10 @@
 
 #include <gtest/gtest.h>
 
+#include "vt/vrt/collection/manager.h"
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"
 #include "data_message.h"
-
-#include "vt/transport.h"
 
 #include <cstdint>
 

--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -42,10 +42,10 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <gtest/gtest.h>
 
 #include "test_parallel_harness.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <memory>
 

--- a/tests/unit/collection/test_collection_common.h
+++ b/tests/unit/collection/test_collection_common.h
@@ -45,7 +45,8 @@
 #if !defined INCLUDED_COLLECTION_TEST_COLLECTION_COMMON_H
 #define INCLUDED_COLLECTION_TEST_COLLECTION_COMMON_H
 
-#include "vt/transport.h"
+#include <vt/topos/index/index.h>
+#include <vt/context/context.h>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>

--- a/tests/unit/collection/test_collection_construct_common.h
+++ b/tests/unit/collection/test_collection_construct_common.h
@@ -47,9 +47,8 @@
 
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"
+#include "vt/vrt/collection/manager.h"
 #include "data_message.h"
-
-#include "vt/transport.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>

--- a/tests/unit/collection/test_collection_group.extended.cc
+++ b/tests/unit/collection/test_collection_group.extended.cc
@@ -48,7 +48,7 @@
 #include "test_collection_common.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <cstdint>
 

--- a/tests/unit/collection/test_destroy.cc
+++ b/tests/unit/collection/test_destroy.cc
@@ -48,7 +48,7 @@
 #include "test_collection_common.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <cstdint>
 

--- a/tests/unit/collection/test_index_types.extended.cc
+++ b/tests/unit/collection/test_index_types.extended.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <cstdint>
 #include <tuple>

--- a/tests/unit/collection/test_insert.extended.cc
+++ b/tests/unit/collection/test_insert.extended.cc
@@ -48,7 +48,7 @@
 #include "test_collection_common.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <cstdint>
 

--- a/tests/unit/collection/test_invoke.cc
+++ b/tests/unit/collection/test_invoke.cc
@@ -45,7 +45,7 @@
 #include "test_parallel_harness.h"
 #include "test_collection_common.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <gtest/gtest.h>
 #include <numeric>

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -48,7 +48,7 @@
 #include "test_collection_common.h"
 #include "data_message.h"
 
-#include <vt/transport.h>
+#include "vt/vrt/collection/manager.h"
 
 #include <dirent.h>
 

--- a/tests/unit/collection/test_lb_lite.extended.cc
+++ b/tests/unit/collection/test_lb_lite.extended.cc
@@ -48,7 +48,7 @@
 #include "test_collection_common.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <cstdint>
 

--- a/tests/unit/collection/test_lbstats_retention.cc
+++ b/tests/unit/collection/test_lbstats_retention.cc
@@ -42,10 +42,12 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/elm_stats.h>
 #include <vt/vrt/collection/balance/model/persistence_median_last_n.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
+#include <vt/vrt/collection/balance/lb_invoke/lb_manager.h>
+#include <vt/vrt/collection/types/type_aliases.h>
+#include <vt/vrt/collection/manager.h>
 
 #include <gtest/gtest.h>
 

--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/comm_overhead.h>
 #include <vt/vrt/collection/balance/lb_comm.h>

--- a/tests/unit/collection/test_model_linear_model.nompi.cc
+++ b/tests/unit/collection/test_model_linear_model.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/linear_model.h>
 

--- a/tests/unit/collection/test_model_multiple_phases.nompi.cc
+++ b/tests/unit/collection/test_model_multiple_phases.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/multiple_phases.h>
 

--- a/tests/unit/collection/test_model_naive_persistence.nompi.cc
+++ b/tests/unit/collection/test_model_naive_persistence.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/naive_persistence.h>
 

--- a/tests/unit/collection/test_model_norm.nompi.cc
+++ b/tests/unit/collection/test_model_norm.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/norm.h>
 

--- a/tests/unit/collection/test_model_per_collection.extended.cc
+++ b/tests/unit/collection/test_model_per_collection.extended.cc
@@ -42,10 +42,10 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/per_collection.h>
 #include <vt/vrt/collection/balance/model/composed_model.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
+#include <vt/vrt/collection/manager.h>
 
 #include <gtest/gtest.h>
 

--- a/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
+++ b/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/persistence_median_last_n.h>
 

--- a/tests/unit/collection/test_model_raw_data.nompi.cc
+++ b/tests/unit/collection/test_model_raw_data.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/raw_data.h>
 

--- a/tests/unit/collection/test_model_select_subphases.nompi.cc
+++ b/tests/unit/collection/test_model_select_subphases.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/model/load_model.h>
 #include <vt/vrt/collection/balance/model/select_subphases.h>
 

--- a/tests/unit/collection/test_query_context.cc
+++ b/tests/unit/collection/test_query_context.cc
@@ -48,7 +48,7 @@
 #include "test_collection_common.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <cstdint>
 

--- a/tests/unit/collection/test_reduce_collection_common.h
+++ b/tests/unit/collection/test_reduce_collection_common.h
@@ -46,7 +46,7 @@
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #if !defined INCLUDED_TEST_REDUCE_COLLECTION_COMMON_H
 #define INCLUDED_TEST_REDUCE_COLLECTION_COMMON_H

--- a/tests/unit/collection/test_send.cc
+++ b/tests/unit/collection/test_send.cc
@@ -49,8 +49,6 @@
 #include "data_message.h"
 #include "test_send.h"
 
-#include "vt/transport.h"
-
 #include <cstdint>
 #include <tuple>
 

--- a/tests/unit/collection/test_send.extended.cc
+++ b/tests/unit/collection/test_send.extended.cc
@@ -49,8 +49,6 @@
 #include "data_message.h"
 #include "test_send.h"
 
-#include "vt/transport.h"
-
 #include <cstdint>
 #include <tuple>
 

--- a/tests/unit/collection/test_send.h
+++ b/tests/unit/collection/test_send.h
@@ -48,7 +48,7 @@
 #include "test_collection_common.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <cstdint>
 #include <tuple>

--- a/tests/unit/collection/test_storage.cc
+++ b/tests/unit/collection/test_storage.cc
@@ -44,7 +44,7 @@
 
 #include "test_parallel_harness.h"
 
-#include <vt/transport.h>
+#include "vt/vrt/collection/manager.h"
 
 #include <gtest/gtest.h>
 

--- a/tests/unit/collectives/test_collectives_reduce.cc
+++ b/tests/unit/collectives/test_collectives_reduce.cc
@@ -48,7 +48,7 @@
 #include "data_message.h"
 #include "test_collectives_reduce.h"
 
-#include "vt/transport.h"
+#include "vt/collective/collective.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/collectives/test_collectives_reduce.extended.cc
+++ b/tests/unit/collectives/test_collectives_reduce.extended.cc
@@ -48,7 +48,8 @@
 #include "data_message.h"
 #include "test_collectives_reduce.h"
 
-#include "vt/transport.h"
+#include "vt/collective/collective.h"
+#include "vt/objgroup/manager.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/collectives/test_collectives_reduce.h
+++ b/tests/unit/collectives/test_collectives_reduce.h
@@ -47,7 +47,8 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/collective/collective.h"
+#include "vt/collective/collective_alg.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/collectives/test_collectives_scatter.extended.cc
+++ b/tests/unit/collectives/test_collectives_scatter.extended.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/collective/collective_alg.h"
 
 #define DEBUG_SCATTER 0
 

--- a/tests/unit/collectives/test_mpi_collective.cc
+++ b/tests/unit/collectives/test_mpi_collective.cc
@@ -43,7 +43,8 @@
 */
 
 #include <gtest/gtest.h>
-#include <vt/transport.h>
+#include "vt/collective/collective.h"
+#include "vt/collective/collective_alg.h"
 
 #include "test_parallel_harness.h"
 

--- a/tests/unit/data_message.h
+++ b/tests/unit/data_message.h
@@ -45,7 +45,7 @@
 #if ! defined __VIRTUAL_TRANSPORT_DATA_MESSAGE__
 #define __VIRTUAL_TRANSPORT_DATA_MESSAGE__
 
-#include "vt/transport.h"
+#include "vt/messaging/message.h"
 
 #include <array>
 #include <cstdint>

--- a/tests/unit/diagnostics/test_diagnostic_value.cc
+++ b/tests/unit/diagnostics/test_diagnostic_value.cc
@@ -45,10 +45,7 @@
 #include <gtest/gtest.h>
 
 #include <checkpoint/checkpoint.h>
-
 #include "test_parallel_harness.h"
-
-#include <vt/transport.h>
 
 #if vt_check_enabled(diagnostics)
 

--- a/tests/unit/epoch/test_epoch.nompi.cc
+++ b/tests/unit/epoch/test_epoch.nompi.cc
@@ -43,14 +43,13 @@
 */
 
 #include <cstring>
-#include <memory>
 
 #include <gtest/gtest.h>
 
 #include "test_harness.h"
 #include "test_parallel_harness.h"
 
-#include "vt/transport.h"
+#include "vt/epoch/epoch_manip.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/group/test_group.cc
+++ b/tests/unit/group/test_group.cc
@@ -48,7 +48,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/group/group_manager.h"
 
 #include <algorithm>
 

--- a/tests/unit/group/test_group.extended.cc
+++ b/tests/unit/group/test_group.extended.cc
@@ -46,7 +46,7 @@
 
 #include "test_parallel_harness.h"
 
-#include "vt/transport.h"
+#include "vt/group/group_manager.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/index/test_index.nompi.cc
+++ b/tests/unit/index/test_index.nompi.cc
@@ -46,7 +46,8 @@
 
 #include "test_harness.h"
 
-#include "vt/transport.h"
+#include "vt/topos/index/index.h"
+#include "vt/topos/index/dense/dense_array.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/index/test_index_linearization.nompi.cc
+++ b/tests/unit/index/test_index_linearization.nompi.cc
@@ -46,7 +46,7 @@
 
 #include "test_harness.h"
 
-#include "vt/transport.h"
+#include "vt/topos/mapping/dense/dense.h"
 
 namespace vt { namespace tests { namespace unit { namespace linear {
 

--- a/tests/unit/lb/test_gossiplb.nompi.cc
+++ b/tests/unit/lb/test_gossiplb.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/lb_common.h>
 #include <vt/vrt/collection/balance/baselb/baselb.h>
 #include <vt/vrt/collection/balance/gossiplb/gossiplb.h>

--- a/tests/unit/lb/test_lb_reader.nompi.cc
+++ b/tests/unit/lb/test_lb_reader.nompi.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/read_lb.h>
 
 #include "test_harness.h"

--- a/tests/unit/lb/test_lb_stats_reader.cc
+++ b/tests/unit/lb/test_lb_stats_reader.cc
@@ -43,11 +43,9 @@
 */
 
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <vector>
 
-#include <vt/transport.h>
 #include <vt/vrt/collection/balance/node_stats.h>
 #include <vt/vrt/collection/balance/stats_restart_reader.h>
 

--- a/tests/unit/location/test_hops.extended.cc
+++ b/tests/unit/location/test_hops.extended.cc
@@ -45,8 +45,7 @@
 #include <gtest/gtest.h>
 
 #include "test_parallel_harness.h"
-
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/location/test_location.cc
+++ b/tests/unit/location/test_location.cc
@@ -43,6 +43,7 @@
 */
 
 #include "test_location_common.h"
+#include "vt/collective/collective_alg.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/location/test_location_common.h
+++ b/tests/unit/location/test_location_common.h
@@ -46,8 +46,8 @@
 #define INCLUDED_TEST_LOCATION_COMMON_H
 
 #include "data_message.h"
-#include "vt/transport.h"
 #include "test_parallel_harness.h"
+#include "vt/topos/location/manager.h"
 
 namespace vt { namespace tests { namespace unit { namespace location {
 

--- a/tests/unit/main.cc
+++ b/tests/unit/main.cc
@@ -42,13 +42,9 @@
 //@HEADER
 */
 
-#include <vector>
-#include <memory>
-
 #include <gtest/gtest.h>
 
 #include "test_harness.h"
-#include "test_parallel_harness.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/mapping/test_mapping.nompi.cc
+++ b/tests/unit/mapping/test_mapping.nompi.cc
@@ -46,9 +46,9 @@
 
 #include "test_harness.h"
 
-#include "vt/transport.h"
 #include "vt/topos/index/index.h"
 #include "vt/topos/mapping/mapping.h"
+#include "vt/topos/mapping/dense/dense.h"
 
 #include <vector>
 

--- a/tests/unit/mapping/test_mapping_registry.cc
+++ b/tests/unit/mapping/test_mapping_registry.cc
@@ -46,9 +46,9 @@
 
 #include "test_parallel_harness.h"
 
-#include "vt/transport.h"
 #include "vt/topos/index/index.h"
 #include "vt/topos/mapping/mapping.h"
+#include "vt/topos/mapping/dense/dense.h"
 #include "vt/registry/auto/map/auto_registry_map.h"
 
 #include <vector>

--- a/tests/unit/memory/test_memory_active.cc
+++ b/tests/unit/memory/test_memory_active.cc
@@ -46,8 +46,7 @@
 
 #include "test_parallel_harness.h"
 #include "data_message.h"
-
-#include "vt/transport.h"
+#include "vt/termination/termination.h"
 
 #include <vector>
 

--- a/tests/unit/memory/test_memory_lifetime.cc
+++ b/tests/unit/memory/test_memory_lifetime.cc
@@ -47,8 +47,8 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 #include "test_helpers.h"
-
-#include "vt/transport.h"
+#include "vt/termination/termination.h"
+#include "vt/pipe/pipe_manager.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/message/test_msgthief.nompi.cc
+++ b/tests/unit/message/test_msgthief.nompi.cc
@@ -46,8 +46,7 @@
 
 // TODO: change to pure unit after #990
 #include "test_parallel_harness.h"
-
-#include "vt/transport.h"
+#include "vt/messaging/message/shared_message.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/objgroup/test_objgroup.cc
+++ b/tests/unit/objgroup/test_objgroup.cc
@@ -44,6 +44,7 @@
 
 #include "test_objgroup_common.h"
 #include "test_helpers.h"
+#include "vt/objgroup/manager.h"
 
 #include <typeinfo>
 

--- a/tests/unit/objgroup/test_objgroup_common.h
+++ b/tests/unit/objgroup/test_objgroup_common.h
@@ -43,7 +43,7 @@
 */
 
 #include "test_parallel_harness.h"
-#include "vt/transport.h"
+#include "vt/collective/reduce/operators/default_msg.h"
 
 #include <numeric>
 

--- a/tests/unit/phase/test_phase_insertions.cc
+++ b/tests/unit/phase/test_phase_insertions.cc
@@ -48,7 +48,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include <vt/transport.h>
+#include <vt/vrt/collection/manager.h>
 
 #if vt_check_enabled(lblite)
 

--- a/tests/unit/phase/test_phase_management.cc
+++ b/tests/unit/phase/test_phase_management.cc
@@ -46,7 +46,7 @@
 
 #include "test_parallel_harness.h"
 
-#include <vt/transport.h>
+#include <vt/phase/phase_manager.h>
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/pipe/test_callback_bcast.cc
+++ b/tests/unit/pipe/test_callback_bcast.cc
@@ -47,7 +47,8 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/pipe/pipe_manager.h"
+#include "vt/collective/collective_alg.h"
 
 #include <memory>
 

--- a/tests/unit/pipe/test_callback_bcast_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_bcast_collection.extended.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <memory>
 

--- a/tests/unit/pipe/test_callback_func.cc
+++ b/tests/unit/pipe/test_callback_func.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/pipe/pipe_manager.h"
 
 namespace vt { namespace tests { namespace unit { namespace func {
 

--- a/tests/unit/pipe/test_callback_func_ctx.cc
+++ b/tests/unit/pipe/test_callback_func_ctx.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/pipe/pipe_manager.h"
 
 #include <memory>
 

--- a/tests/unit/pipe/test_callback_send.cc
+++ b/tests/unit/pipe/test_callback_send.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/pipe/pipe_manager.h"
 
 #include <memory>
 

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 
 #include <memory>
 

--- a/tests/unit/pipe/test_signal_cleanup.cc
+++ b/tests/unit/pipe/test_signal_cleanup.cc
@@ -48,7 +48,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/pipe/pipe_manager.h"
 
 #include <memory>
 

--- a/tests/unit/pool/test_pool.cc
+++ b/tests/unit/pool/test_pool.cc
@@ -46,10 +46,9 @@
 
 #include <gtest/gtest.h>
 
-#include "test_harness.h"
 #include "test_parallel_harness.h"
 
-#include "vt/transport.h"
+#include "vt/messaging/active.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/pool/test_pool_message_sizes.cc
+++ b/tests/unit/pool/test_pool_message_sizes.cc
@@ -46,12 +46,11 @@
 
 #include <gtest/gtest.h>
 
-#include "test_harness.h"
 #include "test_parallel_harness.h"
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/messaging/active.h"
 
 namespace vt { namespace tests { namespace unit { namespace msg_size {
 

--- a/tests/unit/rdma/test_rdma_collection_handle.extended.cc
+++ b/tests/unit/rdma/test_rdma_collection_handle.extended.cc
@@ -44,8 +44,8 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
 #include "test_parallel_harness.h"
+#include "vt/vrt/collection/manager.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/rdma/test_rdma_common.h
+++ b/tests/unit/rdma/test_rdma_common.h
@@ -46,6 +46,7 @@
 #define INCLUDED_VT_TESTS_RDMA_COMMON_H
 
 #include <gtest/gtest.h>
+#include "vt/configs/types/types_type.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/rdma/test_rdma_handle.cc
+++ b/tests/unit/rdma/test_rdma_handle.cc
@@ -44,8 +44,6 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
-#include "test_parallel_harness.h"
 #include "test_rdma_common.h"
 #include "test_rdma_handle.h"
 

--- a/tests/unit/rdma/test_rdma_handle.extended.cc
+++ b/tests/unit/rdma/test_rdma_handle.extended.cc
@@ -44,8 +44,6 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
-#include "test_parallel_harness.h"
 #include "test_rdma_common.h"
 #include "test_rdma_handle.h"
 

--- a/tests/unit/rdma/test_rdma_handle.h
+++ b/tests/unit/rdma/test_rdma_handle.h
@@ -44,8 +44,8 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
 #include "test_parallel_harness.h"
+#include "vt/objgroup/manager.h"
 #include "test_rdma_common.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/rdma/test_rdma_static_sub_handle.extended.cc
+++ b/tests/unit/rdma/test_rdma_static_sub_handle.extended.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/objgroup/manager.h"
 #include "test_parallel_harness.h"
 #include "test_rdma_common.h"
 

--- a/tests/unit/runnable/test_invoke.cc
+++ b/tests/unit/runnable/test_invoke.cc
@@ -44,7 +44,6 @@
 
 #include "test_parallel_harness.h"
 #include "vt/runnable/invoke.h"
-#include <vt/transport.h>
 
 #include <vector>
 #include <numeric>

--- a/tests/unit/runtime/test_cli_arguments.extended.cc
+++ b/tests/unit/runtime/test_cli_arguments.extended.cc
@@ -46,7 +46,7 @@
 
 #include "test_parallel_harness.h"
 
-#include <vt/transport.h>
+#include <vt/configs/arguments/app_config.h>
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/runtime/test_component_construction.cc
+++ b/tests/unit/runtime/test_component_construction.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include <vt/runtime/component/component.h>
 #include "test_parallel_harness.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/runtime/test_initialization.cc
+++ b/tests/unit/runtime/test_initialization.cc
@@ -46,7 +46,7 @@
 
 #include "test_parallel_harness.h"
 
-#include <vt/transport.h>
+#include <vt/collective/startup.h>
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/runtime/test_initialization.nompi.cc
+++ b/tests/unit/runtime/test_initialization.nompi.cc
@@ -46,7 +46,7 @@
 
 #include "test_harness.h"
 
-#include <vt/transport.h>
+#include <vt/collective/startup.h>
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/runtime/test_mpi_access_guards.cc
+++ b/tests/unit/runtime/test_mpi_access_guards.cc
@@ -43,9 +43,10 @@
 */
 
 #include <gtest/gtest.h>
+#include <mpi.h>
 
-#include "vt/transport.h"
 #include "test_parallel_harness.h"
+#include "vt/runtime/mpi_access.h"
 #include "test_helpers.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/scheduler/test_high_level_calls.cc
+++ b/tests/unit/scheduler/test_high_level_calls.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/scheduler/scheduler.h"
 #include "test_parallel_harness.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/scheduler/test_priority_bits.extended.cc
+++ b/tests/unit/scheduler/test_priority_bits.extended.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/scheduler/priority.h"
 #include "test_parallel_harness.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/scheduler/test_priority_queue.extended.cc
+++ b/tests/unit/scheduler/test_priority_queue.extended.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/scheduler/priority_queue.h"
 #include "test_parallel_harness.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/scheduler/test_scheduler_loop.cc
+++ b/tests/unit/scheduler/test_scheduler_loop.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/scheduler/scheduler.h"
 #include "test_parallel_harness.h"
 #include "test_helpers.h"
 

--- a/tests/unit/scheduler/test_scheduler_priorities.extended.cc
+++ b/tests/unit/scheduler/test_scheduler_priorities.extended.cc
@@ -44,7 +44,9 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/scheduler/scheduler.h"
+#include "vt/objgroup/manager.h"
+
 #include "test_parallel_harness.h"
 
 #include <memory>

--- a/tests/unit/scheduler/test_scheduler_progress.extended.cc
+++ b/tests/unit/scheduler/test_scheduler_progress.extended.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/scheduler/scheduler.h"
 #include "test_parallel_harness.h"
 
 #include <memory>

--- a/tests/unit/sequencer/test_sequencer.extended.cc
+++ b/tests/unit/sequencer/test_sequencer.extended.cc
@@ -50,7 +50,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/sequence/sequencer.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/sequencer/test_sequencer_extensive.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_extensive.extended.cc
@@ -50,7 +50,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/sequence/sequencer.h"
 
 using namespace vt;
 using namespace vt::tests::unit;

--- a/tests/unit/sequencer/test_sequencer_for.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_for.extended.cc
@@ -50,7 +50,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/sequence/sequencer.h"
 
 namespace vt { namespace tests { namespace unit { namespace for_ {
 

--- a/tests/unit/sequencer/test_sequencer_nested.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_nested.extended.cc
@@ -50,7 +50,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/sequence/sequencer.h"
 
 namespace vt { namespace tests { namespace unit { namespace nested {
 

--- a/tests/unit/sequencer/test_sequencer_parallel.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_parallel.extended.cc
@@ -55,7 +55,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/sequence/sequencer.h"
 
 namespace vt { namespace tests { namespace unit { namespace parallel {
 

--- a/tests/unit/sequencer/test_sequencer_vrt.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_vrt.extended.cc
@@ -50,7 +50,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/sequence/sequencer.h"
 
 namespace vt { namespace tests { namespace unit { namespace vrt {
 

--- a/tests/unit/serialization/test_serialize_messenger.cc
+++ b/tests/unit/serialization/test_serialize_messenger.cc
@@ -50,7 +50,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/serialization/messaging/serialized_messenger.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/serialization/test_serialize_messenger_virtual.extended.cc
+++ b/tests/unit/serialization/test_serialize_messenger_virtual.extended.cc
@@ -47,7 +47,7 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/context/context_vrtmanager.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/termination/test_integral_set.cc
+++ b/tests/unit/termination/test_integral_set.cc
@@ -47,7 +47,6 @@
 #include "test_parallel_harness.h"
 #include "data_message.h"
 
-#include "vt/transport.h"
 #include "vt/termination/interval/integral_set.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/termination/test_term_chaining.cc
+++ b/tests/unit/termination/test_term_chaining.cc
@@ -48,7 +48,8 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/pipe/pipe_manager.h"
+#include "vt/collective/collective_alg.h"
 #include "vt/messaging/dependent_send_chain.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/termination/test_term_cleanup.cc
+++ b/tests/unit/termination/test_term_cleanup.cc
@@ -48,7 +48,6 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
 #include "vt/messaging/dependent_send_chain.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -48,7 +48,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/vrt/collection/manager.h"
 #include "vt/messaging/collection_chain_set.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/termination/test_termination_action_common.impl.h
+++ b/tests/unit/termination/test_termination_action_common.impl.h
@@ -45,6 +45,8 @@
 #if !defined INCLUDED_TERMINATION_ACTION_COMMON_IMPL_H
 #define INCLUDED_TERMINATION_ACTION_COMMON_IMPL_H
 
+#include "vt/collective/collective_alg.h"
+
 namespace vt { namespace tests { namespace unit { namespace action {
 
 // epoch sequence creation [rooted,collect]

--- a/tests/unit/termination/test_termination_channel_message.h
+++ b/tests/unit/termination/test_termination_channel_message.h
@@ -43,7 +43,8 @@
 */
 
 #include "data_message.h"
-#include "vt/transport.h"
+#include "vt/configs/types/types_type.h"
+#include "vt/messaging/message/message.h"
 
 #if !defined INCLUDED_TERMINATION_CHANNEL_MESSAGES_H
 #define INCLUDED_TERMINATION_CHANNEL_MESSAGES_H

--- a/tests/unit/termination/test_termination_reset.cc
+++ b/tests/unit/termination/test_termination_reset.cc
@@ -48,7 +48,7 @@
 #include "data_message.h"
 #include "test_helpers.h"
 
-#include "vt/transport.h"
+#include "vt/collective/collective_alg.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -46,16 +46,13 @@
 #define __VIRTUAL_TRANSPORT_TEST_PARALLEL_HARNESS__
 
 #include <vector>
-#include <string>
-#include <memory>
 
 #include "test_config.h"
 #include "test_harness.h"
 #include "mpi_singleton.h"
 
-#include "vt/transport.h"
-
-#include <mpi.h>
+#include "vt/collective/collective_ops.h"
+#include "vt/scheduler/scheduler.h"
 
 namespace vt { namespace tests { namespace unit {
 

--- a/tests/unit/timetrigger/test_time_trigger.extended.cc
+++ b/tests/unit/timetrigger/test_time_trigger.extended.cc
@@ -44,7 +44,6 @@
 
 #include <gtest/gtest.h>
 
-#include <vt/transport.h>
 #include <vt/timetrigger/time_trigger_manager.h>
 
 #include "test_parallel_harness.h"

--- a/tests/unit/tls/test_tls.nompi.cc
+++ b/tests/unit/tls/test_tls.nompi.cc
@@ -50,7 +50,7 @@
 #include "test_harness.h"
 #include "test_parallel_harness.h"
 
-#include "vt/transport.h"
+#include "vt/utils/tls/tls.h"
 
 #if vt_check_enabled(openmp)
   #include <omp.h>

--- a/tests/unit/trace/test_trace_spec_reader.cc
+++ b/tests/unit/trace/test_trace_spec_reader.cc
@@ -42,7 +42,9 @@
 //@HEADER
 */
 
-#include <vt/transport.h>
+#include <vt/termination/termination.h>
+#include <vt/collective/collective_alg.h>
+#include <vt/objgroup/manager.h>
 #include <vt/trace/file_spec/spec.h>
 
 #include "test_parallel_harness.h"

--- a/tests/unit/utils/test_bit_packing.nompi.cc
+++ b/tests/unit/utils/test_bit_packing.nompi.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/utils/bits/bits_packer.h"
 #include "test_harness.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/utils/test_demangler_utils.nompi.cc
+++ b/tests/unit/utils/test_demangler_utils.nompi.cc
@@ -44,7 +44,7 @@
 
 #include <gtest/gtest.h>
 
-#include "vt/transport.h"
+#include "vt/utils/demangle/demangle.h"
 #include "test_harness.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/utils/test_safe_union.nompi.cc
+++ b/tests/unit/utils/test_safe_union.nompi.cc
@@ -44,7 +44,6 @@
 
 #include <gtest/gtest.h>
 
-#include <vt/transport.h>
 #include <vt/utils/adt/union.h>
 #include "test_harness.h"
 


### PR DESCRIPTION
Fixes #1390