### PR TITLE
#1557 asan openmp suppression

### DIFF
--- a/cmake-modules/SetCXXCompilerFlags.cmake
+++ b/cmake-modules/SetCXXCompilerFlags.cmake
@@ -23,7 +23,7 @@ elseif (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
 endif ()
 
 if (vt_asan_enabled)
-  list(APPEND TARGET_PUBLIC_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer)
+  list(APPEND TARGET_PUBLIC_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls)
 endif()
 
 if (vt_ubsan_enabled)

--- a/cmake/load_bundled_libraries.cmake
+++ b/cmake/load_bundled_libraries.cmake
@@ -52,7 +52,7 @@ if (vt_asan_enabled)
   if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR
       CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
       CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    message(STATUS "Building with address sanitizer enabled")
+    message(STATUS "Building VT with AddressSanitizer enabled")
   endif()
 endif()
 
@@ -60,7 +60,7 @@ if (vt_ubsan_enabled)
   if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR
       CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
       CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    message(STATUS "Building with undefined behavior sanitizer enabled")
+    message(STATUS "Building VT with UndefinedBehaviorSanitizer enabled")
   else()
     message(SEND_ERROR "Cannot use UBSan without clang or gcc >= 4.8")
   endif()

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -1,1 +1,2 @@
 leak:MPIDI_CH3U_Receive_data_unexpected
+leak:libmpi.so


### PR DESCRIPTION
Fixes #1557 

---

BTW, I still get tons of reports like this one:
```
1: Indirect leak of 15 byte(s) in 1 object(s) allocated from:
1:     #0 0x7f0b3a5539f7 in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:454
1:     #1 0x7f0b34e5c171  (<unknown module>)
```

Did anyone have similar problem with unknown module, and maybe found a solution?