### PR TITLE
1495: fix Alpine build

### DIFF
--- a/ci/deps/libunwind.sh
+++ b/ci/deps/libunwind.sh
@@ -24,7 +24,8 @@ cd ${libunwind_name}
 ./configure \
     --enable-static \
     --enable-shared \
-    --enable-setjmp=no
+    --enable-setjmp=no \
+    --prefix=`/usr/lib/x86_64-linux-gnu/`
 make
 make install
 cd -

--- a/ci/deps/libunwind.sh
+++ b/ci/deps/libunwind.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+if test $# -lt 1
+then
+    echo "usage: ./$0 <libunwind-version>"
+    exit 1
+fi
+
+libunwind_version=$1
+libunwind_name="libunwind-${libunwind_version}"
+libunwind_tar_name=${libunwind_name}.tar.gz
+
+echo "${libunwind_version}"
+echo "${libunwind_name}"
+echo "${libunwind_tar_name}"
+
+wget https://github.com/libunwind/libunwind/releases/download/v${libunwind_version}/${libunwind_tar_name}
+
+tar xzf ${libunwind_tar_name}
+rm ${libunwind_tar_name}
+cd ${libunwind_name}
+./configure \
+    --enable-static \
+    --enable-shared \
+    --enable-setjmp=no
+make
+make install
+cd -
+rm -rf ${libunwind_name}

--- a/ci/docker/alpine-cpp.dockerfile
+++ b/ci/docker/alpine-cpp.dockerfile
@@ -47,8 +47,7 @@ ENV CC=clang \
 COPY ./ci/deps/mpich.sh mpich.sh
 RUN ./mpich.sh 3.3.2 -j4
 
-ENV CMAKE_EXE_LINKER_FLAGS="-lexecinfo" \
-    CC=mpicc \
+ENV CC=mpicc \
     CXX=mpicxx \
     PATH=/usr/lib/ccache/:$PATH
 

--- a/ci/docker/alpine-cpp.dockerfile
+++ b/ci/docker/alpine-cpp.dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
         cmake \
         dpkg \
         libdwarf-dev \
-        libexecinfo-dev \
+        libunwind-dev \
         libtool \
         linux-headers \
         m4 \

--- a/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -y -q && \
     make-guile \
     libomp5 \
     libomp-dev \
-    libunwind-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -36,6 +35,9 @@ RUN ln -s \
 
 ENV CC=${compiler} \
     CXX=clang++
+
+COPY ./ci/deps/libunwind.sh libunwind.sh
+RUN ./libunwind.sh 1.6.2
 
 COPY ./ci/deps/cmake.sh cmake.sh
 RUN ./cmake.sh 3.18.4

--- a/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-clang-cpp.dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y -q && \
     make-guile \
     libomp5 \
     libomp-dev \
+    libunwind-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-gnu-cpp.dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -y -q && \
     valgrind \
     make-guile \
     libomp5 \
+    libunwind-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/ubuntu-18.04-intel-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-intel-cpp.dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -y -q && \
     valgrind \
     make-guile \
     libomp5 \
+    libunwind-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/ubuntu-18.04-intel-oneapi-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-intel-oneapi-cpp.dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -y -q && \
     valgrind \
     make-guile \
     libomp5 \
+    libunwind-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/ubuntu-18.04-nvidia-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-nvidia-cpp.dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y -q && \
     gnupg \
     make-guile \
     libomp5 \
+    libunwind-dev \
     valgrind \
     ccache && \
     apt-get clean && \

--- a/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y -q && \
     make-guile \
     libomp5 \
     libomp-dev \
+    libunwind-dev \
     llvm-10 \
     ccache && \
     apt-get clean && \

--- a/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-clang-cpp.dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -y -q && \
     make-guile \
     libomp5 \
     libomp-dev \
-    libunwind-dev \
     llvm-10 \
     ccache && \
     apt-get clean && \
@@ -37,6 +36,9 @@ RUN ln -s \
 
 ENV CC=${compiler} \
     CXX=clang++
+
+COPY ./ci/deps/libunwind.sh libunwind.sh
+RUN ./libunwind.sh 1.6.2
 
 COPY ./ci/deps/cmake.sh cmake.sh
 RUN ./cmake.sh 3.18.4

--- a/ci/docker/ubuntu-20.04-gnu-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-gnu-cpp.dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -y -q && \
     valgrind \
     make-guile \
     libomp5 \
+    libunwind-dev \
     ccache && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/ubuntu-20.04-gnu-openmpi-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-gnu-openmpi-cpp.dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -y -q && \
     valgrind \
     make-guile \
     libomp5 \
