### PR TITLE
1737 establish gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,6 @@ intel19:
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_intel19
   only:
     refs:
-      - 1737-establish-gitlab-pipeline
       - develop
   tags:
     - intel19_batch
@@ -47,7 +46,6 @@ nvcc_wrapper-vortex:
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_nvcc_wrapper
   only:
     refs:
-      - 1737-establish-gitlab-pipeline
       - develop
   tags:
     - ppc64le 
@@ -66,7 +64,6 @@ arm-stria:
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_gcc
   only:
     refs:
-      - 1737-establish-gitlab-pipeline
       - develop
   tags:
     - aarch64 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,8 +35,8 @@ xlC-vortex:
     FC: "gfortran"
     OMPI_CC: "gcc"
     CC: "gcc"
-    OMPI_CXX: "nvcc_wrapper"
-    CXX: "nvcc_wrapper"
+    OMPI_CXX: "g++"
+    CXX: "g++"
   stage: build
   script:
     - module load cmake/3.18.0
@@ -49,7 +49,7 @@ xlC-vortex:
     - module load cuda/10.1.243
     - module unload spectrum-mpi
     - module load spectrum-mpi/rolling-release
-    - ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_ats2
+    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/build
   only:
     refs:
       - develop
@@ -59,11 +59,16 @@ xlC-vortex:
 
 
 arm-stria:
+  variables:
+    CC: "gcc"
+    CXX: "c++"
   stage: build
   script:
     - module unload devpack-gnu7
     - module load devpack-arm
-    - ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_van1
+    - module load cde/v2.1/ninja
+    - module swap cmake cmake/3.20.5
+    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/build
   only:
     refs:
       - develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ xlC-vortex:
   only:
     refs:
       - develop
-      - merge_request
+      - add_pipeline
   tags:
     - ppc64le 
 
@@ -67,6 +67,6 @@ arm-stria:
   only:
     refs:
       - develop
-      - merge_request
+      - add_pipeline
   tags:
     - aarch64 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,12 +9,12 @@ stages:
 
 intel19:
   variables:
-    - OMPI_FC: "ifort"
-    - FC: "ifort"
-    - OMPI_CC: "icc"
-    - CC: "icc"
-    - OMPI_CXX: "icpc"
-    - CXX: "icpc"
+    OMPI_FC: "ifort"
+    FC: "ifort"
+    OMPI_CC: "icc"
+    CC: "icc"
+    OMPI_CXX: "icpc"
+    CXX: "icpc"
   stage: build
   script:
     - module load cde/v2/cmake/3.19.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# This runs testing for intel 18 and 19 which are not available
+# This runs testing for intel 19 and platforms which are not available
 # in the github testing environment
 
 stages:
@@ -7,7 +7,7 @@ stages:
 
 # before_script:
 
-.intel19:
+intel19:
   variables:
     - OMPI_FC: "ifort"
     - FC: "ifort"
@@ -19,37 +19,39 @@ stages:
   script:
     - module load cde/v2/cmake/3.19.2
     - module load cde/v2/ninja/1.10.1
+    - module unload intel/16.0
     - module load cde/v2/compiler/intel/19.1.2
+    - module unload openmpi-intel/1.10
     - module load cde/v2/intel/19.1.2/openmpi/4.0.5
-    - vt/ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_intel19
+    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_intel19
   only:
     refs:
       - develop
       - merge_request
   tags:
-    - foobar
+    - intel19
 
 xlC-vortex:
   variables:
     OMPI_FC: "gfortran"
-    FC: "gfortran"
+    FC: "xlf"
     OMPI_CC: "gcc"
-    CC: "gcc"
+    CC: "xlc"
     OMPI_CXX: "g++"
-    CXX: "g++"
+    CXX: "xlc++"
   stage: build
   script:
     - module load cmake/3.18.0
     - module load ninja/1.9.0
     - module load git
-    - module unload xl
-    - module unload gcc
-    - module load gcc/7.2.1-redhat
-    - module unload cuda
-    - module load cuda/10.1.243
-    - module unload spectrum-mpi
-    - module load spectrum-mpi/rolling-release
-    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/build
+    # module unload xl
+    # module unload gcc
+    # module load gcc/7.2.1-redhat
+    # module unload cuda
+    # module load cuda/10.1.243
+    # module unload spectrum-mpi
+    # module load spectrum-mpi/rolling-release
+    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_xlC
   only:
     refs:
       - develop
@@ -68,7 +70,7 @@ arm-stria:
     - module load devpack-arm
     - module load cde/v2.1/ninja
     - module swap cmake cmake/3.20.5
-    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/build
+    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_gcc
   only:
     refs:
       - develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ xlC-vortex:
     - module load cuda/10.1.243
     - module unload spectrum-mpi
     - module load spectrum-mpi/rolling-release
