### PR TITLE
1881 LB statistics json file opened too early

### DIFF
--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -90,7 +90,6 @@ struct LBManager : runtime::component::Component<LBManager> {
   std::string name() override { return "LBManager"; }
 
   void startup() override;
-  void initialize() override;
   void finalize() override;
   void fatalError() override;
 


### PR DESCRIPTION
Open the LB statistics json file on first use so that apps have time to programmatically change the options.

Fixes #1881 
