### PR TITLE
1964 Work around serial Gitlab CI build with unix makefiles

### DIFF
--- a/ci/ctest_job_script.cmake
+++ b/ci/ctest_job_script.cmake
@@ -109,6 +109,14 @@ if ( NOT DEFINED ENV{CMAKE_GENERATOR} )
   set(ENV{CMAKE_GENERATOR} "Ninja")
 endif()
 
+if ( NOT "$ENV{CMAKE_GENERATOR}" STREQUAL "Ninja" )
+  if ( NOT DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL} )
+    if ( DEFINED ENV{parallel_level} )
+      set(ENV{CMAKE_BUILD_PARALLEL_LEVEL} "$ENV{parallel_level}")
+    endif()
+  endif()
+endif()
+
 set(CTEST_CMAKE_GENERATOR    $ENV{CMAKE_GENERATOR} )
 set(CTEST_CONFIGURATION_TYPE $ENV{CMAKE_BUILD_TYPE} )
 


### PR DESCRIPTION
The job pool only gives build parallelism to Ninja builds under Gitlab CI. This PR gives a `-j` argument when using Unix Makefiles (that we're forced to use for one of the Gitlab CI builds for the time being).

Closes #1964 