### PR TITLE
1699: Update `.clang-format` syntax

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,9 +4,9 @@ UseTab: Never
 
 AccessModifierOffset: -2
 AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: None
 AlignEscapedNewlines: Left
 AlignOperands: false
 AlignTrailingComments: true
@@ -69,7 +69,7 @@ NamespaceIndentation: None
 PenaltyReturnTypeOnItsOwnLine: 100
 PointerAlignment: Left
 ReflowComments: false
-SortIncludes: false
+SortIncludes: Never
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false

--- a/.clang-format
+++ b/.clang-format
@@ -60,7 +60,7 @@ FixNamespaceComments: true
 IncludeBlocks: Preserve
 IndentCaseLabels: false
 IndentGotoLabels: false
-IndentPPDirectives: PPDIS_None
+IndentPPDirectives: None
 IndentWidth: 2
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -1,6 +1,8 @@
 #!/bin/sh
 #
-# Apply formatting style defined in .clang-format on committed changes.
+# An example hook script to apply formatting style defined in .clang-format
+# on committed changes. Copy this to `.git/hooks/` to have it run after
+# every commit.
 # Prints the resulting changes if there are any.
 
 output=$(git clang-format HEAD~1)

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Apply formatting style defined in .clang-format on committed changes.
+# Prints the resulting changes if there are any.
+
+output=$(git clang-format HEAD~1)
+
+if [ "$output" != "" ]
+then
+    git diff
+fi


### PR DESCRIPTION
- Update .clang-format to match Clang 13 syntax.
- Add post-commit hook to format modified code
  - requires `git clang-format` plugin
  - post-commit works better for me, but this could be easily adapted to pre-commit as well

fixes #1699 