### PR TITLE
Add adapter to use Charm++ LB strategies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ set(
         vrt/collection/balance/baselb
         vrt/collection/balance/hierarchicallb
         vrt/collection/balance/greedylb
+        vrt/collection/balance/charmlb
         vrt/collection/balance/rotatelb
         vrt/collection/balance/temperedlb
         vrt/collection/balance/statsmaplb

--- a/src/vt/vrt/collection/balance/charmlb/TreeStrategyBase.h
+++ b/src/vt/vrt/collection/balance/charmlb/TreeStrategyBase.h
@@ -116,17 +116,14 @@ class Obj : public std::conditional<multi, obj_N_data<N>, obj_1_data>::type
 
   static constexpr auto dimension = N;
 
-  inline Obj(IDType const& _id, const LoadFloatType* _load) //int _oldPe)
+  inline Obj(IDType const& _id, const LoadFloatType _load, std::vector<LoadFloatType>&& vecLoad) //int _oldPe)
   {
     id = _id;
     //oldPe = _oldPe;
-    // The zeroth element of _load will be the traditional walltime load,
-    // and then 1 through N will be the elements of the vector load
-    this->totalload = *_load;
-    _load++;
+    this->totalload = _load;
     for (int i = 0; i < N; i++)
     {
-      this->load[i] = _load[i];
+      this->load[i] = vecLoad[i];
     }
   }
 
@@ -140,10 +137,10 @@ class Obj : public std::conditional<multi, obj_N_data<N>, obj_1_data>::type
 };
 
 template <>
-inline Obj<1>::Obj(IDType const& _id, const LoadFloatType* _load)// int _oldPe)
+inline Obj<1>::Obj(IDType const& _id, const LoadFloatType _load, std::vector<LoadFloatType>&& vecLoad)// int _oldPe)
 {
   id = _id;
-  load = *_load;
+  load = _load;
   //oldPe = _oldPe;
 }
 
@@ -222,11 +219,11 @@ public:
   NodeType id = vt::uninitialized_destination;
   static constexpr auto dimension = N;
 
-  inline Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+  inline Proc(NodeType const& _id, LoadFloatType _bgload, LoadFloatType* _speed)
   {
     id = _id;
     // TODO: implement vector bgload
-    std::fill_n(this->bgload.begin(), N, *_bgload);
+    std::fill_n(this->bgload.begin(), N, _bgload / N);
   }
 
   inline LoadFloatType getLoad() const { return this->totalload; }
@@ -263,10 +260,10 @@ public:
 };
 
 template <>
-Proc<1, false>::Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+Proc<1, false>::Proc(NodeType const& _id, LoadFloatType _bgload, LoadFloatType* _speed)
 {
   id = _id;
-  this->bgload = *_bgload;
+  this->bgload = _bgload;
 }
 template <>
 LoadFloatType Proc<1, false>::getLoad() const
@@ -306,10 +303,10 @@ public:
   static constexpr auto dimension = N;
   std::array<LoadFloatType, N> speed;
 
-  inline Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+  inline Proc(NodeType const& _id, LoadFloatType _bgload, LoadFloatType* _speed)
   {
     id = _id;
-    std::copy_n(_bgload, N, this->bgload.begin());
+    std::fill_n(this->bgload.begin(), N, _bgload / N);
     std::copy_n(_speed, N, this->speed.begin());
   }
 
@@ -347,10 +344,10 @@ public:
 };
 
 template <>
-Proc<1, true>::Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+Proc<1, true>::Proc(NodeType const& _id, LoadFloatType _bgload, LoadFloatType* _speed)
 {
   id = _id;
-  this->bgload = *_bgload;
+  this->bgload = _bgload;
   speed[0] = _speed[0];
 }
 template <>

