### PR TITLE
1901 MPI_Wtime called many times per handler invocation

### DIFF
--- a/src/vt/event/event.cc
+++ b/src/vt/event/event.cc
@@ -198,7 +198,7 @@ void AsyncEvent::finalize() {
   event_container_.clear();
 }
 
-int AsyncEvent::progress() {
+int AsyncEvent::progress(TimeType current_time) {
   theEvent()->testEventsTrigger();
   return 0;
 }

--- a/src/vt/event/event.h
+++ b/src/vt/event/event.h
@@ -178,7 +178,7 @@ struct AsyncEvent : runtime::component::PollableComponent<AsyncEvent> {
   EventStateType testEventComplete(EventType const& event);
   EventType attachAction(EventType const& event, ActionType callable);
   void testEventsTrigger(int const& num_events = num_check_actions);
-  int progress() override;
+  int progress(TimeType current_time) override;
   bool isLocalTerm();
 
   static void eventFinished(EventFinishedMsg* msg);

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -1192,7 +1192,7 @@ bool ActiveMessenger::testPendingAsyncOps() {
   );
 }
 
-int ActiveMessenger::progress() {
+int ActiveMessenger::progress(TimeType current_time) {
   bool const started_irecv_active_msg = tryProcessIncomingActiveMsg();
   bool const started_irecv_data_msg = tryProcessDataMsgRecv();
   processMaybeReadyHanTag();

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1349,6 +1349,8 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \internal
    * \brief Call into the progress engine
    *
+   * \param[in] current_time current time
+   *
    * \return whether any action was taken (progress was made)
    */
   int progress(TimeType current_time) override;

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1351,7 +1351,7 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    *
    * \return whether any action was taken (progress was made)
    */
-  int progress() override;
+  int progress(TimeType current_time) override;
 
   /**
    * \internal

--- a/src/vt/runtime/component/component.h
+++ b/src/vt/runtime/component/component.h
@@ -152,7 +152,7 @@ struct Component : BaseComponent {
    *
    * \return no units processed
    */
-  virtual int progress() override { return 0; }
+  virtual int progress(TimeType current_time) override { return 0; }
 
   /**
    * \brief Empty default diagnostic dump state
@@ -186,7 +186,7 @@ struct PollableComponent : Component<T> {
    *
    * \return number of units processed---zero
    */
-  virtual int progress() override {
+  virtual int progress(TimeType current_time) override {
     vtAbort("PollableComponent should override the empty progress function");
     return 0;
   }

--- a/src/vt/runtime/component/component.h
+++ b/src/vt/runtime/component/component.h
@@ -150,6 +150,8 @@ struct Component : BaseComponent {
   /**
    * \brief Empty default overridden progress method
    *
+   * \param[in] current_time current time
+   *
    * \return no units processed
    */
   virtual int progress(TimeType current_time) override { return 0; }

--- a/src/vt/runtime/component/component_pack.cc
+++ b/src/vt/runtime/component/component_pack.cc
@@ -102,10 +102,10 @@ void ComponentPack::destruct() {
   }
 }
 
-int ComponentPack::progress() {
+int ComponentPack::progress(TimeType current_time) {
   int total = 0;
   for (auto&& pollable : pollable_components_) {
-    total += pollable->progress();
+    total += pollable->progress(current_time);
   }
   return total;
 }

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -112,7 +112,7 @@ public:
    *
    * \return the number of work units processed
    */
-  int progress();
+  int progress(TimeType current_time);
 
   /**
    * \internal \brief Extract the first component from a running pack that

--- a/src/vt/runtime/component/component_pack.h
+++ b/src/vt/runtime/component/component_pack.h
@@ -110,6 +110,8 @@ public:
   /**
    * \internal \brief Invoke the progress function on all pollable components
    *
+   * \param[in] current_time current time
+   *
    * \return the number of work units processed
    */
   int progress(TimeType current_time);

--- a/src/vt/runtime/component/progressable.h
+++ b/src/vt/runtime/component/progressable.h
@@ -57,6 +57,8 @@ struct Progressable {
   /**
    * \brief Progress function for incremental polling
    *
+   * \param[in] current_time current time
+   *
    * \return the number of units executed---zero if no progress was made
    */
   virtual int progress(TimeType current_time) = 0;

--- a/src/vt/runtime/component/progressable.h
+++ b/src/vt/runtime/component/progressable.h
@@ -59,7 +59,7 @@ struct Progressable {
    *
    * \return the number of units executed---zero if no progress was made
    */
-  virtual int progress() = 0;
+  virtual int progress(TimeType current_time) = 0;
 };
 
 }}} /* end namespace vt::runtime::component */

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -123,7 +123,7 @@ struct Runtime {
    *
    * \return returns an unspecified value
    */
-  int progress() { if (p_) return p_->progress(); else return 0; }
+  int progress(TimeType current_time) { if (p_) return p_->progress(current_time); else return 0; }
 
   /**
    * \brief Check if runtime has terminated

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -121,6 +121,8 @@ struct Runtime {
   /**
    * \brief Invoke all the progress functions
    *
+   * \param[in] current_time current time
+   *
    * \return returns an unspecified value
    */
   int progress(TimeType current_time) { if (p_) return p_->progress(current_time); else return 0; }

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -175,7 +175,7 @@ struct Scheduler : runtime::component::Component<Scheduler> {
    * \param[in] msg_only whether to only make progress on the core active
    * messenger
    */
-  void runProgress(bool msg_only = false);
+  void runProgress(bool msg_only = false, TimeType current_time = 0.0 );
 
   /**
    * \brief Runs the scheduler until a condition is met.
@@ -364,14 +364,16 @@ private:
    *
    * \return whether progress was made
    */
-  bool progressMsgOnlyImpl();
+  bool progressMsgOnlyImpl(TimeType current_time);
 
   /**
    * \internal \brief Make progress
    *
+   * \param[in] current_time current time
+   *
    * \return whether progress was made
    */
-  bool progressImpl();
+  bool progressImpl(TimeType current_time);
 
 private:
 

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -174,6 +174,8 @@ struct Scheduler : runtime::component::Component<Scheduler> {
    *
    * \param[in] msg_only whether to only make progress on the core active
    * messenger
+   *
+   * \param[in] current_time current time
    */
   void runProgress(bool msg_only = false, TimeType current_time = 0.0 );
 
@@ -361,6 +363,8 @@ private:
 
   /**
    * \internal \brief Make progress on active message only
+   *
+   * \param[in] current_time current time
    *
    * \return whether progress was made
    */

--- a/src/vt/timetrigger/time_trigger_manager.cc
+++ b/src/vt/timetrigger/time_trigger_manager.cc
@@ -88,8 +88,7 @@ void TimeTriggerManager::triggerReady(TimeType cur_time) {
 }
 
 int TimeTriggerManager::progress(TimeType current_time) {
-  auto const cur_time = current_time;
-  triggerReady(cur_time);
+  triggerReady(current_time);
   return 0;
 }
 

--- a/src/vt/timetrigger/time_trigger_manager.cc
+++ b/src/vt/timetrigger/time_trigger_manager.cc
@@ -87,8 +87,8 @@ void TimeTriggerManager::triggerReady(TimeType cur_time) {
   }
 }
 
-int TimeTriggerManager::progress() {
-  auto const cur_time = timing::getCurrentTime();
+int TimeTriggerManager::progress(TimeType current_time) {
+  auto const cur_time = current_time;
   triggerReady(cur_time);
   return 0;
 }

--- a/src/vt/timetrigger/time_trigger_manager.h
+++ b/src/vt/timetrigger/time_trigger_manager.h
@@ -73,7 +73,7 @@ struct TimeTriggerManager
 
   std::string name() override { return "TimeTriggerManager"; }
 
-  int progress() override;
+  int progress(TimeType current_time) override;
 
   /**
    * \brief Register a time-based trigger with a specific period

--- a/src/vt/timetrigger/trigger.h
+++ b/src/vt/timetrigger/trigger.h
@@ -108,6 +108,8 @@ struct Trigger {
   /**
    * \brief Check if the trigger is ready to be fired
    *
+   * \param[in] current_time current time
+   *
    * \return whether the trigger can be run already
    */
   bool ready(TimeType current_time) const {

--- a/src/vt/worker/worker_group.h
+++ b/src/vt/worker/worker_group.h
@@ -83,7 +83,7 @@ struct WorkerGroupAny
   void spawnWorkers();
   void spawnWorkersBlock(WorkerCommFnType fn);
   void joinWorkers();
-  int progress() override;
+  int progress(TimeType current_time = 0.0) override;
 
   bool commScheduler();
   void enqueueCommThread(WorkUnitType const& work_unit);

--- a/src/vt/worker/worker_group.impl.h
+++ b/src/vt/worker/worker_group.impl.h
@@ -133,7 +133,7 @@ void WorkerGroupAny<WorkerT>::enqueueAllWorkers(WorkUnitType const& work_unit) {
 }
 
 template <typename WorkerT>
-int WorkerGroupAny<WorkerT>::progress() {
+int WorkerGroupAny<WorkerT>::progress(TimeType /* current_time */) {
   for (auto&& elm : workers_) {
     elm->progress();
   }

--- a/src/vt/worker/worker_group_omp.cc
+++ b/src/vt/worker/worker_group_omp.cc
@@ -80,7 +80,7 @@ bool WorkerGroupOMP::commScheduler() {
   return WorkerGroupComm::schedulerComm(finished_fn_);
 }
 
-int WorkerGroupOMP::progress() {
+int WorkerGroupOMP::progress(TimeType current_time) {
   WorkerGroupCounter::progress();
   return 0;
 }

--- a/src/vt/worker/worker_group_omp.cc
+++ b/src/vt/worker/worker_group_omp.cc
@@ -80,7 +80,7 @@ bool WorkerGroupOMP::commScheduler() {
   return WorkerGroupComm::schedulerComm(finished_fn_);
 }
 
-int WorkerGroupOMP::progress(TimeType current_time) {
+int WorkerGroupOMP::progress(TimeType /*current_time*/) {
   WorkerGroupCounter::progress();
   return 0;
 }

--- a/src/vt/worker/worker_group_omp.h
+++ b/src/vt/worker/worker_group_omp.h
@@ -85,7 +85,7 @@ struct WorkerGroupOMP
   void spawnWorkers();
   void spawnWorkersBlock(WorkerCommFnType fn);
   void joinWorkers();
-  int progress() override;
+  int progress(TimeType current_time = 0.0) override;
   bool commScheduler();
 
   // non-thread-safe comm and worker thread enqueue


### PR DESCRIPTION
Closes #1901. Pass the current time from the scheduler to the progress functions.