### PR TITLE
#1582 Fix double free of lb_names_ and lb_stat_name_

### DIFF
--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -391,7 +391,7 @@ bool Runtime::tryFinalize(bool const disable_sig) {
 bool Runtime::needStatsRestartReader() {
   #if vt_check_enabled(lblite)
     if (arg_config_->config_.vt_lb_stats) {
-      auto lbNames = vrt::collection::balance::lb_names_;
+      auto lbNames = vrt::collection::balance::get_lb_names();
       auto mapLB = vrt::collection::balance::LBType::StatsMapLB;
       if (arg_config_->config_.vt_lb_name == lbNames[mapLB]) {
         return true;

--- a/src/vt/runtime/runtime_banner.cc
+++ b/src/vt/runtime/runtime_banner.cc
@@ -312,7 +312,7 @@ void Runtime::printStartupBanner() {
 
       // Check validity of LB passed to VT
       bool found = false;
-      for (auto&& lb : vrt::collection::balance::lb_names_) {
+      for (auto&& lb : vrt::collection::balance::get_lb_names()) {
         if (getAppConfig()->vt_lb_name == lb.second) {
           found = true;
           break;

--- a/src/vt/vrt/collection/balance/lb_common.h
+++ b/src/vt/vrt/collection/balance/lb_common.h
@@ -126,7 +126,7 @@ struct hash<StatisticType> {
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
-extern std::unordered_map<Statistic,std::string> lb_stat_name_;
+std::unordered_map<Statistic, std::string>& get_lb_stat_name();
 
 }}}} /* end namespace vt::vrt::collection::lb */
 

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -84,7 +84,7 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
   vt_debug_print(
     verbose, lb,
     "LBManager::decideLBToRun: phase={}, try_file={}, cached_phase_={}, lb={}\n",
-    phase, try_file, cached_phase_, lb_names_[cached_lb_]
+    phase, try_file, cached_phase_, get_lb_names()[cached_lb_]
   );
 
   if (phase == cached_phase_) {
@@ -101,7 +101,7 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
   }
 
   //--- User-specified map without any change, thus do not run
-  if ((theConfig()->vt_lb_name == lb_names_[LBType::StatsMapLB]) and
+  if ((theConfig()->vt_lb_name == get_lb_names()[LBType::StatsMapLB]) and
       not theStatsReader()->needsLB(phase)) {
     return LBType::NoLB;
   }
@@ -117,7 +117,7 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
     vtAssert(interval != 0, "LB Interval must not be 0");
     if (phase % interval == 1 || (interval == 1 && phase != 0)) {
       bool name_match = false;
-      for (auto&& elm : lb_names_) {
+      for (auto&& elm : get_lb_names()) {
         if (elm.second == theConfig()->vt_lb_name) {
           the_lb = elm.first;
           name_match = true;
@@ -138,7 +138,7 @@ LBType LBManager::decideLBToRun(PhaseType phase, bool try_file) {
   vt_debug_print(
     terse, lb,
     "LBManager::decidedLBToRun: phase={}, return lb_={}\n",
-    phase, lb_names_[the_lb]
+    phase, get_lb_names()[the_lb]
   );
 
   cached_lb_ = the_lb;
@@ -235,7 +235,7 @@ void LBManager::startLB(PhaseType phase, LBType lb) {
       "LBManager::startLB: phase={}, balancer={}, name={}\n",
       phase,
       static_cast<typename std::underlying_type<LBType>::type>(lb),
-      lb_names_[lb]
+      get_lb_names()[lb]
     );
   }
 
@@ -273,7 +273,7 @@ void LBManager::printLBArgsHelp(LBType lb) {
   fmt::print(
     "{}{}LB arguments for {}{}{}:\n",
     debug::vtPre(), debug::green(), debug::magenta(),
-    lb_names_[lb], debug::reset()
+    get_lb_names()[lb], debug::reset()
   );
   fmt::print(sep);
   fmt::print("\n");
@@ -329,11 +329,11 @@ void LBManager::printLBArgsHelp(LBType lb) {
 /*static*/
 void LBManager::printLBArgsHelp(std::string lb_name) {
   if (lb_name.compare("NoLB") == 0) {
-    for (auto&& lb : vrt::collection::balance::lb_names_) {
+    for (auto&& lb : vrt::collection::balance::get_lb_names()) {
       vrt::collection::balance::LBManager::printLBArgsHelp(lb.first);
     }
   } else {
-    for (auto&& lb : vrt::collection::balance::lb_names_) {
+    for (auto&& lb : vrt::collection::balance::get_lb_names()) {
       if (lb_name == lb.second) {
         vrt::collection::balance::LBManager::printLBArgsHelp(lb.first);
         break;
@@ -411,7 +411,7 @@ void LBManager::statsHandler(StatsMsgType* msg) {
         " max={:.2f}, min={:.2f}, sum={:.2f}, avg={:.2f}, var={:.2f},"
         " stdev={:.2f}, nproc={}, cardinality={} skewness={:.2f}, kurtosis={:.2f},"
         " npr={}, imb={:.2f}, num_stats={}\n",
-        lb::lb_stat_name_[stat],
+        lb::get_lb_stat_name()[stat],
         max, min, sum, avg, var, stdv, npr, car, skew, krte, npr, imb,
         stats.size()
       );

--- a/src/vt/vrt/collection/balance/lb_type.cc
+++ b/src/vt/vrt/collection/balance/lb_type.cc
@@ -49,7 +49,7 @@ namespace vt { namespace vrt { namespace collection {
 
 namespace balance {
 
-std::unordered_map<LBType,std::string> lb_names_ = {
+static std::unordered_map<LBType,std::string> lb_names_ = {
   {LBType::NoLB,           std::string{"NoLB"          }},
 # if vt_check_enabled(zoltan)
   {LBType::ZoltanLB,       std::string{"ZoltanLB"      }},
@@ -62,11 +62,15 @@ std::unordered_map<LBType,std::string> lb_names_ = {
   {LBType::RandomLB,       std::string{"RandomLB"      }},
 };
 
+std::unordered_map<LBType, std::string>& get_lb_names() {
+  return lb_names_;
+}
+
 } /* end namespace balance */
 
 namespace lb {
 
-std::unordered_map<Statistic,std::string> lb_stat_name_ = {
+static std::unordered_map<Statistic,std::string> lb_stat_name_ = {
   {Statistic::P_l,         std::string{"P_l"}},
   {Statistic::P_c,         std::string{"P_c"}},
   {Statistic::P_t,         std::string{"P_t"}},
@@ -76,6 +80,10 @@ std::unordered_map<Statistic,std::string> lb_stat_name_ = {
   {Statistic::ObjectRatio, std::string{"ObjectRatio"}},
   {Statistic::EdgeRatio,   std::string{"EdgeRatio"}}
 };
+
+std::unordered_map<Statistic, std::string>& get_lb_stat_name() {
+  return lb_stat_name_;
+}
 
 } /* end namespace lb */
 

--- a/src/vt/vrt/collection/balance/lb_type.h
+++ b/src/vt/vrt/collection/balance/lb_type.h
@@ -84,7 +84,7 @@ struct hash<LBTypeType> {
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-extern std::unordered_map<LBType,std::string> lb_names_;
+std::unordered_map<LBType, std::string>& get_lb_names();
 
 }}}} /* end namespace vt::vrt::collection::balance */
 

--- a/src/vt/vrt/collection/balance/read_lb.cc
+++ b/src/vt/vrt/collection/balance/read_lb.cc
@@ -199,7 +199,7 @@ int eatWhitespace(std::ifstream& file) {
      * Check to make sure we have a valid LB name
      */
     bool valid_lb_found = false;
-    for (auto&& elm : lb_names_) {
+    for (auto&& elm : get_lb_names()) {
       if (lb_name == elm.second) {
         valid_lb_found = true;
       }

--- a/src/vt/vrt/collection/balance/read_lb.h
+++ b/src/vt/vrt/collection/balance/read_lb.h
@@ -120,7 +120,7 @@ struct SpecEntry {
   std::string getName() const { return lb_name_; }
   ParamMapType getParams() const { return params_; }
   LBType getLB() const {
-    for (auto&& elm : lb_names_) {
+    for (auto&& elm : get_lb_names()) {
       if (lb_name_ == elm.second) {
         return elm.first;
       }


### PR DESCRIPTION
Fixes #1582 

---

My test app structure:

- main binary (let's called it `App`) that is linked with static vt and two shared libraries
- two shared libraries (let's called them `First` and `Second`), that are linked with static vt

`App`, `First` and `Second` prints content of vt's `lb_names_` and `lb_stat_name_` map.

After linking `App` with `vt` and with `First` Address Sanitizer immediately complained:

```bash
=================================================================
==24130==ERROR: AddressSanitizer: odr-violation (0x55b568e0c7c0):
  [1] size=56 'lb_stat_name_' /home/strz/repos/darma/src/vt/src/vt/vrt/collection/balance/lb_type.cc:69:43
  [2] size=56 'lb_stat_name_' /home/strz/repos/darma/src/vt/src/vt/vrt/collection/balance/lb_type.cc:69:43
These globals were registered at these points:
  [1]:
    #0 0x7f20c23ee938 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x55b568df9c18 in _sub_I_00099_1 (/home/strz/repos/test_vt_double_free/app/build/App+0x1ac18)
    #2 0x55b568e0125c in __libc_csu_init (/home/strz/repos/test_vt_double_free/app/build/App+0x2225c)

  [2]:
    #0 0x7f20c23ee938 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x7f20c23a2e34 in _sub_I_00099_1 (/home/strz/repos/test_vt_double_free/first_shared_library/install/lib/libFirstSharedLibrary.so+0x1ee34)
    #2 0x7f20c2dc396d  (/lib64/ld-linux-x86-64.so.2+0x1196d)

==24130==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'lb_stat_name_' at /home/strz/repos/darma/src/vt/src/vt/vrt/collection/balance/lb_type.cc:69:43
==24130==ABORTING
```

Simply making that maps `static` and exposing free functions to access them made ASAN happy again.