-    - vt/ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_ats2
+    - ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_ats2
   only:
     refs:
       - develop
@@ -63,7 +63,7 @@ arm-stria:
   script:
     - module unload devpack-gnu7
     - module load devpack-arm
-    - vt/ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_van1
+    - ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_van1
   only:
     refs:
       - develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,72 @@
+# This runs testing for intel 18 and 19 which are not available
+# in the github testing environment
+
+stages:
+  - build
+
+
+# before_script:
+
+.intel19:
+  variables:
+    - OMPI_FC: "ifort"
+    - FC: "ifort"
+    - OMPI_CC: "icc"
+    - CC: "icc"
+    - OMPI_CXX: "icpc"
+    - CXX: "icpc"
+  stage: build
+  script:
+    - module load cde/v2/cmake/3.19.2
+    - module load cde/v2/ninja/1.10.1
+    - module load cde/v2/compiler/intel/19.1.2
+    - module load cde/v2/intel/19.1.2/openmpi/4.0.5
+    - vt/ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_intel19
+  only:
+    refs:
+      - develop
+      - merge_request
+  tags:
+    - foobar
+
+xlC-vortex:
+  variables:
+    OMPI_FC: "gfortran"
+    FC: "gfortran"
+    OMPI_CC: "gcc"
+    CC: "gcc"
+    OMPI_CXX: "nvcc_wrapper"
+    CXX: "nvcc_wrapper"
+  stage: build
+  script:
+    - module load cmake/3.18.0
+    - module load ninja/1.9.0
+    - module load git
+    - module unload xl
+    - module unload gcc
+    - module load gcc/7.2.1-redhat
+    - module unload cuda
+    - module load cuda/10.1.243
+    - module unload spectrum-mpi
+    - module load spectrum-mpi/rolling-release
+    - vt/ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_ats2
+  only:
+    refs:
+      - develop
+      - merge_request
+  tags:
+    - ppc64le 
+
+
+arm-stria:
+  stage: build
+  script:
+    - module unload devpack-gnu7
+    - module load devpack-arm
+    - vt/ci/build_cpp.sh $CI_PROJECT_DIR ~/vt_build_van1
+  only:
+    refs:
+      - develop
+      - merge_request
+  tags:
+    - aarch64 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,25 +29,22 @@ intel19:
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_intel19
   only:
     refs:
-      - develop
+      - add_pipeline
       - merge_requests
   tags:
     - intel19_batch
 
-xlC-vortex:
+nvcc_wrapper-vortex:
   variables:
     OMPI_FC: "gfortran"
-    FC: "xlf"
     OMPI_CC: "gcc"
-    CC: "xlc"
-    OMPI_CXX: "g++"
-    CXX: "xlc++"
+    OMPI_CXX: "nvcc_wrapper"
   stage: build
   script:
-    - module load cmake/3.18.0
+    - module load sparc-dev/cuda-10.1.243_gcc-7.3.1_spmpi-rolling
     - module load ninja/1.9.0
-    - module load git
-    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_xlC
+    - mkdir -p /tmp/$USER
+    - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_nvcc_wrapper
   only:
     refs:
       - develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ intel19:
   only:
     refs:
       - develop
-      - merge_request
+      - add_pipeline
   tags:
     - intel19_batch
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ intel19:
       - develop
       - merge_request
   tags:
-    - intel19
+    - intel19_batch
 
 xlC-vortex:
   variables:
@@ -44,13 +44,6 @@ xlC-vortex:
     - module load cmake/3.18.0
     - module load ninja/1.9.0
     - module load git
-    # module unload xl
-    # module unload gcc
-    # module load gcc/7.2.1-redhat
-    # module unload cuda
-    # module load cuda/10.1.243
-    # module unload spectrum-mpi
-    # module load spectrum-mpi/rolling-release
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_xlC
   only:
     refs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,8 @@ intel19:
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_intel19
   only:
     refs:
-      - add_pipeline
-      - merge_requests
+      - 1737-establish-gitlab-pipeline
+      - develop
   tags:
     - intel19_batch
 
@@ -47,8 +47,8 @@ nvcc_wrapper-vortex:
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_nvcc_wrapper
   only:
     refs:
+      - 1737-establish-gitlab-pipeline
       - develop
-      - merge_requests
   tags:
     - ppc64le 
 
@@ -66,7 +66,7 @@ arm-stria:
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_gcc
   only:
     refs:
+      - 1737-establish-gitlab-pipeline
       - develop
-      - merge_requests
   tags:
     - aarch64 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - build
 
 variables:
-  ASC_WCID: "fy150069"
+  ASC_WCID: "fy140001"
 
 # before_script:
 
