### PR TITLE
1869 Avoid testing when gitlab CI build fails

### DIFF
--- a/ci/ctest_job_script.cmake
+++ b/ci/ctest_job_script.cmake
@@ -143,19 +143,23 @@ set(configureOpts
     "-DCMAKE_JOB_POOL_COMPILE='default_pool'"
     "-DCMAKE_JOB_POOL_LINK='default_pool'"
 )
-ctest_empty_binary_directory(${CTEST_BINARY_DIRECTORY})
+#ctest_empty_binary_directory(${CTEST_BINARY_DIRECTORY})
 ctest_start(Continuous)
-ctest_configure(OPTIONS "${configureOpts}")
+ctest_configure(OPTIONS "${configureOpts}" RETURN_VALUE ret_conf)
 ctest_submit(PARTS Start Configure)
-ctest_build()
-ctest_submit(PARTS Build)
+if (NOT ret_conf)
+  ctest_build(RETURN_VALUE ret_build)
+  ctest_submit(PARTS Build)
 # ctest_upload(FILES
 #     ${CTEST_BINARY_DIRECTORY}/mytest.log
 #     ${CTEST_BINARY_DIRECTORY}/anotherFile.txt
 # )
 # ctest_submit(PARTS Upload Submit)
-ctest_test(PARALLEL_LEVEL $ENV{parallel_level})
-ctest_submit(PARTS Test)
+  if (NOT ret_build)
+    ctest_test(PARALLEL_LEVEL $ENV{parallel_level})
+    ctest_submit(PARTS Test)
+  endif()
+endif()
 if(NOT CMAKE_VERSION VERSION_LESS "3.14")
     ctest_submit(PARTS Done)
 endif()


### PR DESCRIPTION
Don't build or test if configure fails. Don't test if build fails. I also removed the command that clears out the directory because it always fails (for safety, the command only functions correctly if finds a `CMakeLists.txt` file) due to always starting from scratch.

Closes #1869