### PR TITLE
#1605 fmt custom namespace

### DIFF
--- a/cmake/load_bundled_libraries.cmake
+++ b/cmake/load_bundled_libraries.cmake
@@ -22,7 +22,14 @@ add_subdirectory(${PROJECT_LIB_DIR}/CLI)
 # fmt always included in the build
 set(FMT_LIBRARY fmt)
 add_subdirectory(${PROJECT_LIB_DIR}/fmt)
-target_compile_definitions(${FMT_LIBRARY} PUBLIC FMT_INLINE_NAMESPACE_NAME=vt)
+target_compile_definitions(
+  ${FMT_LIBRARY}
+  PUBLIC
+  FMT_BEGIN_NAMESPACE=namespace\ fmt\ \{\ inline\ namespace\ vt\ \{)
+target_compile_definitions(
+  ${FMT_LIBRARY}
+  PUBLIC
+  FMT_END_NAMESPACE=\}\})
 
 # json library always included in the build
 set(JSON_BuildTests OFF)

--- a/cmake/load_bundled_libraries.cmake
+++ b/cmake/load_bundled_libraries.cmake
@@ -22,6 +22,7 @@ add_subdirectory(${PROJECT_LIB_DIR}/CLI)
 # fmt always included in the build
 set(FMT_LIBRARY fmt)
 add_subdirectory(${PROJECT_LIB_DIR}/fmt)
+target_compile_definitions(${FMT_LIBRARY} PUBLIC FMT_INLINE_NAMESPACE_NAME=vt)
 
 # json library always included in the build
 set(JSON_BuildTests OFF)

--- a/cmake/load_bundled_libraries.cmake
+++ b/cmake/load_bundled_libraries.cmake
@@ -22,14 +22,6 @@ add_subdirectory(${PROJECT_LIB_DIR}/CLI)
 # fmt always included in the build
 set(FMT_LIBRARY fmt)
 add_subdirectory(${PROJECT_LIB_DIR}/fmt)
-target_compile_definitions(
-  ${FMT_LIBRARY}
-  PUBLIC
-  FMT_BEGIN_NAMESPACE=namespace\ fmt\ \{\ inline\ namespace\ vt\ \{)
-target_compile_definitions(
-  ${FMT_LIBRARY}
-  PUBLIC
-  FMT_END_NAMESPACE=\}\})
 
 # json library always included in the build
 set(JSON_BuildTests OFF)

--- a/lib/fmt/include/fmt/core.h
+++ b/lib/fmt/include/fmt/core.h
@@ -187,6 +187,10 @@
 #  endif
 #endif
 
+#ifndef FMT_INLINE_NAMESPACE_NAME
+#  define FMT_INLINE_NAMESPACE_NAME v7
+#endif
+
 #ifndef FMT_BEGIN_NAMESPACE
 #  if FMT_USE_INLINE_NAMESPACES
 #    define FMT_INLINE_NAMESPACE inline namespace
@@ -195,14 +199,14 @@
       }
 #  else
 #    define FMT_INLINE_NAMESPACE namespace
