### PR TITLE
#1524: cmake: fix typo in export name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,7 +339,7 @@ export(
                             ${MIMALLOC_LIBRARY_EXPORT}
                             ${FORT_LIBRARY_EXPORT}
                             ${FMT_LIBRARY_EXPORT}
-                            ${CHEKPOINT_EXPORT}
+                            ${CHECKPOINT_EXPORT}
                             ${DETECTOR_EXPORT}
                             ${JSON_LIBRARY}
                             ${BROTLI_LIBRARY}


### PR DESCRIPTION
Fixes #1524