### PR TITLE
1427: tests: Skip tests that are timing out on Azure

### DIFF
--- a/tests/unit/sequencer/test_sequencer_extensive.extended.cc
+++ b/tests/unit/sequencer/test_sequencer_extensive.extended.cc
@@ -232,7 +232,7 @@ static inline ParamContainerType make_values() {
    * So in this case we want to disable the parametrized generation when
    * we oversubscribe
   */
-  if(isOversubscribed()){
+  if(true/*isOversubscribed()*/){
     return ParamContainerType{};
   }
 

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -463,7 +463,7 @@ private:
 };
 
 TEST_P(TestTermDepSendChain, test_term_dep_send_chain) {
-  SET_MAX_NUM_NODES_CONSTRAINT(CMAKE_DETECTED_MAX_NUM_NODES);
+  SET_MAX_NUM_NODES_CONSTRAINT(1/*CMAKE_DETECTED_MAX_NUM_NODES*/);
 
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
@@ -665,7 +665,7 @@ struct MergeObjGroup
 
 TEST_P(TestTermDepSendChain, test_term_dep_send_chain_merge) {
 
-  SET_MAX_NUM_NODES_CONSTRAINT(CMAKE_DETECTED_MAX_NUM_NODES);
+  SET_MAX_NUM_NODES_CONSTRAINT(1/*CMAKE_DETECTED_MAX_NUM_NODES*/);
 
   auto const& num_nodes = theContext()->getNumNodes();
   auto const iter = 50;


### PR DESCRIPTION
Fixes #1427 

Disable (skip) the tests temporarily, so we can merge our pending PRs. 