### PR TITLE
2066: Remove cxx standard override for bundled libraries

### DIFF
--- a/cmake/load_bundled_libraries.cmake
+++ b/cmake/load_bundled_libraries.cmake
@@ -2,9 +2,6 @@
 
 include(SetCXXCompilerFlags)
 
-# Export a minimum version flag for any bundled libraries that don't set their own
-set(CMAKE_CXX_STANDARD 17)
-
 # Optionally include libfort which is used by diagnostics
 if (vt_libfort_enabled)
   set(FORT_ENABLE_TESTING OFF CACHE INTERNAL "")


### PR DESCRIPTION
Fixes #2066 