### PR TITLE
1896 Use only unique filenames in unit tests

### DIFF
--- a/tests/unit/collection/test_checkpoint.extended.cc
+++ b/tests/unit/collection/test_checkpoint.extended.cc
@@ -172,7 +172,7 @@ TEST_F(TestCheckpoint, test_checkpoint_1) {
   auto num_nodes = static_cast<int32_t>(theContext()->getNumNodes());
 
   auto range = vt::Index3D(num_nodes, num_elms, 4);
-  std::string const checkpoint_name{"test_checkpoint_dir"};
+  std::string const checkpoint_name(getUniqueFilenameWithRanks());
   std::string const expected_label{"test_checkpoint_1"};
 
   {
@@ -251,7 +251,7 @@ TEST_F(TestCheckpoint, test_checkpoint_in_place_2) {
   auto num_nodes = static_cast<int32_t>(theContext()->getNumNodes());
 
   auto range = vt::Index3D(num_nodes, num_elms, 4);
-  auto checkpoint_name = "test_checkpoint_dir";
+  std::string const checkpoint_name(getUniqueFilenameWithRanks());
   auto proxy = vt::theCollection()->constructCollective<TestCol>(
     range, "test_checkpoint_in_place_2"
   );
@@ -323,7 +323,7 @@ TEST_F(TestCheckpoint, test_checkpoint_in_place_3) {
   auto num_nodes = static_cast<int32_t>(theContext()->getNumNodes());
 
   auto range = vt::Index3D(num_nodes, num_elms, 4);
-  auto checkpoint_name = "test_checkpoint_dir_2";
+  std::string const checkpoint_name(getUniqueFilenameWithRanks());
   auto proxy = vt::theCollection()->constructCollective<TestCol>(
     range, "test_checkpoint_in_place_3"
   );
@@ -400,7 +400,7 @@ TEST_F(TestCheckpoint, test_checkpoint_no_elements_on_root_rank) {
   auto num_nodes = static_cast<int32_t>(theContext()->getNumNodes());
 
   auto range = vt::Index3D(num_nodes, num_elms, 4);
-  auto checkpoint_name = "test_null_elm_checkpoint_dir";
+  std::string const checkpoint_name(getUniqueFilenameWithRanks());
 
   {
     auto proxy = vt::makeCollection<TestCol>("test_checkpoint_no_elements_on_root_rank")

--- a/tests/unit/runtime/test_initialization.cc
+++ b/tests/unit/runtime/test_initialization.cc
@@ -44,6 +44,7 @@
 #include <gtest/gtest.h>
 
 #include "test_parallel_harness.h"
+#include "test_helpers.h"
 
 #include <vt/collective/startup.h>
 
@@ -170,13 +171,16 @@ TEST_F(TestInitialization, test_initialize_with_file_and_args) {
   static char cli_argument[]{"--cli_argument=100"};
   static char vt_no_terminate[]{"--vt_no_terminate"};
   static char vt_lb_name[]{"--vt_lb_name=RotateLB"};
-  static char vt_input_config[]{"--vt_input_config=test_cfg.toml"};
+
+  std::string config_file(getUniqueFilenameWithRanks(".toml"));
+  std::string config_flag("--vt_input_config=");
+  std::string vt_input_config = config_flag + config_file;
 
   std::vector<char *> custom_args;
   custom_args.emplace_back(prog_name);
   custom_args.emplace_back(cli_argument);
   custom_args.emplace_back(vt_no_terminate);
-  custom_args.emplace_back(vt_input_config);
+  custom_args.emplace_back(strdup(vt_input_config.c_str()));
   custom_args.emplace_back(vt_lb_name);
   custom_args.emplace_back(nullptr);
 
@@ -188,7 +192,7 @@ TEST_F(TestInitialization, test_initialize_with_file_and_args) {
   int this_rank;
   MPI_Comm_rank(comm, &this_rank);
   if (this_rank == 0) {
-    std::ofstream cfg_file_{"test_cfg.toml", std::ofstream::out | std::ofstream::trunc};
+    std::ofstream cfg_file_{config_file.c_str(), std::ofstream::out | std::ofstream::trunc};
     cfg_file_ << "vt_lb_name = RandomLB\n";
     cfg_file_.close();
   }
@@ -213,13 +217,16 @@ TEST_F(TestInitialization, test_initialize_with_file_args_and_appconfig) {
   static char cli_argument[]{"--cli_argument=100"};
   static char vt_no_terminate[]{"--vt_no_terminate"};
   static char vt_lb_name[]{"--vt_lb_name=RotateLB"};
-  static char vt_input_config[]{"--vt_input_config=test_cfg.toml"};
+
+  std::string config_file(getUniqueFilenameWithRanks(".toml"));
+  std::string config_flag("--vt_input_config=");
+  std::string vt_input_config = config_flag + config_file;
 
   std::vector<char*> custom_args;
   custom_args.emplace_back(prog_name);
   custom_args.emplace_back(cli_argument);
   custom_args.emplace_back(vt_no_terminate);
-  custom_args.emplace_back(vt_input_config);
+  custom_args.emplace_back(strdup(vt_input_config.c_str()));
   custom_args.emplace_back(vt_lb_name);
   custom_args.emplace_back(nullptr);
 
@@ -234,7 +241,7 @@ TEST_F(TestInitialization, test_initialize_with_file_args_and_appconfig) {
   int this_rank;
   MPI_Comm_rank(comm, &this_rank);
   if (this_rank == 0) {
-    std::ofstream cfg_file_{"test_cfg.toml", std::ofstream::out | std::ofstream::trunc};
+    std::ofstream cfg_file_{config_file.c_str(), std::ofstream::out | std::ofstream::trunc};
     cfg_file_ << "vt_lb_name = RandomLB\n";
     cfg_file_.close();
   }

--- a/tests/unit/test_helpers.h
+++ b/tests/unit/test_helpers.h
@@ -47,6 +47,7 @@
 #include "vt/context/context.h"
 #include <mpi.h>
 #include <gtest/gtest.h>
+#include <sstream>
 
 namespace vt { namespace tests { namespace unit {
 
@@ -73,6 +74,31 @@ inline bool isOversubscribed() {
   int num_ranks = 0;
   MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
   return num_ranks > CMAKE_DETECTED_MAX_NUM_NODES;
+}
+
+/**
+ * Get a unique filename based on the unit test name.
+ */
+inline std::string getUniqueFilename(const std::string& ext = "") {
+  std::stringstream ss;
+  ss << testing::UnitTest::GetInstance()->current_test_info()->test_suite_name()
+     << "_" << testing::UnitTest::GetInstance()->current_test_info()->name()
+     << ext;
+  std::string str(ss.str());
+  std::replace(str.begin(), str.end(), '/', '_');
+  return str;
+}
+
+/**
+ * Construct a filename containing the number of ranks so that
+ * concurrently-running tests will not cause file system race conditions.
+ * Do not call this from .nompi.cc tests or from addAdditionalArgs().
+ */
+inline std::string getUniqueFilenameWithRanks(const std::string& ext = "") {
+  auto ranks = theContext()->getNumNodes();
+  std::stringstream ss;
+  ss << getUniqueFilename() << "_" << ranks << ext;
+  return ss.str();
 }
 
 /**

--- a/tests/unit/test_parallel_harness.h
+++ b/tests/unit/test_parallel_harness.h
@@ -161,6 +161,9 @@ private:
    *     addArgs(vt_lb_data, vt_lb_data_dir, vt_lb_data_file);
    *   }
    * };
+   *
+   * Make sure all filenames used will be unique across all tests,
+   * parameterizations, and MPI rank counts.
    */
   virtual void addAdditionalArgs() {}
 

--- a/tests/unit/trace/test_trace_spec_reader.cc
+++ b/tests/unit/trace/test_trace_spec_reader.cc
@@ -47,6 +47,7 @@
 #include <vt/trace/file_spec/spec.h>
 
 #include "test_parallel_harness.h"
+#include "test_helpers.h"
 
 #include <fstream>
 
@@ -57,7 +58,7 @@ using TestTraceSpec = TestParallelHarness;
 TEST_F(TestTraceSpec, test_trace_spec_1) {
   using Spec = vt::trace::file_spec::TraceSpec;
 
-  std::string file_name = "test_trace_spec_1.txt";
+  std::string const file_name(getUniqueFilenameWithRanks(".txt"));
   if (theContext()->getNode() == 0) {
     std::ofstream out(file_name);
     out << ""
@@ -88,7 +89,7 @@ TEST_F(TestTraceSpec, test_trace_spec_1) {
 TEST_F(TestTraceSpec, test_trace_spec_2) {
   using Spec = vt::trace::file_spec::TraceSpec;
 
-  std::string file_name = "test_trace_spec_2.txt";
+  std::string const file_name(getUniqueFilenameWithRanks(".txt"));
   if (theContext()->getNode() == 0) {
     std::ofstream out(file_name);
     out << ""
@@ -122,7 +123,7 @@ TEST_F(TestTraceSpec, test_trace_spec_2) {
 TEST_F(TestTraceSpec, test_trace_spec_3) {
   using Spec = vt::trace::file_spec::TraceSpec;
 
-  std::string file_name = "test_trace_spec_3.txt";
+  std::string const file_name(getUniqueFilenameWithRanks(".txt"));
   if (theContext()->getNode() == 0) {
     std::ofstream out(file_name);
     out << ""
@@ -167,7 +168,7 @@ TEST_F(TestTraceSpec, test_trace_spec_3) {
 TEST_F(TestTraceSpec, test_trace_spec_4) {
   using Spec = vt::trace::file_spec::TraceSpec;
 
-  std::string file_name = "test_trace_spec_4.txt";
+  std::string const file_name(getUniqueFilenameWithRanks(".txt"));
   if (theContext()->getNode() == 0) {
     std::ofstream out(file_name);
     out << ""


### PR DESCRIPTION
This PR attempts to stop using the same disk files from multiple unit tests, including runs with different numbers of MPI ranks, so that multiple tests can be run concurrently (as happens in Gitlab CI testing) without file system conflicts. ~~This PR does not yet handle parameterizations or filenames/directories used for LB data files in `addAdditionalArgs()` in `collection/test_lb.extended.cc`. Does anyone have ideas on how to tackle those?~~

Closes #1896 