### PR TITLE
#2119: cmake: install target for checkpoint when included in lib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -340,3 +340,10 @@ export(
   FILE                      "vtTargets.cmake"
   NAMESPACE                 vt::runtime::
 )
+
+if (EXISTS "${PROJECT_LIB_DIR}/checkpoint")
+  install(
+    TARGETS                 checkpoint
+    EXPORT                  ${VIRTUAL_TRANSPORT_LIBRARY}
+  )
+endif()


### PR DESCRIPTION
Fixes #2119