### PR TITLE
1799: do not apply `-ftemplate-backtrace-limit` for older `icpc` versions

### DIFF
--- a/cmake/turn_on_warnings.cmake
+++ b/cmake/turn_on_warnings.cmake
@@ -21,7 +21,10 @@ if(NOT DEFINED VT_WARNING_FLAGS)
   add_cxx_compiler_flag_if_supported("-Wno-unknown-pragmas")
   add_cxx_compiler_flag_if_supported("-Wsign-compare")
   # Not really a warning, is still diagnostic related..
-  add_cxx_compiler_flag_if_supported("-ftemplate-backtrace-limit=100")
+  if (NOT CMAKE_CXX_COMPILER_ID STREQUAL Intel OR
+      NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 2021)
+    add_cxx_compiler_flag_if_supported("-ftemplate-backtrace-limit=100")
+  endif()
 
   if (vt_werror_enabled)   # Treat warning as errors
   add_cxx_compiler_flag_if_supported("-Werror")

--- a/cmake/turn_on_warnings.cmake
+++ b/cmake/turn_on_warnings.cmake
@@ -22,7 +22,7 @@ if(NOT DEFINED VT_WARNING_FLAGS)
   add_cxx_compiler_flag_if_supported("-Wsign-compare")
   # Not really a warning, is still diagnostic related..
   if (NOT CMAKE_CXX_COMPILER_ID STREQUAL Intel OR
-      NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 2021)
+      CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2021)
     add_cxx_compiler_flag_if_supported("-ftemplate-backtrace-limit=100")
   endif()
 


### PR DESCRIPTION
fixes #1799 

- `check_cxx_compiler_flag` doesn't seem to work correctly for this flag (and compilers).
- I have verified that flags are applied correctly for `icpc 2021.6.0`, so I assume that only older versions require this additional `if`.
- AFAIK no [Intel-specific flag](https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/alphabetical-list-of-compiler-options.html) is available.

@lifflander I don't have access to Intel 18/19, so someone has to verify this before merging.