### PR TITLE
1395 Fix GreedyLB Bug

### DIFF
--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -262,9 +262,9 @@ void GreedyLB::recvObjsDirect(std::size_t len, GreedyLBTypes::ObjIDType* objs) {
 }
 
 void GreedyLB::transferObjs(std::vector<GreedyProc>&& in_load) {
-#define SCATTER 0
+#define SCATTER 1
 #define PT2PT 0
-#define BROADCAST 1
+#define BROADCAST 0
 
 #if SCATTER
   std::size_t max_recs = 1, max_bytes = 0;

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -267,7 +267,7 @@ void GreedyLB::transferObjs(std::vector<GreedyProc>&& in_load) {
 #define BROADCAST 1
 
 #if SCATTER
-  std::size_t max_recs = 0, max_bytes = 0;
+  std::size_t max_recs = 1, max_bytes = 0;
 #endif
   std::vector<GreedyProc> load(std::move(in_load));
   std::vector<std::vector<GreedyLBTypes::ObjIDType>> node_transfer(load.size());

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -272,7 +272,7 @@ void GreedyLB::recvObjsDirect(std::size_t len, GreedyLBTypes::ObjIDType* objs) {
 }
 
 void GreedyLB::transferObjs(std::vector<GreedyProc>&& in_load) {
-  std::size_t max_recs = 1, max_bytes = 0;
+  std::size_t max_recs = 1;
   std::vector<GreedyProc> load(std::move(in_load));
   std::vector<std::vector<GreedyLBTypes::ObjIDType>> node_transfer(load.size());
   for (auto&& elm : load) {
@@ -290,7 +290,7 @@ void GreedyLB::transferObjs(std::vector<GreedyProc>&& in_load) {
   }
 
   if (strat_ == DataDistStrategy::scatter) {
-    max_bytes =  max_recs * sizeof(GreedyLBTypes::ObjIDType);
+    std::size_t max_bytes =  max_recs * sizeof(GreedyLBTypes::ObjIDType);
     vt_debug_print(
       normal, lb,
       "GreedyLB::transferObjs: max_recs={}, max_bytes={}\n",

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.h
@@ -86,7 +86,9 @@ private:
   void runBalancer(ObjSampleType&& objs, LoadProfileType&& profile);
   void transferObjs(std::vector<GreedyProc>&& load);
   ObjIDType objSetNode(NodeType const& node, ObjIDType const& id);
-  void recvObjsDirect(GreedyLBTypes::ObjIDType* objs);
+  void recvObjsDirect(std::size_t len, GreedyLBTypes::ObjIDType* objs);
+  void recvObjs(GreedySendMsg* msg);
+  void recvObjsBcast(GreedyBcastMsg* msg);
   void finishedTransferExchange();
   void collectHandler(GreedyCollectMsg* msg);
 

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.h
@@ -60,6 +60,17 @@
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
+/**
+ * \enum DataDistStrategy
+ *
+ * \brief How to distribute the data after the centralized LB makes a decision.
+ */
+enum struct DataDistStrategy : uint8_t {
+  SCATTER = 0,
+  BCAST = 1,
+  PT2PT = 2
+};
+
 struct GreedyLB : BaseLB {
   using ElementLoadType  = std::unordered_map<ObjIDType,TimeType>;
   using TransferType     = std::map<NodeType, std::vector<ObjIDType>>;
@@ -107,6 +118,8 @@ private:
   double max_threshold = 0.0f;
   double min_threshold = 0.0f;
   bool auto_threshold = true;
+
+  DataDistStrategy strat_ = DataDistStrategy::SCATTER;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.h
@@ -124,4 +124,18 @@ private:
 
 }}}} /* end namespace vt::vrt::collection::lb */
 
+namespace std {
+
+template <>
+struct hash<::vt::vrt::collection::lb::DataDistStrategy> {
+  size_t operator()(::vt::vrt::collection::lb::DataDistStrategy const& in) const {
+    using under = std::underlying_type<
+      ::vt::vrt::collection::lb::DataDistStrategy
+    >::type;
+    return std::hash<under>()(static_cast<under>(in));
+  }
+};
+
+} /* end namespace std */
+
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_GREEDYLB_GREEDYLB_H*/

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.h
@@ -66,9 +66,9 @@ namespace vt { namespace vrt { namespace collection { namespace lb {
  * \brief How to distribute the data after the centralized LB makes a decision.
  */
 enum struct DataDistStrategy : uint8_t {
-  SCATTER = 0,
-  BCAST = 1,
-  PT2PT = 2
+  scatter = 0,
+  bcast = 1,
+  pt2pt = 2
 };
 
 struct GreedyLB : BaseLB {
@@ -119,7 +119,7 @@ private:
   double min_threshold = 0.0f;
   bool auto_threshold = true;
 
-  DataDistStrategy strat_ = DataDistStrategy::SCATTER;
+  DataDistStrategy strat_ = DataDistStrategy::scatter;
 };
 
 }}}} /* end namespace vt::vrt::collection::lb */

--- a/src/vt/vrt/collection/balance/greedylb/greedylb_msgs.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb_msgs.h
@@ -129,6 +129,44 @@ struct GreedyCollectMsg : GreedyLBTypes, collective::ReduceTMsg<GreedyPayload> {
   }
 };
 
+struct GreedySendMsg : GreedyLBTypes, vt::Message {
+  using MessageParentType = vt::Message;
+  vt_msg_serialize_required(); // vector
+
+  GreedySendMsg() = default;
+  explicit GreedySendMsg(std::vector<GreedyLBTypes::ObjIDType> const& in)
+    : transfer_(in)
+  { }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    MessageParentType::serialize(s);
+    s | transfer_;
+  }
+
+  std::vector<GreedyLBTypes::ObjIDType> transfer_;
+};
+
+struct GreedyBcastMsg : GreedyLBTypes, vt::Message {
+  using MessageParentType = vt::Message;
+  vt_msg_serialize_required(); // vector
+
+  using DataType = std::vector<std::vector<GreedyLBTypes::ObjIDType>>;
+
+  GreedyBcastMsg() = default;
+  explicit GreedyBcastMsg(DataType const& in)
+    : transfer_(in)
+  { }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    MessageParentType::serialize(s);
+    s | transfer_;
+  }
+
+  DataType transfer_;
+};
+
 }}}} /* end namespace vt::vrt::collection::lb */
 
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_GREEDYLB_GREEDYLB_MSGS_H*/

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -169,7 +169,7 @@ auto balancers = ::testing::Values(
     "TemperedLB",
     "GreedyLB:strategy=scatter",
     "GreedyLB:strategy=pt2pt",
-    "GreedyLB:strategy=broadcast"
+    "GreedyLB:strategy=bcast"
 #   if vt_check_enabled(zoltan)
     , "ZoltanLB"
 #   endif

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -101,6 +101,12 @@ void TestLoadBalancer::runTest() {
       fmt::print("Using lb_args {}\n", lb_args);
     }
   }
