### PR TITLE
2002: Runnable: Rename begin()/end() to start()/finish()

### DIFF
--- a/src/vt/context/runnable_context/collection.cc
+++ b/src/vt/context/runnable_context/collection.cc
@@ -45,20 +45,20 @@
 
 namespace vt { namespace ctx {
 
-void Collection::begin() {
+void Collection::start() {
   set_();
 }
 
-void Collection::end() {
+void Collection::finish() {
   clear_();
 }
 
 void Collection::suspend() {
-  end();
+  finish();
 }
 
 void Collection::resume() {
-  begin();
+  start();
 }
 
 }} /* end namespace vt::ctx */

--- a/src/vt/context/runnable_context/collection.h
+++ b/src/vt/context/runnable_context/collection.h
@@ -76,12 +76,12 @@ struct Collection {
   /**
    * \brief Set the collection context
    */
-  void begin();
+  void start();
 
   /**
    * \brief Remove the collection context
    */
-  void end();
+  void finish();
 
   void suspend();
   void resume();

--- a/src/vt/context/runnable_context/continuation.h
+++ b/src/vt/context/runnable_context/continuation.h
@@ -67,7 +67,7 @@ struct Continuation {
   /**
    * \brief After the task runs, invoke the continuation if non-null
    */
-  void end() {
+  void finish() {
     if (cont_) {
       cont_();
     }

--- a/src/vt/context/runnable_context/lb_data.cc
+++ b/src/vt/context/runnable_context/lb_data.cc
@@ -46,14 +46,14 @@
 
 namespace vt { namespace ctx {
 
-void LBData::begin() {
+void LBData::start() {
   // record start time
   if (should_instrument_) {
     lb_data_->startTime();
   }
 }
 
-void LBData::end() {
+void LBData::finish() {
   // record end time
   if (should_instrument_) {
     lb_data_->stopTime();
@@ -65,11 +65,11 @@ void LBData::send(elm::ElementIDStruct dest, MsgSizeType bytes) {
 }
 
 void LBData::suspend() {
-  end();
+  finish();
 }
 
 void LBData::resume() {
-  begin();
+  start();
 }
 
 typename LBData::ElementIDStruct const& LBData::getCurrentElementID() const {

--- a/src/vt/context/runnable_context/lb_data.h
+++ b/src/vt/context/runnable_context/lb_data.h
@@ -84,12 +84,12 @@ struct LBData {
   /**
    * \brief Set the context and timing for a collection task
    */
-  void begin();
+  void start();
 
   /**
    * \brief Remove the context and store timing for a collection task
    */
-  void end();
+  void finish();
 
   /**
    * \brief Record LB data whenever a message is sent and a collection

--- a/src/vt/context/runnable_context/set_context.cc
+++ b/src/vt/context/runnable_context/set_context.cc
@@ -47,7 +47,7 @@
 
 namespace vt { namespace ctx {
 
-void SetContext::begin() {
+void SetContext::start() {
   // we have to handle the ugly handler-inside-handler case.. preserve the
   // previous context (pop) and set the new task (push)
   prev_task_ = theContext()->getTask();
@@ -60,7 +60,7 @@ void SetContext::begin() {
   );
 }
 
-void SetContext::end() {
+void SetContext::finish() {
   vt_debug_print(
     verbose, context,
     "{}: end(): prev={}, task={}\n",
@@ -80,7 +80,7 @@ void SetContext::suspend() {
     print_ptr(this), print_ptr(prev_task_.get()), print_ptr(cur_task_.get())
   );
 
-  end();
+  finish();
 }
 
 void SetContext::resume() {
@@ -90,7 +90,7 @@ void SetContext::resume() {
     print_ptr(this), print_ptr(prev_task_.get()), print_ptr(cur_task_.get())
   );
 
-  begin();
+  start();
 }
 
 }} /* end namespace vt::ctx */

--- a/src/vt/context/runnable_context/set_context.h
+++ b/src/vt/context/runnable_context/set_context.h
@@ -81,12 +81,12 @@ struct SetContext {
   /**
    * \brief Preserve the existing task and replace with a new one
    */
-  void begin();
+  void start();
 
   /**
    * \brief Restore the previous existing task to the context (if there was one)
    */
-  void end();
+  void finish();
 
   void suspend();
 

--- a/src/vt/context/runnable_context/td.cc
+++ b/src/vt/context/runnable_context/td.cc
@@ -53,7 +53,7 @@ TD::TD(EpochType in_ep)
   theTerm()->produce(ep_);
 }
 
-void TD::begin() {
+void TD::start() {
   theTerm()->pushEpoch(ep_);
 
 #if vt_check_enabled(fcontext)
@@ -63,7 +63,7 @@ void TD::begin() {
 #endif
 }
 
-void TD::end() {
+void TD::finish() {
 #if vt_check_enabled(fcontext)
   auto& epoch_stack = theTerm()->getEpochStack();
 

--- a/src/vt/context/runnable_context/td.h
+++ b/src/vt/context/runnable_context/td.h
@@ -81,15 +81,15 @@ struct TD {
   explicit TD(MsgPtrT const& msg);
 
   /**
-   * \brief During begin \c TD will capture the epoch stack size and push \c ep_
+   * \brief During start \c TD will capture the epoch stack size and push \c ep_
    */
-  void begin();
+  void start();
 
   /**
-   * \brief During end \c TD will pop all epochs off of the stack down to the
-   * size in captured in \c begin()
+   * \brief During finish \c TD will pop all epochs off of the stack down to the
+   * size in captured in \c start()
    */
-  void end();
+  void finish();
 
   /**
    * \brief When suspended, \c TD will preserve any epochs pushed on the stack

--- a/src/vt/context/runnable_context/td.h
+++ b/src/vt/context/runnable_context/td.h
@@ -87,7 +87,7 @@ struct TD {
 
   /**
    * \brief During finish \c TD will pop all epochs off of the stack down to the
-   * size in captured in \c start()
+   * size it captured in \c start()
    */
   void finish();
 

--- a/src/vt/context/runnable_context/trace.cc
+++ b/src/vt/context/runnable_context/trace.cc
@@ -54,7 +54,7 @@
 
 namespace vt { namespace ctx {
 
-void Trace::begin() {
+void Trace::start() {
   if (not is_traced_) {
     return;
   }
@@ -76,7 +76,7 @@ void Trace::begin() {
   }
 }
 
-void Trace::end() {
+void Trace::finish() {
   if (not is_traced_) {
     return;
   }
@@ -85,12 +85,12 @@ void Trace::end() {
 }
 
 void Trace::suspend() {
-  end();
+  finish();
 }
 
 void Trace::resume() {
   // @todo: connect up the last event to this new one after suspension
-  begin();
+  start();
 }
 
 }} /* end namespace vt::ctx */

--- a/src/vt/context/runnable_context/trace.h
+++ b/src/vt/context/runnable_context/trace.h
@@ -101,8 +101,8 @@ struct Trace {
    */
   trace::TraceEventIDType getEvent() const { return event_; }
 
-  void begin();
-  void end();
+  void start();
+  void finish();
   void suspend();
   void resume();
 

--- a/src/vt/runnable/runnable.cc
+++ b/src/vt/runnable/runnable.cc
@@ -150,10 +150,10 @@ void RunnableNew::run() {
   if (suspended_) {
     resume();
   } else {
-    begin();
+    start();
   }
 #else
-  begin();
+  start();
 #endif
 
   vtAssert(task_ != nullptr, "Must have a valid task to run");
@@ -194,13 +194,13 @@ void RunnableNew::run() {
 
 #if vt_check_enabled(fcontext)
   if (done_) {
-    end();
+    finish();
   } else {
     suspended_ = true;
     suspend();
   }
 #else
-  end();
+  finish();
 #endif
 
 #if vt_check_enabled(fcontext)
@@ -212,24 +212,24 @@ void RunnableNew::run() {
 #endif
 }
 
-void RunnableNew::begin() {
-  contexts_.setcontext.begin();
-  if (contexts_.has_td) contexts_.td.begin();
-  if (contexts_.has_col) contexts_.col.begin();
-  if (contexts_.has_lb) contexts_.lb.begin();
+void RunnableNew::start() {
+  contexts_.setcontext.start();
+  if (contexts_.has_td) contexts_.td.start();
+  if (contexts_.has_col) contexts_.col.start();
+  if (contexts_.has_lb) contexts_.lb.start();
 #if vt_check_enabled(trace_enabled)
-  if (contexts_.has_trace) contexts_.trace.begin();
+  if (contexts_.has_trace) contexts_.trace.start();
 #endif
 }
 
-void RunnableNew::end() {
-  contexts_.setcontext.end();
-  if (contexts_.has_td) contexts_.td.end();
-  if (contexts_.has_col) contexts_.col.end();
-  if (contexts_.has_cont) contexts_.cont.end();
-  if (contexts_.has_lb) contexts_.lb.end();
+void RunnableNew::finish() {
+  contexts_.setcontext.finish();
+  if (contexts_.has_td) contexts_.td.finish();
+  if (contexts_.has_col) contexts_.col.finish();
+  if (contexts_.has_cont) contexts_.cont.finish();
+  if (contexts_.has_lb) contexts_.lb.finish();
 #if vt_check_enabled(trace_enabled)
-  if (contexts_.has_trace) contexts_.trace.end();
+  if (contexts_.has_trace) contexts_.trace.finish();
 #endif
 }
 

--- a/src/vt/runnable/runnable.h
+++ b/src/vt/runnable/runnable.h
@@ -234,15 +234,15 @@ public:
 private:
   /**
    * \internal \brief Loop through all the contexts associated with this
-   * runnable and invoke \c begin() on them.
+   * runnable and invoke \c start() on them.
    */
-  void begin();
+  void start();
 
   /**
    * \internal \brief Loop through all the contexts associated with this
-   * runnable and invoke \c end() on them.
+   * runnable and invoke \c finish() on them.
    */
-  void end();
+  void finish();
 
   /**
    * \internal \brief Loop through all the contexts associated with this


### PR DESCRIPTION
Fixes #2002 