### PR TITLE
#1563: cmake: enable MPI guards by default regardless of build

### DIFF
--- a/cmake/configure_options.cmake
+++ b/cmake/configure_options.cmake
@@ -98,12 +98,7 @@ else()
     set(vt_feature_cmake_mimalloc "0")
 endif()
 
-string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_CMAKE_BUILD_TYPE)
-if (LOWERCASE_CMAKE_BUILD_TYPE STREQUAL "debug")
-    option(vt_mpi_guards "Build VT with poison MPI calls: code invoked from VT callbacks cannot invoke MPI functions" ON)
-else()
-    option(vt_mpi_guards "Build VT with poison MPI calls: code invoked from VT callbacks cannot invoke MPI functions" OFF)
-endif()
+option(vt_mpi_guards "Build VT with poison MPI calls: code invoked from VT callbacks cannot invoke MPI functions" ON)
 
 if ((vt_mpi_guards OR vt_trace_only) AND PERL_FOUND)
     message(STATUS "user MPI prevention guards enabled")


### PR DESCRIPTION
Fixes #1563