### PR TITLE
#1839: use unsigned types for left shifts in BitPacker

### DIFF
--- a/src/vt/utils/bits/bits_packer.h
+++ b/src/vt/utils/bits/bits_packer.h
@@ -46,8 +46,26 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <cstring>
 
 namespace vt { namespace utils {
+
+// Non-constexpr C++14 version of bit_cast
+// See: https://en.cppreference.com/w/cpp/numeric/bit_cast
+template<typename Dst, typename Src>
+std::enable_if_t<
+  sizeof(Dst) == sizeof(Src)
+  && std::is_trivially_copyable<Dst>::value
+  && std::is_trivially_copyable<Src>::value
+  && std::is_trivially_constructible<Dst>::value,
+  Dst
+>
+bit_cast(const Src &src) {
+  Dst dst;
+  std::memcpy(&dst, &src, sizeof(Dst));
+  return dst;
+}
+
 
 struct BitPacker {
   using FieldType         = int64_t;

--- a/src/vt/utils/bits/bits_packer.impl.h
+++ b/src/vt/utils/bits/bits_packer.impl.h
@@ -122,13 +122,9 @@ BitPacker::setFieldDynamic(
   using UnsignedBitField = std::make_unsigned_t<BitField>;
   auto const nbits = (sizeof(BitField) * 8) - len;
   field = field & ~(gen_bit_mask(len) << start);
-  UnsignedBitField seg;
-  // Static cast will not work for negative types if we end up with that
-  std::memcpy(&seg, &segment, sizeof(UnsignedBitField));
-  auto bits = ((seg << nbits) >> nbits) << start;
-  BitField field_bits;
-  std::memcpy(&field_bits, &bits, sizeof(BitField));
-  field = field | field_bits;
+  auto seg = bit_cast<UnsignedBitField>(static_cast<BitField>(segment));
+  UnsignedBitField bits = ((seg << nbits) >> nbits) << start;
+  field = field | bit_cast<BitField>( bits );
 }
 
 template <FieldType start, FieldType len, typename BitField>

--- a/src/vt/utils/bits/bits_packer.impl.h
+++ b/src/vt/utils/bits/bits_packer.impl.h
@@ -117,7 +117,9 @@ BitPacker::setFieldDynamic(
 ) {
   auto const nbits = (sizeof(BitField) * 8) - len;
   field = field & ~(gen_bit_mask(len) << start);
-  field = field | (((static_cast<BitField>(segment) << nbits) >> nbits) << start);
+  using UnsignedBitField = std::make_unsigned_t<BitField>;
+  auto bits = static_cast<BitField>(((static_cast<UnsignedBitField>(segment) << nbits) >> nbits) << start);
+  field = field | bits;
 }
 
 template <FieldType start, FieldType len, typename BitField>

--- a/src/vt/utils/bits/bits_packer.impl.h
+++ b/src/vt/utils/bits/bits_packer.impl.h
@@ -125,8 +125,10 @@ BitPacker::setFieldDynamic(
   UnsignedBitField seg;
   // Static cast will not work for negative types if we end up with that
   std::memcpy(&seg, &segment, sizeof(UnsignedBitField));
-  auto bits = static_cast<BitField>(((seg << nbits) >> nbits) << start);
-  field = field | bits;
+  auto bits = ((seg << nbits) >> nbits) << start;
+  BitField field_bits;
+  std::memcpy(&field_bits, &bits, sizeof(BitField));
+  field = field | field_bits;
 }
 
 template <FieldType start, FieldType len, typename BitField>


### PR DESCRIPTION
fixes #1839 