### PR TITLE
1723 Include user-defined fields in json LB data files

### DIFF
--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -161,7 +161,7 @@ void ActiveMessenger::startup() {
   // Hook to collect LB data about objgroups
   thePhase()->registerHookCollective(phase::PhaseHook::End, [this]{
     theNodeLBData()->addNodeLBData(
-      bare_handler_dummy_elm_id_for_lb_data_, &bare_handler_lb_data_
+      bare_handler_dummy_elm_id_for_lb_data_, &bare_handler_lb_data_, nullptr
     );
   });
 #endif

--- a/src/vt/objgroup/manager.cc
+++ b/src/vt/objgroup/manager.cc
@@ -68,7 +68,7 @@ void ObjGroupManager::startup() {
         auto proxy = elm::ElmIDBits::getObjGroupProxy(elm_id.id, false);
         vtAssertExpr(proxy == obj.first);
         theNodeLBData()->registerObjGroupInfo(elm_id, obj.first);
-        theNodeLBData()->addNodeLBData(elm_id, &holder->getLBData());
+        theNodeLBData()->addNodeLBData(elm_id, &holder->getLBData(), nullptr);
       }
     }
   });

--- a/src/vt/vrt/collection/balance/col_lb_data.impl.h
+++ b/src/vt/vrt/collection/balance/col_lb_data.impl.h
@@ -74,7 +74,7 @@ void CollectionLBData::syncNextPhase(CollectStatsMsg<ColT>* msg, ColT* col) {
 
   auto const proxy = col->getProxy();
   auto const subphase = getFocusedSubPhase(proxy);
-  theNodeLBData()->addNodeLBData(col->elm_id_, &col->lb_data_, subphase);
+  theNodeLBData()->addNodeLBData(col->elm_id_, &col->lb_data_, col, subphase);
 
   std::vector<uint64_t> idx;
   for (index::NumDimensionsType i = 0; i < col->getIndex().ndims(); i++) {

--- a/src/vt/vrt/collection/balance/lb_data_holder.cc
+++ b/src/vt/vrt/collection/balance/lb_data_holder.cc
@@ -82,6 +82,12 @@ std::unique_ptr<nlohmann::json> LBDataHolder::toJson(PhaseType phase) const {
       j["tasks"][i]["resource"] = "cpu";
       j["tasks"][i]["node"] = theContext()->getNode();
       j["tasks"][i]["time"] = time;
+      if (user_defined_json_.find(phase) != user_defined_json_.end()) {
+        auto user_def_phase = user_defined_json_.at(phase);
+        if (user_def_phase.find(id) != user_def_phase.end()) {
+          j["tasks"][i]["user_defined"] = user_def_phase.at(id);
+        }
+      }
       outputEntity(j["tasks"][i]["entity"], id);
 
       auto const& subphase_times = elm.second.subphase_loads;

--- a/src/vt/vrt/collection/balance/lb_data_holder.cc
+++ b/src/vt/vrt/collection/balance/lb_data_holder.cc
@@ -83,9 +83,12 @@ std::unique_ptr<nlohmann::json> LBDataHolder::toJson(PhaseType phase) const {
       j["tasks"][i]["node"] = theContext()->getNode();
       j["tasks"][i]["time"] = time;
       if (user_defined_json_.find(phase) != user_defined_json_.end()) {
-        auto user_def_phase = user_defined_json_.at(phase);
-        if (user_def_phase.find(id) != user_def_phase.end()) {
-          j["tasks"][i]["user_defined"] = user_def_phase.at(id);
+        auto user_def_this_phase = user_defined_json_.at(phase);
+        if (user_def_this_phase.find(id) != user_def_this_phase.end()) {
+          auto &user_def = user_def_this_phase.at(id);
+          if (!user_def.empty()) {
+            j["tasks"][i]["user_defined"] = user_def;
+          }
         }
       }
       outputEntity(j["tasks"][i]["entity"], id);

--- a/src/vt/vrt/collection/balance/lb_data_holder.cc
+++ b/src/vt/vrt/collection/balance/lb_data_holder.cc
@@ -83,11 +83,11 @@ std::unique_ptr<nlohmann::json> LBDataHolder::toJson(PhaseType phase) const {
       j["tasks"][i]["node"] = theContext()->getNode();
       j["tasks"][i]["time"] = time;
       if (user_defined_json_.find(phase) != user_defined_json_.end()) {
-        auto user_def_this_phase = user_defined_json_.at(phase);
+        auto &user_def_this_phase = user_defined_json_.at(phase);
         if (user_def_this_phase.find(id) != user_def_this_phase.end()) {
           auto &user_def = user_def_this_phase.at(id);
-          if (!user_def.empty()) {
-            j["tasks"][i]["user_defined"] = user_def;
+          if (!user_def->empty()) {
+            j["tasks"][i]["user_defined"] = *user_def;
           }
         }
       }

--- a/src/vt/vrt/collection/balance/lb_data_holder.h
+++ b/src/vt/vrt/collection/balance/lb_data_holder.h
@@ -51,7 +51,7 @@
 #include <unordered_map>
 #include <memory>
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
@@ -111,7 +111,9 @@ public:
   /// Node communication graph for each subphase
   std::unordered_map<PhaseType, std::unordered_map<SubphaseType, CommMapType>> node_subphase_comm_;
   /// User-defined data from each phase
-  std::unordered_map<PhaseType, std::unordered_map<ElementIDStruct, nlohmann::json>> user_defined_json_;
+  std::unordered_map<PhaseType, std::unordered_map<
+    ElementIDStruct, std::shared_ptr<nlohmann::json>
+  >> user_defined_json_;
   /// Node indices for each ID along with the proxy ID
   std::unordered_map<ElementIDStruct, std::tuple<VirtualProxyType, std::vector<uint64_t>>> node_idx_;
   /// Map from id to objgroup proxy

--- a/src/vt/vrt/collection/balance/lb_data_holder.h
+++ b/src/vt/vrt/collection/balance/lb_data_holder.h
@@ -51,7 +51,7 @@
 #include <unordered_map>
 #include <memory>
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
@@ -76,6 +76,7 @@ struct LBDataHolder {
     s | node_data_;
     s | node_comm_;
     s | node_subphase_comm_;
+    s | user_defined_json_;
     s | node_idx_;
   }
 
@@ -109,6 +110,8 @@ public:
   std::unordered_map<PhaseType, CommMapType> node_comm_;
   /// Node communication graph for each subphase
   std::unordered_map<PhaseType, std::unordered_map<SubphaseType, CommMapType>> node_subphase_comm_;
+  /// User-defined data from each phase
+  std::unordered_map<PhaseType, std::unordered_map<ElementIDStruct, nlohmann::json>> user_defined_json_;
   /// Node indices for each ID along with the proxy ID
   std::unordered_map<ElementIDStruct, std::tuple<VirtualProxyType, std::vector<uint64_t>>> node_idx_;
   /// Map from id to objgroup proxy

--- a/src/vt/vrt/collection/balance/node_lb_data.cc
+++ b/src/vt/vrt/collection/balance/node_lb_data.cc
@@ -245,7 +245,8 @@ void NodeLBData::registerObjGroupInfo(
 }
 
 void NodeLBData::addNodeLBData(
-  ElementIDStruct id, elm::ElementLBData* in, SubphaseType focused_subphase
+  ElementIDStruct id, elm::ElementLBData* in, StorableType *storable,
+  SubphaseType focused_subphase
 ) {
   vt_debug_print(
     normal, lb,

--- a/src/vt/vrt/collection/balance/node_lb_data.cc
+++ b/src/vt/vrt/collection/balance/node_lb_data.cc
@@ -284,7 +284,7 @@ void NodeLBData::addNodeLBData(
   }
 
   if (storable) {
-    stats_->user_defined_json_[phase][id] = std::make_shared<nlohmann::json>(
+    lb_data_->user_defined_json_[phase][id] = std::make_shared<nlohmann::json>(
       storable->toJson()
     );
   }

--- a/src/vt/vrt/collection/balance/node_lb_data.cc
+++ b/src/vt/vrt/collection/balance/node_lb_data.cc
@@ -282,6 +282,10 @@ void NodeLBData::addNodeLBData(
     }
   }
 
+  if (storable) {
+    stats_->user_defined_json_[phase][id] = storable->toJson();
+  }
+
   in->updatePhase(1);
 
   auto model = theLBManager()->getLoadModel();

--- a/src/vt/vrt/collection/balance/node_lb_data.cc
+++ b/src/vt/vrt/collection/balance/node_lb_data.cc
@@ -56,6 +56,7 @@
 #include <unordered_map>
 #include <cstdio>
 #include <sys/stat.h>
+#include <memory>
 
 #include <fmt/core.h>
 
@@ -283,7 +284,9 @@ void NodeLBData::addNodeLBData(
   }
 
   if (storable) {
-    stats_->user_defined_json_[phase][id] = storable->toJson();
+    stats_->user_defined_json_[phase][id] = std::make_shared<nlohmann::json>(
+      storable->toJson()
+    );
   }
 
   in->updatePhase(1);

--- a/src/vt/vrt/collection/balance/node_lb_data.h
+++ b/src/vt/vrt/collection/balance/node_lb_data.h
@@ -55,6 +55,7 @@
 #include "vt/objgroup/proxy/proxy_objgroup.h"
 #include "vt/utils/json/base_appender.h"
 #include "vt/vrt/collection/balance/lb_data_holder.h"
+#include "vt/vrt/collection/types/storage/storable.h"
 
 #include <string>
 #include <unordered_map>
@@ -78,6 +79,7 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
  */
 struct NodeLBData : runtime::component::Component<NodeLBData> {
   using MigrateFnType       = std::function<void(NodeType)>;
+  using StorableType = vt::vrt::collection::storage::Storable;
 
   /**
    * \internal \brief System call to construct \c NodeLBData
@@ -131,7 +133,7 @@ public:
    * \param[in] focused_subphase the focused subphase (optional)
    */
   void addNodeLBData(
-    ElementIDStruct id, elm::ElementLBData* in,
+    ElementIDStruct id, elm::ElementLBData* in, StorableType *storable,
     SubphaseType focused_subphase = elm::ElementLBData::no_subphase
   );
 

--- a/src/vt/vrt/collection/types/storage/storable.cc
+++ b/src/vt/vrt/collection/types/storage/storable.cc
@@ -56,4 +56,14 @@ void Storable::valRemove(std::string const& str) {
   }
 }
 
+nlohmann::json Storable::toJson() {
+  nlohmann::json j;
+  for (auto iter = map_.begin(); iter != map_.end(); ++iter) {
+    if (iter->second->shouldJson()) {
+      j[iter->first] = iter->second->toJson();
+    }
+  }
+  return j;
+}
+
 }}}} /* end namespace vt::vrt::collection::storage */

--- a/src/vt/vrt/collection/types/storage/storable.h
+++ b/src/vt/vrt/collection/types/storage/storable.h
@@ -76,7 +76,17 @@ struct Storable {
    * \param[in] u the value
    */
   template <typename U>
-  void valInsert(std::string const& str, U&& u, bool dump_to_json = false);
+  void valInsert(std::string const& str, U&& u);
+
+  /**
+   * \brief Insert a new key/value pair
+   *
+   * \param[in] str the key
+   * \param[in] u the value
+   * \param[in] dump_to_json whether to include in json file
+   */
+  template <typename U>
+  void valInsert(std::string const& str, U&& u, bool dump_to_json);
 
   /**
    * \brief Get the value from a key

--- a/src/vt/vrt/collection/types/storage/storable.h
+++ b/src/vt/vrt/collection/types/storage/storable.h
@@ -76,7 +76,7 @@ struct Storable {
    * \param[in] u the value
    */
   template <typename U>
-  void valInsert(std::string const& str, U&& u);
+  void valInsert(std::string const& str, U&& u, bool dump_to_json = false);
 
   /**
    * \brief Get the value from a key

--- a/src/vt/vrt/collection/types/storage/storable.h
+++ b/src/vt/vrt/collection/types/storage/storable.h
@@ -114,6 +114,13 @@ struct Storable {
    */
   void valRemove(std::string const& str);
 
+  /**
+   * \brief Generate the json if applicable
+   *
+   * \return the json
+   */
+  nlohmann::json toJson();
+
 private:
   /// Map of type-erased, stored values
   std::unordered_map<std::string, std::unique_ptr<StoreElmBase>> map_;

--- a/src/vt/vrt/collection/types/storage/storable.impl.h
+++ b/src/vt/vrt/collection/types/storage/storable.impl.h
@@ -54,6 +54,19 @@ void Storable::serialize(SerializerT& s) {
 }
 
 template <typename U>
+void Storable::valInsert(std::string const& str, U&& u) {
+  map_.emplace(
+    std::piecewise_construct,
+    std::forward_as_tuple(str),
+    std::forward_as_tuple(
+      std::make_unique<StoreElm<typename std::decay<U>::type>>(
+        std::forward<U>(u)
+      )
+    )
+  );
+}
+
+template <typename U>
 void Storable::valInsert(std::string const& str, U&& u, bool dump_to_json) {
   map_.emplace(
     std::piecewise_construct,

--- a/src/vt/vrt/collection/types/storage/storable.impl.h
+++ b/src/vt/vrt/collection/types/storage/storable.impl.h
@@ -54,13 +54,13 @@ void Storable::serialize(SerializerT& s) {
 }
 
 template <typename U>
-void Storable::valInsert(std::string const& str, U&& u) {
+void Storable::valInsert(std::string const& str, U&& u, bool dump_to_json) {
   map_.emplace(
     std::piecewise_construct,
     std::forward_as_tuple(str),
     std::forward_as_tuple(
       std::make_unique<StoreElm<typename std::decay<U>::type>>(
-        std::forward<U>(u)
+        std::forward<U>(u), dump_to_json
       )
     )
   );

--- a/src/vt/vrt/collection/types/storage/store_elm.h
+++ b/src/vt/vrt/collection/types/storage/store_elm.h
@@ -46,6 +46,8 @@
 
 #include "vt/config.h"
 
+#include <nlohmann/json.hpp>
+
 #include <checkpoint/checkpoint.h>
 
 #include <type_traits>
@@ -72,6 +74,13 @@ struct StoreElmBase {
    * \return whether to dump
    */
   virtual bool shouldJson() const = 0;
+
+  /**
+   * \brief Generate the json if applicable
+   *
+   * \return the json
+   */
+  virtual nlohmann::json toJson() = 0;
 
   /**
    * \brief Get the value as \c T
@@ -184,6 +193,17 @@ struct StoreElm<
    * \return whether to dump
    */
   bool shouldJson() const { return dump_to_json_; }
+
+  /**
+   * \brief Generate the json if applicable
+   *
+   * \return the json
+   */
+  nlohmann::json toJson()
+  {
+    nlohmann::json j(elm_);
+    return j;
+  }
 
 private:
   T elm_ = {};                  /**< The stored value */
@@ -305,6 +325,17 @@ struct StoreElm<
    * \return whether to dump
    */
   bool shouldJson() const { return dump_to_json_; }
+
+  /**
+   * \brief Generate the json if applicable
+   *
+   * \return the json
+   */
+  nlohmann::json toJson()
+  {
+    nlohmann::json j(wrapper_.elm_);
+    return j;
+  }
 
 private:
   detail::ByteWrapper<T> wrapper_ = {}; /**< The byte-copyable value wrapper */

--- a/src/vt/vrt/collection/types/storage/store_elm.h
+++ b/src/vt/vrt/collection/types/storage/store_elm.h
@@ -234,7 +234,7 @@ struct StoreElm<
    *
    * \return the json
    */
-  nlohmann::json toJson()
+  nlohmann::json toJson() override
   {
     return StoreElm::maybeGenerateJson<T>(elm_);
   }
@@ -357,7 +357,7 @@ struct StoreElm<
    *
    * \return the json
    */
-  nlohmann::json toJson()
+  nlohmann::json toJson() override
   {
     return StoreElm::maybeGenerateJson<T>(wrapper_.elm_);
   }

--- a/src/vt/vrt/collection/types/storage/store_elm.h
+++ b/src/vt/vrt/collection/types/storage/store_elm.h
@@ -146,11 +146,13 @@ struct StoreElm<
    *
    * \param[in] u the value
    * \param[in] dump_to_json whether to dump this to json LB data file
-   *
-   * @todo: make this disabled if not jsonable
    */
   template <typename U>
-  StoreElm(U&& u, bool dump_to_json)
+  StoreElm(
+    U&& u, bool dump_to_json, typename std::enable_if<
+      nlohmann::detail::has_to_json<nlohmann::json,U>::value
+    >::type* = nullptr
+  )
     : elm_(std::forward<U>(u)),
       dump_to_json_(dump_to_json)
   { }
@@ -278,11 +280,13 @@ struct StoreElm<
    *
    * \param[in] u the value
    * \param[in] dump_to_json whether to dump this to json LB data file
-   *
-   * @todo: make this disabled if not jsonable
    */
   template <typename U>
-  StoreElm(U&& u, bool dump_to_json)
+  StoreElm(
+    U&& u, bool dump_to_json, typename std::enable_if<
+      nlohmann::detail::has_to_json<nlohmann::json,U>::value
+    >::type* = nullptr
+  )
     : wrapper_(detail::ByteWrapper<T>{std::forward<U>(u)}),
       dump_to_json_(dump_to_json)
   { }

--- a/src/vt/vrt/collection/types/storage/store_elm.h
+++ b/src/vt/vrt/collection/types/storage/store_elm.h
@@ -67,6 +67,13 @@ struct StoreElmBase {
   virtual ~StoreElmBase() {}
 
   /**
+   * \brief Whether the value should be dumped to the json LB data file
+   *
+   * \return whether to dump
+   */
+  virtual bool shouldJson() const = 0;
+
+  /**
    * \brief Get the value as \c T
    *
    * \return the value
@@ -126,6 +133,20 @@ struct StoreElm<
   { }
 
   /**
+   * \brief Construct with value
+   *
+   * \param[in] u the value
+   * \param[in] dump_to_json whether to dump this to json LB data file
+   *
+   * @todo: make this disabled if not jsonable
+   */
+  template <typename U>
+  StoreElm(U&& u, bool dump_to_json)
+    : elm_(std::forward<U>(u)),
+      dump_to_json_(dump_to_json)
+  { }
+
+  /**
    * \brief Serialization re-constructor
    *
    * \param[in] SERIALIZE_CONSTRUCT_TAG tag
@@ -139,7 +160,8 @@ struct StoreElm<
    */
   template <typename SerializerT>
   void serialize(SerializerT& s) {
-    s | elm_;
+    s | elm_
+      | dump_to_json_;
   }
 
   /**
@@ -156,8 +178,17 @@ struct StoreElm<
    */
   T const& get() const { return elm_; }
 
+  /**
+   * \brief Whether the value should be dumped to the json LB data file
+   *
+   * \return whether to dump
+   */
+  bool shouldJson() const { return dump_to_json_; }
+
 private:
   T elm_ = {};                  /**< The stored value */
+
+  bool dump_to_json_ = false;
 };
 
 namespace detail {
@@ -223,6 +254,20 @@ struct StoreElm<
   { }
 
   /**
+   * \brief Construct with value
+   *
+   * \param[in] u the value
+   * \param[in] dump_to_json whether to dump this to json LB data file
+   *
+   * @todo: make this disabled if not jsonable
+   */
+  template <typename U>
+  StoreElm(U&& u, bool dump_to_json)
+    : wrapper_(detail::ByteWrapper<T>{std::forward<U>(u)}),
+      dump_to_json_(dump_to_json)
+  { }
+
+  /**
    * \brief Serialization re-constructor
    *
    * \param[in] SERIALIZE_CONSTRUCT_TAG tag
@@ -236,7 +281,8 @@ struct StoreElm<
    */
   template <typename SerializerT>
   void serialize(SerializerT& s) {
-    s | wrapper_;
+    s | wrapper_
+      | dump_to_json_;
   }
 
   /**
@@ -253,8 +299,17 @@ struct StoreElm<
    */
   T const& get() const { return wrapper_.elm_; }
 
+  /**
+   * \brief Whether the value should be dumped to the json LB data file
+   *
+   * \return whether to dump
+   */
+  bool shouldJson() const { return dump_to_json_; }
+
 private:
   detail::ByteWrapper<T> wrapper_ = {}; /**< The byte-copyable value wrapper */
+
+  bool dump_to_json_ = false;
 };
 
 }}}} /* end namespace vt::vrt::collection::storage */

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -507,9 +507,9 @@ struct TestDumpUserdefinedData : TestParallelHarnessParam<bool> { };
 
 std::string
 getJsonStringForPhase(
-  vt::PhaseType phase,  vt::vrt::collection::balance::StatsData in
+  vt::PhaseType phase, vt::vrt::collection::balance::LBDataHolder in
 ) {
-  using vt::vrt::collection::balance::StatsData;
+  using vt::vrt::collection::balance::LBDataHolder;
   using JSONAppender = vt::util::json::Appender<std::stringstream>;
   std::stringstream ss{std::ios_base::out | std::ios_base::in};
   auto ap = std::make_unique<JSONAppender>("phases", std::move(ss), false);
@@ -533,13 +533,13 @@ TEST_P(TestDumpUserdefinedData, test_dump_userdefined_json) {
     proxy = vt::theCollection()->constructCollective<MyCol>(range);
   });
 
-  vt::vrt::collection::balance::StatsData sd;
+  vt::vrt::collection::balance::LBDataHolder lbdh;
   PhaseType write_phase = 0;
 
   {
     PhaseType phase = write_phase;
-    sd.node_data_[phase];
-    sd.node_comm_[phase];
+    lbdh.node_data_[phase];
+    lbdh.node_comm_[phase];
 
     vt::Index1D idx(this_node * 1);
     auto elm_ptr = proxy(idx).tryGetLocalPtr();
@@ -548,14 +548,14 @@ TEST_P(TestDumpUserdefinedData, test_dump_userdefined_json) {
       auto elm_id = elm_ptr->getElmID();
       elm_ptr->valInsert("hello", std::string("world"), should_dump);
       elm_ptr->valInsert("elephant", 123456789, should_dump);
-      sd.user_defined_json_[phase][elm_id] = std::make_shared<nlohmann::json>(
+      lbdh.user_defined_json_[phase][elm_id] = std::make_shared<nlohmann::json>(
         elm_ptr->toJson()
       );
-      sd.node_data_[phase][elm_id].whole_phase_load = 1.0;
+      lbdh.node_data_[phase][elm_id].whole_phase_load = 1.0;
     }
   }
 
-  auto json_str = getJsonStringForPhase(write_phase, sd);
+  auto json_str = getJsonStringForPhase(write_phase, lbdh);
   fmt::print("{}\n", json_str);
   if (should_dump) {
     EXPECT_NE(json_str.find("user_defined"), std::string::npos);

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -512,6 +512,81 @@ TEST_F(TestRestoreLBData, test_restore_lb_data_data_1) {
   // @todo: clean up files
 }
 
+struct TestDumpUserdefinedData : TestParallelHarnessParam<bool> { };
+
+std::string
+getJsonStringForPhase(
+  vt::PhaseType phase,  vt::vrt::collection::balance::StatsData in
+) {
+  using vt::vrt::collection::balance::StatsData;
+  using JSONAppender = vt::util::json::Appender<std::stringstream>;
+  std::stringstream ss{std::ios_base::out | std::ios_base::in};
+  auto ap = std::make_unique<JSONAppender>("phases", std::move(ss), false);
+  auto j = in.toJson(phase);
+  ap->addElm(*j);
+  ss = ap->finish();
+  return ss.str();
+}
+
+TEST_P(TestDumpUserdefinedData, test_dump_userdefined_json) {
+  bool should_dump = GetParam();
+
+  auto this_node = vt::theContext()->getNode();
+  auto num_nodes = vt::theContext()->getNumNodes();
+
+  vt::vrt::collection::CollectionProxy<MyCol> proxy;
+  auto const range = vt::Index1D(num_nodes * 1);
+
+  // Construct a collection
+  runInEpochCollective([&] {
+    proxy = vt::theCollection()->constructCollective<MyCol>(range);
+  });
+
+  vt::vrt::collection::balance::StatsData sd;
+  PhaseType write_phase = 0;
+
+  {
+    PhaseType phase = write_phase;
+    sd.node_data_[phase];
+    sd.node_comm_[phase];
+
+    vt::Index1D idx(this_node * 1);
+    auto elm_ptr = proxy(idx).tryGetLocalPtr();
+    EXPECT_NE(elm_ptr, nullptr);
+    if (elm_ptr != nullptr) {
+      auto elm_id = elm_ptr->getElmID();
+
+      elm_ptr->valInsert("hello", std::string("world"), should_dump);
+      elm_ptr->valInsert("elephant", 123456789, should_dump);
+      sd.user_defined_json_[phase][elm_id] = elm_ptr->toJson();
+
+      sd.node_data_[phase][elm_id].whole_phase_load = 1.0;
+    }
+  }
+
+  auto json_str = getJsonStringForPhase(write_phase, sd);
+  fmt::print("{}\n", json_str);
+  if (should_dump) {
+    EXPECT_NE(json_str.find("user_defined"), std::string::npos);
+    EXPECT_NE(json_str.find("hello"), std::string::npos);
+    EXPECT_NE(json_str.find("world"), std::string::npos);
+    EXPECT_NE(json_str.find("elephant"), std::string::npos);
+    EXPECT_NE(json_str.find("123456789"), std::string::npos);
+  } else {
+    EXPECT_EQ(json_str.find("user_defined"), std::string::npos);
+    EXPECT_EQ(json_str.find("hello"), std::string::npos);
+    EXPECT_EQ(json_str.find("world"), std::string::npos);
+    EXPECT_EQ(json_str.find("elephant"), std::string::npos);
+    EXPECT_EQ(json_str.find("123456789"), std::string::npos);
+  }
+}
+
+auto const booleans = ::testing::Values(false, true);
+
+INSTANTIATE_TEST_SUITE_P(
+  DumpUserdefinedDataExplode, TestDumpUserdefinedData, booleans
+);
+
 }}}} // end namespace vt::tests::unit::lb
 
 #endif /*vt_check_enabled(lblite)*/

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -335,14 +335,6 @@ getLBDataForPhase(
 
 TEST_F(TestRestoreLBData, test_restore_lb_data_data_1) {
   auto this_node = vt::theContext()->getNode();
-  std::string out_file_name = "test_restore_lb_data_1.%p.json";
-  std::size_t rank = out_file_name.find("%p");
-  auto str_rank = std::to_string(this_node);
-  if (rank == std::string::npos) {
-    out_file_name = out_file_name + str_rank;
-  } else {
-    out_file_name.replace(rank, 2, str_rank);
-  }
 
   vt::vrt::collection::CollectionProxy<MyCol> proxy;
   auto const range = vt::Index1D(num_elms);
@@ -508,8 +500,6 @@ TEST_F(TestRestoreLBData, test_restore_lb_data_data_1) {
 
   // @todo: compare subphase comm when writing/reading is implemented
   // @todo: detailed comparison of subphase comm data
-
-  // @todo: clean up files
 }
 
 struct TestDumpUserdefinedData : TestParallelHarnessParam<bool> { };

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -53,6 +53,7 @@
 #include "vt/utils/json/json_appender.h"
 
 #include <nlohmann/json.hpp>
+#include <memory>
 
 #include <dirent.h>
 
@@ -545,11 +546,11 @@ TEST_P(TestDumpUserdefinedData, test_dump_userdefined_json) {
     EXPECT_NE(elm_ptr, nullptr);
     if (elm_ptr != nullptr) {
       auto elm_id = elm_ptr->getElmID();
-
       elm_ptr->valInsert("hello", std::string("world"), should_dump);
       elm_ptr->valInsert("elephant", 123456789, should_dump);
-      sd.user_defined_json_[phase][elm_id] = elm_ptr->toJson();
-
+      sd.user_defined_json_[phase][elm_id] = std::make_shared<nlohmann::json>(
+        elm_ptr->toJson()
+      );
       sd.node_data_[phase][elm_id].whole_phase_load = 1.0;
     }
   }


### PR DESCRIPTION
This PR adds the ability to dump items stored in collection elements as user-defined data in LB data json files. I also added a commit that removes some stale lines of code from an existing unit test.

Closes #1723 
