### PR TITLE
1756 Allow computing LB statistics from outside LBManager

### DIFF
--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -233,7 +233,7 @@ protected:
 
   void defaultPostLBWork(ReassignmentMsg* r);
 
-private:
+public:
   /**
    * \brief Compute statistics given a load model
    *
@@ -248,6 +248,8 @@ private:
   );
 
   void statsHandler(StatsMsgType* msg);
+
+private:
   bool isCollectiveComm(elm::CommCategory cat) const;
 
 private:


### PR DESCRIPTION
In support of LB data replay.

Closes #1756.