### PR TITLE
1930 Add new microbenchmarks

### DIFF
--- a/src/vt/runnable/make_runnable.h
+++ b/src/vt/runnable/make_runnable.h
@@ -85,11 +85,6 @@ struct RunnableMaker {
   RunnableMaker(RunnableMaker const&) = delete;
   RunnableMaker(RunnableMaker&&) = default;
 
-  ~RunnableMaker() {
-    if (impl_ != nullptr and not is_done_) {
-      vtAbort("A runnable was created but never executed or enqueued!")
-    }
-  }
 
   /**
    * \brief Add a continuation

--- a/tests/perf/collection_local_send.cc
+++ b/tests/perf/collection_local_send.cc
@@ -80,7 +80,7 @@ struct NodeObj {
 
   void complete() {
   }
-  
+
   void perfMakeRunnable(MyMsg* in_msg) {
     theTerm()->disableTD();
 

--- a/tests/perf/collection_local_send.cc
+++ b/tests/perf/collection_local_send.cc
@@ -1,0 +1,130 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                 reduce.cc
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+#include "common/test_harness.h"
+#include <vt/transport.h>
+
+#include <fmt-vt/core.h>
+
+using namespace vt;
+using namespace vt::tests::perf::common;
+
+static constexpr int num_iters = 1000000;
+
+struct MyTest : PerfTestHarness { };
+struct MyMsg : vt::Message {};
+
+struct NodeObj;
+vt::objgroup::proxy::Proxy<NodeObj> global_proxy;
+
+void dummyHandler(MyMsg*) {}
+
+struct TestCol : vt::Collection<TestCol, vt::Index1D> {
+  using ColMsg = vt::CollectionMessage<TestCol>;
+  void han(ColMsg* msg) {}
+};
+
+struct NodeObj {
+  struct ReduceMsg : vt::collective::ReduceNoneMsg { };
+
+  explicit NodeObj(MyTest* test_obj) : test_obj_(test_obj) { }
+  void initialize() {
+    proxy_ = global_proxy = vt::theObjGroup()->getProxy<NodeObj>(this);
+
+    auto range = vt::Index1D(8);
+    col_proxy = vt::makeCollection<TestCol>("test")
+      .bounds(range)
+      .bulkInsert()
+      .wait();
+    // fmt::print("ptr={}\n", print_ptr(col_proxy.lm));
+  }
+
+  void complete() {
+  }
+  
+  void perfMakeRunnable(MyMsg* in_msg) {
+    for (int i = 0; i < num_iters; i++) {
+      //msgs.emplace_back(makeMessage<TestCol::ColMsg>());
+    }
+
+    theTerm()->disableTD();
+
+    test_obj_->StartTimer(fmt::format("colSend {}", num_iters));
+    perfRunBenchmark();
+    test_obj_->StopTimer(fmt::format("colSend {}", num_iters));
+
+    theTerm()->enableTD();
+  }
+
+  void perfRunBenchmark() {
+    // fmt::print("ptr={}\n", print_ptr(col_proxy.lm));
+    for (int i = 0; i < num_iters; i++) {
+      auto m = makeMessage<TestCol::ColMsg>();
+      //auto m = msgs[i];
+      col_proxy[0].template sendMsg<TestCol::ColMsg, &TestCol::han>(m);
+      vt::theSched()->runSchedulerOnceImpl();
+    }
+  }
+
+private:
+  std::vector<MsgSharedPtr<TestCol::ColMsg>> msgs;
+  HandlerType han;
+  MyTest* test_obj_ = nullptr;
+  vt::objgroup::proxy::Proxy<NodeObj> proxy_ = {};
+  vt::CollectionProxy<TestCol> col_proxy;
+  int reduce_counter_ = -1;
+  int i = 0;
+};
+
+VT_PERF_TEST(MyTest, test_collection_local_send) {
+  auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
+    "test_collection_local_send", this
+  );
+
+  grp_proxy[my_node_].invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();
+
+  if (theContext()->getNode() == 0) {
+    grp_proxy[my_node_].send<MyMsg, &NodeObj::perfMakeRunnable>();
+  }
+}
+
+VT_PERF_TEST_MAIN()

--- a/tests/perf/collection_local_send.cc
+++ b/tests/perf/collection_local_send.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                 reduce.cc
+//                           collection_local_send.cc
 //                       DARMA/vt => Virtual Transport
 //
 // Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC

--- a/tests/perf/collection_local_send_prealloc.cc
+++ b/tests/perf/collection_local_send_prealloc.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                           collection_local_send_prealloc.cc
+//                      collection_local_send_prealloc.cc
 //                       DARMA/vt => Virtual Transport
 //
 // Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC

--- a/tests/perf/collection_local_send_prealloc.cc
+++ b/tests/perf/collection_local_send_prealloc.cc
@@ -80,7 +80,7 @@ struct NodeObj {
 
   void complete() {
   }
-  
+
 
   void perfMakeRunnablePreAllocate(MyMsg* in_msg) {
     for (int i = 0; i < num_iters; i++) {

--- a/tests/perf/common/test_harness.h
+++ b/tests/perf/common/test_harness.h
@@ -175,7 +175,7 @@ private:
 protected:
   bool gen_file_ = false;
   bool verbose_ = false;
-  uint32_t num_runs_ = 50;
+  uint32_t num_runs_ = 20;
   uint32_t current_run_ = 0;
   std::vector<char*> custom_args_ = {};
 

--- a/tests/perf/make_runnable_micro.cc
+++ b/tests/perf/make_runnable_micro.cc
@@ -1,0 +1,125 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                 reduce.cc
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+#include "common/test_harness.h"
+#include <vt/collective/collective_ops.h>
+#include <vt/objgroup/manager.h>
+#include <vt/messaging/active.h>
+
+#include <fmt-vt/core.h>
+
+using namespace vt;
+using namespace vt::tests::perf::common;
+
+static constexpr int num_iters = 1000000;
+
+struct MyTest : PerfTestHarness { };
+struct MyMsg : vt::Message {};
+
+struct NodeObj;
+vt::objgroup::proxy::Proxy<NodeObj> global_proxy;
+
+void dummyHandler(MyMsg*) {}
+
+struct NodeObj {
+  struct ReduceMsg : vt::collective::ReduceNoneMsg { };
+
+  explicit NodeObj(MyTest* test_obj) : test_obj_(test_obj) { }
+  void initialize() {
+    proxy_ = global_proxy = vt::theObjGroup()->getProxy<NodeObj>(this);
+  }
+
+  void complete() {
+  }
+  
+  void perfMakeRunnable(MyMsg* in_msg) {
+    for (int i = 0; i < num_iters; i++) {
+      msgs.emplace_back(makeMessage<MyMsg>());
+    }
+
+    han = auto_registry::makeAutoHandler<MyMsg, &dummyHandler>();
+
+    theTerm()->any_epoch_state_.incrementDependency();
+
+    test_obj_->StartTimer(fmt::format("makeRunnable {}", num_iters));
+    perfRunBenchmark();
+    test_obj_->StopTimer(fmt::format("makeRunnable {}", num_iters));
+
+    theTerm()->any_epoch_state_.decrementDependency();
+  }
+
+  void perfRunBenchmark() {
+    for (int i = 0; i < num_iters; i++) {
+      {
+	bool add_context = true;
+	auto r = runnable::makeRunnable(msgs[i], false, han, 0, add_context)
+	  .withContinuation(nullptr)
+	  .withTag(TagType{0})
+	  .withTDEpochFromMsg(false);
+	r.enqueue();
+      }
+      vt::theSched()->runSchedulerOnceImpl();
+    }
+  }
+
+private:
+  std::vector<MsgSharedPtr<MyMsg>> msgs;
+  HandlerType han;
+  MyTest* test_obj_ = nullptr;
+  vt::objgroup::proxy::Proxy<NodeObj> proxy_ = {};
+  int reduce_counter_ = -1;
+  int i = 0;
+};
+
+VT_PERF_TEST(MyTest, test_ping_pong) {
+  auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
+    "test_reduce", this
+  );
+
+  grp_proxy[my_node_].invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();
+
+  if (theContext()->getNode() == 0) {
+    grp_proxy[my_node_].send<MyMsg, &NodeObj::perfMakeRunnable>();
+  }
+}
+
+VT_PERF_TEST_MAIN()

--- a/tests/perf/make_runnable_micro.cc
+++ b/tests/perf/make_runnable_micro.cc
@@ -106,7 +106,7 @@ private:
 
 VT_PERF_TEST(MyTest, test_make_runnable_micro) {
   auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
-    "test_reduce", this
+    "test_make_runnable_micro", this
   );
 
   grp_proxy[my_node_].invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();

--- a/tests/perf/make_runnable_micro.cc
+++ b/tests/perf/make_runnable_micro.cc
@@ -51,7 +51,7 @@
 using namespace vt;
 using namespace vt::tests::perf::common;
 
-static constexpr int num_iters = 1000000;
+static constexpr int num_iters = 100000;
 
 struct MyTest : PerfTestHarness { };
 struct MyMsg : vt::Message {};

--- a/tests/perf/make_runnable_micro.cc
+++ b/tests/perf/make_runnable_micro.cc
@@ -104,7 +104,7 @@ private:
   int i = 0;
 };
 
-VT_PERF_TEST(MyTest, test_ping_pong) {
+VT_PERF_TEST(MyTest, test_make_runnable_micro) {
   auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
     "test_reduce", this
   );

--- a/tests/perf/objgroup_local_send.cc
+++ b/tests/perf/objgroup_local_send.cc
@@ -1,0 +1,122 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                                 reduce.cc
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+#include "common/test_harness.h"
+#include <vt/transport.h>
+
+#include <fmt-vt/core.h>
+
+using namespace vt;
+using namespace vt::tests::perf::common;
+
+static constexpr int num_iters = 1000000;
+
+struct MyTest : PerfTestHarness { };
+struct MyMsg : vt::Message {};
+
+struct NodeObj;
+vt::objgroup::proxy::Proxy<NodeObj> global_proxy;
+
+void dummyHandler(MyMsg*) {}
+
+struct TestObj {
+  void han(MyMsg* msg) {}
+};
+
+struct NodeObj {
+  struct ReduceMsg : vt::collective::ReduceNoneMsg { };
+
+  explicit NodeObj(MyTest* test_obj) : test_obj_(test_obj) { }
+  void initialize() {
+    proxy_ = global_proxy = vt::theObjGroup()->getProxy<NodeObj>(this);
+
+    obj_proxy = vt::theObjGroup()->makeCollective<TestObj>("testObj");
+  }
+
+  void complete() {
+  }
+  
+  void perfMakeRunnable(MyMsg* in_msg) {
+    for (int i = 0; i < num_iters; i++) {
+      msgs.emplace_back(makeMessage<MyMsg>());
+    }
+
+    theTerm()->disableTD();
+
+    test_obj_->StartTimer(fmt::format("colSend {}", num_iters));
+    perfRunBenchmark();
+    test_obj_->StopTimer(fmt::format("colSend {}", num_iters));
+
+    theTerm()->enableTD();
+  }
+
+  void perfRunBenchmark() {
+    for (int i = 0; i < num_iters; i++) {
+      auto m = msgs[i];
+      obj_proxy[0].template sendMsg<MyMsg, &TestObj::han>(m);
+      vt::theSched()->runSchedulerOnceImpl();
+    }
+  }
+
+private:
+  std::vector<MsgSharedPtr<MyMsg>> msgs;
+  HandlerType han;
+  MyTest* test_obj_ = nullptr;
+  vt::objgroup::proxy::Proxy<NodeObj> proxy_ = {};
+  vt::objgroup::proxy::Proxy<TestObj> obj_proxy;
+  int reduce_counter_ = -1;
+  int i = 0;
+};
+
+VT_PERF_TEST(MyTest, test_collection_local_send) {
+  auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
+    "test_collection_local_send", this
+  );
+
+  grp_proxy[my_node_].invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();
+
+  if (theContext()->getNode() == 0) {
+    grp_proxy[my_node_].send<MyMsg, &NodeObj::perfMakeRunnable>();
+  }
+}
+
+VT_PERF_TEST_MAIN()

--- a/tests/perf/objgroup_local_send.cc
+++ b/tests/perf/objgroup_local_send.cc
@@ -107,9 +107,9 @@ private:
   int i = 0;
 };
 
-VT_PERF_TEST(MyTest, test_collection_local_send) {
+VT_PERF_TEST(MyTest, test_objgroup_local_send) {
   auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
-    "test_collection_local_send", this
+    "test_objgroup_local_send", this
   );
 
   grp_proxy[my_node_].invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();

--- a/tests/perf/objgroup_local_send.cc
+++ b/tests/perf/objgroup_local_send.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                 reduce.cc
+//                            objgroup_local_send.cc
 //                       DARMA/vt => Virtual Transport
 //
 // Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC

--- a/tests/perf/objgroup_local_send.cc
+++ b/tests/perf/objgroup_local_send.cc
@@ -74,7 +74,7 @@ struct NodeObj {
 
   void complete() {
   }
-  
+
   void perfMakeRunnable(MyMsg* in_msg) {
     for (int i = 0; i < num_iters; i++) {
       msgs.emplace_back(makeMessage<MyMsg>());

--- a/tests/perf/ping_pong.cc
+++ b/tests/perf/ping_pong.cc
@@ -139,8 +139,7 @@ private:
 template <>
 void NodeObj::finishedPing<max_bytes>(FinishedPingMsg<max_bytes>* msg) {
   addPerfStats(max_bytes);
-
-  theTerm()->any_epoch_state_.decrementDependency();
+  theTerm()->enableTD();
 }
 
 VT_PERF_TEST(MyTest, test_ping_pong) {
@@ -151,7 +150,7 @@ VT_PERF_TEST(MyTest, test_ping_pong) {
     .invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();
 
   if (theContext()->getNode() == 0) {
-    theTerm()->any_epoch_state_.incrementDependency();
+    theTerm()->disableTD();
   }
 
   StartTimer(fmt::format("{} Bytes", min_bytes));

--- a/tests/perf/ping_pong_am.cc
+++ b/tests/perf/ping_pong_am.cc
@@ -110,7 +110,7 @@ void handlerFinished(MyMsg* msg) {
 
 VT_PERF_TEST(MyTest, test_ping_pong_am) {
   auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
-    "test_reduce", this
+    "test_ping_pong_am", this
   );
 
   if (theContext()->getNode() == 0) {

--- a/tests/perf/ping_pong_am.cc
+++ b/tests/perf/ping_pong_am.cc
@@ -108,7 +108,7 @@ void handlerFinished(MyMsg* msg) {
   }
 }
 
-VT_PERF_TEST(MyTest, test_ping_pong) {
+VT_PERF_TEST(MyTest, test_ping_pong_am) {
   auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
     "test_reduce", this
   );

--- a/tests/perf/reduce.cc
+++ b/tests/perf/reduce.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                 reduce.cc
+//                                  reduce.cc
 //                       DARMA/vt => Virtual Transport
 //
 // Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC

--- a/tests/perf/reduce.cc
+++ b/tests/perf/reduce.cc
@@ -90,7 +90,7 @@ private:
   int i = 0;
 };
 
-VT_PERF_TEST(MyTest, test_ping_pong) {
+VT_PERF_TEST(MyTest, test_reduce) {
   auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
     "test_reduce", this
   );

--- a/tests/perf/reduce.cc
+++ b/tests/perf/reduce.cc
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                 ping_pong.cc
+//                                 reduce.cc
 //                       DARMA/vt => Virtual Transport
 //
 // Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
@@ -50,116 +50,58 @@
 using namespace vt;
 using namespace vt::tests::perf::common;
 
-static constexpr int64_t const min_bytes = 1;
-static constexpr int64_t const max_bytes = 16777216;
-
-static constexpr int64_t num_pings = 10;
-
-static constexpr NodeType const ping_node = 0;
-static constexpr NodeType const pong_node = 1;
-
-vt::EpochType the_epoch = vt::no_epoch;
+static constexpr int num_iters = 10;
 
 struct MyTest : PerfTestHarness { };
 
 struct NodeObj {
-  template <int64_t num_bytes>
-  struct PingMsg : Message {
-    int64_t count = 0;
-    std::array<char, num_bytes> payload_;
-
-    PingMsg() : Message() { }
-    explicit PingMsg(int64_t const in_count) : Message(), count(in_count) { }
-  };
-
-  template <int64_t num_bytes>
-  struct FinishedPingMsg : Message {
-    int64_t prev_bytes = 0;
-
-    FinishedPingMsg(int64_t const in_prev_bytes)
-      : Message(),
-        prev_bytes(in_prev_bytes) { }
-  };
+  struct ReduceMsg : vt::collective::ReduceNoneMsg { };
 
   explicit NodeObj(MyTest* test_obj) : test_obj_(test_obj) { }
   void initialize() { proxy_ = vt::theObjGroup()->getProxy<NodeObj>(this); }
 
-  void addPerfStats(int64_t const& num_bytes) {
-    test_obj_->StopTimer(fmt::format("{} Bytes", num_bytes));
+  struct MyMsg : vt::Message {};
+
+  void reduceComplete(ReduceMsg* msg) {
+    reduce_counter_++;
+    test_obj_->StopTimer(fmt::format("{} reduce", i));
     test_obj_->GetMemoryUsage();
-    test_obj_->StartTimer(fmt::format("{} Bytes", num_bytes * 2));
-  }
-
-  template <int64_t num_bytes>
-  void finishedPing(FinishedPingMsg<num_bytes>* msg) {
-    // End of iteration for node 0
-    addPerfStats(num_bytes);
-
-    if (num_bytes != max_bytes) {
-      constexpr auto new_num_bytes = num_bytes * 2;
-      test_obj_->StartTimer(fmt::format("{} Bytes", new_num_bytes));
-
-      proxy_[pong_node]
-        .send<
-          NodeObj::PingMsg<new_num_bytes>, &NodeObj::pingPong<new_num_bytes>
-        >();
-    } else {
+    if (i < num_iters) {
+      i++;
+      auto this_node = theContext()->getNode();
+      proxy_[this_node].send<MyMsg, &NodeObj::perfReduce>();
+    } else if (theContext()->getNode() == 0) {
+      theTerm()->any_epoch_state_.decrementDependency();
     }
   }
-
-  template <int64_t num_bytes>
-  void pingPong(PingMsg<num_bytes>* in_msg) {
-    auto const& cnt = in_msg->count;
-
-    if (cnt >= num_pings) {
-      // End of iteration for node 1
-      addPerfStats(num_bytes);
-
-      proxy_[0]
-        .send<
-          NodeObj::FinishedPingMsg<num_bytes>,
-          &NodeObj::finishedPing<num_bytes>>(num_bytes);
-    } else {
-      NodeType const next =
-        theContext()->getNode() == ping_node ? pong_node : ping_node;
-
-      auto msg = vt::makeMessage<NodeObj::PingMsg<num_bytes>>(cnt + 1);
-      proxy_[next]
-        .sendMsg<NodeObj::PingMsg<num_bytes>, &NodeObj::pingPong<num_bytes>>(
-          msg
-        );
-    }
+  
+  void perfReduce(MyMsg* in_msg) {
+    test_obj_->StartTimer(fmt::format("{} reduce", i));
+    auto cb = theCB()->makeBcast<NodeObj, ReduceMsg, &NodeObj::reduceComplete>(proxy_);
+    auto msg = makeMessage<ReduceMsg>();
+    proxy_.reduce(msg.get(), cb);
   }
 
 private:
   MyTest* test_obj_ = nullptr;
   vt::objgroup::proxy::Proxy<NodeObj> proxy_ = {};
+  int reduce_counter_ = -1;
+  int i = 0;
 };
-
-template <>
-void NodeObj::finishedPing<max_bytes>(FinishedPingMsg<max_bytes>* msg) {
-  addPerfStats(max_bytes);
-
-  theTerm()->any_epoch_state_.decrementDependency();
-}
 
 VT_PERF_TEST(MyTest, test_ping_pong) {
   auto grp_proxy = vt::theObjGroup()->makeCollective<NodeObj>(
-    "test_ping_pong", this
+    "test_reduce", this
   );
-  grp_proxy[my_node_]
-    .invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();
 
   if (theContext()->getNode() == 0) {
     theTerm()->any_epoch_state_.incrementDependency();
   }
 
-  StartTimer(fmt::format("{} Bytes", min_bytes));
+  grp_proxy[my_node_].invoke<decltype(&NodeObj::initialize), &NodeObj::initialize>();
 
-  if (my_node_ == 0) {
-    grp_proxy[pong_node]
-      .send<NodeObj::PingMsg<min_bytes>, &NodeObj::pingPong<min_bytes>>();
-  }
+  using MsgType = typename NodeObj::MyMsg;
+  grp_proxy[my_node_].send<MsgType, &NodeObj::perfReduce>();
 }
 
 VT_PERF_TEST_MAIN()


### PR DESCRIPTION
Closes #1930. Depends on changes to runnable (e.g., makeRunnable, RunnableNew) from #1899 and #1914, and possibly others.