### PR TITLE
#1604 put CLI11 in vt namespace

### DIFF
--- a/lib/CLI/CLI/CLI11.hpp
+++ b/lib/CLI/CLI/CLI11.hpp
@@ -61,6 +61,9 @@
 #include <utility>
 #include <vector>
 
+namespace vt {
+
+
 
 // Verbatim copy from CLI/Version.hpp:
 
@@ -8220,4 +8223,6 @@ inline std::string Formatter::make_option_usage(const Option *opt) const {
 }
 
 } // namespace CLI
+
+} // namespace vt
 

--- a/src/vt/configs/arguments/args.h
+++ b/src/vt/configs/arguments/args.h
@@ -53,11 +53,13 @@
 #include <vector>
 #include <tuple>
 
+namespace vt {
+
 namespace CLI {
 class App;
 } /* end namespace CLI */
 
-namespace vt { namespace arguments {
+namespace arguments {
 
 /**
  * \struct ArgConfig
@@ -108,6 +110,7 @@ private:
   bool parsed_ = false;
 };
 
-}} /* end namespace vt::arguments */
+} // namespace arguments
+} // namespace vt
 
 #endif /*INCLUDED_VT_CONFIGS_ARGUMENTS_ARGS_H*/


### PR DESCRIPTION
Fixes #1604 

----

I didn't upgrade CLI11 to the newest version, API changed a bit. If we want to do so, let's open another issue for that. Also script generating single header file was changed, and I opened issue in CLI11 repo reporting problem with support for custom namespace - before upgrading we want it to be fixed

https://github.com/CLIUtils/CLI11/issues/680