### PR TITLE
 #1357 fix build errors reporting 

### DIFF
--- a/ci/azure/azure-clang-10-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-10-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-clang-3.9-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-3.9-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-clang-5.0-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-5.0-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-clang-8-alpine-mpich.yml
+++ b/ci/azure/azure-clang-8-alpine-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-clang-9-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-9-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-gcc-10-ubuntu-openmpi.yml
+++ b/ci/azure/azure-gcc-10-ubuntu-openmpi.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-gcc-5-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-5-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-gcc-6-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-6-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-gcc-7-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-7-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-gcc-8-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-8-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-gcc-9-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-9-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-intel-18-ubuntu-mpich-extended.yml
+++ b/ci/azure/azure-intel-18-ubuntu-mpich-extended.yml
@@ -139,7 +139,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-intel-18-ubuntu-mpich.yml
+++ b/ci/azure/azure-intel-18-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-intel-19-ubuntu-mpich.yml
+++ b/ci/azure/azure-intel-19-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-nvidia-10-ubuntu-mpich-extended.yml
+++ b/ci/azure/azure-nvidia-10-ubuntu-mpich-extended.yml
@@ -139,7 +139,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-nvidia-10-ubuntu-mpich.yml
+++ b/ci/azure/azure-nvidia-10-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-nvidia-11-ubuntu-mpich-extended.yml
+++ b/ci/azure/azure-nvidia-11-ubuntu-mpich-extended.yml
@@ -139,7 +139,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/ci/azure/azure-nvidia-11-ubuntu-mpich.yml
+++ b/ci/azure/azure-nvidia-11-ubuntu-mpich.yml
@@ -145,7 +145,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)

--- a/scripts/azure-workflow-template.yml
+++ b/scripts/azure-workflow-template.yml
@@ -135,7 +135,8 @@ stages:
                 "$(Build.Repository.Name)"                          \
                 "$GITHUB_PAT"                                       \
                 "$(Build.BuildId)"                                  \
-                "$(System.JobId)"
+                "$(System.JobId)"                                   \
+                "$(Agent.JobStatus)"
 
         env:
           GITHUB_PAT: $(github_pat)


### PR DESCRIPTION
Fixes #1357 

So the problem is that if for any reason the build fails without generating logs (from compilation and tests) the script gets empty reports and thinks that it means that everything went super well.

To fix this I pass the pipeline's status to the script, so if the status is not `Succeeded` or `SucceededWithIssues` and the compilation and tests reports are empty then it means that something really bad happened.