### PR TITLE
#1546: compile error with gcc11

### DIFF
--- a/src/vt/trace/trace_common.h
+++ b/src/vt/trace/trace_common.h
@@ -47,6 +47,7 @@
 #include "vt/configs/types/types_type.h"
 
 #include <cstdint>
+#include <cstddef>
 
 namespace vt { namespace trace {
 


### PR DESCRIPTION
`trace_common.h` was missing the include for `size_t`. It seems like on the compilers we test `size_t` was probably included by transitive includes, but this is not the case on more recent versions of gcc (tested on 11.1.0) and thus fails.

Closes #1546 