### PR TITLE
#1592 Update clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ Language: Cpp
 ColumnLimit: 80
 UseTab: Never
 
-AccessModifierOffset: -4
+AccessModifierOffset: -2
 AlignAfterOpenBracket: AlwaysBreak
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false


### PR DESCRIPTION
Fixes #1592 

----

About the preprocessor directives indention, what style do we prefer?
(paragraph `IndentPPDirectives` at https://clang.llvm.org/docs/ClangFormatStyleOptions.html)

`None`:

```cpp
#if FOO
#if BAR
#include <foo>
#endif
#endif
```

`AfterHash`:

```cpp
#if FOO
#  if BAR
#    include <foo>
#  endif
#endif
```

`BeforeHash`:

```cpp
#if FOO
  #if BAR
    #include <foo>
  #endif
#endif
```

Currently we have `BeforeHash`.