### PR TITLE
1129 improve api for subphases

### DIFF
--- a/examples/collection/lb_iter.cc
+++ b/examples/collection/lb_iter.cc
@@ -52,14 +52,13 @@ struct IterCol : vt::Collection<IterCol, vt::Index1D> {
   struct IterMsg : vt::CollectionMessage<IterCol> {
     IterMsg() = default;
     IterMsg(
-      int64_t const in_work_amt, int64_t const in_iter, int64_t const subphase
+      int64_t const in_work_amt, int64_t const in_iter
     )
-      : iter_(in_iter), work_amt_(in_work_amt), subphase_(subphase)
+      : iter_(in_iter), work_amt_(in_work_amt)
     { }
 
     int64_t iter_ = 0;
     int64_t work_amt_ = 0;
-    int64_t subphase_ = 0;
   };
 
   void iterWork(IterMsg* msg);
@@ -77,7 +76,6 @@ private:
 static double weight = 1.0f;
 
 void IterCol::iterWork(IterMsg* msg) {
-  this->lb_data_.setSubPhase(msg->subphase_);
   double val = 0.1f;
   double val2 = 0.4f * msg->work_amt_;
   auto const idx = getIndex().x();
@@ -130,14 +128,14 @@ int main(int argc, char** argv) {
   for (int i = 0; i < num_iter; i++) {
     auto cur_time = vt::timing::getCurrentTime();
 
-    vt::runInEpochCollective([=]{
-      proxy.broadcastCollective<IterCol::IterMsg,&IterCol::iterWork>(10, i, 0);
+    vt::runSubphaseCollective([=]{
+      proxy.broadcastCollective<IterCol::IterMsg,&IterCol::iterWork>(10, i);
     });
-    vt::runInEpochCollective([=]{
-      proxy.broadcastCollective<IterCol::IterMsg,&IterCol::iterWork>(5,  i, 1);
+    vt::runSubphaseCollective([=]{
+      proxy.broadcastCollective<IterCol::IterMsg,&IterCol::iterWork>(5,  i);
     });
-    vt::runInEpochCollective([=]{
-      proxy.broadcastCollective<IterCol::IterMsg,&IterCol::iterWork>(15, i, 2);
+    vt::runSubphaseCollective([=]{
+      proxy.broadcastCollective<IterCol::IterMsg,&IterCol::iterWork>(15, i);
     });
 
     auto total_time = vt::timing::getCurrentTime() - cur_time;

--- a/src/vt/elm/elm_lb_data.h
+++ b/src/vt/elm/elm_lb_data.h
@@ -81,9 +81,7 @@ struct ElementLBData {
     NodeType to, ElementIDStruct from_perm,
     double bytes, bool bcast
   );
-  void updatePhase(PhaseType const& inc = 1);
-  void resetPhase();
-  PhaseType getPhase() const;
+  void updatePhase(PhaseType const& phase);
   TimeType getLoad(PhaseType const& phase) const;
   TimeType getLoad(PhaseType phase, SubphaseType subphase) const;
 
@@ -101,7 +99,6 @@ struct ElementLBData {
   void serialize(Serializer& s) {
     s | cur_time_started_;
     s | cur_time_;
-    s | cur_phase_;
     s | phase_timings_;
     s | phase_comm_;
     s | subphase_timings_;
@@ -122,7 +119,6 @@ protected:
 protected:
   bool cur_time_started_ = false;
   TimeType cur_time_ = 0.0;
-  PhaseType cur_phase_ = fst_lb_phase;
   std::unordered_map<PhaseType, TimeType> phase_timings_ = {};
   std::unordered_map<PhaseType, CommMapType> phase_comm_ = {};
 

--- a/src/vt/elm/elm_lb_data.h
+++ b/src/vt/elm/elm_lb_data.h
@@ -90,8 +90,6 @@ struct ElementLBData {
   CommMapType const& getComm(PhaseType const& phase);
   std::vector<CommMapType> const& getSubphaseComm(PhaseType phase);
   std::vector<TimeType> const& getSubphaseTimes(PhaseType phase);
-  void setSubPhase(SubphaseType subphase);
-  SubphaseType getSubPhase() const;
 
   // these are just for unit testing
   std::size_t getLoadPhaseCount() const;
@@ -106,7 +104,6 @@ struct ElementLBData {
     s | cur_phase_;
     s | phase_timings_;
     s | phase_comm_;
-    s | cur_subphase_;
     s | subphase_timings_;
     s | subphase_comm_;
   }
@@ -129,7 +126,6 @@ protected:
   std::unordered_map<PhaseType, TimeType> phase_timings_ = {};
   std::unordered_map<PhaseType, CommMapType> phase_comm_ = {};
 
-  SubphaseType cur_subphase_ = 0;
   std::unordered_map<PhaseType, std::vector<TimeType>> subphase_timings_ = {};
   std::unordered_map<PhaseType, std::vector<CommMapType>> subphase_comm_ = {};
 };

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -160,8 +160,10 @@ void ActiveMessenger::startup() {
 #if vt_check_enabled(lblite)
   // Hook to collect LB data about objgroups
   thePhase()->registerHookCollective(phase::PhaseHook::End, [this]{
+    auto const phase = thePhase()->getCurrentPhase();
     theNodeLBData()->addNodeLBData(
-      bare_handler_dummy_elm_id_for_lb_data_, &bare_handler_lb_data_, nullptr
+      bare_handler_dummy_elm_id_for_lb_data_, &bare_handler_lb_data_, nullptr,
+      phase
     );
   });
 #endif

--- a/src/vt/objgroup/manager.cc
+++ b/src/vt/objgroup/manager.cc
@@ -60,6 +60,7 @@ void ObjGroupManager::startup() {
 #if vt_check_enabled(lblite)
   // Hook to collect LB data about objgroups
   thePhase()->registerHookCollective(phase::PhaseHook::End, []{
+    auto const phase = thePhase()->getCurrentPhase();
     auto& objs = theObjGroup()->objs_;
     for (auto&& obj : objs) {
       auto holder = obj.second.get();
@@ -68,7 +69,9 @@ void ObjGroupManager::startup() {
         auto proxy = elm::ElmIDBits::getObjGroupProxy(elm_id.id, false);
         vtAssertExpr(proxy == obj.first);
         theNodeLBData()->registerObjGroupInfo(elm_id, obj.first);
-        theNodeLBData()->addNodeLBData(elm_id, &holder->getLBData(), nullptr);
+        theNodeLBData()->addNodeLBData(
+          elm_id, &holder->getLBData(), nullptr, phase
+        );
       }
     }
   });

--- a/src/vt/phase/phase_manager.cc
+++ b/src/vt/phase/phase_manager.cc
@@ -160,6 +160,7 @@ void PhaseManager::nextPhaseCollective() {
   runHooks(PhaseHook::EndPostMigration);
 
   cur_phase_++;
+  cur_subphase_ = 0;
 
   vt_debug_print(
     normal, phase,

--- a/src/vt/phase/phase_manager.h
+++ b/src/vt/phase/phase_manager.h
@@ -106,6 +106,18 @@ struct PhaseManager : runtime::component::Component<PhaseManager> {
   PhaseType getCurrentPhase() const { return cur_phase_; }
 
   /**
+   * \brief Get the current subphase
+   *
+   * \return the current subphase
+   */
+  SubphaseType getCurrentSubphase() const { return cur_subphase_; }
+
+  /**
+   * \brief Advance subphase
+   */
+  void advanceSubphase() { ++cur_subphase_; }
+
+  /**
    * \brief Collectively register a phase hook that triggers depending on the
    * type of hook
    *
@@ -200,6 +212,7 @@ public:
   template <typename SerializerT>
   void serialize(SerializerT& s) {
     s | cur_phase_
+      | cur_subphase_
       | proxy_
       | collective_hooks_
       | rooted_hooks_
@@ -213,6 +226,7 @@ public:
 
 private:
   PhaseType cur_phase_ = 0;                 /**< Current phase */
+  SubphaseType cur_subphase_ = 0;           /**< Current subphase */
   ObjGroupProxyType proxy_ = no_obj_group;  /**< Objgroup proxy  */
   HookIDMapType collective_hooks_;          /**< Collective regisstered hooks */
   HookIDMapType rooted_hooks_;              /**< Rooted regisstered hooks  */

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -76,6 +76,12 @@ void runInEpochCollective(Callable&& fn);
 template <typename Callable>
 void runInEpochCollective(std::string const& label, Callable&& fn);
 
+template <typename Callable>
+void runSubphaseCollective(Callable&& fn);
+
+template <typename Callable>
+void runSubphaseCollective(std::string const& label, Callable&& fn);
+
 namespace messaging {
 
 template <typename T>

--- a/src/vt/scheduler/scheduler.impl.h
+++ b/src/vt/scheduler/scheduler.impl.h
@@ -47,6 +47,7 @@
 #include "vt/config.h"
 #include "vt/messaging/active.h"
 #include "vt/termination/termination.h"
+#include "vt/phase/phase_manager.h"
 
 namespace vt {
 
@@ -69,6 +70,20 @@ void runInEpochCollective(Callable&& fn) {
 template <typename Callable>
 void runInEpochCollective(std::string const& label, Callable&& fn) {
   auto ep = theTerm()->makeEpochCollective(label);
+  runInEpoch(ep, std::forward<Callable>(fn));
+}
+
+template <typename Callable>
+void runSubphaseCollective(Callable&& fn) {
+  runSubphaseCollective("UNLABELED", std::forward<Callable>(fn));
+}
+
+template <typename Callable>
+void runSubphaseCollective(std::string const& label, Callable&& fn) {
+  auto ep = theTerm()->makeEpochCollective(label);
+  theTerm()->addActionEpoch(ep, [=]{
+    thePhase()->advanceSubphase();
+  });
   runInEpoch(ep, std::forward<Callable>(fn));
 }
 

--- a/src/vt/vrt/collection/balance/col_lb_data.impl.h
+++ b/src/vt/vrt/collection/balance/col_lb_data.impl.h
@@ -61,20 +61,22 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 template <typename ColT>
 /*static*/
 void CollectionLBData::syncNextPhase(CollectStatsMsg<ColT>* msg, ColT* col) {
-  auto& lb_data = col->lb_data_;
+  auto const phase = thePhase()->getCurrentPhase();
 
   vt_debug_print(
     normal, lb,
-    "ElementLBData: syncNextPhase ({}) (idx={}): lb_data.getPhase()={}, "
+    "ElementLBData: syncNextPhase ({}) (idx={}): phase()={}, "
     "msg->getPhase()={}\n",
-    print_ptr(col), col->getIndex(), lb_data.getPhase(), msg->getPhase()
+    print_ptr(col), col->getIndex(), phase, msg->getPhase()
   );
 
-  vtAssert(lb_data.getPhase() == msg->getPhase(), "Phases must match");
+  vtAssert(phase == msg->getPhase(), "Phases must match");
 
   auto const proxy = col->getProxy();
   auto const subphase = getFocusedSubPhase(proxy);
-  theNodeLBData()->addNodeLBData(col->elm_id_, &col->lb_data_, col, subphase);
+  theNodeLBData()->addNodeLBData(
+    col->elm_id_, &col->lb_data_, col, phase, subphase
+  );
 
   std::vector<uint64_t> idx;
   for (index::NumDimensionsType i = 0; i < col->getIndex().ndims(); i++) {

--- a/src/vt/vrt/collection/balance/node_lb_data.cc
+++ b/src/vt/vrt/collection/balance/node_lb_data.cc
@@ -247,14 +247,13 @@ void NodeLBData::registerObjGroupInfo(
 
 void NodeLBData::addNodeLBData(
   ElementIDStruct id, elm::ElementLBData* in, StorableType *storable,
-  SubphaseType focused_subphase
+  PhaseType phase, SubphaseType focused_subphase
 ) {
   vt_debug_print(
     normal, lb,
     "NodeLBData::addNodeLBData: id={}\n", id
   );
 
-  auto const phase = in->getPhase();
   auto const& total_load = in->getLoad(phase, focused_subphase);
 
   auto &phase_data = lb_data_->node_data_[phase];
@@ -289,7 +288,7 @@ void NodeLBData::addNodeLBData(
     );
   }
 
-  in->updatePhase(1);
+  in->updatePhase(phase + 1);
 
   auto model = theLBManager()->getLoadModel();
   in->releaseLBDataFromUnneededPhases(phase, model->getNumPastPhasesNeeded());

--- a/src/vt/vrt/collection/balance/node_lb_data.h
+++ b/src/vt/vrt/collection/balance/node_lb_data.h
@@ -134,6 +134,7 @@ public:
    */
   void addNodeLBData(
     ElementIDStruct id, elm::ElementLBData* in, StorableType *storable,
+    PhaseType phase,
     SubphaseType focused_subphase = elm::ElementLBData::no_subphase
   );
 

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -2263,7 +2263,6 @@ void CollectionManager::restoreFromFileInPlace(
 
     auto ptr = elm_holder->lookup(idx).getRawPtr();
     checkpoint::deserializeInPlaceFromFile<ColT>(file_name, static_cast<ColT*>(ptr));
-    ptr->lb_data_.resetPhase();
   }
 }
 
@@ -2306,7 +2305,6 @@ CollectionManager::restoreFromFile(
     // @todo: error check the file read with bytes in directory
 
     auto col_ptr = checkpoint::deserializeFromFile<ColT>(file_name);
-    col_ptr->lb_data_.resetPhase();
     elms.emplace_back(std::make_tuple(idx, std::move(col_ptr)));
   }
 

--- a/tests/unit/phase/test_phase_insertions.cc
+++ b/tests/unit/phase/test_phase_insertions.cc
@@ -75,7 +75,7 @@ struct MyCol : vt::Collection<MyCol,vt::Index1D> {
     s | val;
   }
 
-  vt::PhaseType getPhase() { return this->getLBData().getPhase(); }
+  vt::PhaseType getPhase() { return vt::thePhase()->getCurrentPhase(); }
 
   double val = 0.0;
 };

--- a/tests/unit/phase/test_subphase_management.cc
+++ b/tests/unit/phase/test_subphase_management.cc
@@ -1,0 +1,735 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                         test_subphase_management.cc
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_parallel_harness.h"
+#include "test_helpers.h"
+
+#include <vt/vrt/collection/manager.h>
+#include <vt/messaging/collection_chain_set.h>
+#include <vt/phase/phase_manager.h>
+
+#if vt_check_enabled(lblite)
+
+namespace vt { namespace tests { namespace unit { namespace subphase {
+
+static constexpr int const num_elms = 32;
+static constexpr int const num_phases = 3;
+
+struct MyCol : vt::Collection<MyCol,vt::Index1D> {
+  MyCol() = default;
+
+  explicit MyCol(checkpoint::SERIALIZE_CONSTRUCT_TAG) {}
+};
+
+struct MyMsg : vt::CollectionMessage<MyCol> {
+  explicit MyMsg(vt::PhaseType expected_subphase) {
+    expected_subphase_ = expected_subphase;
+  }
+
+  vt::PhaseType expected_subphase_ = vt::no_lb_phase;
+};
+
+void colHandler(MyMsg* msg, MyCol* col) {
+  EXPECT_EQ(vt::thePhase()->getCurrentSubphase(), msg->expected_subphase_);
+}
+
+struct MyObjgrp {
+  MyObjgrp() = default;
+  MyObjgrp(const MyObjgrp& obj) = delete;
+  MyObjgrp& operator=(const MyObjgrp& obj) = delete;
+  MyObjgrp(MyObjgrp&&) noexcept = default;
+  MyObjgrp& operator=(MyObjgrp&& obj) noexcept = default;
+  ~MyObjgrp() = default;
+
+  void handler(MyMsg* msg) { }
+};
+
+using TestSubphaseManagement = TestParallelHarness;
+
+TEST_F(TestSubphaseManagement, test_no_subphases) {
+  auto range = vt::Index1D(num_elms);
+
+  auto this_node = theContext()->getNode();
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runInEpochCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+
+    runInEpochCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+
+    runInEpochCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_subphase_collective) {
+  auto range = vt::Index1D(num_elms);
+
+  auto this_node = theContext()->getNode();
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_subphase_collective_with_non_1) {
+  auto range = vt::Index1D(num_elms);
+
+  auto this_node = theContext()->getNode();
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    runInEpochCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_subphase_collective_with_non_2) {
+  auto range = vt::Index1D(num_elms);
+
+  auto this_node = theContext()->getNode();
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    runInEpochCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+      }
+    });
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_subphase_collective_nested_with_non) {
+  auto range = vt::Index1D(num_elms);
+
+  auto this_node = theContext()->getNode();
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    runInEpochCollective([&]{
+      runSubphaseCollective([&]{
+        if (this_node == 0) {
+          c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+          o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+          c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+          o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+        }
+      });
+      ++expected_subphase;
+
+      runSubphaseCollective([&]{
+        if (this_node == 0) {
+          c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+          o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+        }
+      });
+      ++expected_subphase;
+    });
+
+    runSubphaseCollective([&]{
+      if (this_node == 0) {
+        c_proxy.broadcast<MyMsg, colHandler>(expected_subphase);
+        o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+      }
+    });
+    ++expected_subphase;
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_chainset_no_subphases) {
+  auto range = vt::Index1D(num_elms);
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  std::unique_ptr<vt::messaging::CollectionChainSet<vt::Index1D>> chains
+    = std::make_unique<vt::messaging::CollectionChainSet<vt::Index1D>>(c_proxy);
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runInEpochCollective([&]{
+      chains->nextStepCollective("first", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+
+      chains->nextStepCollective("second", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+
+      chains->nextStepCollective("third", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+
+      chains->phaseDone();
+    });
+
+    runInEpochCollective([&]{
+      o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+    });
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_chainset_subphases_1) {
+  auto range = vt::Index1D(num_elms);
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  std::unique_ptr<vt::messaging::CollectionChainSet<vt::Index1D>> chains
+    = std::make_unique<vt::messaging::CollectionChainSet<vt::Index1D>>(c_proxy);
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runInEpochCollective([&]{
+      chains->nextStepCollectiveSubphase("first", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("second", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("third", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->phaseDone();
+    });
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_chainset_subphases_2) {
+  auto range = vt::Index1D(num_elms);
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  std::unique_ptr<vt::messaging::CollectionChainSet<vt::Index1D>> chains
+    = std::make_unique<vt::messaging::CollectionChainSet<vt::Index1D>>(c_proxy);
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runInEpochCollective([&]{
+      o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+    });
+
+    runInEpochCollective([&]{
+      chains->nextStepCollectiveSubphase("first", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("second", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("third", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->phaseDone();
+    });
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_chainset_subphases_3) {
+  auto range = vt::Index1D(num_elms);
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  std::unique_ptr<vt::messaging::CollectionChainSet<vt::Index1D>> chains
+    = std::make_unique<vt::messaging::CollectionChainSet<vt::Index1D>>(c_proxy);
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runInEpochCollective([&]{
+      chains->nextStepCollectiveSubphase("first", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("second", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("third", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->phaseDone();
+    });
+
+    runInEpochCollective([&]{
+      o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+    });
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_chainset_subphases_with_rooted) {
+  auto range = vt::Index1D(num_elms);
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  std::unique_ptr<vt::messaging::CollectionChainSet<vt::Index1D>> chains
+    = std::make_unique<vt::messaging::CollectionChainSet<vt::Index1D>>(c_proxy);
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runInEpochCollective([&]{
+      chains->nextStepCollectiveSubphase("first", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollective("second", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+
+      chains->nextStepCollectiveSubphase("third", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->phaseDone();
+    });
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+TEST_F(TestSubphaseManagement, test_collective_and_chainset_subphases) {
+  auto range = vt::Index1D(num_elms);
+
+  auto o_proxy = vt::theObjGroup()->makeCollective<MyObjgrp>();
+
+  auto c_proxy = vt::makeCollection<MyCol>()
+    .bounds(range)
+    .bulkInsert()
+    .wait();
+
+  std::unique_ptr<vt::messaging::CollectionChainSet<vt::Index1D>> chains
+    = std::make_unique<vt::messaging::CollectionChainSet<vt::Index1D>>(c_proxy);
+
+  PhaseType n_subphases = 0;
+  for (int phase = 0; phase < num_phases; phase++) {
+    PhaseType expected_subphase = 0;
+
+    runInEpochCollective([&]{
+      chains->nextStepCollectiveSubphase("first", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("second", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->phaseDone();
+    });
+
+    runSubphaseCollective([&]{
+      o_proxy.broadcast<MyMsg, &MyObjgrp::handler>(expected_subphase);
+    });
+    ++expected_subphase;
+
+    runInEpochCollective([&]{
+      chains->nextStepCollectiveSubphase("third", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->nextStepCollectiveSubphase("fourth", [=](vt::Index1D idx) {
+        return c_proxy(idx).template send<MyMsg, colHandler>(expected_subphase);
+      });
+      ++expected_subphase;
+
+      chains->phaseDone();
+    });
+
+    if (phase == 0) {
+      n_subphases = expected_subphase + 1;
+    } else {
+      EXPECT_EQ(n_subphases, expected_subphase + 1);
+    }
+
+    // Go to the next phase.
+    vt::thePhase()->nextPhaseCollective();
+
+    auto lbdh = theNodeLBData()->getLBData();
+    ASSERT_TRUE(lbdh->node_data_.find(phase) != lbdh->node_data_.end());
+    auto &phase_data = lbdh->node_data_.at(phase);
+    for (auto &obj_data : phase_data) {
+      EXPECT_EQ(obj_data.second.subphase_loads.size(), n_subphases);
+    }
+  }
+}
+
+}}}} // end namespace vt::tests::unit::subphase
+
+#endif /*vt_check_enabled(lblite)*/


### PR DESCRIPTION
The PR adds tracking of subphases to the `PhaseManager` and removes it from `ElementLBData`. Similarly, it moves tracking of phases from `PhaseManager` to `ElementLBData`, although that is not an essential part of this PR and could be reversed.

This PR adds `CollectionChainSet::nextStepCollectiveSubphase()` (could be renamed) and `runSubphaseCollective` to the API for advancing the subphase. The API for explicitly setting the subphase on each collection element has been removed.

A subphase ends at the termination of the epoch created by `nextStepCollectiveSubphase` or `runSubphaseCollective` and may contain work that preceded the call and did not fall explicitly within an earlier subphase. If there is no work following termination of an epoch that defines a subphase, there will be an empty subphase following it.

Closes #1129 