+  if (lb_name.substr(0, 8).compare("GreedyLB") == 0) {
+    vt::theConfig()->vt_lb_name = "GreedyLB";
+    auto strat_arg = lb_name.substr(9, lb_name.size() - 9);
+    fmt::print("strat_arg={}\n", strat_arg);
+    vt::theConfig()->vt_lb_args = strat_arg;
+  }
 
   vt::theCollective()->barrier();
 
@@ -161,7 +167,9 @@ auto balancers = ::testing::Values(
     "RotateLB",
     "HierarchicalLB",
     "TemperedLB",
-    "GreedyLB"
+    "GreedyLB:strategy=scatter",
+    "GreedyLB:strategy=pt2pt",
+    "GreedyLB:strategy=broadcast"
 #   if vt_check_enabled(zoltan)
     , "ZoltanLB"
 #   endif


### PR DESCRIPTION
Fixes #1395

- I've started by trying to identify where the bug is, and it seems anecdotally to be in the scatter.
- I determined this by implementing alternative strategies to the scatter (pt2pt send, and broadcast), which both seem to "fix" the problem. After 1000 runs it doesn't occur with both the send and broadcast, whereas before it always triggered with that many runs when scatter is enabled.
- The data indicates some bad data that occasionally shows up when scatter is enabled. However, even when it fails, address sanitizer is clean, so it's not memory corruption/overwriting

```
vt: [1] (t) lb: migrateObjectTo, obj_id=25770721283, home=-24827, from=1, to=25687, found=false
vt: [1] (t) lb: transferMigrations: obj_id=(25770721283,-24827,1), to_node=25687
```

See how the home is corruption (negative value), which is never allowed.

- I think I have identified the edge case, which is when the scatter has zero elements in it. This might be what is causing the problem. ~I'm writing a new scatter unit test to provide coverage over this devolved use case.~

- **It turns out that the bug is unrelated to the scatter implementation which works perfectly fine. But the zero element edge case is the one causing problems due to a bug in the computed `max_recs` when no data exists. I have solved the bug, and run ctest/gtest 1000s of times with the fix and it never fails anymore with this fix.**