### PR TITLE
#1443 Make the scheduler loop exception-safe

### DIFF
--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -116,6 +116,14 @@ struct Scheduler : runtime::component::Component<Scheduler> {
   using EventTriggerContType = std::vector<TriggerContainerType>;
   using RunnablePtrType      = std::unique_ptr<runnable::RunnableNew>;
 
+  struct SchedulerLoopGuard {
+    SchedulerLoopGuard(Scheduler* scheduler);
+    ~SchedulerLoopGuard();
+
+  private:
+    Scheduler* scheduler_ = nullptr;
+  };
+
 # if vt_check_enabled(priorities)
   using UnitType             = PriorityUnit;
 # else


### PR DESCRIPTION
Fixes #1443 

---

In the end, I decided to take a "RAII" approach. I think it will be easier to (if ever necessary) add new functionalities for loop start and loop end this way, than remembering to also change try-catch block.