--- a/src/vt/vrt/collection/balance/charmlb/TreeStrategyBase.h
+++ b/src/vt/vrt/collection/balance/charmlb/TreeStrategyBase.h
@@ -1,0 +1,437 @@
+#ifndef TREESTRATEGYBASE_H
+#define TREESTRATEGYBASE_H
+
+#include "vt/configs/types/types_type.h"
+
+#include "vt/config.h"
+#include "vt/vrt/collection/balance/lb_common.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <random>
+
+using LoadFloatType = double;
+
+namespace TreeStrategy
+{
+template <typename T, bool is_ptr = std::is_pointer<T>::value>
+struct CmpLoadGreater
+{
+};
+
+template <typename T>
+struct CmpLoadGreater<T, true>
+{
+  inline bool operator()(const T a, const T b) const
+  {
+    return (a->getLoad() > b->getLoad());
+  }
+};
+
+template <typename T>
+struct CmpLoadGreater<T, false>
+{
+  inline bool operator()(const T& a, const T& b) const
+  {
+    return (a.getLoad() > b.getLoad());
+  }
+};
+
+template <typename T, bool is_ptr = std::is_pointer<T>::value>
+struct CmpLoadLess
+{
+};
+
+template <typename T>
+struct CmpLoadLess<T, true>
+{
+  inline bool operator()(const T a, const T b) const
+  {
+    return (a->getLoad() < b->getLoad());
+  }
+};
+
+template <typename T>
+struct CmpLoadLess<T, false>
+{
+  inline bool operator()(const T& a, const T& b) const
+  {
+    return (a.getLoad() < b.getLoad());
+  }
+};
+
+template <typename T, bool is_ptr = std::is_pointer<T>::value>
+struct CmpId
+{
+};
+
+template <typename T>
+struct CmpId<T, true>
+{
+  inline bool operator()(const T a, const T b) const { return (a->id < b->id); }
+};
+
+template <typename T>
+struct CmpId<T, false>
+{
+  inline bool operator()(const T& a, const T& b) const { return (a.id < b.id); }
+};
+
+template <typename T>
+T* ptr(T& obj)
+{
+  return &obj;
+}  // turn reference into pointer
+
+template <typename T>
+T* ptr(T* obj)
+{
+  return obj;
+}  // obj is already pointer, return it
+
+// ---------------- Obj --------------------
+
+struct obj_1_data
+{
+  LoadFloatType load;
+};
+template <int N>
+struct obj_N_data
+{
+  LoadFloatType totalload;
+  std::array<LoadFloatType, N> load = {};
+};
+
+template <int N, bool multi = (N > 1)>
+class Obj : public std::conditional<multi, obj_N_data<N>, obj_1_data>::type
+{
+  using IDType = vt::vrt::collection::balance::ElementIDStruct;
+ public:
+  IDType id;
+  //int oldPe;
+
+  static constexpr auto dimension = N;
+
+  inline Obj(IDType const& _id, LoadFloatType* _load) //int _oldPe)
+  {
+    id = _id;
+    //oldPe = _oldPe;
+    // The zeroth element of _load will be the traditional walltime load,
+    // and then 1 through N will be the elements of the vector load
+    this->totalload = *_load;
+    _load++;
+    for (int i = 0; i < N; i++)
+    {
+      this->load[i] = _load[i];
+    }
+  }
+
+  inline LoadFloatType getLoad() const { return this->totalload; }
+  inline LoadFloatType getLoad(int dim) const
+  {
+    return this->load[dim];
+  }
+  void setPosition(std::vector<float>& position) {}
+  LoadFloatType operator[](size_t dim) const { return getLoad(dim); }
+};
+
+template <>
+inline Obj<1>::Obj(IDType const& _id, LoadFloatType* _load)// int _oldPe)
+{
+  id = _id;
+  load = *_load;
+  //oldPe = _oldPe;
+}
+
+template <>
+inline LoadFloatType Obj<1>::getLoad() const
+{
+  return load;
+}
+
+template <>
+inline LoadFloatType Obj<1>::getLoad(int) const
+{
+  return getLoad();
+}
+
+template <int N>
+class ObjPos : public Obj<N>
+{
+public:
+  static constexpr bool isPosition = true;
+  bool hasPosition = false;
+  std::vector<float> position;
+
+  inline void setPosition(std::vector<float>& pos)
+  {
+    assert(!position.empty());
+    hasPosition = true;
+    position = pos;
+  }
+};
+
+// ------------------ Proc ------------------
+
+/**
+ * class Proc<int N, bool rateAware>
+ * This just shows the interface. only the specializations (below) are defined
+ * N: number of dimensions of vector load
+ * rateAware: true if speed aware, false otherwise
+ */
+template <int N, bool rateAware, bool multi = (N > 1)>
+class Proc
+{
+ public:
+  LoadFloatType getLoad() const;         // returns current load of processor
+  LoadFloatType getLoad(int dim) const;  // returns current load of processor
+  LoadFloatType operator[](size_t dim) const;
+  void assign(const Obj<N>* o);  // add object loads to this processor's loads
+  void assign(const Obj<N>& o);  // add object loads to this processor's loads
+
+  void resetLoad();              // sets processor loads to background loads
+  bool operator==(const Proc& element) const;
+};
+
+template <int N>
+struct proc_N_data
+{
+  std::array<LoadFloatType, N> load = {};
+  std::array<LoadFloatType, N> bgload = {};
+  LoadFloatType totalload = 0;
+};
+struct proc_1_data
+{
+  LoadFloatType load = 0;
+  LoadFloatType bgload = 0;
+};
+
+// --------- Proc rateAware=false specializations ---------
+
+template <int N, bool multi>
+class Proc<N, false, multi>
+    : public std::conditional<multi, proc_N_data<N>, proc_1_data>::type {
+  using NodeType = vt::NodeType;
+  using ObjIDType = vt::vrt::collection::balance::ElementIDStruct;
+
+public:
+  NodeType id = vt::uninitialized_destination;
+  static constexpr auto dimension = N;
+  std::vector<ObjIDType> objs;
+
+  inline Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+  {
+    id = _id;
+    // TODO: implement vector bgload
+    std::fill_n(this->bgload.begin(), N, *_bgload);
+  }
+
+  inline LoadFloatType getLoad() const { return this->totalload; }
+
+  inline LoadFloatType getLoad(int dim) const
+  {
+    assert(dim < dimension);
+    return this->load[dim];
+  }
+
+  LoadFloatType operator[](size_t dim) const { return getLoad(dim); }
+
+  inline void assign(const Obj<N>* o)
+  {
+    for (int i = 0; i < N; i++)
+    {
+      this->load[i] += o->load[i];
+      this->totalload += o->load[i];
+    }
+    objs.push_back(o->id);
+  }
+  inline void assign(const Obj<N>& o) { assign(&o); }
+
+  inline void resetLoad()
+  {
+    this->totalload = 0;
+    for (int i = 0; i < N; i++)
+    {
+      this->load[i] = this->bgload[i];
+      this->totalload += this->bgload[i];
+    }
+  }
+
+  bool operator==(const Proc& element) const { return id == element.id; };
+};
+
+template <>
+Proc<1, false>::Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+{
+  id = _id;
+  this->bgload = *_bgload;
+}
+template <>
+LoadFloatType Proc<1, false>::getLoad() const
+{
+  return this->load;
+}
+template <>
+LoadFloatType Proc<1, false>::getLoad(int) const
+{
+  return getLoad();
+}
+template <>
+void Proc<1, false>::assign(const Obj<1>* o)
+{
+  this->load += o->load;
+  objs.push_back(o->id);
+}
+
+template <>
+void Proc<1, false>::resetLoad()
+{
+  this->load = this->bgload;
+}
+
+// --------- Proc rateAware=true specializations ---------
+
+// TODO further specialize for N=1 by having speed not be an array?
+
+template <int N, bool multi>
+class Proc<N, true, multi>
+    : public std::conditional<multi, proc_N_data<N>, proc_1_data>::type
+{
+  using NodeType = vt::NodeType;
+  using ObjIDType = vt::vrt::collection::balance::ElementIDStruct;
+
+public:
+  NodeType id = vt::uninitialized_destination;
+  static constexpr auto dimension = N;
+  std::vector<ObjIDType> objs;
+  std::array<LoadFloatType, N> speed;
+
+  inline Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+  {
+    id = _id;
+    std::copy_n(_bgload, N, this->bgload.begin());
+    std::copy_n(_speed, N, this->speed.begin());
+  }
+
+  inline LoadFloatType getLoad() const { return this->totalload; }
+
+  inline LoadFloatType getLoad(int dim) const
+  {
+    assert(dim < dimension);
+    return this->load[dim];
+  }
+
+  LoadFloatType operator[](size_t dim) const { return getLoad(dim); }
+
+  inline void assign(const Obj<N>* o)
+  {
+    for (int i = 0; i < N; i++)
+    {
+      this->load[i] += (o->load[i] / speed[i]);
+      this->totalload += (o->load[i] / speed[i]);
+    }
+    objs.push_back(o->id);
+  }
+  inline void assign(const Obj<N>& o) { assign(&o); }
+
+  inline void resetLoad()
+  {
+    this->totalload = 0;
+    for (int i = 0; i < N; i++)
+    {
+      this->load[i] = this->bgload[i];
+      this->totalload += this->bgload[i];
+    }
+  }
+
+  bool operator==(const Proc& element) const { return id == element.id; };
+};
+
+template <>
+Proc<1, true>::Proc(NodeType const& _id, LoadFloatType* _bgload, LoadFloatType* _speed)
+{
+  id = _id;
+  this->bgload = *_bgload;
+  speed[0] = _speed[0];
+}
+template <>
+LoadFloatType Proc<1, true>::getLoad() const
+{
+  return this->load;
+}
+template <>
+LoadFloatType Proc<1, true>::getLoad(int) const
+{
+  return getLoad();
+}
+template <>
+LoadFloatType Proc<1, true>::operator[](size_t) const
+{
+  return getLoad();
+}
+template <>
+void Proc<1, true>::assign(const Obj<1>* o)
+{
+  this->load += (o->load / speed[0]);
+  objs.push_back(o->id);
+}
+template <>
+void Proc<1, true>::resetLoad()
+{
+  this->load = this->bgload;
+}
+
+template <typename O, typename P>
+class Solution
+{
+  public:
+  void assign(const O& obj, P& proc)
+  {
+    proc.assign(obj);
+  }
+};
+
+// ---------------- Strategy --------------------
+
+template <typename O, typename P, typename S>
+class Strategy
+{
+ public:
+  virtual void solve(std::vector<O>& objs, std::vector<P>& procs, S& solution,
+                     bool objsSorted = false) = 0;
+  virtual ~Strategy() {}
+};
+
+template <typename O, typename P, typename S>
+class Random : public Strategy<O, P, S>
+{
+ public:
+  Random()
+  {
+    std::random_device rd;
+    rng = std::mt19937(rd());
+  }
+  void solve(std::vector<O>& objs, std::vector<P>& procs, S& solution, bool objsSorted)
+  {
+    std::uniform_int_distribution<int> uni(0, procs.size() - 1);
+    for (const auto& o : objs) solution.assign(o, procs[uni(rng)]);
+  }
+
+ private:
+  std::mt19937 rng;
+};
+
+template <typename O, typename P, typename S>
+class Dummy : public Strategy<O, P, S>
+{
+ public:
+  void solve(std::vector<O>& objs, std::vector<P>& procs, S& solution, bool objsSorted) {
+    for (const auto& o : objs)
+      solution.assign(o, procs[ptr(o)->oldPe]);
+  }  // do nothing
+};
+
+}  // namespace TreeStrategy
+
+#endif /* TREESTRATEGYBASE_H */

--- a/src/vt/vrt/collection/balance/charmlb/TreeStrategyBase.h
+++ b/src/vt/vrt/collection/balance/charmlb/TreeStrategyBase.h
@@ -116,7 +116,7 @@ class Obj : public std::conditional<multi, obj_N_data<N>, obj_1_data>::type
 
   static constexpr auto dimension = N;
 
-  inline Obj(IDType const& _id, LoadFloatType* _load) //int _oldPe)
+  inline Obj(IDType const& _id, const LoadFloatType* _load) //int _oldPe)
   {
     id = _id;
     //oldPe = _oldPe;
@@ -140,7 +140,7 @@ class Obj : public std::conditional<multi, obj_N_data<N>, obj_1_data>::type
 };
 
 template <>