+    libunwind-dev \
     ccache \
     python3 \
     ssh && \

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -24,6 +24,7 @@ function(link_target_with_vt)
     LINK_ATOMIC
     LINK_MPI
     LINK_FMT
+    LINK_UNWIND
     LINK_ENG_FORMAT
     LINK_ZLIB
     LINK_FCONTEXT
@@ -94,9 +95,15 @@ function(link_target_with_vt)
     target_link_libraries(${ARG_TARGET} PRIVATE gtest)
   endif()
 
-  # FIXME! do the usual ARG_LINK_UNWIND here
-  if (NOT DEFINED APPLE)
-    target_link_libraries(${ARG_TARGET} PRIVATE unwind)
+  if (NOT DEFINED ARG_LINK_UNWIND AND ${ARG_DEFAULT_LINK_SET} OR ARG_LINK_UNWIND)
+    if (${ARG_DEBUG_LINK})
+      message(STATUS "link_target_with_vt: unwind=${ARG_LINK_UNWIND}")
+    endif()
+    if (NOT DEFINED APPLE)
+      target_link_libraries(
+        ${ARG_TARGET} PUBLIC ${ARG_BUILD_TYPE} unwind
+      )
+    endif()
   endif()
 
   if (NOT ARG_LINK_VT_LIB)

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -94,7 +94,10 @@ function(link_target_with_vt)
     target_link_libraries(${ARG_TARGET} PRIVATE gtest)
   endif()
 
-  target_link_libraries(${ARG_TARGET} PRIVATE unwind)
+  # FIXME! do the usual ARG_LINK_UNWIND here
+  if (NOT DEFINED APPLE)
+    target_link_libraries(${ARG_TARGET} PRIVATE unwind)
+  endif()
 
   if (NOT ARG_LINK_VT_LIB)
     # Unconditionally link the VT library for this target unless linking the VT

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -94,6 +94,8 @@ function(link_target_with_vt)
     target_link_libraries(${ARG_TARGET} PRIVATE gtest)
   endif()
 
+  target_link_libraries(${ARG_TARGET} PRIVATE unwind)
+
   if (NOT ARG_LINK_VT_LIB)
     # Unconditionally link the VT library for this target unless linking the VT
     # library itself itself

--- a/src/vt/configs/error/stack_out.cc
+++ b/src/vt/configs/error/stack_out.cc
@@ -67,9 +67,8 @@ DumpStackType dumpStack(int skip) {
   }
 
   // Unwind frames one by one, going up the frame stack.
