### PR TITLE
1344 Avoid explicit message size in send() parameters by storing it on MsgSharedPtr

### DIFF
--- a/src/vt/group/global/group_default.cc
+++ b/src/vt/group/global/group_default.cc
@@ -150,7 +150,7 @@ namespace vt { namespace group { namespace global {
 
 /*static*/ EventType DefaultGroup::broadcast(
   MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-  MsgSizeType const& size, bool const is_root, bool* const deliver
+  bool const is_root, bool* const deliver
 ) {
   // By default use the default_group_->spanning_tree_
   auto const& msg = base.get();
@@ -169,7 +169,7 @@ namespace vt { namespace group { namespace global {
   vt_debug_print(
     normal, broadcast,
     "DefaultGroup::broadcast msg={}, size={}, from={}, dest={}, is_root={}\n",
-    print_ptr(base.get()), size, from, dest, print_bool(is_root)
+    print_ptr(base.get()), base.size(), from, dest, print_bool(is_root)
   );
 
   if ((num_children > 0 || send_to_root) && (!this_node_dest || first_send)) {
@@ -186,11 +186,11 @@ namespace vt { namespace group { namespace global {
           normal, broadcast,
           "DefaultGroup::broadcast *send* size={}, from={}, child={}, send={}, "
           "msg={}\n",
-          size, from, child, print_bool(send), print_ptr(msg)
+          base.size(), from, child, print_bool(send), print_ptr(msg)
         );
 
         if (send) {
-          theMsg()->sendMsgBytesWithPut(child, base, size, send_tag);
+          theMsg()->sendMsgBytesWithPut(child, base, send_tag);
         }
       });
     }
@@ -205,7 +205,7 @@ namespace vt { namespace group { namespace global {
         print_bool(is_root), root_node, dest, print_ptr(msg)
       );
 
-      theMsg()->sendMsgBytesWithPut(root_node, base, size, send_tag);
+      theMsg()->sendMsgBytesWithPut(root_node, base, send_tag);
     }
   }
 

--- a/src/vt/group/global/group_default.h
+++ b/src/vt/group/global/group_default.h
@@ -76,7 +76,7 @@ struct DefaultGroup {
 public:
   static EventType broadcast(
     MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-    MsgSizeType const& size, bool const is_root, bool* const deliver
+    bool const is_root, bool* const deliver
   );
 
 private:

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -299,7 +299,6 @@ private:
    *
    * \param[in] base the message to send
    * \param[in] from sender node
-   * \param[in] size number of bytes of the message being sent
    * \param[in] is_root whether this node is the root
    * \param[out] deliver whether the caller should deliver locally
    *
@@ -307,7 +306,7 @@ private:
    */
   EventType sendGroup(
     MsgSharedPtr<BaseMsgType> const& base, NodeType const from,
-    MsgSizeType const size, bool const is_root,
+    bool const is_root,
     bool* const deliver
   );
 
@@ -316,7 +315,6 @@ private:
    *
    * \param[in] base the message to send
    * \param[in] from sender node
-   * \param[in] size number of bytes of the message being sent
    * \param[in] is_root whether this node is the root
    * \param[out] deliver whether the caller should deliver locally
    *
@@ -324,7 +322,7 @@ private:
    */
   EventType sendGroupCollective(
     MsgSharedPtr<BaseMsgType> const& base, NodeType const from,
-    MsgSizeType const size, bool const is_root,
+    bool const is_root,
     bool* const deliver
   );
 
@@ -393,7 +391,6 @@ private:
    *
    * \param[in] msg the message to send
    * \param[in] from sender node
-   * \param[in] size number of bytes of the message being sent
    * \param[in] is_root whether this node is the root
    * \param[out] deliver whether the caller should deliver locally
    *
@@ -401,7 +398,7 @@ private:
    */
   static EventType groupHandler(
     MsgSharedPtr<BaseMsgType> const& msg, NodeType const from,
-    MsgSizeType const msg_size, bool const is_root,
+    bool const is_root,
     bool* const deliver
   );
 

--- a/src/vt/group/group_manager_active_attorney.cc
+++ b/src/vt/group/group_manager_active_attorney.cc
@@ -52,11 +52,11 @@ namespace vt { namespace group {
 
 /*static*/ EventType GroupActiveAttorney::groupHandler(
   MsgSharedPtr<BaseMsgType> const& msg, NodeType const& from,
-  MsgSizeType const& msg_size, bool const is_root,
+  bool const is_root,
   bool* const deliver
 ) {
   return GroupManager::groupHandler(
-    msg, from, msg_size, is_root, deliver
+    msg, from, is_root, deliver
   );
 }
 

--- a/src/vt/group/group_manager_active_attorney.h
+++ b/src/vt/group/group_manager_active_attorney.h
@@ -61,7 +61,7 @@ struct GroupActiveAttorney {
 private:
   static EventType groupHandler(
     MsgSharedPtr<BaseMsgType> const& msg, NodeType const& from,
-    MsgSizeType const& msg_size, bool const is_root,
+    bool const is_root,
     bool* const deliver
   );
 };

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -180,7 +180,7 @@ void ActiveMessenger::packMsg(
 
 EventType ActiveMessenger::sendMsgBytesWithPut(
   NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base,
-  MsgSizeType const& msg_size, TagType const& send_tag
+  TagType const& send_tag
 ) {
   auto msg = base.get();
   auto const& is_term = envelopeIsTerm(msg->env);
@@ -192,7 +192,7 @@ EventType ActiveMessenger::sendMsgBytesWithPut(
     vt_debug_print(
       normal, active,
       "sendMsgBytesWithPut: size={}, dest={}, is_put={}, is_put_packed={}\n",
-      msg_size, dest, print_bool(is_put), print_bool(is_put_packed)
+      base.size(), dest, print_bool(is_put), print_bool(is_put_packed)
     );
   }
 
@@ -201,7 +201,7 @@ EventType ActiveMessenger::sendMsgBytesWithPut(
     "Destination {} should != this node"
   );
 
-  MsgSizeType new_msg_size = msg_size;
+  MsgSizeType new_msg_size = base.size();
 
   if (is_put && !is_put_packed) {
     auto const& put_ptr = envelopeGetPutPtr(msg->env);
@@ -226,12 +226,12 @@ EventType ActiveMessenger::sendMsgBytesWithPut(
         verbose, active,
         "sendMsgBytesWithPut: (put) put_ptr={}, size:[msg={},put={},rem={}],"
         "dest={}, max_pack_size={}, direct_buf_pack={}\n",
-        put_ptr, msg_size, put_size, rem_size, dest, max_pack_direct_size,
+        put_ptr, base.size(), put_size, rem_size, dest, max_pack_direct_size,
         print_bool(direct_buf_pack)
       );
     }
     if (direct_buf_pack) {
-      packMsg(msg, msg_size, put_ptr, put_size);
+      packMsg(msg, base.size(), put_ptr, put_size);
       new_msg_size += put_size;
       envelopeSetPutTag(msg->env, PutPackedTag);
       setPackedPutType(msg->env);
@@ -422,7 +422,7 @@ EventType ActiveMessenger::sendMsgBytes(
 }
 
 EventType ActiveMessenger::doMessageSend(
-  MsgSharedPtr<BaseMsgType>& base, MsgSizeType msg_size
+  MsgSharedPtr<BaseMsgType>& base
 ) {
   auto const& send_tag = static_cast<MPI_TagType>(MPITag::ActiveMsgTag);
 
@@ -457,7 +457,7 @@ EventType ActiveMessenger::doMessageSend(
       // if (cur_event == trace::no_trace_event) {
       auto event = makeTraceCreationSend(
         base, handler, auto_registry::RegistryTypeEnum::RegGeneral,
-        msg_size, is_bcast
+        is_bcast
       );
       envelopeSetTraceEvent(msg->env, event);
     }
@@ -476,11 +476,11 @@ EventType ActiveMessenger::doMessageSend(
 
   bool deliver = false;
   EventType const ret_event = group::GroupActiveAttorney::groupHandler(
-    base, uninitialized_destination, msg_size, true, &deliver
+    base, uninitialized_destination, true, &deliver
   );
 
   if (deliver) {
-    sendMsgBytesWithPut(dest, base, msg_size, send_tag);
+    sendMsgBytesWithPut(dest, base, send_tag);
     return no_event;
   }
 
@@ -866,7 +866,7 @@ bool ActiveMessenger::recvDataMsg(
 
 bool ActiveMessenger::processActiveMsg(
   MsgSharedPtr<BaseMsgType> const& base, NodeType const& from,
-  MsgSizeType const& size, bool insert, ActionType cont
+  bool insert, ActionType cont
 ) {
   using ::vt::group::GroupActiveAttorney;
 
@@ -874,7 +874,7 @@ bool ActiveMessenger::processActiveMsg(
 
   // Call group handler
   bool deliver = false;
-  GroupActiveAttorney::groupHandler(base, from, size, false, &deliver);
+  GroupActiveAttorney::groupHandler(base, from, false, &deliver);
 
   auto const is_term = envelopeIsTerm(msg->env);
 
@@ -889,7 +889,7 @@ bool ActiveMessenger::processActiveMsg(
   if (deliver) {
     return prepareActiveMsgToRun(base,from,insert,cont);
   } else {
-    amForwardCounterGauge.incrementUpdate(size, 1);
+    amForwardCounterGauge.incrementUpdate(base.size(), 1);
 
     if (cont != nullptr) {
       cont();
@@ -1064,7 +1064,8 @@ void ActiveMessenger::finishPendingActiveMsgAsyncRecv(InProgressIRecv* irecv) {
 
   MessageType* msg = reinterpret_cast<MessageType*>(buf);
   envelopeInitRecv(msg->env);
-  MsgPtr<MessageType> base = MsgPtr<MessageType>{msg};
+  // Derive the message size from the number of bytes actually received
+  MsgPtr<MessageType> base{msg, static_cast<ByteType>(num_probe_bytes)};
 
   auto const is_term = envelopeIsTerm(msg->env);
   auto const is_put = envelopeIsPut(msg->env);
@@ -1075,7 +1076,7 @@ void ActiveMessenger::finishPendingActiveMsgAsyncRecv(InProgressIRecv* irecv) {
       normal, active,
       "finishPendingActiveMsgAsyncRecv: msg_size={}, sender={}, is_put={}, "
       "is_bcast={}, handler={}\n",
-      num_probe_bytes, sender, print_bool(is_put),
+      base.size(), sender, print_bool(is_put),
       print_bool(envelopeIsBcast(msg->env)), envelopeGetHandler(msg->env)
     );
   }
@@ -1106,14 +1107,14 @@ void ActiveMessenger::finishPendingActiveMsgAsyncRecv(InProgressIRecv* irecv) {
         1, put_tag, sender,
         [=](PtrLenPairType ptr, ActionType deleter){
           envelopeSetPutPtr(base->env, std::get<0>(ptr), std::get<1>(ptr));
-          processActiveMsg(base, sender, num_probe_bytes, true, deleter);
+          processActiveMsg(base, sender, true, deleter);
         }
      );
     }
   }
 
   if (!is_put || put_finished) {
-    processActiveMsg(base, sender, msg_bytes, true);
+    processActiveMsg(MsgPtr<MessageType>(base, msg_bytes), sender, true); // Note: use updated msg_bytes for message size
   }
 }
 

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -395,10 +395,9 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   template <typename MsgT>
   void setTagMessage(MsgT* msg, TagType tag);
 
-  template <typename MsgPtrT>
   trace::TraceEventIDType makeTraceCreationSend(
-    MsgPtrT msg, HandlerType const handler, auto_registry::RegistryTypeEnum type,
-    bool is_bcast
+    HandlerType const handler, auto_registry::RegistryTypeEnum type,
+    ByteType serialized_msg_size, bool is_bcast
   );
 
   // With serialization, the correct method is resolved via SFINAE.

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -398,7 +398,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   template <typename MsgPtrT>
   trace::TraceEventIDType makeTraceCreationSend(
     MsgPtrT msg, HandlerType const handler, auto_registry::RegistryTypeEnum type,
-    MsgSizeType msg_size, bool is_bcast
+    bool is_bcast
   );
 
   // With serialization, the correct method is resolved via SFINAE.
@@ -408,7 +408,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     NodeType dest,
     HandlerType han,
     MsgSharedPtr<MsgT>& msg,
-    ByteType msg_size,
     TagType tag
   );
 
@@ -428,7 +427,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     NodeType dest,
     HandlerType han,
     MsgSharedPtr<MsgT>& msg,
-    ByteType msg_size,
     TagType tag
   ) {
 #ifndef vt_quirked_serialize_method_detection
@@ -437,7 +435,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
       "Message prohibiting serialization must not have a serialization function."
     );
 #endif
-    return sendMsgCopyableImpl<MsgT>(dest, han, msg, msg_size, tag);
+    return sendMsgCopyableImpl<MsgT>(dest, han, msg, tag);
   }
 
   // Serializable and serialization required on this type.
@@ -453,7 +451,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     NodeType dest,
     HandlerType han,
     MsgSharedPtr<MsgT>& msg,
-    ByteType msg_size,
     TagType tag
   ) {
 #ifndef vt_quirked_serialize_method_detection
@@ -462,7 +459,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
       "Message requiring serialization must have a serialization function."
     );
 #endif
-    return sendMsgSerializableImpl<MsgT>(dest, han, msg, msg_size, tag);
+    return sendMsgSerializableImpl<MsgT>(dest, han, msg, tag);
   }
 
   // Serializable, but support is only for derived types.
@@ -479,7 +476,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     NodeType dest,
     HandlerType han,
     MsgSharedPtr<MsgT>& msg,
-    ByteType msg_size,
     TagType tag
   ) {
 #ifndef vt_quirked_serialize_method_detection
@@ -488,7 +484,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
        "Message supporting serialization must have a serialization function."
      );
 #endif
-    return sendMsgCopyableImpl<MsgT>(dest, han, msg, msg_size, tag);
+    return sendMsgCopyableImpl<MsgT>(dest, han, msg, tag);
   }
 
   // Messaged marked as prohibiting serialization cannot define
@@ -505,7 +501,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     NodeType dest,
     HandlerType han,
     MsgSharedPtr<MsgT>& msg,
-    ByteType msg_size,
     TagType tag
   ) {
 #ifndef vt_quirked_serialize_method_detection
@@ -514,7 +509,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
       "Message prohibiting serialization must not have a serialization function."
     );
 #endif
-    return sendMsgCopyableImpl<MsgT>(dest, han, msg, msg_size, tag);
+    return sendMsgCopyableImpl<MsgT>(dest, han, msg, tag);
   }
 
   template <typename MsgT>
@@ -522,7 +517,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
     NodeType dest,
     HandlerType han,
     MsgSharedPtr<MsgT>& msg,
-    ByteType msg_size,
     TagType tag
   );
 
@@ -1328,7 +1322,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \return the event for tracking the send completion
    */
   EventType doMessageSend(
-    MsgSharedPtr<BaseMsgType>& msg, MsgSizeType msg_size
+    MsgSharedPtr<BaseMsgType>& msg
   );
 
   /**
@@ -1424,7 +1418,6 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    *
    * \param[in] base the message ptr
    * \param[in] sender the sender of the message
-   * \param[in] size the size of the message
    * \param[in] insert whether to insert the message if handler does not exist
    * \param[in] cont continuation after message is processed
    *
@@ -1432,7 +1425,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    */
   bool processActiveMsg(
     MsgSharedPtr<BaseMsgType> const& base, NodeType const& sender,
-    MsgSizeType const& size, bool insert, ActionType cont = nullptr
+    bool insert, ActionType cont = nullptr
   );
 
   /**
@@ -1491,14 +1484,13 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    *
    * \param[in] dest the destination of the message
    * \param[in] base the message base pointer
-   * \param[in] msg_size the size of the message
    * \param[in] send_tag the send tag on the message
    *
    * \return the event to test/wait for completion
    */
   EventType sendMsgBytesWithPut(
     NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base,
-    MsgSizeType const& msg_size, TagType const& send_tag
+    TagType const& send_tag
   );
 
   /**

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -58,7 +58,6 @@
 
 namespace vt { namespace messaging {
 
-constexpr ByteType msgsize_not_specified = static_cast<ByteType>(-1);
 constexpr NodeType broadcast_dest = uninitialized_destination;
 
 template <typename MsgPtrT>
@@ -106,15 +105,15 @@ void ActiveMessenger::setTagMessage(MsgT* msg, TagType tag) {
 template <typename MsgPtrT>
 trace::TraceEventIDType ActiveMessenger::makeTraceCreationSend(
   MsgPtrT msg, HandlerType const handler, auto_registry::RegistryTypeEnum type,
-  MsgSizeType msg_size, bool is_bcast
+  bool is_bcast
 ) {
   #if vt_check_enabled(trace_enabled)
     trace::TraceEntryIDType ep = auto_registry::handlerTraceID(handler, type);
     trace::TraceEventIDType event = trace::no_trace_event;
     if (not is_bcast) {
-      event = theTrace()->messageCreation(ep, msg_size);
+      event = theTrace()->messageCreation(ep, msg.size());
     } else {
-      event = theTrace()->messageCreationBcast(ep, msg_size);
+      event = theTrace()->messageCreationBcast(ep, msg.size());
     }
     return event;
   #else
@@ -127,7 +126,6 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgSerializableImpl(
   NodeType dest,
   HandlerType han,
   MsgSharedPtr<MsgT>& msg,
-  ByteType msg_size,
   TagType tag
 ) {
   // These calls eventually end up back and the non-serialized sendMsgImpl,
@@ -164,7 +162,6 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgCopyableImpl(
   NodeType dest,
   HandlerType han,
   MsgSharedPtr<MsgT>& msg,
-  ByteType msg_size,
   TagType tag
 ) {
   static_assert(
@@ -194,9 +191,6 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgCopyableImpl(
   if (is_bcast) {
     dest = theContext()->getNode();
   }
-  if (msg_size == msgsize_not_specified) {
-    msg_size = sizeof(MsgT);
-  }
   if (tag != no_tag) {
     envelopeSetTag(rawMsg->env, tag);
   }
@@ -206,7 +200,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgCopyableImpl(
   envelopeSetIsLocked(rawMsg->env, true);
 
   auto base = msg.template to<BaseMsgType>();
-  return PendingSendType(base, msg_size);
+  return PendingSendType(base);
 }
 
 template <typename MsgT>
@@ -217,7 +211,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
   TagType tag
 ) {
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT>
@@ -228,8 +222,8 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgSz(
   ByteType msg_size,
   TagType tag
 ) {
-  MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msg_size, tag);
+  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly proveded message size
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT>
@@ -240,7 +234,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgAuto(
   TagType tag
 ) {
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
@@ -251,12 +245,12 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgSz(
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
-  MsgSharedPtr<MsgT> msgptr = msg.msg_;
+  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly proveded message size
 
   setBroadcastType(msgptr->env, deliver_to_sender);
 
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msg_size, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 
@@ -272,7 +266,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
   setBroadcastType(msgptr->env, deliver_to_sender);
 
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msgsize_not_specified, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 
@@ -284,7 +278,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
 ) {
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
@@ -295,8 +289,8 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgSz(
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
-  MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msg_size, tag);
+  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly proveded message size
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
@@ -307,7 +301,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgAuto(
 ) {
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
@@ -318,7 +312,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msgsize_not_specified, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 
@@ -332,7 +326,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   setBroadcastType(msgptr->env, deliver_to_sender);
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msgsize_not_specified, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 
@@ -344,7 +338,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
 ) {
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename FunctorT, typename MsgT>
@@ -357,7 +351,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   setBroadcastType(msgptr->env, deliver_to_sender);
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msgsize_not_specified, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 
@@ -379,7 +373,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename FunctorT>
@@ -400,7 +394,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msgsize_not_specified, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 
@@ -412,7 +406,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgAuto(
 ) {
   auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT>
@@ -432,7 +426,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
 
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   auto tag = no_tag;
-  return sendMsgImpl<MsgT>(dest, han, msgptr, msgsize_not_specified, tag);
+  return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
@@ -455,7 +449,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   setBroadcastType(msgptr->env, deliver_to_sender);
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msgsize_not_specified, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 
@@ -467,7 +461,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
 ) {
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   return sendMsgImpl<MsgT>(
-    broadcast_dest, han, msgptr, msgsize_not_specified, tag
+    broadcast_dest, han, msgptr, tag
   );
 }
 

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -102,25 +102,6 @@ void ActiveMessenger::setTagMessage(MsgT* msg, TagType tag) {
   envelopeSetTag(msg->env, tag);
 }
 
-template <typename MsgPtrT>
-trace::TraceEventIDType ActiveMessenger::makeTraceCreationSend(
-  MsgPtrT msg, HandlerType const handler, auto_registry::RegistryTypeEnum type,
-  bool is_bcast
-) {
-  #if vt_check_enabled(trace_enabled)
-    trace::TraceEntryIDType ep = auto_registry::handlerTraceID(handler, type);
-    trace::TraceEventIDType event = trace::no_trace_event;
-    if (not is_bcast) {
-      event = theTrace()->messageCreation(ep, msg.size());
-    } else {
-      event = theTrace()->messageCreationBcast(ep, msg.size());
-    }
-    return event;
-  #else
-    return trace::no_trace_event;
-  #endif
-}
-
 template <typename MsgT>
 ActiveMessenger::PendingSendType ActiveMessenger::sendMsgSerializableImpl(
   NodeType dest,

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -222,7 +222,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgSz(
   ByteType msg_size,
   TagType tag
 ) {
-  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly proveded message size
+  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly provided message size
   return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 
@@ -245,7 +245,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgSz(
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
-  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly proveded message size
+  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly provided message size
 
   setBroadcastType(msgptr->env, deliver_to_sender);
 
@@ -289,7 +289,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgSz(
   TagType tag
 ) {
   auto const han = auto_registry::makeAutoHandler<MsgT,f>();
-  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly proveded message size
+  MsgSharedPtr<MsgT> msgptr(msg.msg_, msg_size); // Note: use explicitly provided message size
   return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
 

--- a/src/vt/messaging/message/smart_ptr.h
+++ b/src/vt/messaging/message/smart_ptr.h
@@ -103,18 +103,18 @@ struct MsgSharedPtr final {
 
   MsgSharedPtr(std::nullptr_t) {}
 
-  MsgSharedPtr(T* in) {
-    init(in, statics::Holder::getImpl<T>());
+  MsgSharedPtr(T* in, ByteType size=no_byte) {
+    init(in, size == no_byte ? sizeof(T) : size, statics::Holder::getImpl<T>());
   }
 
   // Overload to retain ORIGINAL type-erased implementation.
-  MsgSharedPtr(T* in, MsgPtrImplBase* impl) {
-    init(in, impl);
+  MsgSharedPtr(T* in, ByteType size, MsgPtrImplBase* impl) {
+    init(in, size, impl);
   }
 
-  MsgSharedPtr(MsgSharedPtr<T> const& in) {
+  MsgSharedPtr(MsgSharedPtr<T> const& in, ByteType size=no_byte) {
     if (in != nullptr) {
-      init(in.get(), in.impl_);
+      init(in.get(), (size == no_byte ? in.size() : size), in.impl_);
     }
   }
 
@@ -129,7 +129,7 @@ struct MsgSharedPtr final {
 
   MsgSharedPtr<T>& operator=(MsgSharedPtr<T> const& in) {
     clear();
-    init(in.get(), in.impl_);
+    init(in.get(), in.size(), in.impl_);
     return *this;
   }
 
@@ -153,6 +153,7 @@ struct MsgSharedPtr final {
   MsgSharedPtr<U> to() const {
     return MsgSharedPtr<U>(
       reinterpret_cast<U*>(ptr_),
+      size_, // retain ORIGINAL size
       /*N.B. retain ORIGINAL-type implementation*/ impl_);
   }
 
@@ -201,6 +202,18 @@ struct MsgSharedPtr final {
   }
 
   /**
+   * \brief Explicit access to message size
+   *
+   * \return the owned message, never null
+   */
+  inline ByteType size() const {
+    vtAssert(
+      ptr_, "Access attempted of invalid MsgPtr."
+    );
+    return size_;
+  }
+
+  /**
    * \internal
    * \brief Checks to see if a message is owned.
    *
@@ -214,6 +227,7 @@ struct MsgSharedPtr final {
     auto nrefs = envelopeGetRef(m.get()->env);
     return os << "MsgSharedPtr("
               <<              m.ptr_    << ","
+              << "size=" << m.size_ << ","
               << "ref="    << nrefs
               << ")";
   }
@@ -232,6 +246,7 @@ struct MsgSharedPtr final {
 
       // skip footprinting of members, we rely on message size estimate instead
       s.skip(impl_);
+      s.skip(size_);
       s.skip(ptr_);
     }
   }
@@ -241,7 +256,7 @@ private:
   /// Performs state-ownership, always taking an additional message ref.
   /// Should probably be called every constructor; must ONLY be
   /// called from fresh (zero-init member) or clear() state.
-  void init(T* msgPtr, MsgPtrImplBase* impl) {
+  void init(T* msgPtr, ByteType size, MsgPtrImplBase* impl) {
     vtAssert(
       msgPtr,
       "MsgPtr cannot wrap 'null' messages."
@@ -250,6 +265,7 @@ private:
     assert("given impl" && impl);
 
     ptr_ = msgPtr;
+    size_ = size;
     impl_ = impl;
 
     // Could be moved to type-erased impl..
@@ -273,6 +289,7 @@ private:
   /// Move. Must be invoked on fresh/clear state.
   void moveFrom(MsgSharedPtr<T>&& in) {
     ptr_ = in.ptr_;
+    size_ = in.size_;
     impl_ = in.impl_;
     // clean take - nullify/prevent other cleanup
     in.ptr_ = nullptr;
@@ -281,6 +298,8 @@ private:
 private:
   // Underlying raw message - access as correct type via get()
   BaseMsgType* ptr_ = nullptr;
+  // Message size preserved before type erasure
+  ByteType size_ = no_byte;
   // Type-erased implementation support.
   // Object has a STATIC LIFETIME / is not owned / should not be deleted.
   MsgPtrImplBase* impl_ = nullptr;
@@ -378,7 +397,7 @@ inline MsgPtr<T> promoteMsgOwner(T* const msg) {
 template <typename T>
 [[deprecated("Do not use: no direct replacement")]]
 inline MsgPtr<T> promoteMsg(MsgPtr<T> msg) {
-  return MsgPtr<T>{msg.get()};
+  return MsgPtr<T>{msg.get(), msg.size()};
 }
 
 /**

--- a/src/vt/messaging/pending_send.cc
+++ b/src/vt/messaging/pending_send.cc
@@ -55,8 +55,7 @@ PendingSend::PendingSend(EpochType ep, EpochActionType const& in_action)
 }
 
 PendingSend::PendingSend(PendingSend&& in) noexcept
-  : msg_size_(std::move(in.msg_size_)),
-    epoch_produced_(std::move(in.epoch_produced_))
+  : epoch_produced_(std::move(in.epoch_produced_))
 {
   std::swap(msg_, in.msg_);
   std::swap(epoch_action_, in.epoch_action_);
@@ -65,7 +64,7 @@ PendingSend::PendingSend(PendingSend&& in) noexcept
 
 void PendingSend::sendMsg() {
   if (send_action_ == nullptr) {
-    theMsg()->doMessageSend(msg_, msg_size_);
+    theMsg()->doMessageSend(msg_);
   } else {
     send_action_(msg_);
   }

--- a/src/vt/messaging/pending_send.h
+++ b/src/vt/messaging/pending_send.h
@@ -81,15 +81,12 @@ struct PendingSend final {
    * internal message-sending action is applied.
    *
    * \param[in] in_msg the message to send
-   * \param[in] in_msg_size the size of the message (type is erased)
    * \param[in] in_action the "send" action to run, if overridden.
    */
   PendingSend(
     MsgSharedPtr<BaseMsgType>& in_msg,
-    ByteType in_msg_size,
     SendActionType in_action = nullptr
   ) : msg_(in_msg)
-    , msg_size_(in_msg_size)
     , send_action_(in_action)
   {
     produceMsg();
@@ -115,7 +112,6 @@ struct PendingSend final {
     MsgSharedPtr<MsgT>& in_msg,
     SendActionType in_action
   ) : msg_(in_msg.template toVirtual<BaseMsgType>())
-    , msg_size_(sizeof(MsgT))
     , send_action_(in_action)
   {
     produceMsg();
@@ -186,7 +182,6 @@ private:
 
 private:
   MsgPtr<BaseMsgType> msg_ = nullptr;
-  ByteType msg_size_ = no_byte;
   SendActionType send_action_ = {};
   EpochActionType epoch_action_ = {};
   EpochType epoch_produced_ = no_epoch;

--- a/src/vt/serialization/messaging/serialized_messenger.impl.h
+++ b/src/vt/serialization/messaging/serialized_messenger.impl.h
@@ -401,8 +401,7 @@ template <typename MsgT, typename BaseT>
         );
 
         auto base_msg = msg.template to<BaseMsgType>();
-        ByteType msg_sz = sizeof(MsgT);
-        return messaging::PendingSend(base_msg, msg_sz, [=](MsgPtr<BaseMsgType> in){
+        return messaging::PendingSend(base_msg, [=](MsgPtr<BaseMsgType> in){
           runnable::makeRunnable(msg, true, typed_handler, node)
             .withTDEpochFromMsg()
             .enqueue();

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -833,9 +833,10 @@ void CollectionManager::invokeMsgImpl(
   auto reg_type = HandlerManager::isHandlerMember(han) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
+  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msgPtr.get());
 
   trace_event = theMsg()->makeTraceCreationSend(
-    msgPtr, han, reg_type, false
+    han, reg_type, msg_size, false
   );
 #endif
 
@@ -962,8 +963,10 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
   auto reg_type = HandlerManager::isHandlerMember(han) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
+  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
+
   auto event = theMsg()->makeTraceCreationSend(
-    msg, han, reg_type, true
+    han, reg_type, msg_size, false
   );
   msg->setFromTraceEvent(event);
 #endif
@@ -1121,8 +1124,10 @@ messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
   auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
+  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
+
   auto event = theMsg()->makeTraceCreationSend(
-    msg, handler, reg_type, true
+    handler, reg_type, msg_size, false
   );
   msg->setFromTraceEvent(event);
 # endif
@@ -1459,8 +1464,10 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
+  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
+
   auto event = theMsg()->makeTraceCreationSend(
-    msg, handler, reg_type, false
+    handler, reg_type, msg_size, false
   );
   msg->setFromTraceEvent(event);
 #endif

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -834,9 +834,10 @@ void CollectionManager::invokeMsgImpl(
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msgPtr.get());
+  const bool is_bcast = false;
 
   trace_event = theMsg()->makeTraceCreationSend(
-    han, reg_type, msg_size, false
+    han, reg_type, msg_size, is_bcast
   );
 #endif
 
@@ -964,9 +965,10 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
+  const bool is_bcast = true;
 
   auto event = theMsg()->makeTraceCreationSend(
-    han, reg_type, msg_size, false
+    han, reg_type, msg_size, is_bcast
   );
   msg->setFromTraceEvent(event);
 #endif
@@ -1125,9 +1127,10 @@ messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
+  const bool is_bcast = true;
 
   auto event = theMsg()->makeTraceCreationSend(
-    handler, reg_type, msg_size, false
+    handler, reg_type, msg_size, is_bcast
   );
   msg->setFromTraceEvent(event);
 # endif
@@ -1465,9 +1468,10 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
   auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
+  const bool is_bcast = false;
 
   auto event = theMsg()->makeTraceCreationSend(
-    handler, reg_type, msg_size, false
+    handler, reg_type, msg_size, is_bcast
   );
   msg->setFromTraceEvent(event);
 #endif

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -833,10 +833,9 @@ void CollectionManager::invokeMsgImpl(
   auto reg_type = HandlerManager::isHandlerMember(han) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
-  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msgPtr.get());
 
   trace_event = theMsg()->makeTraceCreationSend(
-    msgPtr, han, reg_type, msg_size, false
+    msgPtr, han, reg_type, false
   );
 #endif
 
@@ -963,9 +962,8 @@ messaging::PendingSend CollectionManager::broadcastCollectiveMsgImpl(
   auto reg_type = HandlerManager::isHandlerMember(han) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
-  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
   auto event = theMsg()->makeTraceCreationSend(
-    msg, han, reg_type, msg_size, true
+    msg, han, reg_type, true
   );
   msg->setFromTraceEvent(event);
 #endif
@@ -1123,9 +1121,8 @@ messaging::PendingSend CollectionManager::broadcastMsgUntypedHandler(
   auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
-  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
   auto event = theMsg()->makeTraceCreationSend(
-    msg, handler, reg_type, msg_size, true
+    msg, handler, reg_type, true
   );
   msg->setFromTraceEvent(event);
 # endif
@@ -1462,9 +1459,8 @@ messaging::PendingSend CollectionManager::sendMsgUntypedHandler(
   auto reg_type = HandlerManager::isHandlerMember(handler) ?
     auto_registry::RegistryTypeEnum::RegVrtCollectionMember :
     auto_registry::RegistryTypeEnum::RegVrtCollection;
-  auto msg_size = vt::serialization::MsgSizer<MsgT>::get(msg.get());
   auto event = theMsg()->makeTraceCreationSend(
-    msg, handler, reg_type, msg_size, false
+    msg, handler, reg_type, false
   );
   msg->setFromTraceEvent(event);
 #endif

--- a/src/vt/vrt/context/context_vrtmanager.impl.h
+++ b/src/vt/vrt/context/context_vrtmanager.impl.h
@@ -139,7 +139,6 @@ messaging::PendingSend VirtualContextManager::sendSerialMsg(
   VirtualProxyType const& toProxy, MsgT *const msg
 ) {
   auto base_msg = promoteMsg(msg).template to<BaseMsgType>();
-  ByteType msg_sz = sizeof(MsgT);
 
   if (theContext()->getWorker() == worker_id_comm_thread) {
     NodeType const& home_node = VirtualProxyBuilder::getVirtualNode(toProxy);
@@ -159,7 +158,7 @@ messaging::PendingSend VirtualContextManager::sendSerialMsg(
 
     // route the message to the destination using the location manager
     messaging::PendingSend pending(
-      base_msg, msg_sz, [=](MsgPtr<BaseMsgType> mymsg){
+      base_msg, [=](MsgPtr<BaseMsgType> mymsg){
         // Uses special implementation overload not exposed in theMsg..
         MsgT* typed_msg = reinterpret_cast<MsgT*>(mymsg.get());
         auto sendSerialHan = auto_registry::makeAutoHandler<MsgT,virtualTypedMsgHandler<MsgT>>();
@@ -188,7 +187,7 @@ messaging::PendingSend VirtualContextManager::sendSerialMsg(
     return pending;
   } else {
     return messaging::PendingSend(
-      base_msg, msg_sz, [=](MsgPtr<BaseMsgType> mymsg) {
+      base_msg, [=](MsgPtr<BaseMsgType> mymsg) {
         #if vt_threading_enabled
         theWorkerGrp()->enqueueCommThread([=]{
           auto typed_msg = reinterpret_cast<MsgT*>(mymsg.get());
@@ -335,8 +334,7 @@ messaging::PendingSend VirtualContextManager::sendMsg(
   );
 
   auto base_msg = msg.template to<BaseMsgType>();
-  ByteType msg_sz = sizeof(MsgT);
-  return messaging::PendingSend(base_msg, msg_sz,
+  return messaging::PendingSend(base_msg,
     [=](MsgPtr<BaseMsgType> mymsg){
       // route the message to the destination using the location manager
       auto msg_shared = promoteMsg(reinterpret_cast<MsgT*>(mymsg.get()));


### PR DESCRIPTION
Fixes #1344