-inline Obj<1>::Obj(IDType const& _id, LoadFloatType* _load)// int _oldPe)
+inline Obj<1>::Obj(IDType const& _id, const LoadFloatType* _load)// int _oldPe)
 {
   id = _id;
   load = *_load;

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.cc
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.cc
@@ -260,15 +260,11 @@ void CharmLB::runBalancer(
 
   using Solution_t = TreeStrategy::Solution<ObjType, ProcType>;
   auto strategy = TreeStrategy::Greedy<ObjType, ProcType, Solution_t>();
-  Solution_t solution; // Dummy solution object, passes through assignments to underlying node
+  Solution_t solution(nodes);
   strategy.solve(recs, nodes, solution, false);
 
   std::vector<CharmDecision> decisions;
-  for (auto&& node : nodes)
-  {
-    decisions.emplace_back(node.id, std::move(node.objs));
-  }
-  return transferObjs(std::move(decisions));
+  return transferObjs(std::move(solution.decisions));
 }
 
 CharmLB::ObjIDType CharmLB::objSetNode(

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.cc
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.cc
@@ -1,0 +1,443 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                 charmlb.cc
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include "vt/vrt/collection/balance/charmlb/TreeStrategyBase.h"
+#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_CC
+#define INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_CC
+
+#include "vt/config.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb.fwd.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb_types.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb_constants.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb_msgs.h"
+#include "vt/vrt/collection/balance/read_lb.h"
+#include "vt/serialization/messaging/serialized_messenger.h"
+#include "vt/context/context.h"
+#include "vt/vrt/collection/manager.h"
+#include "vt/collective/reduce/reduce.h"
+#include "vt/vrt/collection/balance/lb_args_enum_converter.h"
+#include "vt/timing/timing.h"
+
+#include <unordered_map>
+#include <memory>
+#include <vector>
+#include <algorithm>
+#include <cassert>
+
+// Include Charm++ LB file
+#include "vt/vrt/collection/balance/charmlb/greedy.h"
+
+namespace vt { namespace vrt { namespace collection { namespace lb {
+
+/*static*/ objgroup::proxy::Proxy<CharmLB> CharmLB::scatter_proxy = {};
+
+void CharmLB::init(objgroup::proxy::Proxy<CharmLB> in_proxy) {
+  proxy = scatter_proxy = in_proxy;
+}
+
+/*static*/ std::unordered_map<std::string, std::string>
+CharmLB::getInputKeysWithHelp() {
+  std::unordered_map<std::string, std::string> const keys_help = {
+    {
+      "min",
+      R"(
+Values: <double>
+Default: 0.8
+Description:
+  The load threshold of objects to consider for potential migration on each
+  rank. All objects over threshold * average_load on each rank will be
+  considered. If the parameter "auto" is set to "true", this will be the minimum
+  threshold; otherwise, it sets the threshold directly.
+)"
+    },
+    {
+      "max",
+      R"(
+Values: <double>
+Default: 1.004
+Description:
+  The maximum load threshold for objects to consider on each node which is only
+  used if "auto" is "true".
+)"
+    },
+    {
+      "auto",
+      R"(
+Values: {true, false}
+Default: true
+Description:
+  Automatically determine the threshold between "min" and "max" using
+  calculated I (imbalance metric) with the formula
+  min(max(1-I, min), max).
+)"
+    },
+    {
+      "strategy",
+      R"(
+Values: {scatter, bcast, pt2pt}
+Default: scatter
+Description:
+  How to distribute the data after the centralized LB makes a decision
+)"
+    }
+  };
+  return keys_help;
+}
+
+void CharmLB::inputParams(balance::SpecEntry* spec) {
+  auto keys_help = getInputKeysWithHelp();
+
+  std::vector<std::string> allowed;
+  for (auto&& elm : keys_help) {
+    allowed.push_back(elm.first);
+  }
+  spec->checkAllowedKeys(allowed);
+  min_threshold = spec->getOrDefault<double>("min", charm_threshold_p);
+  max_threshold = spec->getOrDefault<double>("max", charm_max_threshold_p);
+  auto_threshold = spec->getOrDefault<bool>("auto", charm_auto_threshold_p);
+
+  balance::LBArgsEnumConverter<DataDistStrategy> strategy_converter_(
+    "strategy", "DataDistStrategy", {
+      {DataDistStrategy::scatter, "scatter"},
+      {DataDistStrategy::pt2pt,   "pt2pt"},
+      {DataDistStrategy::bcast,   "bcast"}
+    }
+  );
+  strat_ = strategy_converter_.getFromSpec(spec, strat_);
+}
+
+void CharmLB::runLB(TimeType total_load) {
+  this_load = loadMilli(total_load);
+  buildHistogram();
+  loadStats();
+}
+
+void CharmLB::loadStats() {
+  auto const& this_node = theContext()->getNode();
+  auto avg_load = getAvgLoad();
+  auto total_load = getSumLoad();
+  auto I = getStats()->at(lb::Statistic::P_l).at(lb::StatisticQuantity::imb);
+
+  bool should_lb = false;
+  this_load_begin = this_load;
+
+  if (avg_load > 0.0000000001) {
+    should_lb = I > charm_tolerance;
+  }
+
+  if (auto_threshold) {
+    this_threshold = std::min(std::max(1.0f - I, min_threshold), max_threshold);
+  }
+
+  if (this_node == 0) {
+    vt_print(
+      lb,
+      "CharmLB loadStats: load={}, total={}, avg={}, I={:.2f},"
+      "should_lb={}, auto={}, threshold={}\n",
+      TimeTypeWrapper(this_load / 1000), TimeTypeWrapper(total_load / 1000),
+      TimeTypeWrapper(avg_load / 1000), I, should_lb, auto_threshold,
+      TimeTypeWrapper(this_threshold / 1000)
+    );
+    fflush(stdout);
+  }
+
+  if (should_lb) {
+    calcLoadOver();
+    reduceCollect();
+  }
+}
+
+void CharmLB::collectHandler(CharmCollectMsg* msg) {
+  vt_debug_print(
+    normal, lb,
+    "CharmLB::collectHandler: entries size={}\n",
+    msg->getConstVal().getSample().size()
+  );
+
+  for (auto&& elm : msg->getConstVal().getSample()) {
+    vt_debug_print(
+      verbose, lb,
+      "\t collectHandler: bin={}, num={}\n",
+      elm.first, elm.second.size()
+    );
+  }
+
+  auto objs = std::move(msg->getVal().getSampleMove());
+  auto profile = std::move(msg->getVal().getLoadProfileMove());
+  runBalancer(std::move(objs),std::move(profile));
+}
+
+void CharmLB::reduceCollect() {
+  vt_debug_print(
+    verbose, lb,
+    "CharmLB::reduceCollect: load={}, load_begin={} load_over.size()={}\n",
+    TimeTypeWrapper(this_load / 1000),
+    TimeTypeWrapper(this_load_begin / 1000), load_over.size()
+  );
+  using MsgType = CharmCollectMsg;
+  auto cb = vt::theCB()->makeSend<CharmLB, MsgType, &CharmLB::collectHandler>(proxy[0]);
+  auto msg = makeMessage<MsgType>(load_over,this_load);
+  proxy.template reduce<collective::PlusOp<CharmPayload>>(msg.get(),cb);
+}
+
+void CharmLB::runBalancer(
+  ObjSampleType&& in_objs, LoadProfileType&& in_profile
+) {
+  using ObjType = TreeStrategy::Obj<1>;
+  using ProcType = TreeStrategy::Proc<1, false>;
+  auto const& num_nodes = theContext()->getNumNodes();
+  ObjSampleType objs{std::move(in_objs)};
+  LoadProfileType profile{std::move(in_profile)};
+  std::vector<ObjType> recs;
+  vt_debug_print(
+    normal, lb,
+    "CharmLB::runBalancer: objs={}, profile={}\n",
+    objs.size(), profile.size()
+  );
+  for (auto&& elm : objs) {
+    auto const& bin = elm.first;
+    auto const& obj_list = elm.second;
+    for (auto&& obj : obj_list) {
+      std::array<LoadType, 1> load = {static_cast<LoadType>(bin)};
+      recs.emplace_back(obj, load.data());
+    }
+  }
+
+  auto nodes = std::vector<ProcType>{};
+  for (NodeType n = 0; n < num_nodes; n++) {
+    auto iter = profile.find(n);
+    vtAssert(iter != profile.end(), "Must have load profile");
+    std::array<LoadType, 1> load = {iter->second};
+    std::array<LoadType, 1> speed = {0}; // Dummy for now
+    nodes.emplace_back(n,load.data(), speed.data());
+    vt_debug_print(
+      verbose, lb,
+      "\t CharmLB::runBalancer: node={}, profile={}\n",
+      n, iter->second
+    );
+  }
+
+  using Solution_t = TreeStrategy::Solution<ObjType, ProcType>;
+  auto strategy = TreeStrategy::Greedy<ObjType, ProcType, Solution_t>();
+  Solution_t solution; // Dummy solution object, passes through assignments to underlying node
+  strategy.solve(recs, nodes, solution, false);
+
+  std::vector<CharmDecision> decisions;
+  for (auto&& node : nodes)
+  {
+    decisions.emplace_back(node.id, std::move(node.objs));
+  }
+  return transferObjs(std::move(decisions));
+}
+
+CharmLB::ObjIDType CharmLB::objSetNode(
+  NodeType const& node, ObjIDType const& id
+) {
+  auto new_id = id;
+  new_id.curr_node = node;
+  return new_id;
+}
+
+void CharmLB::recvObjs(CharmSendMsg* msg) {
+  vt_debug_print(
+    normal, lb,
+    "recvObjs: msg->transfer_.size={}\n", msg->transfer_.size()
+  );
+  recvObjsDirect(msg->transfer_.size(), msg->transfer_.data());
+}
+
+void CharmLB::recvObjsBcast(CharmBcastMsg* msg) {
+  auto const n = theContext()->getNode();
+  vt_debug_print(
+    normal, lb,
+    "recvObjs: msg->transfer_.size={}\n", msg->transfer_[n].size()
+  );
+  recvObjsDirect(msg->transfer_[n].size(), msg->transfer_[n].data());
+}
+
+void CharmLB::recvObjsDirect(std::size_t len, CharmLBTypes::ObjIDType* objs) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_recs = len;
+  vt_debug_print(
+    normal, lb,
+    "recvObjsDirect: num_recs={}\n", num_recs
+  );
+
+  for (std::size_t i = 0; i < len; i++) {
+    auto const to_node = objGetNode(objs[i]);
+    auto const new_obj_id = objSetNode(this_node,objs[i]);
+    vt_debug_print(
+      verbose, lb,
+      "\t recvObjs: i={}, to_node={}, obj={}, new_obj_id={}, num_recs={}"
+      "\n",
+      i, to_node, objs[i], new_obj_id, num_recs
+    );
+
+    migrateObjectTo(new_obj_id, to_node);
+  }
+}
+
+/*static*/ void CharmLB::recvObjsHan(CharmLBTypes::ObjIDType* objs) {
+  vt_debug_print(
+    verbose, lb,
+    "recvObjsHan: num_recs={}\n", *objs
+  );
+  scatter_proxy.get()->recvObjsDirect(static_cast<std::size_t>(objs->id), objs+1);
+}
+
+void CharmLB::transferObjs(std::vector<CharmDecision>&& in_decision) {
+  std::size_t max_recs = 1;
+  std::vector<CharmDecision> load(std::move(in_decision));
+  std::vector<std::vector<CharmLBTypes::ObjIDType>> node_transfer(load.size());
+  for (auto&& elm : load) {
+    auto const& node = elm.node_;
+    auto const& objs = elm.objs_;
+    for (auto&& obj : objs) {
+      auto const cur_node = objGetNode(obj);
+      // transfer required from `cur_node' to `node'
+      if (cur_node != node) {
+        auto const new_obj_id = objSetNode(node, obj);
+        node_transfer[cur_node].push_back(new_obj_id);
+        max_recs = std::max(max_recs, node_transfer[cur_node].size() + 1);
+      }
+    }
+  }
+
+  if (strat_ == DataDistStrategy::scatter) {
+    std::size_t max_bytes =  max_recs * sizeof(CharmLBTypes::ObjIDType);
+    vt_debug_print(
+      normal, lb,
+      "CharmLB::transferObjs: max_recs={}, max_bytes={}\n",
+      max_recs, max_bytes
+    );
+    theCollective()->scatter<CharmLBTypes::ObjIDType,recvObjsHan>(
+      max_bytes*load.size(),max_bytes,nullptr,[&](NodeType node, void* ptr){
+        auto ptr_out = reinterpret_cast<CharmLBTypes::ObjIDType*>(ptr);
+        auto const& proc = node_transfer[node];
+        auto const& rec_size = proc.size();
+        ptr_out->id = rec_size;
+        for (size_t i = 0; i < rec_size; i++) {
+          *(ptr_out + i + 1) = proc[i];
+        }
+      }
+    );
+  } else if (strat_ == DataDistStrategy::pt2pt) {
+    for (NodeType n = 0; n < theContext()->getNumNodes(); n++) {
+      vtAssert(
+        node_transfer.size() == static_cast<size_t>(theContext()->getNumNodes()),
+        "Must contain all nodes"
+      );
+      proxy[n].send<CharmSendMsg, &CharmLB::recvObjs>(node_transfer[n]);
+    }
+  } else if (strat_ == DataDistStrategy::bcast) {
+    proxy.broadcast<CharmBcastMsg, &CharmLB::recvObjsBcast>(node_transfer);
+  }
+}
+
+double CharmLB::getAvgLoad() const {
+  return getStats()->at(lb::Statistic::P_l).at(lb::StatisticQuantity::avg);
+}
+
+double CharmLB::getMaxLoad() const {
+  return getStats()->at(lb::Statistic::P_l).at(lb::StatisticQuantity::max);
+}
+
+double CharmLB::getSumLoad() const {
+  return getStats()->at(lb::Statistic::P_l).at(lb::StatisticQuantity::sum);
+}
+
+void CharmLB::loadOverBin(ObjBinType bin, ObjBinListType& bin_list) {
+  auto avg_load = getAvgLoad();
+  auto const threshold = this_threshold * avg_load;
+  auto const obj_id = bin_list.back();
+
+  load_over[bin].push_back(obj_id);
+  bin_list.pop_back();
+
+  auto const& obj_time_milli = loadMilli(load_model_->getWork(obj_id, {balance::PhaseOffset::NEXT_PHASE, balance::PhaseOffset::WHOLE_PHASE}));
+
+  this_load -= obj_time_milli;
+
+  vt_debug_print(
+    normal, lb,
+    "loadOverBin: this_load_begin={}, this_load={}, threshold={}: "
+    "adding unit: bin={}, milli={}\n",
+    TimeTypeWrapper(this_load_begin / 1000),
+    TimeTypeWrapper(this_load / 1000), TimeTypeWrapper(threshold / 1000),
+    bin, obj_time_milli
+  );
+}
+
+void CharmLB::calcLoadOver() {
+  auto avg_load = getAvgLoad();
+  auto const threshold = this_threshold * avg_load;
+
+  vt_debug_print(
+    normal, lb,
+    "calcLoadOver: this_load={}, avg_load={}, threshold={}\n",
+    TimeTypeWrapper(this_load / 1000),
+    TimeTypeWrapper(avg_load / 1000),
+    TimeTypeWrapper(threshold / 1000)
+  );
+
+  auto cur_item = obj_sample.begin();
+  while (this_load > threshold && cur_item != obj_sample.end()) {
+    if (cur_item->second.size() != 0) {
+      loadOverBin(cur_item->first, cur_item->second);
+    } else {
+      cur_item++;
+    }
+  }
+
+  for (size_t i = 0; i < obj_sample.size(); i++) {
+    auto obj_iter = obj_sample.find(i);
+    if (obj_iter != obj_sample.end() && obj_iter->second.size() == 0) {
+      obj_sample.erase(obj_iter);
+    }
+  }
+}
+
+}}}} /* end namespace vt::vrt::collection::lb */
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_CC*/

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.cc
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.cc
@@ -256,6 +256,7 @@ void CharmLB::runBalancerHelper(
 ) {
   using ObjType = TreeStrategy::Obj<N>;
   using ProcType = TreeStrategy::Proc<N, false>;
+  using SolutionType = TreeStrategy::Solution<ObjType, ProcType>;
 
   vt_print(lb, "CharmLB::runBalancer Running with {} dimensions\n", N);
 
@@ -289,13 +290,11 @@ void CharmLB::runBalancerHelper(
     );
   }
 