-  int i = 0;
   do {
-    if (i++ < skip) {
+    if (skip-- > 0) {
       continue;
     }
 

--- a/src/vt/configs/error/stack_out.cc
+++ b/src/vt/configs/error/stack_out.cc
@@ -53,7 +53,7 @@
 namespace vt { namespace debug { namespace stack {
 
 DumpStackType dumpStack(int skip) {
-  StackVectorType stack;
+  DumpStackType stack;
 
   unw_cursor_t cursor;
   unw_context_t context;
@@ -103,11 +103,10 @@ DumpStackType dumpStack(int skip) {
   }
   while (unw_step(&cursor) > 0);
 
-  // FIXME! - is "truncated" backup still necessary?
-  return std::make_tuple("",stack);
+  return stack;
 }
 
-std::string prettyPrintStack(StackVectorType const& stack) {
+std::string prettyPrintStack(DumpStackType const& stack) {
   auto green      = ::vt::debug::green();
   auto bred       = ::vt::debug::bred();
   auto reset      = ::vt::debug::reset();

--- a/src/vt/configs/error/stack_out.cc
+++ b/src/vt/configs/error/stack_out.cc
@@ -48,7 +48,6 @@
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #include <cxxabi.h>
-#include <tuple>
 
 namespace vt { namespace debug { namespace stack {
 

--- a/src/vt/configs/error/stack_out.cc
+++ b/src/vt/configs/error/stack_out.cc
@@ -45,6 +45,7 @@
 #include "vt/configs/debug/debug_colorize.h"
 #include "vt/context/context.h"
 
+#include <fmt/core.h>
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #include <cxxabi.h>
@@ -58,8 +59,12 @@ DumpStackType dumpStack(int skip) {
   unw_context_t context;
 
   // Initialize cursor to current frame for local unwinding.
-  unw_getcontext(&context);
-  unw_init_local(&cursor, &context);
+  if (unw_getcontext(&context) != 0) {
+    fmt::print("unw_getcontext failed");
+  }
+  if (unw_init_local(&cursor, &context) != 0) {
+    fmt::print("unw_init_local failed");
+  }
 
   // Unwind frames one by one, going up the frame stack.
   int i = 0;
@@ -69,7 +74,9 @@ DumpStackType dumpStack(int skip) {
     }
 
     unw_word_t offset, pc;
-    unw_get_reg(&cursor, UNW_REG_IP, &pc);
+    if (unw_get_reg(&cursor, UNW_REG_IP, &pc) != 0) {
+      fmt::print("unw_get_reg failed");
+    }
     if (pc == 0) {
       break;
     }
@@ -91,7 +98,7 @@ DumpStackType dumpStack(int skip) {
       std::free(demangled);
     } else {
       // FIXME!
-      std::printf(" -- error: unable to obtain symbol name for this frame\n");
+      fmt::print(" -- error: unable to obtain symbol name for this frame\n");
     }
   }
   while (unw_step(&cursor) > 0);

--- a/src/vt/configs/error/stack_out.h
+++ b/src/vt/configs/error/stack_out.h
@@ -47,14 +47,11 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
-#include <tuple>
-#include <string>
 
 namespace vt { namespace debug { namespace stack {
 
-using StackTupleType  = std::tuple<int32_t, uint64_t, std::string, std::size_t>;
-using StackVectorType = std::vector<StackTupleType>;
-using DumpStackType = std::tuple<std::string, StackVectorType>;
+using StackTupleType  = std::tuple<int32_t,uint64_t,std::string,std::size_t>;
+using DumpStackType   = std::vector<StackTupleType>;
 
 /*
  * This function automatically produce a backtrace of the stack with demangled
@@ -62,7 +59,7 @@ using DumpStackType = std::tuple<std::string, StackVectorType>;
  */
 DumpStackType dumpStack(int skip = 0);
 
-std::string prettyPrintStack(StackVectorType const& stack);
+std::string prettyPrintStack(DumpStackType const& stack);
 
 }}} /* end namespace vt::debug::stack */
 

--- a/src/vt/configs/error/stack_out.h
+++ b/src/vt/configs/error/stack_out.h
@@ -45,13 +45,14 @@
 #define INCLUDED_VT_CONFIGS_ERROR_STACK_OUT_H
 
 #include <cstdlib>
+#include <string>
 #include <vector>
 #include <tuple>
 #include <string>
 
 namespace vt { namespace debug { namespace stack {
 
-using StackTupleType = std::tuple<int32_t, void *, std::string, std::size_t>;
+using StackTupleType  = std::tuple<int32_t, uint64_t, std::string, std::size_t>;
 using StackVectorType = std::vector<StackTupleType>;
 using DumpStackType = std::tuple<std::string, StackVectorType>;
 

--- a/src/vt/configs/error/stack_out.h
+++ b/src/vt/configs/error/stack_out.h
@@ -46,6 +46,7 @@
 
 #include <cstdlib>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace vt { namespace debug { namespace stack {
@@ -54,7 +55,7 @@ using StackTupleType  = std::tuple<int32_t,uint64_t,std::string,std::size_t>;
 using DumpStackType   = std::vector<StackTupleType>;
 
 /*
- * This function automatically produce a backtrace of the stack with demangled
+ * This function automatically produces a backtrace of the stack with demangled
  * function names and method name.
  */
 DumpStackType dumpStack(int skip = 0);

--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -276,7 +276,7 @@ void Runtime::pauseForDebugger() {
 # endif
   if (Runtime::nodeStackWrite()) {
     auto stack = debug::stack::dumpStack();
-    auto stack_pretty = debug::stack::prettyPrintStack(std::get<1>(stack));
+    auto stack_pretty = debug::stack::prettyPrintStack(stack);
     if (vt::theConfig()->vt_stack_file != "") {
       Runtime::writeToFile(stack_pretty);
     } else {
@@ -602,7 +602,7 @@ void Runtime::output(
     if (dump) {
       if (Runtime::nodeStackWrite()) {
         auto stack = debug::stack::dumpStack();
-        auto stack_pretty = debug::stack::prettyPrintStack(std::get<1>(stack));
+        auto stack_pretty = debug::stack::prettyPrintStack(stack);
         if (theConfig()->vt_stack_file != "") {
           Runtime::writeToFile(stack_pretty);
         } else {

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -61,7 +61,6 @@ TEST_F(TestStackDumping, find_function_names) {
   EXPECT_NE(stack_pretty.find("Dump Stack Backtrace"), std::string::npos);
   EXPECT_NE(stack_pretty.find("vt::debug::stack::dumpStack"), std::string::npos);
   EXPECT_NE(stack_pretty.find("vt::tests::unit::TestStackDumping"), std::string::npos);
-  EXPECT_NE(stack_pretty.find("main"), std::string::npos);
 }
 
 TEST_F(TestStackDumping, skip_first_function) {
@@ -73,7 +72,6 @@ TEST_F(TestStackDumping, skip_first_function) {
   EXPECT_NE(stack_pretty.find("Dump Stack Backtrace"), std::string::npos);
   EXPECT_EQ(stack_pretty.find("vt::debug::stack::dumpStack"), std::string::npos);
   EXPECT_NE(stack_pretty.find("vt::tests::unit::TestStackDumping"), std::string::npos);
-  EXPECT_NE(stack_pretty.find("main"), std::string::npos);
 }
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -45,7 +45,6 @@
 #include <gtest/gtest.h>
 
 #include "test_parallel_harness.h"
-#include "vt/configs/error/pretty_print_stack.h"
 #include "vt/configs/error/stack_out.h"
 
 namespace vt { namespace tests { namespace unit {

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -54,7 +54,7 @@ struct TestStackDumping : TestParallelHarness {};
 
 TEST_F(TestStackDumping, find_function_names) {
   auto stack = debug::stack::dumpStack();
-  auto stack_pretty = debug::stack::prettyPrintStack(std::get<1>(stack));
+  auto stack_pretty = debug::stack::prettyPrintStack(stack);
 
   fmt::print("{}", stack_pretty);
 
@@ -65,7 +65,7 @@ TEST_F(TestStackDumping, find_function_names) {
 
 TEST_F(TestStackDumping, skip_first_function) {
   auto stack = debug::stack::dumpStack(1);
-  auto stack_pretty = debug::stack::prettyPrintStack(std::get<1>(stack));
+  auto stack_pretty = debug::stack::prettyPrintStack(stack);
 
   fmt::print("{}", stack_pretty);
 

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -64,4 +64,16 @@ TEST_F(TestStackDumping, find_function_names) {
   EXPECT_NE(stack_pretty.find("main"), std::string::npos);
 }
 
+TEST_F(TestStackDumping, skip_first_function) {
+  auto stack = debug::stack::dumpStack(1);
+  auto stack_pretty = debug::stack::prettyPrintStack(std::get<1>(stack));
+
+  fmt::print("{}", stack_pretty);
+
+  EXPECT_NE(stack_pretty.find("Dump Stack Backtrace"), std::string::npos);
+  EXPECT_EQ(stack_pretty.find("vt::debug::stack::dumpStack"), std::string::npos);
+  EXPECT_NE(stack_pretty.find("vt::tests::unit::TestStackDumping"), std::string::npos);
+  EXPECT_NE(stack_pretty.find("main"), std::string::npos);
+}
+
 }}} // end namespace vt::tests::unit

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -1,0 +1,67 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                            test_stack_dumping.cc
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "vt/configs/error/pretty_print_stack.h"
+#include "vt/configs/error/stack_out.h"
+
+namespace vt { namespace tests { namespace unit {
+
+struct TestStackDumping : TestParallelHarness {};
+
+TEST_F(TestStackDumping, find_function_names) {
+  auto stack = debug::stack::dumpStack();
+  auto stack_pretty = debug::stack::prettyPrintStack(std::get<1>(stack));
+
+  fmt::print("{}", stack_pretty);
+
+  EXPECT_NE(stack_pretty.find("Dump Stack Backtrace"), std::string::npos);
+  EXPECT_NE(stack_pretty.find("vt::debug::stack::dumpStack"), std::string::npos);
+  EXPECT_NE(stack_pretty.find("vt::tests::unit::TestStackDumping"), std::string::npos);
+  EXPECT_NE(stack_pretty.find("main"), std::string::npos);
+}
+
+}}} // end namespace vt::tests::unit


### PR DESCRIPTION
fixes #1495

Fixes the stack dumping issues with Alpine build by replacing `libexecinfo` with `libunwind`.
Does a minor cleanup of our backtrace-generating code as well.

---
~cc52339 is the simplest workaround to the failing test - it just disables stack printing. I will try to come up with an actual fix.~
~Confirmed that it works with:~
```
ctest --output-on-failure --repeat-until-fail 100 -R TestMpiAccessGuardDeathTest.test_mpi_access_prevented_proc_2
```
~(unfixed version crashes every couple of runs).~