### PR TITLE
2048: Remove duplicated `struct CommMsg`

### DIFF
--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
@@ -102,24 +102,6 @@ private:
   void reduceCount(ReduceMsg* msg);
   void allocateShareEdgeGIDs();
 
-  struct CommMsg : vt::Message {
-    using MessageParentType = vt::Message;
-    vt_msg_serialize_required(); // comm_
-
-    CommMsg() = default;
-    explicit CommMsg(ElementCommType in_comm)
-      : comm_(in_comm)
-    { }
-
-    ElementCommType comm_;
-
-    template <typename SerializerT>
-    void serialize(SerializerT& s) {
-      MessageParentType::serialize(s);
-      s | comm_;
-    }
-  };
-
   void recvSharedEdges(CommMsg* msg);
 
 private:


### PR DESCRIPTION
fixes #2048 