-#    define FMT_END_NAMESPACE \
-      }                       \
-      using namespace v7;     \
+#    define FMT_END_NAMESPACE                    \
+      }                                          \
+      using namespace FMT_INLINE_NAMESPACE_NAME; \
       }
 #  endif
 #  define FMT_BEGIN_NAMESPACE \
     namespace fmt {           \
-    FMT_INLINE_NAMESPACE v7 {
+    FMT_INLINE_NAMESPACE FMT_INLINE_NAMESPACE_NAME {
 #endif
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
@@ -500,7 +504,7 @@ constexpr basic_string_view<typename S::char_type> to_string_view(const S& s) {
 
 namespace detail {
 void to_string_view(...);
-using fmt::v7::to_string_view;
+using fmt::FMT_INLINE_NAMESPACE_NAME::to_string_view;
 
 // Specifies whether S is a string type convertible to fmt::basic_string_view.
 // It should be a constexpr function but MSVC 2017 fails to compile it in

--- a/lib/fmt/include/fmt/core.h
+++ b/lib/fmt/include/fmt/core.h
@@ -187,10 +187,6 @@
 #  endif
 #endif
 
-#ifndef FMT_INLINE_NAMESPACE_NAME
-#  define FMT_INLINE_NAMESPACE_NAME v7
-#endif
-
 #ifndef FMT_BEGIN_NAMESPACE
 #  if FMT_USE_INLINE_NAMESPACES
 #    define FMT_INLINE_NAMESPACE inline namespace
@@ -199,14 +195,14 @@
       }
 #  else
 #    define FMT_INLINE_NAMESPACE namespace
-#    define FMT_END_NAMESPACE                    \
-      }                                          \
-      using namespace FMT_INLINE_NAMESPACE_NAME; \
+#    define FMT_END_NAMESPACE \
+      }                       \
+      using namespace v7;     \
       }
 #  endif
 #  define FMT_BEGIN_NAMESPACE \
     namespace fmt {           \
-    FMT_INLINE_NAMESPACE FMT_INLINE_NAMESPACE_NAME {
+    FMT_INLINE_NAMESPACE v7 {
 #endif
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
@@ -504,7 +500,7 @@ constexpr basic_string_view<typename S::char_type> to_string_view(const S& s) {
 
 namespace detail {
 void to_string_view(...);
-using fmt::FMT_INLINE_NAMESPACE_NAME::to_string_view;
+using fmt::to_string_view;
 
 // Specifies whether S is a string type convertible to fmt::basic_string_view.
 // It should be a constexpr function but MSVC 2017 fails to compile it in

--- a/lib/fmt/include/fmt/core.h
+++ b/lib/fmt/include/fmt/core.h
@@ -197,12 +197,12 @@
 #    define FMT_INLINE_NAMESPACE namespace
 #    define FMT_END_NAMESPACE \
       }                       \
-      using namespace v7;     \
+      using namespace vt;     \
       }
 #  endif
 #  define FMT_BEGIN_NAMESPACE \
     namespace fmt {           \
-    FMT_INLINE_NAMESPACE v7 {
+    FMT_INLINE_NAMESPACE vt {
 #endif
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)

--- a/src/vt/elm/elm_id.h
+++ b/src/vt/elm/elm_id.h
@@ -100,7 +100,7 @@ namespace fmt {
 
 /// Custom fmt formatter/print for \c vt::elm::ElementIDStruct
 template <>
-struct formatter<vt::elm::ElementIDStruct> {
+struct formatter<::vt::elm::ElementIDStruct> {
   /// Presentation format:
   ///  - 'x' - hex (default)
   ///  - 'd' - decimal
@@ -127,7 +127,7 @@ struct formatter<vt::elm::ElementIDStruct> {
   /// Formats the epoch using the parsed format specification (presentation)
   /// stored in this formatter.
   template <typename FormatContext>
-  auto format(vt::elm::ElementIDStruct const& e, FormatContext& ctx) {
+  auto format(::vt::elm::ElementIDStruct const& e, FormatContext& ctx) {
     std::string id_format =
       presentation == 'b' ? "{:b}" : (presentation == 'd' ? "{:d}" : "{:x}");
     auto fmt_str = "(" + id_format + ",{},{},{})";

--- a/src/vt/epoch/epoch_type.h
+++ b/src/vt/epoch/epoch_type.h
@@ -114,7 +114,7 @@ namespace fmt {
 
 /// Custom fmt formatter/print for \c EpochType
 template <>
-struct formatter<vt::epoch::EpochType> {
+struct formatter<::vt::epoch::EpochType> {
   /// Presentation format:
   ///  - 'x' - hex (default)
   ///  - 'd' - decimal
@@ -141,7 +141,7 @@ struct formatter<vt::epoch::EpochType> {
   /// Formats the epoch using the parsed format specification (presentation)
   /// stored in this formatter.
   template <typename FormatContext>
-  auto format(vt::epoch::EpochType const& e, FormatContext& ctx) {
+  auto format(::vt::epoch::EpochType const& e, FormatContext& ctx) {
     return format_to(
       ctx.out(),
       presentation == 'b' ? "{:b}" : (presentation == 'd' ? "{:d}" : "{:x}"),


### PR DESCRIPTION
Fixes #1605 

---

`fmt` has macros `FMT_BEGIN_NAMESPACE` and `FMT_END_NAMESPACE`, but unfortunately, internally it explicitly uses full namespace (in core.h):

```cpp
namespace detail {
void to_string_view(...);
using fmt::v7::to_string_view;
...
```

To use it, we would have to hardcode our namespace anyway.

To solve this I extracted this "inner" namespace into an additional macro, so it could be simply defined in cmake.

---

I opened an issue in fmt repo regarding this problem
fmtlib/fmt#2642

---

### Everything above is no longer valid. fmt team remove qualifying by inline namespace from `core.h`.

I copied their fix into our `fmt/core.h` and define `FMT_BEGIN_NAMESPACE` and `FMT_END_NAMESPACE`.