### PR TITLE
2068: Use specific version of intel oneapi for docker image

### DIFF
--- a/ci/docker/ubuntu-intel-oneapi-cpp.dockerfile
+++ b/ci/docker/ubuntu-intel-oneapi-cpp.dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
-    intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
+    intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.2.1 \
     ca-certificates \
     less \
     curl \


### PR DESCRIPTION
Fixes #2068