### PR TITLE
1818 Fix argument reversal in build_cpp script

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -197,7 +197,7 @@ then
         # To easily tell if compilation of given file succeeded special progress bar is used
         # (controlled by variable NINJA_STATUS)
         export NINJA_STATUS="[ninja][%f/%t] "
-        time cmake --build ${dashj} . --target "${target}" | tee "$OUTPUT_TMP"
+        time cmake --build . ${dashj} --target "${target}" | tee "$OUTPUT_TMP"
         compilation_ret=${PIPESTATUS[0]}
         sed -i '/ninja: build stopped:/d' "$OUTPUT_TMP"
 
@@ -206,7 +206,7 @@ then
     elif test "$GENERATOR" = "Unix Makefiles"
     then
         # Gcc outputs warnings and errors to stderr, so there's not much to do
-        time cmake --build ${dashj} . --target "${target}" 2> >(tee "$OUTPUT_TMP")
+        time cmake --build . ${dashj} --target "${target}" 2> >(tee "$OUTPUT_TMP")
         compilation_ret=$?
         WARNS_ERRS=$(cat "$OUTPUT_TMP")
     fi
@@ -215,7 +215,7 @@ then
     WARNS_ERRS=${WARNS_ERRS//$'\n'/$DELIMITER}
     echo "$WARNS_ERRS" > "$OUTPUT"
 else
-    time cmake --build ${dashj} . --target "${target}"
+    time cmake --build . ${dashj} --target "${target}"
     compilation_ret=$?
 fi
 


### PR DESCRIPTION
The `.` must come before the `-j N`.

Fixes #1818 

