### PR TITLE
1943 scheduler check optimizations

### DIFF
--- a/src/vt/scheduler/base_unit.cc
+++ b/src/vt/scheduler/base_unit.cc
@@ -56,8 +56,6 @@ void BaseUnit::execute() {
         theSched()->suspend(tid, std::move(r_));
       }
     #endif
-    delete r_;
-    r_ = nullptr;
   } else if (work_) {
     work_();
   }

--- a/src/vt/scheduler/base_unit.cc
+++ b/src/vt/scheduler/base_unit.cc
@@ -50,10 +50,14 @@ namespace vt { namespace sched {
 void BaseUnit::execute() {
   if (r_) {
     r_->run();
-    if (not r_->isDone()) {
-      auto tid = r_->getThreadID();
-      theSched()->suspend(tid, std::move(r_));
-    }
+    #if vt_check_enabled(fcontext)
+      if (not r_->isDone()) {
+        auto tid = r_->getThreadID();
+        theSched()->suspend(tid, std::move(r_));
+      }
+    #endif
+    delete r_;
+    r_ = nullptr;
   } else if (work_) {
     work_();
   }

--- a/src/vt/scheduler/scheduler.cc
+++ b/src/vt/scheduler/scheduler.cc
@@ -128,9 +128,15 @@ void Scheduler::runWorkUnit(UnitType& work) {
 
   workUnitCount.increment(1);
 
+#if vt_check_enabled(mpi_access_guards)
   ++action_depth_;
+#endif
+
   work();
+
+#if vt_check_enabled(mpi_access_guards)
   --action_depth_;
+#endif
 
 #if vt_check_enabled(mpi_access_guards)
   if (action_depth_ == 0) {

--- a/src/vt/scheduler/scheduler.h
+++ b/src/vt/scheduler/scheduler.h
@@ -137,7 +137,7 @@ struct Scheduler : runtime::component::Component<Scheduler> {
   void preDiagnostic() override;
 
   /**
-   * \internal \brief Check for termination when running on a since node
+   * \internal \brief Check for termination when running on a single node
    */
   static void checkTermSingleNode();
 

--- a/src/vt/scheduler/suspended_units.cc
+++ b/src/vt/scheduler/suspended_units.cc
@@ -50,6 +50,7 @@ namespace vt { namespace sched {
 void SuspendedUnits::addSuspended(
   ThreadIDType tid, RunnablePtrType runnable, PriorityType p
 ) {
+#if vt_check_enabled(fcontext)
   vtAssert(runnable->isSuspended(), "Runnable must be suspended to add");
 
   units_.emplace(
@@ -59,15 +60,18 @@ void SuspendedUnits::addSuspended(
       detail::SuspendedRunnable{std::move(runnable), p}
     )
   );
+#endif
 }
 
 void SuspendedUnits::resumeRunnable(ThreadIDType tid) {
+#if vt_check_enabled(fcontext)
   auto iter = units_.find(tid);
   vtAbortIf(iter == units_.end(), "Must have valid thread ID to resume");
   auto r = std::move(iter->second.runnable_);
   auto p = iter->second.priority_;
   theSched()->enqueue(p, std::move(r));
   units_.erase(iter);
+#endif
 }
 
 }} /* end namespace vt::sched */

--- a/src/vt/scheduler/suspended_units.cc
+++ b/src/vt/scheduler/suspended_units.cc
@@ -60,6 +60,8 @@ void SuspendedUnits::addSuspended(
       detail::SuspendedRunnable{std::move(runnable), p}
     )
   );
+#else
+  vtAssert(false, "Invalid code path");
 #endif
 }
 
@@ -71,6 +73,8 @@ void SuspendedUnits::resumeRunnable(ThreadIDType tid) {
   auto p = iter->second.priority_;
   theSched()->enqueue(p, std::move(r));
   units_.erase(iter);
+#else
+  vtAssert(false, "Invalid code path");
 #endif
 }
 


### PR DESCRIPTION
Closes #1943. Add vt_check_enabled statements to reduce unneeded code in the scheduler. 