### PR TITLE
1708 Subdirectory creation for checkpointing fails on empty rank

### DIFF
--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2083,8 +2083,14 @@ std::string CollectionManager::makeMetaFilename(
   auto this_node = theContext()->getNode();
   if (make_sub_dirs) {
 
+    int flag = 0;
+    flag = mkdir(file_base.c_str(), S_IRWXU);
+    if (flag < 0 && errno != EEXIST) {
+      throw std::runtime_error("Failed to create directory: " + file_base);
+    }
+
     auto subdir = fmt::format("{}/directory-{}", file_base, this_node);
-    int flag = mkdir(subdir.c_str(), S_IRWXU);
+    flag = mkdir(subdir.c_str(), S_IRWXU);
     if (flag < 0 && errno != EEXIST) {
       throw std::runtime_error("Failed to create directory: " + subdir);
     }


### PR DESCRIPTION
This PR does not include a test, but it has been tested in a DARMA-based application. #1709 will provide appropriate testing once completed.

Fixes #1708 
