### PR TITLE
#1643: Fix EMPIRE compilation error - method is untested within vt

### DIFF
--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2098,7 +2098,7 @@ template <typename ColT, typename IndexT>
 std::set<IndexT> CollectionManager::getLocalIndices(
   CollectionProxyWrapType<ColT> proxy
 ) {
-  auto elm_holder = findElmHolder<IndexT>(proxy);
+  auto elm_holder = findElmHolder<IndexT>(proxy.getProxy());
   std::set<IndexT> local;
   elm_holder->foreach([&](IndexT const& idx, Indexable<IndexT>*) {
     local.insert(idx);


### PR DESCRIPTION
Fixes #1643