### PR TITLE
1423 Make message ref count limit configurable, print max when enabled

### DIFF
--- a/src/vt/configs/arguments/app_config.h
+++ b/src/vt/configs/arguments/app_config.h
@@ -166,6 +166,8 @@ struct AppConfig {
   bool vt_pause = false;
   bool vt_no_assert_fail = false;
   std::size_t vt_max_mpi_send_size = 1ull << 30;
+  int16_t vt_msg_ref_count_max = 1000;
+  bool vt_print_max_ref_count = false;
 
 #if (vt_feature_fcontext != 0)
   bool vt_ult_disable = false;
@@ -319,6 +321,8 @@ struct AppConfig {
       | vt_pause
       | vt_no_assert_fail
       | vt_max_mpi_send_size
+      | vt_msg_ref_count_max
+      | vt_print_max_ref_count
 
       | vt_debug_level
       | vt_debug_level_val

--- a/src/vt/configs/arguments/args.cc
+++ b/src/vt/configs/arguments/args.cc
@@ -501,7 +501,8 @@ void ArgConfig::addRuntimeArgs(CLI::App& app) {
   auto max_size = "Maximum MPI send size (causes larger messages to be split "
                   "into multiple MPI sends)";
   auto assert = "Do not abort the program when vtAssert(..) is invoked";
-
+  auto max_ref = "Maximum ref count for messages (when reached assertion will fail)";
+  auto print_max = "Print the maximum ref count reached for debugging";
 
   auto a1 = app.add_option(
     "--vt_max_mpi_send_size", config_.vt_max_mpi_send_size, max_size, true
@@ -509,11 +510,18 @@ void ArgConfig::addRuntimeArgs(CLI::App& app) {
   auto a2 = app.add_flag(
     "--vt_no_assert_fail", config_.vt_no_assert_fail, assert
   );
-
+  auto a3 = app.add_option(
+    "--vt_msg_ref_count_max", config_.vt_msg_ref_count_max, max_ref, true
+  );
+  auto a4 = app.add_flag(
+    "--vt_print_max_ref_count", config_.vt_print_max_ref_count, print_max
+  );
 
   auto configRuntime = "Runtime";
   a1->group(configRuntime);
   a2->group(configRuntime);
+  a3->group(configRuntime);
+  a4->group(configRuntime);
 }
 
 void ArgConfig::addThreadingArgs(CLI::App& app) {

--- a/src/vt/context/context.h
+++ b/src/vt/context/context.h
@@ -197,6 +197,24 @@ struct Context : runtime::component::Component<Context> {
   trace::TraceEventIDType getTraceEventCurrentTask() const;
 #endif
 
+  /**
+   * \brief Get the maximum observed reference count for the current runtime
+   *
+   * \return the maximum reference count observed
+   */
+  RefType getMaxObservedRefCount() const {
+    return max_observed_ref_count;
+  }
+
+  /**
+   * \brief Set a new maximum observed reference count
+   *
+   * \param[in] new_max the new max
+   */
+  void setMaxObservedRefCount(RefType new_max) {
+    max_observed_ref_count = new_max;
+  }
+
 protected:
   /**
    * \brief Set the current running task
@@ -225,6 +243,7 @@ private:
   MPI_Comm communicator_ = MPI_COMM_WORLD;
   DeclareClassInsideInitTLS(Context, WorkerIDType, thisWorker_, no_worker_id)
   runnable::RunnableNew* cur_task_ = nullptr;
+  RefType max_observed_ref_count = 1;
 };
 
 }} // end namespace vt::ctx

--- a/src/vt/messaging/envelope/envelope_ref.impl.h
+++ b/src/vt/messaging/envelope/envelope_ref.impl.h
@@ -60,12 +60,6 @@ inline void envelopeRef(Env& env) {
     "This is can be caused by explicitly using 'new Message(..)' "
     "instead of a MsgPtr/makeMessage/makeSharedMessage construct."
   );
-  vtAssertInfo(
-    envp->ref >= 0 and envp->ref < 100,
-    "Bad ref-count on message ref-increment. "
-    "Message ref-count must never be negative and cannnot exceed limit (100).",
-    static_cast<RefType>(envp->ref)
-  );
 
   envp->ref++;
 }

--- a/src/vt/runtime/runtime_banner.cc
+++ b/src/vt/runtime/runtime_banner.cc
@@ -245,6 +245,13 @@ void Runtime::printStartupBanner() {
       green, reset, compile, magenta, opt, reset, reset
     );
   };
+  auto opt_change =
+    [=](std::string opt, std::string compile, std::string reason) -> std::string {
+    return fmt::format(
+      "{}Option:{} {}, is disabled because {}{}{} is {}{}\n",
+      green, reset, compile, magenta, opt, reset, reason, reset
+    );
+  };
 
   auto f8 = fmt::format("{}Runtime Configuration:{}\n", green, reset);
   fmt::print("{}{}{}", vt_pre, f8, reset);
@@ -803,6 +810,29 @@ void Runtime::printStartupBanner() {
     );
     auto f_max_arg = opt_on("--vt_max_mpi_send_size", f_max);
     fmt::print("{}\t{}{}", vt_pre, f_max_arg, reset);
+  }
+
+  {
+    auto max_ref_opt = "Maximum ref count for messages";
+    if (getAppConfig()->vt_msg_ref_count_max != 0) {
+      auto ref_msg = fmt::format(
+        "{} is set to \"{}\"",
+        max_ref_opt, getAppConfig()->vt_msg_ref_count_max
+      );
+      auto f11 = opt_on("--vt_msg_ref_count_max", ref_msg);
+      fmt::print("{}\t{}{}", vt_pre, f11, reset);
+    } else {
+      auto f11 = opt_change("--vt_msg_ref_count_max", max_ref_opt, "== 0");
+      fmt::print("{}\t{}{}", vt_pre, f11, reset);
+    }
+  }
+
+  if (getAppConfig()->vt_print_max_ref_count) {
+    auto max_msg = fmt::format(
+      "Printing whenever a new maximum ref count is reached across all messages"
+    );
+    auto f11 = opt_on("--vt_print_max_ref_count", max_msg);
+    fmt::print("{}\t{}{}", vt_pre, f11, reset);
   }
 
   {


### PR DESCRIPTION
Fixes #1423

@nmm0 Let me know if this satisfies your needs.

Added two new options:
- `--vt_vt_msg_ref_count_max` which allows the user to set the ref count limit where the assert triggers
- `--vt_print_max_ref_count`, which prints the message type every time a new maximum ref count is observed

The second looks like this when enabled:

<img width="1455" alt="Screen Shot 2021-05-05 at 16 18 22" src="https://user-images.githubusercontent.com/3324465/117221148-8cf19980-adbd-11eb-936c-89a2f1e214a8.png">
