### PR TITLE
1757 Allow destroying an LB from outside the LBManager

### DIFF
--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -378,6 +378,14 @@ void LBManager::startup() {
   });
 }
 
+void LBManager::destroyLB() {
+  // Destruct the objgroup that was used for LB
+  if (destroy_lb_ != nullptr) {
+    destroy_lb_();
+    destroy_lb_ = nullptr;
+  }
+}
+
 void LBManager::finishedLB(PhaseType phase) {
   vt_debug_print(
     normal, lb,
@@ -387,11 +395,7 @@ void LBManager::finishedLB(PhaseType phase) {
   theNodeLBData()->startIterCleanup(phase, model_->getNumPastPhasesNeeded());
   theNodeLBData()->outputLBDataForPhase(phase);
 
-  // Destruct the objgroup that was used for LB
-  if (destroy_lb_ != nullptr) {
-    destroy_lb_();
-    destroy_lb_ = nullptr;
-  }
+  destroyLB();
 }
 
 void LBManager::statsHandler(StatsMsgType* msg) {

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -166,6 +166,8 @@ public:
    */
   static void printLBArgsHelp(std::string lb);
 
+  void destroyLB();
+
 protected:
   /**
    * \internal


### PR DESCRIPTION
In support of LB data replay.

Closes #1757 
