### PR TITLE
#1594: Don't try to print cudaEvent_t, since it's an incomplete type as declared by CUDA headers

### DIFF
--- a/src/vt/messaging/async_op_cuda.h
+++ b/src/vt/messaging/async_op_cuda.h
@@ -89,7 +89,7 @@ struct AsyncOpCUDA : AsyncOp {
   bool poll() override {
     auto ret = cudaEventQuery(event_);
     if (cudaSuccess != ret && cudaErrorNotReady != ret) {
-      vtAbort(fmt::format("Failure on stream event {:x}: {}: {}", event_, cudaGetErrorName(ret), cudaGetErrorString(ret)));
+      vtAbort(fmt::format("Failure on stream event: {}: {}", cudaGetErrorName(ret), cudaGetErrorString(ret)));
     }
     return ret == cudaSuccess;
   }


### PR DESCRIPTION
Fixes #1594