@@ -20,12 +20,7 @@ intel19:
     SCHEDULER_PARAMETERS: "--account=${ASC_WCID} --partition=short,batch --time=1:00:00 --nodes=1"
   stage: build
   script:
-    - module load cde/v2/cmake/3.19.2
-    - module load cde/v2/ninja/1.10.1
-    - module unload intel/16.0
-    - module load cde/v2/compiler/intel/19.1.2
-    - module unload openmpi-intel/1.10
-    - module load cde/v2/intel/19.1.2/openmpi/4.0.5
+    - source /projects/empire/installs/chama/INTEL-RELEASE-OPENMP-SHARED/trilinos/latest-link/load_matching_env.sh
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_intel19
   only:
     refs:
@@ -40,8 +35,7 @@ nvcc_wrapper-vortex:
     OMPI_CXX: "nvcc_wrapper"
   stage: build
   script:
-    - module load sparc-dev/cuda-10.1.243_gcc-7.3.1_spmpi-rolling
-    - module load ninja/1.9.0
+    - source /projects/empire/installs/vortex/CUDA-10.1.243_GNU-7.3.1_SPMPI-ROLLING-RELEASE-CUDA-STATIC/trilinos/latest-link/load_matching_env.sh
     - mkdir -p /tmp/$USER
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_nvcc_wrapper
   only:
@@ -57,10 +51,7 @@ arm-stria:
     CXX: "c++"
   stage: build
   script:
-    - module unload devpack-gnu7
-    - module load devpack-arm
-    - module load cde/v2.1/ninja
-    - module swap cmake cmake/3.20.5
+    - source /projects/empire/installs/stria/ARM-20.1_OPENMPI-4.0.5-RELEASE-OPENMP-STATIC/trilinos/latest-link/load_matching_env.sh
     - ci/build_cpp.sh $CI_PROJECT_DIR $CI_PROJECT_DIR/vt_build_gcc
   only:
     refs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,8 @@
 stages:
   - build
 
+variables:
+  ASC_WCID: "fy150069"
 
 # before_script:
 
@@ -15,6 +17,7 @@ intel19:
     CC: "icc"
     OMPI_CXX: "icpc"
     CXX: "icpc"
+    SCHEDULER_PARAMETERS: "--account=${ASC_WCID} --partition=short,batch --time=1:00:00 --nodes=1"
   stage: build
   script:
     - module load cde/v2/cmake/3.19.2
@@ -27,7 +30,7 @@ intel19:
   only:
     refs:
       - develop
-      - add_pipeline
+      - merge_requests
   tags:
     - intel19_batch
 
@@ -48,7 +51,7 @@ xlC-vortex:
   only:
     refs:
       - develop
-      - add_pipeline
+      - merge_requests
   tags:
     - ppc64le 
 
@@ -67,6 +70,6 @@ arm-stria:
   only:
     refs:
       - develop
-      - add_pipeline
+      - merge_requests
   tags:
     - aarch64 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,10 +110,6 @@ add_subdirectory(src)
 #
 option(VT_BUILD_TESTS "Build VT tests" ON)
 
-message("VT_BUILD_TESTS is: $VT_BUILD_TESTS")
-message("CMAKE_PROJECT_NAME is: $CMAKE_PROJECT_NAME")
-message("CMAKE_PROJECT_NAME is: $CMAKE_PROJECT_NAME")
-
 if (VT_BUILD_TESTS
    AND "${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
   # CTest implies enable_testing() and defines the BUILD_TESTING option.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,8 @@ add_subdirectory(src)
 #
 option(VT_BUILD_TESTS "Build VT tests" ON)
 
-if (VT_BUILD_TESTS
-   AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if ($VT_BUILD_TESTS
+   AND ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
   # CTest implies enable_testing() and defines the BUILD_TESTING option.
   # The default of BUILD_TESTING is ON.
   # Testing is only enabled if the actual project being built is VT.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,12 @@ add_subdirectory(src)
 #
 option(VT_BUILD_TESTS "Build VT tests" ON)
 
-if ($VT_BUILD_TESTS
-   AND ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+message("VT_BUILD_TESTS is: $VT_BUILD_TESTS")
+message("CMAKE_PROJECT_NAME is: $CMAKE_PROJECT_NAME")
+message("CMAKE_PROJECT_NAME is: $CMAKE_PROJECT_NAME")
+
+if (VT_BUILD_TESTS
+   AND "${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
   # CTest implies enable_testing() and defines the BUILD_TESTING option.
   # The default of BUILD_TESTING is ON.
   # Testing is only enabled if the actual project being built is VT.


### PR DESCRIPTION
Fixes #1737

This sets up a gitlab pipeline to cover three platforms not available externally. Hopefully the use of a fork is not a problem, but the main repo would not let me push a branch.