### PR TITLE
1533: Fix typo in MPI access guard error message

### DIFF
--- a/src/vt/pmpi/generate_mpi_wrappers.pl
+++ b/src/vt/pmpi/generate_mpi_wrappers.pl
@@ -256,7 +256,7 @@ sub emit_guard {
   vtAbortIf (
     not vt::runtime::ScopedMPIAccess::mpiCallsAllowed(),
     "The MPI function '$name' was called from a VT handler."
-    " MPI functions should not used inside user code invoked from VT handlers."
+    " MPI functions should not be used inside user code invoked from VT handlers."
   );
 MPI_GUARD
 }

--- a/tests/unit/runtime/test_mpi_access_guards.cc
+++ b/tests/unit/runtime/test_mpi_access_guards.cc
@@ -75,7 +75,7 @@ static void attempt_mpi_access() {
 static void message_handler(DummyMsg* msg) {
   if (expected_to_fail_on_mpi_access) {
     ASSERT_THROW(attempt_mpi_access(), std::runtime_error) <<
-      "MPI functions should not used inside user code invoked from VT handlers";
+      "MPI functions should not be used inside user code invoked from VT handlers";
   } else {
     attempt_mpi_access();
     SUCCEED();


### PR DESCRIPTION
Fixes #1533