### PR TITLE
#1955: Suppress spurious warning about method declared but not used

### DIFF
--- a/tests/unit/lb/test_lb_data_comm.cc
+++ b/tests/unit/lb/test_lb_data_comm.cc
@@ -127,10 +127,17 @@ struct ReduceMsg : SerializeRequired<
       )
   { }
 
+#if defined(__INTEL_COMPILER)
+#pragma warning(push)
+#pragma warning(disable : 177)
+#endif
   template <typename SerializerT>
   void serialize(SerializerT& s) {
     MessageParentType::serialize(s);
   }
+#if defined(__INTEL_COMPILER)
+#pragma warning(pop)
+#endif
 };
 struct ColProxyMsg : vt::Message {
   using ProxyType = vt::CollectionProxy<MyCol>;


### PR DESCRIPTION
Fixes #1955