-  using Solution_t = TreeStrategy::Solution<ObjType, ProcType>;
   //auto strategy = TreeStrategy::Greedy<ObjType, ProcType, Solution_t>();
-  auto strategy = TreeStrategy::RKdLB<ObjType, ProcType, Solution_t>();
-  Solution_t solution(nodes);
+  auto strategy = TreeStrategy::RKdLB<ObjType, ProcType, SolutionType>();
+  SolutionType solution(nodes);
   strategy.solve(recs, nodes, solution, false);
 
-  std::vector<CharmDecision> decisions;
   return transferObjs(std::move(solution.decisions));
 }
 

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.fwd.h
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.fwd.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                  lb_type.h
+//                                charmlb.fwd.h
 //                       DARMA/vt => Virtual Transport
 //
 // Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
@@ -41,51 +41,15 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_LB_TYPE_H
-#define INCLUDED_VT_VRT_COLLECTION_BALANCE_LB_TYPE_H
+#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_FWD_H
+#define INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_FWD_H
 
 #include "vt/config.h"
 
-#include <unordered_map>
-#include <string>
-#include <type_traits>
+namespace vt { namespace vrt { namespace collection { namespace lb {
 
-namespace vt { namespace vrt { namespace collection { namespace balance {
+struct CharmLB;
 
-enum struct LBType : int8_t {
-    NoLB             = 0
-  , GreedyLB         = 1
-  , HierarchicalLB   = 2
-  , RotateLB         = 3
-  , TemperedLB       = 4
-  , StatsMapLB       = 5
-# if vt_check_enabled(zoltan)
-  , ZoltanLB         = 6
-# endif
-  , RandomLB         = 7
-  , CharmLB          = 8
-};
+}}}} /* end namespace vt::vrt::collection::lb */
 
-}}}} /* end namespace vt::vrt::collection::balance */
-
-namespace std {
-
-template <>
-struct hash<vt::vrt::collection::balance::LBType> {
-  size_t operator()(vt::vrt::collection::balance::LBType const& in) const {
-    using LBUnderType =
-      std::underlying_type<vt::vrt::collection::balance::LBType>::type;
-    auto const val = static_cast<LBUnderType>(in);
-    return std::hash<LBUnderType>()(val);
-  }
-};
-
-} /* end namespace std */
-
-namespace vt { namespace vrt { namespace collection { namespace balance {
-
-std::unordered_map<LBType, std::string>& get_lb_names();
-
-}}}} /* end namespace vt::vrt::collection::balance */
-
-#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_LB_TYPE_H*/
+#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_FWD_H*/

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.h
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.h
@@ -62,7 +62,7 @@
 
 namespace vt { namespace vrt { namespace collection { namespace lb {
 
-struct CharmLB : LoadSamplerBaseLB {
+struct CharmLB : BaseLB {
   using ElementLoadType  = std::unordered_map<ObjIDType,TimeType>;
   using TransferType     = std::map<NodeType, std::vector<ObjIDType>>;
   using LoadType         = double;
@@ -85,8 +85,6 @@ private:
   void loadStats();
   void finishedLB();
   void reduceCollect();
-  void calcLoadOver();
-  void loadOverBin(ObjBinType bin, ObjBinListType& bin_list);
   void transferObjs(std::vector<CharmDecision>&& decision);
   ObjIDType objSetNode(NodeType const& node, ObjIDType const& id);
   void recvObjsDirect(std::size_t len, CharmLBTypes::ObjIDType* objs);

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.h
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.h
@@ -1,0 +1,122 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                  charmlb.h
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_H
+#define INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_H
+
+#include "vt/config.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb.fwd.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb_types.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb_constants.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb_msgs.h"
+#include "vt/vrt/collection/balance/baselb/load_sampler.h"
+#include "vt/timing/timing.h"
+
+#include "vt/vrt/collection/balance/greedylb/greedylb.h"
+
+#include <unordered_map>
+#include <map>
+#include <vector>
+#include <memory>
+#include <list>
+
+namespace vt { namespace vrt { namespace collection { namespace lb {
+
+struct CharmLB : LoadSamplerBaseLB {
+  using ElementLoadType  = std::unordered_map<ObjIDType,TimeType>;
+  using TransferType     = std::map<NodeType, std::vector<ObjIDType>>;
+  using LoadType         = double;
+  using LoadProfileType  = std::unordered_map<NodeType,LoadType>;
+
+  CharmLB() = default;
+  virtual ~CharmLB() {}
+
+  void init(objgroup::proxy::Proxy<CharmLB> in_proxy);
+  void runLB(TimeType total_load) override;
+  void inputParams(balance::SpecEntry* spec) override;
+
+  static std::unordered_map<std::string, std::string> getInputKeysWithHelp();
+
+private:
+  double getAvgLoad() const;
+  double getMaxLoad() const;
+  double getSumLoad() const;
+
+  void loadStats();
+  void finishedLB();
+  void reduceCollect();
+  void calcLoadOver();
+  void loadOverBin(ObjBinType bin, ObjBinListType& bin_list);
+  void runBalancer(ObjSampleType&& objs, LoadProfileType&& profile);
+  void transferObjs(std::vector<CharmDecision>&& decision);
+  ObjIDType objSetNode(NodeType const& node, ObjIDType const& id);
+  void recvObjsDirect(std::size_t len, CharmLBTypes::ObjIDType* objs);
+  void recvObjs(CharmSendMsg* msg);
+  void recvObjsBcast(CharmBcastMsg* msg);
+  void finishedTransferExchange();
+  void collectHandler(CharmCollectMsg* msg);
+
+  // This must stay static due to limitations in the scatter implementation
+  // (does not work with objgroups)
+  static void recvObjsHan(CharmLBTypes::ObjIDType* objs);
+  static objgroup::proxy::Proxy<CharmLB> scatter_proxy;
+
+private:
+  double this_threshold = 0.0f;
+  LoadType this_load_begin = 0.0f;
+  ObjSampleType load_over;
+  objgroup::proxy::Proxy<CharmLB> proxy = {};
+
+  // Parameters read from LB spec file
+  double max_threshold = 0.0f;
+  double min_threshold = 0.0f;
+  bool auto_threshold = true;
+
+  DataDistStrategy strat_ = DataDistStrategy::scatter;
+  LoadType this_load = 0.0f;
+};
+
+}}}} /* end namespace vt::vrt::collection::lb */
+
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_H*/

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.h
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.h
@@ -87,7 +87,6 @@ private:
   void reduceCollect();
   void calcLoadOver();
   void loadOverBin(ObjBinType bin, ObjBinListType& bin_list);
-  void runBalancer(ObjLoadListType&& objs, LoadProfileType&& profile);
   void transferObjs(std::vector<CharmDecision>&& decision);
   ObjIDType objSetNode(NodeType const& node, ObjIDType const& id);
   void recvObjsDirect(std::size_t len, CharmLBTypes::ObjIDType* objs);
@@ -95,6 +94,11 @@ private:
   void recvObjsBcast(CharmBcastMsg* msg);
   void finishedTransferExchange();
   void collectHandler(CharmCollectMsg* msg);
+
+  template <int N>
+  void runBalancer(int dimension, ObjLoadListType&& objs, LoadProfileType&& profile);
+  template <int N>
+  void runBalancerHelper(ObjLoadListType&& objs, LoadProfileType&& profile);
 
   // This must stay static due to limitations in the scatter implementation
   // (does not work with objgroups)

--- a/src/vt/vrt/collection/balance/charmlb/charmlb.h
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb.h
@@ -87,7 +87,7 @@ private:
   void reduceCollect();
   void calcLoadOver();
   void loadOverBin(ObjBinType bin, ObjBinListType& bin_list);
-  void runBalancer(ObjSampleType&& objs, LoadProfileType&& profile);
+  void runBalancer(ObjLoadListType&& objs, LoadProfileType&& profile);
   void transferObjs(std::vector<CharmDecision>&& decision);
   ObjIDType objSetNode(NodeType const& node, ObjIDType const& id);
   void recvObjsDirect(std::size_t len, CharmLBTypes::ObjIDType* objs);
@@ -104,7 +104,7 @@ private:
 private:
   double this_threshold = 0.0f;
   LoadType this_load_begin = 0.0f;
-  ObjSampleType load_over;
+  ObjLoadListType obj_loads;
   objgroup::proxy::Proxy<CharmLB> proxy = {};
 
   // Parameters read from LB spec file

--- a/src/vt/vrt/collection/balance/charmlb/charmlb_constants.h
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb_constants.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                  lb_type.h
+//                             charmlb_constants.h
 //                       DARMA/vt => Virtual Transport
 //
 // Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
@@ -41,51 +41,20 @@
 //@HEADER
 */
 
-#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_LB_TYPE_H
-#define INCLUDED_VT_VRT_COLLECTION_BALANCE_LB_TYPE_H
+#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_CONSTANTS_H
+#define INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_CONSTANTS_H
 
 #include "vt/config.h"
 
-#include <unordered_map>
-#include <string>
-#include <type_traits>
+namespace vt { namespace vrt { namespace collection { namespace lb {
 
-namespace vt { namespace vrt { namespace collection { namespace balance {
+static constexpr NodeType const charm_root             = 0;
+static constexpr int32_t  const charm_bin_size         = 10;
+static constexpr bool     const charm_auto_threshold_p = true;
+static constexpr double   const charm_tolerance        = 0.05f;
+static constexpr double   const charm_threshold_p      = 0.3f;
+static constexpr double   const charm_max_threshold_p  = 1.004f;
 
-enum struct LBType : int8_t {
-    NoLB             = 0
-  , GreedyLB         = 1
-  , HierarchicalLB   = 2
-  , RotateLB         = 3
-  , TemperedLB       = 4
-  , StatsMapLB       = 5
-# if vt_check_enabled(zoltan)
-  , ZoltanLB         = 6
-# endif
-  , RandomLB         = 7
-  , CharmLB          = 8
-};
+}}}} /* end namespace vt::vrt::collection::lb */
 
-}}}} /* end namespace vt::vrt::collection::balance */
-
-namespace std {
-
-template <>
-struct hash<vt::vrt::collection::balance::LBType> {
-  size_t operator()(vt::vrt::collection::balance::LBType const& in) const {
-    using LBUnderType =
-      std::underlying_type<vt::vrt::collection::balance::LBType>::type;
-    auto const val = static_cast<LBUnderType>(in);
-    return std::hash<LBUnderType>()(val);
-  }
-};
-
-} /* end namespace std */
-
-namespace vt { namespace vrt { namespace collection { namespace balance {
-
-std::unordered_map<LBType, std::string>& get_lb_names();
-
-}}}} /* end namespace vt::vrt::collection::balance */
-
-#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_LB_TYPE_H*/
+#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_CONSTANTS_H*/

--- a/src/vt/vrt/collection/balance/charmlb/charmlb_msgs.h
+++ b/src/vt/vrt/collection/balance/charmlb/charmlb_msgs.h
@@ -1,0 +1,172 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               charmlb_msgs.h
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_MSGS_H
+#define INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_MSGS_H
+
+#include "vt/config.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb_types.h"
+#include "vt/messaging/message.h"
+#include "vt/collective/reduce/operators/default_msg.h"
+
+#include <unordered_map>
+#include <cassert>
+
+namespace vt { namespace vrt { namespace collection { namespace lb {
+
+struct CharmPayload : CharmLBTypes {
+  CharmPayload() = default;
+  CharmPayload(ObjSampleType const& in_sample, LoadType const& in_profile)
+    : sample_(in_sample)
+  {
+    auto const& this_node = theContext()->getNode();
+    auto iter = load_profile_.find(this_node);
+    auto end_iter = load_profile_.end();
+    vtAssert(iter == end_iter, "Must not exist");
+    load_profile_.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(this_node),
+      std::forward_as_tuple(in_profile)
+    );
+  }
+
+  friend CharmPayload operator+(CharmPayload ld1, CharmPayload const& ld2) {
+    auto& sample1 = ld1.sample_;
+    auto const& sample2 = ld2.sample_;
+    for (auto&& elm : sample2) {
+      auto const& bin = elm.first;
+      auto const& entries = elm.second;
+      for (auto&& entry : entries) {
+        sample1[bin].push_back(entry);
+      }
+    }
+    auto& load1 = ld1.load_profile_;
+    auto const& load2 = ld2.load_profile_;
+    for (auto&& elm : load2) {
+      auto const& proc = elm.first;
+      auto const& load = elm.second;
+      vtAssert(load1.find(proc) == load1.end(), "Must not exist");
+      load1[proc] = load;
+    }
+    return ld1;
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | sample_ | load_profile_;
+  }
+
+  ObjSampleType const& getSample() const { return sample_; }
+  ObjSampleType&& getSampleMove() { return std::move(sample_); }
+  LoadProfileType const& getLoadProfile() const { return load_profile_; }
+  LoadProfileType&& getLoadProfileMove() { return std::move(load_profile_); }
+
+protected:
+  LoadProfileType load_profile_;
+  ObjSampleType sample_;
+};
+
+struct CharmCollectMsg : CharmLBTypes, collective::ReduceTMsg<CharmPayload> {
+  using MessageParentType = collective::ReduceTMsg<CharmPayload>;
+  vt_msg_serialize_required(); // prev. serialize(1)
+
+  CharmCollectMsg() = default;
+  CharmCollectMsg(ObjSampleType const& in_load, LoadType const& in_profile)
+    : collective::ReduceTMsg<CharmPayload>(CharmPayload{in_load,in_profile})
+  { }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    MessageParentType::serialize(s);
+  }
+
+  ObjSampleType const& getLoad() const {
+    return collective::ReduceTMsg<CharmPayload>::getConstVal().getSample();
+  }
+
+  ObjSampleType&& getLoadMove() {
+    return collective::ReduceTMsg<CharmPayload>::getVal().getSampleMove();
+  }
+};
+
+struct CharmSendMsg : CharmLBTypes, vt::Message {
+  using MessageParentType = vt::Message;
+  vt_msg_serialize_required(); // vector
+
+  CharmSendMsg() = default;
+  explicit CharmSendMsg(std::vector<CharmLBTypes::ObjIDType> const& in)
+    : transfer_(in)
+  { }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    MessageParentType::serialize(s);
+    s | transfer_;
+  }
+
+  std::vector<CharmLBTypes::ObjIDType> transfer_;
+};
+
+struct CharmBcastMsg : CharmLBTypes, vt::Message {
+  using MessageParentType = vt::Message;
+  vt_msg_serialize_required(); // vector
+
+  using DataType = std::vector<std::vector<CharmLBTypes::ObjIDType>>;
+
+  CharmBcastMsg() = default;
+  explicit CharmBcastMsg(DataType const& in)
+    : transfer_(in)
+  { }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    MessageParentType::serialize(s);
+    s | transfer_;
+  }
+
+  DataType transfer_;
+};
+
+}}}} /* end namespace vt::vrt::collection::lb */
+
+#endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_CHARMLB_CHARMLB_MSGS_H*/

--- a/src/vt/vrt/collection/balance/charmlb/greedy.h
+++ b/src/vt/vrt/collection/balance/charmlb/greedy.h
@@ -1,0 +1,137 @@
+#ifndef GREEDY_H_
+#define GREEDY_H_
+
+#include "TreeStrategyBase.h"
+//#include "pheap.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <queue>
+#include <random>
+#include <vector>
+
+namespace TreeStrategy
+{
+template <typename O, typename P, typename S>
+class Greedy : public Strategy<O, P, S>
+{
+public:
+  void solve(std::vector<O>& objs, std::vector<P>& procs, S& solution,
+             bool objsSorted = false)
+  {
+    if (!objsSorted) std::sort(objs.begin(), objs.end(), CmpLoadGreater<O>());
+    std::priority_queue<P, std::vector<P>, CmpLoadGreater<P>> procHeap(
+        CmpLoadGreater<P>(), procs);
+
+    for (const auto& o : objs)
+    {
+      P p = procHeap.top();
+      procHeap.pop();
+      solution.assign(o, p);  // update solution (assumes solution updates processor load)
+      procHeap.push(p);
+    }
+  }
+};
+
+template <typename P, typename S>
+class Greedy<Obj<1>, P, S> : public Strategy<Obj<1>, P, S>
+{
+public:
+  void solve(std::vector<Obj<1>>& objs, std::vector<P>& procs, S& solution,
+             bool objsSorted)
+  {
+    if (!objsSorted) std::sort(objs.begin(), objs.end(), CmpLoadGreater<Obj<1>>());
+    std::priority_queue<P, std::vector<P>, CmpLoadGreater<P>> procHeap(
+        CmpLoadGreater<P>(), procs);
+
+    for (const auto& o : objs)
+    {
+      P p = procHeap.top();
+      procHeap.pop();
+      solution.assign(o, p);  // update solution (assumes solution updates processor load)
+      procHeap.push(p);
+    }
+  }
+};
+
+}
+
+/* namespace TreeStrategy */
+/* { */
+/* template <typename O, typename P, typename S> */
+/* class Greedy : public Strategy<O, P, S> */
+/* { */
+/*  public: */
+/*   void solve(std::vector<O>& objs, std::vector<P>& procs, S& solution, bool objsSorted) */
+/*   { */
+/*     // Sorts by maxload in vector */
+/*     if (!objsSorted) std::sort(objs.begin(), objs.end(), CmpLoadGreater<O>()); */
+
+/*     std::vector<ProcHeap<P>> heaps; */
+/*     for (int i = 0; i < O::dimension; i++) */
+/*     { */
+/*       heaps.push_back(ProcHeap<P>(procs, i)); */
+/*     } */
+
+/*     std::array<float, O::dimension> averageLoad; */
+
+/*     for (const auto& o : objs) */
+/*     { */
+/*       for (int i = 0; i < O::dimension; i++) */
+/*       { */
+/*         averageLoad[i] += o.load[i]; */
+/*       } */
+/*     } */
+
+/*     for (int i = 0; i < O::dimension; i++) */
+/*     { */
+/*       averageLoad[i] /= objs.size(); */
+/*     } */
+
+/*     for (const auto& o : objs) */
+/*     { */
+/*       int maxdimension = 0; */
+/*       float maxfactor = 0; */
+/*       for (int i = 0; i < O::dimension; i++) */
+/*       { */
+/*         if (o.load[i] / averageLoad[i] > maxfactor) */
+/*         { */
+/*           maxfactor = o.load[i] / averageLoad[i]; */
+/*           maxdimension = i; */
+/*         } */
+/*       } */
+/*       P p = heaps[maxdimension].top(); */
+/*       solution.assign(o, p);  // update solution (assumes solution updates processor load) */
+/*       for (int i = 0; i < O::dimension; i++) */
+/*       { */
+/*         heaps[i].remove(p); */
+/*         heaps[i].push(p); */
+/*       } */
+/*     } */
+/*   } */
+/* }; */
+
+/* template <typename P, typename S> */
+/* class Greedy<Obj<1>, P, S> : public Strategy<Obj<1>, P, S> */
+/* { */
+/* public: */
+/*   void solve(std::vector<Obj<1>>& objs, std::vector<P>& procs, S& solution, */
+/*              bool objsSorted) */
+/*   { */
+/*     if (!objsSorted) std::sort(objs.begin(), objs.end(), CmpLoadGreater<Obj<1>>()); */
+/*     std::priority_queue<P, std::vector<P>, CmpLoadGreater<P>> procHeap( */
+/*         CmpLoadGreater<P>(), procs); */
+
+/*     for (const auto& o : objs) */
+/*     { */
+/*       P p = procHeap.top(); */
+/*       procHeap.pop(); */
+/*       solution.assign(o, p);  // update solution (assumes solution updates processor load) */
+/*       procHeap.push(p); */
+/*     } */
+/*   } */
+/* }; */
+
+
+#endif // GREEDY_H_

--- a/src/vt/vrt/collection/balance/charmlb/kd.h
+++ b/src/vt/vrt/collection/balance/charmlb/kd.h
@@ -1,0 +1,460 @@
+#ifndef KD_H
+#define KD_H
+
+#include <array>
+#ifdef DEBUG
+#  include <iostream>
+#endif
+#include <limits>
+#include <random>
+#include <stack>
+#include <utility>
+
+using KDFloatType = double;
+
+template <typename TreeType, typename Elem, int N=Elem::dimension>
+class BaseKDNode
+{
+protected:
+  Elem data;
+  unsigned int size = 1;
+  TreeType* left = nullptr;
+  TreeType* right = nullptr;
+  KDFloatType norm;
+
+  BaseKDNode(const Elem& key) : data(key), norm(calcNorm(data)) {}
+
+  template <typename T>
+  static KDFloatType calcNorm(const T& x)
+  {
+    KDFloatType sum = 0;
+    for (int i = 0; i < N; i++)
+    {
+      const auto element = x[i];
+      const auto elementSq = element * element;
+      sum += elementSq * elementSq;
+    }
+    return sum;
+  }
+
+  template <typename A, typename B>
+  static KDFloatType calcNorm(const A& a, const B& b)
+  {
+    KDFloatType sum = 0;
+    for (int i = 0; i < N; i++)
+    {
+      const auto element = a[i] + b[i];
+      const auto elementSq = element * element;
+      sum += elementSq * elementSq;
+    }
+    return sum;
+  }
+
+  template <typename A, typename B>
+  static std::array<KDFloatType, N> addVecs(const A& a, const B& b)
+  {
+    std::array<KDFloatType, N> sum = {0};
+    for (int i = 0; i < N; i++)
+    {
+      sum[i] = a[i] + b[i];
+    }
+
+    return sum;
+  }
+
+#ifdef DEBUG
+public:
+  static void printTree(TreeType tree, std::string prefix = "")
+  {
+    std::cout << prefix;
+    for (int i = 0; i < N; i++) std::cout << tree->data[i] << " ";
+    std::cout << std::endl;
+    if (tree->left != nullptr) printTree(tree->left, prefix + "L  ");
+    if (tree->right != nullptr) printTree(tree->right, prefix + "R  ");
+  }
+#endif
+};
+
+template <typename Elem, int N=Elem::dimension>
+class KDNode : BaseKDNode<KDNode<Elem, N>, Elem>
+{
+  using base = BaseKDNode<KDNode<Elem, N>, Elem>;
+  using kdt = KDNode*;
+public:
+  KDNode(const Elem& key) : base(key) {}
+
+  static kdt insert(kdt t, const Elem& x, unsigned int depth = 0)
+  {
+    if (t == nullptr)
+      t = new KDNode(x);
+    else
+    {
+      t->size++;
+      const auto dim = depth % N;
+      if (x[dim] < t->data[dim])
+	t->left = insert(t->left, x, depth + 1);
+      else
+	t->right = insert(t->right, x, depth + 1);
+    }
+    return t;
+  }
+
+  static Elem findMin(kdt t, unsigned int targetDim, unsigned int depth = 0)
+  {
+    assert(t != nullptr);
+    const auto dim = depth % N;
+    if (dim == targetDim)
+    {
+      if (t->left == nullptr)
+	return t->data;
+      else
+	return findMin(t->left, targetDim, depth + 1);
+    }
+    else
+    {
+      auto obj = t->data;
+      if (t->left != nullptr)
+      {
+	const auto left = findMin(t->left, targetDim, depth + 1);
+	if (left[targetDim] < obj[targetDim])
+	  obj = left;
+      }
+      if (t->right != nullptr)
+      {
+	const auto right = findMin(t->right, targetDim, depth + 1);
+	if (right[targetDim] < obj[targetDim])
+	  obj = right;
+      }
+      return obj;
+    }
+  }
+
+  static kdt remove(kdt t, const Elem& x, unsigned int depth = 0)
+  {
+    const auto dim = depth % N;
+    t->size--;
+
+    if (t->data == x)
+    {
+      if (t->right != nullptr)
+      {
+	t->data = findMin(t->right, dim, depth + 1);
+	t->right = remove(t->right, t->data, depth + 1);
+      }
+      else if (t->left != nullptr)
+      {
+	t->data = findMin(t->left, dim, depth + 1);
+	t->right = remove(t->left, t->data, depth + 1);
+	t->left = nullptr;
+      }
+      else
+      {
+	delete t;
+	t = nullptr;
+      }
+    }
+    else if (x[dim] < t->data[dim])
+      t->left = remove(t->left, x, depth + 1);
+    else
+      t->right = remove(t->right, x, depth + 1);
+
+    return t;
+  }
+
+  template <typename T>
+  static Elem* findMinNorm(kdt t, const T& x)
+  {
+    std::array<KDFloatType, N> mins = {0};
+    KDFloatType bestNorm = std::numeric_limits<KDFloatType>::max();
+    return findMinNormHelper(t, x, 0, nullptr, bestNorm, mins);
+  }
+
+private:
+  template <typename T>
+  static Elem* findMinNormHelper(kdt t, const T& x, unsigned int depth, Elem* bestObj,
+                                 KDFloatType& bestNorm, std::array<KDFloatType, N>& minBounds)
+  {
+    const auto dim = depth % N;
+
+    if (t->left != nullptr)
+    {
+      bestObj = findMinNormHelper(t->left, x, depth + 1, bestObj, bestNorm, minBounds);
+    }
+    if (t->norm < bestNorm)
+    {
+      const auto rootNorm = base::calcNorm(x, t->data);
+      if (rootNorm < bestNorm)
+      {
+	bestObj = &(t->data);
+	bestNorm = rootNorm;
+      }
+    }
+    if (t->right != nullptr)
+    {
+      const auto oldMin = minBounds[dim];
+      minBounds[dim] = t->data[dim];
+      if (base::calcNorm(x, minBounds) < bestNorm)
+      {
+	bestObj = findMinNormHelper(t->right, x, depth + 1, bestObj, bestNorm, minBounds);
+      }
+      minBounds[dim] = oldMin;
+    }
+
+    return bestObj;
+  }
+};
+
+template <typename Elem, int N = Elem::dimension,
+          typename Engine = std::default_random_engine>
+class RKDNode : BaseKDNode<RKDNode<Elem, N, Engine>, Elem>
+{
+  using base = BaseKDNode<RKDNode<Elem, N, Engine>, Elem>;
+  using rkdt = RKDNode*;
+private:
+  int discr;
+
+  static int random(int min, int max)
+  {
+    static Engine rng;
+    return std::uniform_int_distribution<int>(min, max)(rng);
+  }
+
+public:
+  RKDNode(const Elem& key) : base(key), discr(random(0, N - 1)) {}
+
+  static rkdt insert(rkdt t, const Elem& x)
+  {
+    std::stack<std::pair<rkdt, bool>> stack;
+    while (t != nullptr && random(0, t->size) > 0)
+    {
+      t->size++;
+      const int i = t->discr;
+      const bool isLeftChild = x[i] < t->data[i];
+      stack.emplace(t, isLeftChild);
+      if (isLeftChild)
+      {
+        t = t->left;
+      }
+      else
+      {
+        t = t->right;
+      }
+    }
+
+    t = insert_at_root(t, x);
+
+    while (!stack.empty())
+    {
+      const std::pair<rkdt, bool>& entry = stack.top();
+      const rkdt parent = entry.first;
+      const bool isLeftChild = entry.second;
+      if (isLeftChild)
+        parent->left = t;
+      else
+        parent->right = t;
+      t = parent;
+      stack.pop();
+    }
+    return t;
+  }
+
+  static rkdt remove(rkdt t, const Elem& x)
+  {
+    if (t == nullptr) return nullptr;
+    const int i = t->discr;
+    if (t->data == x)
+    {
+      const auto newRoot = join(t->left, t->right, i);
+      delete t;
+      return newRoot;
+    }
+    t->size--;
+    if (x[i] < t->data[i])
+      t->left = remove(t->left, x);
+    else
+      t->right = remove(t->right, x);
+    return t;
+  }
+
+  static rkdt insert_at_root(rkdt t, const Elem& x)
+  {
+    rkdt r = new RKDNode(x);
+    if (t != nullptr) r->size += t->size;
+    auto p = split(t, r);
+    r->left = p.first;
+    r->right = p.second;
+    return r;
+  }
+
+  // This splits t's subtrees at whatever r specifies
+  // t might be nullptr, r cannot be
+  static std::pair<rkdt, rkdt> split(rkdt t, rkdt r)
+  {
+    if (t == nullptr) return std::make_pair(nullptr, nullptr);
+    const int i = r->discr;
+    const int j = t->discr;
+
+    // t and r discriminate in the same dimension, so just resplit the appropriate subtree
+    // of t
+    if (i == j)
+    {
+      if (r->data[i] < t->data[i])
+      {
+        const auto p = split(t->left, r);
+        t->left = p.second;
+        const int splitSize = (p.first == nullptr) ? 0 : p.first->size;
+        t->size -= splitSize;
+        return std::make_pair(p.first, t);
+      }
+      else
+      {
+        const auto p = split(t->right, r);
+        t->right = p.first;
+        const int splitSize = (p.second == nullptr) ? 0 : p.second->size;
+        t->size -= splitSize;
+        return std::make_pair(t, p.second);
+      }
+    }
+    // t and r discriminate on different dimensions, so recursively split both subtrees of
+    // t
+    else
+    {
+      const auto L = split(t->left, r);
+      const auto R = split(t->right, r);
+      if (r->data[i] < t->data[i])
+      {
+        t->left = L.second;
+        t->right = R.second;
+        const int splitSize = ((L.first == nullptr) ? 0 : L.first->size) +
+                              ((R.first == nullptr) ? 0 : R.first->size);
+        t->size -= splitSize;
+
+        return std::make_pair(join(L.first, R.first, j), t);
+      }
+      else
+      {
+        t->left = L.first;
+        t->right = R.first;
+        const int splitSize = ((L.second == nullptr) ? 0 : L.second->size) +
+                              ((R.second == nullptr) ? 0 : R.second->size);
+        t->size -= splitSize;
+
+        return std::make_pair(t, join(L.second, R.second, j));
+      }
+    }
+  }
+
+  static rkdt join(rkdt l, rkdt r, int dim)
+  {
+    if (l == nullptr) return r;
+    if (r == nullptr) return l;
+
+    const int m = l->size;
+    const int n = r->size;
+    const int u = random(0, m + n - 1);
+    if (u < m)
+    {
+      l->size += r->size;
+      if (l->discr == dim)
+      {
+        l->right = join(l->right, r, dim);
+        return l;
+      }
+      else
+      {
+        auto R = split(r, l);
+        l->left = join(l->left, R.first, dim);
+        l->right = join(l->right, R.second, dim);
+        return l;
+      }
+    }
+    else
+    {
+      r->size += l->size;
+      if (r->discr == dim)
+      {
+        r->left = join(l, r->left, dim);
+        return r;
+      }
+      else
+      {
+        auto L = split(l, r);
+        r->left = join(L.first, r->left, dim);
+        r->right = join(L.second, r->right, dim);
+        return r;
+      }
+    }
+  }
+
+  template <typename T>
+  static Elem* findMinNorm(rkdt t, const T& x)
+  {
+    std::array<KDFloatType, N> mins = {0};
+    KDFloatType bestNorm = std::numeric_limits<KDFloatType>::max();
+    return findMinNormHelper(t, x, nullptr, bestNorm, mins);
+  }
+
+private:
+  template <typename T>
+  static Elem* findMinNormHelper(rkdt t, const T& x, Elem* bestObj, KDFloatType& bestNorm,
+                                 std::array<KDFloatType, N>& minBounds)
+  {
+    const auto dim = t->discr;
+
+    if (t->left != nullptr)
+    {
+      bestObj = findMinNormHelper(t->left, x, bestObj, bestNorm, minBounds);
+    }
+    if (t->norm < bestNorm)
+    {
+      const auto rootNorm = base::calcNorm(x, t->data);
+      if (rootNorm < bestNorm)
+      {
+        bestObj = &(t->data);
+        bestNorm = rootNorm;
+      }
+    }
+    if (t->right != nullptr)
+    {
+      const auto oldMin = minBounds[dim];
+      minBounds[dim] = t->data[dim];
+      if (base::calcNorm(x, minBounds) < bestNorm)
+      {
+        bestObj = findMinNormHelper(t->right, x, bestObj, bestNorm, minBounds);
+      }
+      minBounds[dim] = oldMin;
+    }
+
+    return bestObj;
+  }
+
+  static Elem findMin(rkdt t, unsigned int targetDim)
+  {
+    assert(t != nullptr);
+    const auto dim = t->discr;
+    if (dim == targetDim)
+    {
+      if (t->left == nullptr)
+        return t->data;
+      else
+        return findMin(t->left, targetDim);
+    }
+    else
+    {
+      auto obj = t->data;
+      if (t->left != nullptr)
+      {
+        const auto left = findMin(t->left, targetDim);
+        if (left[targetDim] < obj[targetDim]) obj = left;
+      }
+      if (t->right != nullptr)
+      {
+        const auto right = findMin(t->right, targetDim);
+        if (right[targetDim] < obj[targetDim]) obj = right;
+      }
+      return obj;
+    }
+  }
+};
+
+#endif /* KD_H */

--- a/src/vt/vrt/collection/balance/charmlb/kdlb.h
+++ b/src/vt/vrt/collection/balance/charmlb/kdlb.h
@@ -1,0 +1,50 @@
+#ifndef KDLB_H
+#define KDLB_H
+
+#include "TreeStrategyBase.h"
+#include "kd.h"
+#include <iostream>
+
+namespace TreeStrategy
+{
+template <typename O, typename P, typename S, typename T>
+class BaseKdLB : public Strategy<O, P, S>
+{
+public:
+  BaseKdLB() = default;
+  void solve(std::vector<O>& objs, std::vector<P>& procs, S& solution, bool objsSorted)
+  {
+    // Sorts by maxload in vector
+    if (!objsSorted) std::sort(objs.begin(), objs.end(), CmpLoadGreater<O>());
+
+    auto objsIter = objs.begin();
+    T* tree = nullptr;
+    for (size_t i = 0; i < procs.size() && objsIter != objs.end(); i++, objsIter++)
+    {
+      solution.assign(*objsIter, procs[i]);
+      tree = T::insert(tree, procs[i]);
+    }
+
+    for (; objsIter != objs.end(); objsIter++)
+    {
+      auto proc = *(T::findMinNorm(tree, *objsIter));
+      tree = T::remove(tree, proc);
+      solution.assign(*objsIter, proc);
+      tree = T::insert(tree, proc);
+    }
+  }
+};
+
+template <typename O, typename P, typename S>
+class KdLB : public BaseKdLB<O, P, S, KDNode<P>>
+{
+};
+
+template <typename O, typename P, typename S>
+class RKdLB : public BaseKdLB<O, P, S, RKDNode<P>>
+{
+};
+
+}  // namespace TreeStrategy
+
+#endif /* KDLB_H */

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -52,6 +52,7 @@
 #include "vt/vrt/collection/balance/node_stats.h"
 #include "vt/vrt/collection/balance/hierarchicallb/hierlb.h"
 #include "vt/vrt/collection/balance/greedylb/greedylb.h"
+#include "vt/vrt/collection/balance/charmlb/charmlb.h"
 #include "vt/vrt/collection/balance/rotatelb/rotatelb.h"
 #include "vt/vrt/collection/balance/temperedlb/temperedlb.h"
 #include "vt/vrt/collection/balance/statsmaplb/statsmaplb.h"
@@ -243,6 +244,7 @@ void LBManager::startLB(PhaseType phase, LBType lb) {
   switch (lb) {
   case LBType::HierarchicalLB: lb_instances_["chosen"] = makeLB<lb::HierarchicalLB>(); break;
   case LBType::GreedyLB:       lb_instances_["chosen"] = makeLB<lb::GreedyLB>();       break;
+  case LBType::CharmLB:        lb_instances_["chosen"] = makeLB<lb::CharmLB>();       break;
   case LBType::RotateLB:       lb_instances_["chosen"] = makeLB<lb::RotateLB>();       break;
   case LBType::TemperedLB:     lb_instances_["chosen"] = makeLB<lb::TemperedLB>();     break;
   case LBType::StatsMapLB:     lb_instances_["chosen"] = makeLB<lb::StatsMapLB>();     break;
@@ -282,6 +284,9 @@ void LBManager::printLBArgsHelp(LBType lb) {
     break;
   case LBType::GreedyLB:
     help = lb::GreedyLB::getInputKeysWithHelp();
+    break;
+  case LBType::CharmLB:
+    help = lb::CharmLB::getInputKeysWithHelp();
     break;
   case LBType::RotateLB:
     help = lb::RotateLB::getInputKeysWithHelp();

--- a/src/vt/vrt/collection/balance/lb_type.cc
+++ b/src/vt/vrt/collection/balance/lb_type.cc
@@ -60,6 +60,7 @@ static std::unordered_map<LBType,std::string> lb_names_ = {
   {LBType::TemperedLB,     std::string{"TemperedLB"    }},
   {LBType::StatsMapLB,     std::string{"StatsMapLB"    }},
   {LBType::RandomLB,       std::string{"RandomLB"      }},
+  {LBType::CharmLB,        std::string{"CharmLB"      }},
 };
 
 std::unordered_map<LBType, std::string>& get_lb_names() {

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -86,6 +86,7 @@ void colHandler(MyMsg*, MyCol* col) {
 
 struct TestLoadBalancerOther : TestParallelHarnessParam<std::string> { };
 struct TestLoadBalancerGreedy : TestParallelHarnessParam<std::string> { };
+struct TestLoadBalancerCharm : TestParallelHarnessParam<std::string> { };
 
 void runTest(std::string lb_name) {
   vt::theConfig()->vt_lb = true;
@@ -103,6 +104,12 @@ void runTest(std::string lb_name) {
   if (lb_name.substr(0, 8).compare("GreedyLB") == 0) {
     vt::theConfig()->vt_lb_name = "GreedyLB";
     auto strat_arg = lb_name.substr(9, lb_name.size() - 9);
+    fmt::print("strat_arg={}\n", strat_arg);
+    vt::theConfig()->vt_lb_args = strat_arg;
+  }
+  if (lb_name.substr(0, 7).compare("CharmLB") == 0) {
+    vt::theConfig()->vt_lb_name = "CharmLB";
+    auto strat_arg = lb_name.substr(8, lb_name.size() - 8);
     fmt::print("strat_arg={}\n", strat_arg);
     vt::theConfig()->vt_lb_args = strat_arg;
   }
@@ -148,6 +155,15 @@ TEST_P(TestLoadBalancerGreedy, test_load_balancer_greedy_keep_last_elm) {
   runTest(GetParam());
 }
 
+TEST_P(TestLoadBalancerCharm, test_load_balancer_charm_2) {
+  runTest(GetParam());
+}
+
+TEST_P(TestLoadBalancerCharm, test_load_balancer_charm_keep_last_elm) {
+  vt::theConfig()->vt_lb_keep_last_elm = true;
+  runTest(GetParam());
+}
+
 struct MyCol2 : vt::Collection<MyCol2,vt::Index1D> {};
 
 using TestLoadBalancerNoWork = TestParallelHarness;
@@ -188,12 +204,23 @@ auto balancers_greedy = ::testing::Values(
     "GreedyLB:strategy=bcast"
 );
 
+auto balancers_charm = ::testing::Values(
+    "CharmLB:strategy=scatter",
+    "CharmLB:strategy=pt2pt",
+    "CharmLB:strategy=bcast"
+);
+
+
 INSTANTIATE_TEST_SUITE_P(
   LoadBalancerExplodeOther, TestLoadBalancerOther, balancers_other
 );
 
 INSTANTIATE_TEST_SUITE_P(
   LoadBalancerExplodeGreedy, TestLoadBalancerGreedy, balancers_greedy
+);
+
+INSTANTIATE_TEST_SUITE_P(
+  LoadBalancerExplodeCharm, TestLoadBalancerCharm, balancers_charm
 );
 
 struct TestParallelHarnessWithStatsDumping : TestParallelHarnessParam<int> {


### PR DESCRIPTION
This can be used to run any Charm++ TreeLB based strategy as a balancer for VT. Currently it's hardcoded to use RKdLB, a vector based strategy based on the relaxed k-d tree, but that can be modified by changing `src/vt/vrt/collection/balance/charmlb/charmlb.cc` (see comments in that file that show how to use Charm++'s GreedyLB strategy instead, for example).