### PR TITLE
#1523 don't fail job on Azure infrastructure failure

### DIFF
--- a/ci/azure/azure-clang-10-alpine-mpich.yml
+++ b/ci/azure/azure-clang-10-alpine-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push alpine-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-clang-10-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-10-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-clang-3.9-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-3.9-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-clang-5.0-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-5.0-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-clang-9-ubuntu-mpich.yml
+++ b/ci/azure/azure-clang-9-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-gcc-10-ubuntu-openmpi.yml
+++ b/ci/azure/azure-gcc-10-ubuntu-openmpi.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean-openmpi'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-gcc-5-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-5-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-gcc-6-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-6-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-gcc-7-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-7-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             source /etc/docker-setup.sh
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-gcc-8-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-8-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-gcc-9-ubuntu-mpich.yml
+++ b/ci/azure/azure-gcc-9-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-intel-18-ubuntu-mpich-extended.yml
+++ b/ci/azure/azure-intel-18-ubuntu-mpich-extended.yml
@@ -69,6 +69,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -90,11 +91,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -106,6 +111,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -129,6 +135,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -147,6 +154,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -156,6 +164,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -163,13 +173,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-intel-18-ubuntu-mpich.yml
+++ b/ci/azure/azure-intel-18-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-intel-19-ubuntu-mpich.yml
+++ b/ci/azure/azure-intel-19-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-nvidia-10-ubuntu-mpich-extended.yml
+++ b/ci/azure/azure-nvidia-10-ubuntu-mpich-extended.yml
@@ -69,6 +69,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -90,11 +91,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -106,6 +111,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -129,6 +135,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -147,6 +154,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -156,6 +164,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -163,13 +173,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-nvidia-10-ubuntu-mpich.yml
+++ b/ci/azure/azure-nvidia-10-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-nvidia-11-ubuntu-mpich-extended.yml
+++ b/ci/azure/azure-nvidia-11-ubuntu-mpich-extended.yml
@@ -69,6 +69,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -90,11 +91,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -106,6 +111,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -129,6 +135,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -147,6 +154,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -156,6 +164,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -163,13 +173,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/ci/azure/azure-nvidia-11-ubuntu-mpich.yml
+++ b/ci/azure/azure-nvidia-11-ubuntu-mpich.yml
@@ -75,6 +75,7 @@ stages:
             echo setup
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -96,11 +97,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -112,6 +117,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -135,6 +141,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -153,6 +160,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -162,6 +170,8 @@ stages:
           dockerComposeCommand: 'push ubuntu-cpp-clean'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -169,13 +179,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done

--- a/scripts/workflow-azure-template.yml
+++ b/scripts/workflow-azure-template.yml
@@ -65,6 +65,7 @@ stages:
             [% job_setup %]
       - task: Bash@3
         displayName: Build timestamp for caching
+        continueOnError: true
         inputs:
           targetType: 'inline'
           script: |
@@ -86,11 +87,15 @@ stages:
             echo "##vso[task.setvariable variable=TS_DAY]$val"
       - task: Bash@3
         displayName: Output timestamp for caching
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: 'echo "my pipeline variable is $(TS) $(TS_YEAR) $(TS_MONTH) $(TS_DAY)"'
       - task: Cache@2
         displayName: Update cache
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           securityNamespace: cache
           key: $(Agent.OS) | "$(cache_name)" | $(TS_YEAR) | $(TS_MONTH) | $(TS_DAY) | $(TS)
@@ -102,6 +107,7 @@ stages:
             $(Agent.OS) | "$(cache_name)"
       - task: Bash@3
         displayName: Check for changes in containers
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -125,6 +131,7 @@ stages:
           CODECOV_TOKEN: $(codecov_token)
       - task: Bash@3
         displayName: Put compilation's and tests' logs in PR comment
+        continueOnError: true
         condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           targetType: 'inline'
@@ -143,6 +150,7 @@ stages:
           GITHUB_PAT: $(github_pat)
       - task: DockerCompose@0
         displayName: Push container to registry
+        continueOnError: true
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/develop'))
         inputs:
           containerregistrytype: 'Container Registry'
@@ -152,6 +160,8 @@ stages:
           dockerComposeCommand: 'push [% docker_target %]'
       - task: Bash@3
         displayName: Create artifacts
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetType: 'inline'
           script: |
@@ -159,13 +169,24 @@ stages:
             zip -j $(Agent.TempDirectory)/cmake-output.log.gz $(build_root)/vt/cmake-output.log
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake test output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/LastTest.log.gz'
           artifact: 'CMakeLastTestLog'
           publishLocation: 'pipeline'
       - task: PublishPipelineArtifact@1
         displayName: Upload CMake full output artifact
+        continueOnError: true
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
         inputs:
           targetPath: '$(Agent.TempDirectory)/cmake-output.log.gz'
           artifact: 'CMakeOutputLog'
           publishLocation: 'pipeline'
+      - task: Bash@3
+        displayName: Finish pipeline
+        condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo Done


### PR DESCRIPTION
Fixes #1523 

* `continueOnError: true` makes a given task continue to next one even if there was an error. Result of failed task is `SucceededWithIssues`
* `condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')` makes a given task runnable if previus was succedded or failed, but was marked as `continueOnError`