### PR TITLE
1932 reduce calls to thecontext

### DIFF
--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -169,7 +169,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgCopyableImpl(
   }
 
   if (is_bcast) {
-    dest = theContext()->getNode();
+    dest = this_node_;
   }
   if (tag != no_tag) {
     envelopeSetTag(rawMsg->env, tag);

--- a/src/vt/termination/termination.impl.h
+++ b/src/vt/termination/termination.impl.h
@@ -120,7 +120,7 @@ inline void TerminationDetector::produceConsume(
 
       // If a node is not passed, use the current node (self-prod/cons)
       if (node == uninitialized_destination) {
-	      node = this_node_;
+        node = this_node_;
       }
 
       if (produce) {

--- a/src/vt/termination/termination.impl.h
+++ b/src/vt/termination/termination.impl.h
@@ -120,7 +120,7 @@ inline void TerminationDetector::produceConsume(
 
       // If a node is not passed, use the current node (self-prod/cons)
       if (node == uninitialized_destination) {
-	node = this_node_;
+	      node = this_node_;
       }
 
       if (produce) {


### PR DESCRIPTION
Closes #1932. 
Remove some calls to theContext() in ActiveMessenger and TerminationDetector via using a member variable or a local variable.