### PR TITLE
276 Callback parameterization

### DIFF
--- a/examples/callback/callback.cc
+++ b/examples/callback/callback.cc
@@ -141,19 +141,19 @@ int main(int argc, char** argv) {
     auto cb_functor = vt::theCB()->makeSend<CallbackFunctor>(dest);
     bounceCallback(cb_functor);
 
-    auto cb_func = vt::theCB()->makeSend<TestMsg,callbackFunc>(dest);
+    auto cb_func = vt::theCB()->makeSend<callbackFunc>(dest);
     bounceCallback(cb_func);
 
-    auto cb_obj = vt::theCB()->makeSend<MyObj,TestMsg,&MyObj::handler>(obj[dest]);
+    auto cb_obj = vt::theCB()->makeSend<&MyObj::handler>(obj[dest]);
     bounceCallback(cb_obj);
 
-    auto cb_obj_bcast = vt::theCB()->makeBcast<MyObj,TestMsg,&MyObj::handler>(obj);
+    auto cb_obj_bcast = vt::theCB()->makeBcast<&MyObj::handler>(obj);
     bounceCallback(cb_obj_bcast);
 
-    auto cb_col = vt::theCB()->makeSend<MyCol,TestMsg,colHan>(col[5]);
+    auto cb_col = vt::theCB()->makeSend<colHan>(col[5]);
     bounceCallback(cb_col);
 
-    auto cb_col_bcast = vt::theCB()->makeBcast<MyCol,TestMsg,colHan>(col);
+    auto cb_col_bcast = vt::theCB()->makeBcast<colHan>(col);
     bounceCallback(cb_col_bcast);
   }
 

--- a/examples/collection/jacobi1d_vt.cc
+++ b/examples/collection/jacobi1d_vt.cc
@@ -73,9 +73,7 @@ static constexpr double const default_tol = 1.0e-02;
 
 struct NodeObj {
   bool is_finished_ = false;
-  struct WorkFinishedMsg : vt::Message {};
-
-  void workFinishedHandler(WorkFinishedMsg*) { is_finished_ = true; }
+  void workFinishedHandler() { is_finished_ = true; }
   bool isWorkFinished() { return is_finished_; }
 };
 using NodeObjProxy = vt::objgroup::proxy::Proxy<NodeObj>;
@@ -119,18 +117,11 @@ public:
 
   };
 
-  struct ReduxMsg : vt::collective::ReduceTMsg<double> {
-    ReduxMsg() = default;
-    explicit ReduxMsg(double in_val) : ReduceTMsg<double>(in_val) { }
-  };
-
-  void checkCompleteCB(ReduxMsg* msg) {
+  void checkCompleteCB(double normRes) {
     //
     // Only one object for the reduction will visit
     // this function
     //
-
-    double normRes = msg->getConstVal();
 
     auto const iter_max_reached = iter_ > maxIter_;
     auto const norm_res_done = normRes < default_tol;
@@ -143,7 +134,7 @@ public:
       fmt::print(to_print);
 
       // Notify all nodes that computation is finished
-      objProxy_.broadcast<NodeObj::WorkFinishedMsg, &NodeObj::workFinishedHandler>();
+      objProxy_.broadcast<&NodeObj::workFinishedHandler>();
     } else {
       fmt::print(" ## ITER {} >> Residual Norm = {} \n", iter_, normRes);
     }
@@ -184,9 +175,9 @@ public:
     }
 
     auto proxy = this->getCollectionProxy();
-    auto cb = vt::theCB()->makeSend<&LinearPb1DJacobi::checkCompleteCB>(proxy[0]);
-    auto msg2 = vt::makeMessage<ReduxMsg>(maxNorm);
-    proxy.reduce<vt::collective::MaxOp<double>>(msg2.get(),cb);
+    proxy.reduce<&LinearPb1DJacobi::checkCompleteCB, vt::collective::MaxOp>(
+      proxy[0], maxNorm
+    );
 
   }
 

--- a/examples/collection/jacobi1d_vt.cc
+++ b/examples/collection/jacobi1d_vt.cc
@@ -184,9 +184,7 @@ public:
     }
 
     auto proxy = this->getCollectionProxy();
-    auto cb = vt::theCB()->makeSend<
-      LinearPb1DJacobi,ReduxMsg,&LinearPb1DJacobi::checkCompleteCB
-    >(proxy[0]);
+    auto cb = vt::theCB()->makeSend<&LinearPb1DJacobi::checkCompleteCB>(proxy[0]);
     auto msg2 = vt::makeMessage<ReduxMsg>(maxNorm);
     proxy.reduce<vt::collective::MaxOp<double>>(msg2.get(),cb);
 

--- a/examples/collection/jacobi2d_vt.cc
+++ b/examples/collection/jacobi2d_vt.cc
@@ -80,9 +80,7 @@ static constexpr double const default_tol = 1.0e-02;
 
 struct NodeObj {
   bool is_finished_ = false;
-  struct WorkFinishedMsg : vt::Message {};
-
-  void workFinishedHandler(WorkFinishedMsg*) { is_finished_ = true; }
+  void workFinishedHandler() { is_finished_ = true; }
   bool isWorkFinished() { return is_finished_; }
 };
 using NodeObjProxy = vt::objgroup::proxy::Proxy<NodeObj>;
@@ -129,19 +127,12 @@ public:
   };
 
 
-  struct ReduxMsg : vt::collective::ReduceTMsg<double> {
-    ReduxMsg() = default;
-    explicit ReduxMsg(double in_val) : ReduceTMsg<double>(in_val) { }
-  };
-
-
-  void checkCompleteCB(ReduxMsg* msg) {
+  void checkCompleteCB(double const normRes) {
     //
     // Only one object for the reduction will visit
     // this function
     //
 
-    const double normRes = msg->getConstVal();
     auto const iter_max_reached = iter_ > maxIter_;
     auto const norm_res_done = normRes < default_tol;
 
@@ -153,7 +144,7 @@ public:
       fmt::print(to_print);
 
       // Notify all nodes that computation is finished
-      objProxy_.broadcast<NodeObj::WorkFinishedMsg, &NodeObj::workFinishedHandler>();
+      objProxy_.broadcast<&NodeObj::workFinishedHandler>();
     } else {
       fmt::print(" ## ITER {} >> Residual Norm = {} \n", iter_, normRes);
     }
@@ -222,9 +213,9 @@ public:
     }
 
     auto proxy = this->getCollectionProxy();
-    auto cb = vt::theCB()->makeSend<&LinearPb2DJacobi::checkCompleteCB>(proxy(0,0));
-    auto msg2 = vt::makeMessage<ReduxMsg>(maxNorm);
-    proxy.reduce<vt::collective::MaxOp<double>>(msg2.get(),cb);
+    proxy.reduce<&LinearPb2DJacobi::checkCompleteCB, vt::collective::MaxOp>(
+      proxy(0,0), maxNorm
+    );
   }
 
   struct VecMsg : vt::CollectionMessage<LinearPb2DJacobi> {

--- a/examples/collection/jacobi2d_vt.cc
+++ b/examples/collection/jacobi2d_vt.cc
@@ -222,9 +222,7 @@ public:
     }
 
     auto proxy = this->getCollectionProxy();
-    auto cb = vt::theCB()->makeSend<
-      LinearPb2DJacobi,ReduxMsg,&LinearPb2DJacobi::checkCompleteCB
-    >(proxy(0,0));
+    auto cb = vt::theCB()->makeSend<&LinearPb2DJacobi::checkCompleteCB>(proxy(0,0));
     auto msg2 = vt::makeMessage<ReduxMsg>(maxNorm);
     proxy.reduce<vt::collective::MaxOp<double>>(msg2.get(),cb);
   }

--- a/examples/collection/reduce_integral.cc
+++ b/examples/collection/reduce_integral.cc
@@ -101,21 +101,17 @@ public:
       numPartsPerObject_(default_nparts_object)
   { }
 
-  struct CheckIntegral {
-
-    void operator()(ReduceMsg* msg) {
-      fmt::print(" >> The integral over [0, 1] is {}\n", msg->getConstVal());
-      fmt::print(
-        " >> The absolute error is {}\n",
-        std::fabs(msg->getConstVal() - exactIntegral)
-      );
-      //
-      // Set the 'root_reduce_finished' variable to true.
-      //
-      root_reduce_finished = true;
-    }
-
-  };
+  void checkIntegral(double val) {
+    fmt::print(" >> The integral over [0, 1] is {}\n", val);
+    fmt::print(
+      " >> The absolute error is {}\n",
+      std::fabs(val - exactIntegral)
+    );
+    //
+    // Set the 'root_reduce_finished' variable to true.
+    //
+    root_reduce_finished = true;
+  }
 
   struct InitMsg : vt::CollectionMessage<Integration1D> {
 
@@ -177,9 +173,9 @@ public:
     //
 
     auto proxy = this->getCollectionProxy();
-    auto msgCB = vt::makeMessage<ReduceMsg>(quadsum);
-    auto cback = vt::theCB()->makeSend<CheckIntegral>(reduce_root_node);
-    proxy.reduce<vt::collective::PlusOp<double>>(msgCB.get(),cback);
+    proxy.reduce<&Integration1D::checkIntegral, vt::collective::PlusOp>(
+      proxy[0], quadsum
+    );
   }
 
 };

--- a/examples/collection/transpose.cc
+++ b/examples/collection/transpose.cc
@@ -58,8 +58,6 @@ struct RequestDataMsg : vt::CollectionMessage<ColT> {
   vt::NodeType node_;
 };
 
-struct InitMsg : vt::collective::ReduceNoneMsg { };
-
 struct DataMsg : vt::Message {
   using MessageParentType = vt::Message;
   vt_msg_serialize_required(); // by payload_
@@ -170,7 +168,7 @@ struct Block : vt::Collection<Block, vt::Index1D> {
     );
   }
 
-  void doneInit(InitMsg* msg) {
+  void doneInit() {
     if (getIndex().x() == 0) {
       auto proxy = this->getCollectionProxy();
       auto proxy_msg = vt::makeMessage<ProxyMsg>(proxy.getProxy());
@@ -183,9 +181,7 @@ struct Block : vt::Collection<Block, vt::Index1D> {
     initialize();
     // Wait for all initializations to complete
     auto proxy = this->getCollectionProxy();
-    auto cb = vt::theCB()->makeBcast<&Block::doneInit>(proxy);
-    auto empty = vt::makeMessage<InitMsg>();
-    proxy.reduce(empty.get(), cb);
+    proxy.allreduce<&Block::doneInit>();
   }
 
 private:

--- a/examples/collection/transpose.cc
+++ b/examples/collection/transpose.cc
@@ -183,7 +183,7 @@ struct Block : vt::Collection<Block, vt::Index1D> {
     initialize();
     // Wait for all initializations to complete
     auto proxy = this->getCollectionProxy();
-    auto cb = vt::theCB()->makeBcast<Block, InitMsg, &Block::doneInit>(proxy);
+    auto cb = vt::theCB()->makeBcast<&Block::doneInit>(proxy);
     auto empty = vt::makeMessage<InitMsg>();
     proxy.reduce(empty.get(), cb);
   }

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -11,6 +11,7 @@ set(
   hello_world_virtual_context_remote
   ring
   objgroup
+  hello_reduce
 )
 
 foreach(EXAMPLE_NAME ${HELLO_WORLD_EXAMPLES})

--- a/examples/hello_world/hello_reduce.cc
+++ b/examples/hello_world/hello_reduce.cc
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
   vt::NodeType const root = 0;
 
   auto r = vt::theCollective()->global();
-  r->reduce<vt::collective::PlusOp, reduceResult>(vt::Node{root}, 50, 52.334);
+  r->reduce<reduceResult, vt::collective::PlusOp>(vt::Node{root}, 50, 52.334);
 
   vt::finalize();
   return 0;

--- a/examples/hello_world/hello_world_collection_reduce.cc
+++ b/examples/hello_world/hello_world_collection_reduce.cc
@@ -45,24 +45,19 @@
 
 /// [Hello world reduce collection]
 struct Hello : vt::Collection<Hello, vt::Index1D> {
-  using ReduceMsg = vt::collective::ReduceTMsg<int>;
-
-  void done(ReduceMsg* msg) {
-    fmt::print("Reduce complete at {} value {}\n", this->getIndex(), msg->getVal());
+  void done(int val, double val2) {
+    fmt::print("Reduce complete at {} value {} {}\n", getIndex(), val, val2);
   }
 
   void doWork() {
-    fmt::print("Hello from {}\n", this->getIndex());
+    fmt::print("Hello from {}\n", getIndex());
 
     // Get the proxy for the collection
-    auto proxy = this->getCollectionProxy();
+    auto proxy = getCollectionProxy();
 
-    // Create a callback for when the reduction finishes
-    auto cb = vt::theCB()->makeSend<&Hello::done>(proxy(2));
-
-    // Create and send the reduction message holding an int
-    auto red_msg = vt::makeMessage<ReduceMsg>(this->getIndex().x());
-    proxy.reduce<vt::collective::PlusOp<int>>(red_msg.get(),cb);
+    auto val = getIndex().x();
+    auto val2 = 2.4;
+    proxy.allreduce<&Hello::done, vt::collective::PlusOp>(val, val2);
   }
 };
 

--- a/examples/hello_world/hello_world_collection_reduce.cc
+++ b/examples/hello_world/hello_world_collection_reduce.cc
@@ -58,7 +58,7 @@ struct Hello : vt::Collection<Hello, vt::Index1D> {
     auto proxy = this->getCollectionProxy();
 
     // Create a callback for when the reduction finishes
-    auto cb = vt::theCB()->makeSend<Hello,ReduceMsg,&Hello::done>(proxy(2));
+    auto cb = vt::theCB()->makeSend<&Hello::done>(proxy(2));
 
     // Create and send the reduction message holding an int
     auto red_msg = vt::makeMessage<ReduceMsg>(this->getIndex().x());

--- a/examples/hello_world/hello_world_collection_reduce.cc
+++ b/examples/hello_world/hello_world_collection_reduce.cc
@@ -46,7 +46,7 @@
 /// [Hello world reduce collection]
 struct Hello : vt::Collection<Hello, vt::Index1D> {
   void done(int val, double val2) {
-    fmt::print("Reduce complete at {} value {} {}\n", getIndex(), val, val2);
+    fmt::print("Reduce complete at {} values {} {}\n", getIndex(), val, val2);
   }
 
   void doWork() {

--- a/src/vt/collective/collective_scope.cc
+++ b/src/vt/collective/collective_scope.cc
@@ -83,7 +83,7 @@ TagType CollectiveScope::mpiCollectiveAsync(ActionType action) {
   NodeType collective_root = 0;
 
   using CollectiveMsg = CollectiveAlg::CollectiveMsg;
-  auto cb = theCB()->makeBcast<CollectiveMsg,&CollectiveAlg::runCollective>();
+  auto cb = theCB()->makeBcast<&CollectiveAlg::runCollective>();
   auto msg = makeMessage<CollectiveMsg>(is_user_tag_, scope_, tag, collective_root);
 
   // The tag for the reduce is a combination of the scope and seq tag.

--- a/src/vt/collective/reduce/get_reduce_stamp.h
+++ b/src/vt/collective/reduce/get_reduce_stamp.h
@@ -48,6 +48,7 @@
 #include "vt/collective/reduce/reduce_scope.h"
 #include "vt/messaging/message.h"
 
+#include <tuple>
 #include <utility>
 #include <type_traits>
 

--- a/src/vt/collective/reduce/get_reduce_stamp.h
+++ b/src/vt/collective/reduce/get_reduce_stamp.h
@@ -45,6 +45,11 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_GET_REDUCE_STAMP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/reduce_scope.h"
+#include "vt/messaging/message.h"
+
+#include <utility>
+#include <type_traits>
 
 namespace vt { namespace collective { namespace reduce {
 

--- a/src/vt/collective/reduce/operators/default_msg.h
+++ b/src/vt/collective/reduce/operators/default_msg.h
@@ -51,11 +51,31 @@
 
 #include <array>
 #include <vector>
+#include <variant>
 
 namespace vt { namespace collective { namespace reduce { namespace operators {
 
 template <typename>
 struct ReduceCombine;
+
+template <typename T, typename enabled = void>
+struct GetCallbackType;
+
+template <typename T>
+struct GetCallbackType<T> {
+  using CallbackType = Callback<T>;
+  using MsgT = T;
+};
+
+template <typename... Args>
+struct GetCallbackType<std::tuple<Args...>> {
+  using CallbackType = Callback<Args...>;
+};
+
+template <typename T>
+struct GetCallbackType<Callback<T>> {
+  using MsgT = T;
+};
 
 template <typename DataType>
 struct ReduceDataMsg : SerializeIfNeeded<
@@ -63,15 +83,21 @@ struct ReduceDataMsg : SerializeIfNeeded<
   ReduceDataMsg<DataType>,
   DataType
 >, ReduceCombine<void> {
+
+  using DataT = DataType;
+  using CallbackParamType = typename GetCallbackType<DataType>::CallbackType;
+  using CallbackMsgType = Callback<ReduceDataMsg<DataType>>;
+
   using MessageParentType = SerializeIfNeeded<
     ReduceMsg,
     ReduceDataMsg<DataType>,
     DataType
   >;
 
-  using CallbackType = CallbackU;
-
   ReduceDataMsg() = default;
+  ReduceDataMsg(ReduceDataMsg const&) = default;
+  ReduceDataMsg(ReduceDataMsg&&) = default;
+
   explicit ReduceDataMsg(DataType&& in_val)
     : MessageParentType(), ReduceCombine<void>(),
       val_(std::forward<DataType>(in_val))
@@ -84,46 +110,73 @@ struct ReduceDataMsg : SerializeIfNeeded<
   DataType const& getConstVal() const { return val_; }
   DataType& getVal() { return val_; }
   DataType&& getMoveVal() { return std::move(val_); }
-  CallbackType getCallback() { return cb_; }
 
-  template <typename MsgT>
-  void setCallback(Callback<MsgT> cb) { cb_ = CallbackType{cb}; }
+  bool isMsgCallback() const { return cb_.index() == 0; }
+  bool isParamCallback() const { return cb_.index() == 1; }
+  CallbackMsgType getMsgCallback() { return std::get<0>(cb_); }
+  CallbackParamType getParamCallback() { return std::get<1>(cb_); }
+  bool hasValidCallback() {
+    if (isMsgCallback()) {
+      return getMsgCallback().valid();
+    } else {
+      return getParamCallback().valid();
+    }
+  }
+
+  template <typename CallbackT>
+  void setCallback(CallbackT cb) {
+    if constexpr (std::is_same_v<CallbackT, CallbackParamType>) {
+      cb_ = cb;
+    } else if (
+      std::is_convertible_v<
+        typename GetCallbackType<CallbackT>::MsgT*, ReduceDataMsg<DataType>*
+      >
+    ) {
+      auto cb_ptr = reinterpret_cast<Callback<ReduceDataMsg<DataType>>*>(&cb);
+      cb_ = *cb_ptr;
+    } else {
+      static_assert(
+        std::is_same_v<CallbackT, CallbackParamType> or
+        std::is_convertible_v<
+          typename GetCallbackType<CallbackT>::MsgT*, ReduceDataMsg<DataType>*
+        >,
+        "Must be a convertible message callback or parameterized callback"
+      );
+    }
+  }
 
   template <typename SerializeT>
   void serialize(SerializeT& s) {
     MessageParentType::serialize(s);
     s | val_;
-    s | cb_;
+    int index = cb_.index();
+    s | index;
+    if (s.isUnpacking()) {
+      if (index == 0) {
+        CallbackMsgType cb;
+        s | cb;
+        cb_ = cb;
+      } else {
+        CallbackParamType cb;
+        s | cb;
+        cb_ = cb;
+      }
+    } else {
+      if (index == 0) {
+        s | std::get<0>(cb_);
+      } else {
+        s | std::get<1>(cb_);
+      }
+    }
   }
 
 protected:
   DataType val_    = {};
-  CallbackType cb_ = {};
+  std::variant<CallbackMsgType, CallbackParamType> cb_;
 };
 
 template <typename T>
-struct ReduceTMsg : SerializeIfNeeded<
-  ReduceDataMsg<T>,
-  ReduceTMsg<T>
-> {
-  using MessageParentType = SerializeIfNeeded<
-    ReduceDataMsg<T>,
-    ReduceTMsg<T>
-  >;
-
-  ReduceTMsg() = default;
-  explicit ReduceTMsg(T&& in_val)
-    : MessageParentType(std::forward<T>(in_val))
-  { }
-  explicit ReduceTMsg(T const& in_val)
-    : MessageParentType(in_val)
-  { }
-
-  template <typename SerializeT>
-  inline void serialize(SerializeT& s) {
-    MessageParentType::serialize(s);
-  }
-};
+using ReduceTMsg = ReduceDataMsg<T>;
 
 template <typename T, std::size_t N>
 struct ReduceArrMsg : SerializeIfNeeded<

--- a/src/vt/collective/reduce/operators/default_msg.h
+++ b/src/vt/collective/reduce/operators/default_msg.h
@@ -80,6 +80,7 @@ struct ReduceDataMsg : SerializeIfNeeded<
     : MessageParentType(), ReduceCombine<void>(), val_(in_val)
   { }
 
+  DataType& getTuple() { return val_; }
   DataType const& getConstVal() const { return val_; }
   DataType& getVal() { return val_; }
   DataType&& getMoveVal() { return std::move(val_); }

--- a/src/vt/collective/reduce/operators/default_op.impl.h
+++ b/src/vt/collective/reduce/operators/default_op.impl.h
@@ -51,18 +51,31 @@ namespace vt { namespace collective { namespace reduce { namespace operators {
 
 struct NoCombine {};
 
+template <typename>
+struct IsTuple : std::false_type {};
+template <typename... Args>
+struct IsTuple<std::tuple<Args...>> : std::true_type {};
+
 template <typename T>
 template <typename MsgT, typename Op, typename ActOp>
 /*static*/ void ReduceCombine<T>::msgHandler(MsgT* msg) {
   if (msg->isRoot()) {
-    auto cb = msg->getCallback();
     vt_debug_print(
       terse, reduce,
-      "ROOT: reduce root: valid={}, ptr={}\n", cb.valid(), print_ptr(msg)
+      "ROOT: reduce root: ptr={}\n", print_ptr(msg)
     );
-    if (cb.valid()) {
+    if (msg->hasValidCallback()) {
       envelopeUnlockForForwarding(msg->env);
-      cb.template send<MsgT>(msg);
+      if (msg->isParamCallback()) {
+        if constexpr (IsTuple<typename MsgT::DataT>::value) {
+          msg->getParamCallback().sendTuple(std::move(msg->getVal()));
+        }
+      } else {
+        // We need to force the type the the more specific one here
+        auto cb = msg->getMsgCallback();
+        auto typed_cb = reinterpret_cast<Callback<MsgT>*>(&cb);
+        typed_cb->send(msg);
+      }
     } else if (msg->root_handler_ != uninitialized_handler) {
       auto_registry::getAutoHandler(msg->root_handler_)->dispatch(msg, nullptr);
     } else {
@@ -75,8 +88,7 @@ template <typename MsgT, typename Op, typename ActOp>
     MsgT* cur_msg = msg->template getNext<MsgT>();
     vt_debug_print(
       verbose, reduce,
-      "leaf: fst valid={}, ptr={}\n", fst_msg->getCallback().valid(),
-      print_ptr(fst_msg)
+      "leaf: fst ptr={}\n", print_ptr(fst_msg)
     );
     while (cur_msg != nullptr) {
       ReduceCombine<>::combine<MsgT,Op,ActOp>(fst_msg, cur_msg);

--- a/src/vt/collective/reduce/operators/default_op.impl.h
+++ b/src/vt/collective/reduce/operators/default_op.impl.h
@@ -74,7 +74,7 @@ template <typename MsgT, typename Op, typename ActOp>
         // We need to force the type the the more specific one here
         auto cb = msg->getMsgCallback();
         auto typed_cb = reinterpret_cast<Callback<MsgT>*>(&cb);
-        typed_cb->send(msg);
+        typed_cb->sendMsg(msg);
       }
     } else if (msg->root_handler_ != uninitialized_handler) {
       auto_registry::getAutoHandler(msg->root_handler_)->dispatch(msg, nullptr);

--- a/src/vt/collective/reduce/operators/default_op.impl.h
+++ b/src/vt/collective/reduce/operators/default_op.impl.h
@@ -71,7 +71,7 @@ template <typename MsgT, typename Op, typename ActOp>
           msg->getParamCallback().sendTuple(std::move(msg->getVal()));
         }
       } else {
-        // We need to force the type the the more specific one here
+        // We need to force the type the more specific one here
         auto cb = msg->getMsgCallback();
         auto typed_cb = reinterpret_cast<Callback<MsgT>*>(&cb);
         typed_cb->sendMsg(msg);

--- a/src/vt/collective/reduce/operators/default_op.impl.h
+++ b/src/vt/collective/reduce/operators/default_op.impl.h
@@ -71,7 +71,7 @@ template <typename MsgT, typename Op, typename ActOp>
           msg->getParamCallback().sendTuple(std::move(msg->getVal()));
         }
       } else {
-        // We need to force the type the more specific one here
+        // We need to force the type to the more specific one here
         auto cb = msg->getMsgCallback();
         auto typed_cb = reinterpret_cast<Callback<MsgT>*>(&cb);
         typed_cb->sendMsg(msg);

--- a/src/vt/collective/reduce/operators/functors/and_op.h
+++ b/src/vt/collective/reduce/operators/functors/and_op.h
@@ -58,8 +58,10 @@ struct AndOp {
 
 template <typename... Params>
 struct AndOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = AndOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<AndOp>(v1, v2);
+    opTuple<AndOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/and_op.h
+++ b/src/vt/collective/reduce/operators/functors/and_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_AND_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 namespace vt { namespace collective { namespace reduce { namespace operators {
 
@@ -52,6 +53,13 @@ template <typename T>
 struct AndOp {
   void operator()(T& v1, T const& v2) {
     v1 = v1 && v2;
+  }
+};
+
+template <typename... Params>
+struct AndOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<AndOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/bit_and_op.h
+++ b/src/vt/collective/reduce/operators/functors/bit_and_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_BIT_AND_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 namespace vt { namespace collective { namespace reduce { namespace operators {
 
@@ -52,6 +53,13 @@ template <typename T>
 struct BitAndOp {
   void operator()(T& v1, T const& v2) {
     v1 = v1 & v2;
+  }
+};
+
+template <typename... Params>
+struct BitAndOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<BitAndOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/bit_and_op.h
+++ b/src/vt/collective/reduce/operators/functors/bit_and_op.h
@@ -58,8 +58,10 @@ struct BitAndOp {
 
 template <typename... Params>
 struct BitAndOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = BitAndOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<BitAndOp>(v1, v2);
+    opTuple<BitAndOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/bit_or_op.h
+++ b/src/vt/collective/reduce/operators/functors/bit_or_op.h
@@ -58,8 +58,10 @@ struct BitOrOp {
 
 template <typename... Params>
 struct BitOrOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = BitOrOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<BitOrOp>(v1, v2);
+    opTuple<BitOrOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/bit_or_op.h
+++ b/src/vt/collective/reduce/operators/functors/bit_or_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_BIT_OR_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 namespace vt { namespace collective { namespace reduce { namespace operators {
 
@@ -52,6 +53,13 @@ template <typename T>
 struct BitOrOp {
   void operator()(T& v1, T const& v2) {
     v1 = v1 | v2;
+  }
+};
+
+template <typename... Params>
+struct BitOrOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<BitOrOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/bit_xor_op.h
+++ b/src/vt/collective/reduce/operators/functors/bit_xor_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_BIT_XOR_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 namespace vt { namespace collective { namespace reduce { namespace operators {
 
@@ -52,6 +53,13 @@ template <typename T>
 struct BitXorOp {
   void operator()(T& v1, T const& v2) {
     v1 = v1 ^ v2;
+  }
+};
+
+template <typename... Params>
+struct BitXorOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<BitXorOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/bit_xor_op.h
+++ b/src/vt/collective/reduce/operators/functors/bit_xor_op.h
@@ -58,8 +58,10 @@ struct BitXorOp {
 
 template <typename... Params>
 struct BitXorOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = BitXorOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<BitXorOp>(v1, v2);
+    opTuple<BitXorOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/max_op.h
+++ b/src/vt/collective/reduce/operators/functors/max_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_MAX_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 #include <algorithm>
 
@@ -54,6 +55,13 @@ template <typename T>
 struct MaxOp {
   void operator()(T& v1, T const& v2) {
     v1 = std::max(v1,v2);
+  }
+};
+
+template <typename... Params>
+struct MaxOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<MaxOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/max_op.h
+++ b/src/vt/collective/reduce/operators/functors/max_op.h
@@ -60,8 +60,10 @@ struct MaxOp {
 
 template <typename... Params>
 struct MaxOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = MaxOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<MaxOp>(v1, v2);
+    opTuple<MaxOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/min_op.h
+++ b/src/vt/collective/reduce/operators/functors/min_op.h
@@ -60,8 +60,10 @@ struct MinOp {
 
 template <typename... Params>
 struct MinOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = MinOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<MinOp>(v1, v2);
+    opTuple<MinOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/min_op.h
+++ b/src/vt/collective/reduce/operators/functors/min_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_MIN_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 #include <algorithm>
 
@@ -54,6 +55,13 @@ template <typename T>
 struct MinOp {
   void operator()(T& v1, T const& v2) {
     v1 = std::min(v1,v2);
+  }
+};
+
+template <typename... Params>
+struct MinOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<MinOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/none_op.h
+++ b/src/vt/collective/reduce/operators/functors/none_op.h
@@ -52,6 +52,11 @@ using NoneType = char;
 
 template <typename T>
 struct None {
+  static_assert(
+    std::is_same_v<T, char> or std::is_same_v<T, std::tuple<>>,
+    "Must be empty data"
+  );
+
   void operator()(T& v1, T const& v2) {}
 };
 

--- a/src/vt/collective/reduce/operators/functors/or_op.h
+++ b/src/vt/collective/reduce/operators/functors/or_op.h
@@ -58,8 +58,10 @@ struct OrOp {
 
 template <typename... Params>
 struct OrOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = OrOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<OrOp>(v1, v2);
+    opTuple<OrOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/or_op.h
+++ b/src/vt/collective/reduce/operators/functors/or_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_OR_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 namespace vt { namespace collective { namespace reduce { namespace operators {
 
@@ -52,6 +53,13 @@ template <typename T>
 struct OrOp {
   void operator()(T& v1, T const& v2) {
     v1 = v1 || v2;
+  }
+};
+
+template <typename... Params>
+struct OrOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<OrOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/plus_op.h
+++ b/src/vt/collective/reduce/operators/functors/plus_op.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_COLLECTIVE_REDUCE_OPERATORS_FUNCTORS_PLUS_OP_H
 
 #include "vt/config.h"
+#include "vt/collective/reduce/operators/functors/tuple_op_helper.h"
 
 namespace vt { namespace collective { namespace reduce { namespace operators {
 
@@ -52,6 +53,13 @@ template <typename T>
 struct PlusOp {
   void operator()(T& v1, T const& v2) {
     v1 = v1 + v2;
+  }
+};
+
+template <typename... Params>
+struct PlusOp<std::tuple<Params...>> {
+  void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
+    opTuple<PlusOp>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/operators/functors/plus_op.h
+++ b/src/vt/collective/reduce/operators/functors/plus_op.h
@@ -58,8 +58,10 @@ struct PlusOp {
 
 template <typename... Params>
 struct PlusOp<std::tuple<Params...>> {
+  template <typename X>
+  using GetAsType = PlusOp<X>;
   void operator()(std::tuple<Params...>& v1, std::tuple<Params...> const& v2) {
-    opTuple<PlusOp>(v1, v2);
+    opTuple<PlusOp<std::tuple<Params...>>>(v1, v2);
   }
 };
 

--- a/src/vt/collective/reduce/reduce.h
+++ b/src/vt/collective/reduce/reduce.h
@@ -171,25 +171,16 @@ struct Reduce : virtual collective::tree::Tree {
   //////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////
-  template <typename ReturnT, typename... Args>
-  struct FunctionTraitsArgs;
-
-  template <typename ReturnT, typename... Args>
-  struct FunctionTraitsArgs<ReturnT(*)(Args...)> {
-    using TupleType = std::tuple<std::decay_t<Args>...>;
-    using ReturnType = ReturnT;
-  };
-
   template <template<typename Arg> class Op, auto f, typename... Params>
   PendingSendType reduce(Node root, Params&&... params) {
-    using Tuple = typename FunctionTraitsArgs<decltype(f)>::TupleType;
+    using Tuple = typename FuncTraits<decltype(f)>::TupleType;
     using OpT = Op<Tuple>;
     return reduce<OpT, f>(root, std::forward<Params>(params)...);
   }
 
   template <typename Op, auto f, typename... Params>
   PendingSendType reduce(Node root, Params&&... params) {
-    using Tuple = typename FunctionTraitsArgs<decltype(f)>::TupleType;
+    using Tuple = typename FuncTraits<decltype(f)>::TupleType;
     using MsgT = ReduceTMsg<Tuple>;
 
     auto msg = vt::makeMessage<MsgT>(std::tuple{std::forward<Params>(params)...});

--- a/src/vt/collective/reduce/reduce.h
+++ b/src/vt/collective/reduce/reduce.h
@@ -181,11 +181,7 @@ struct Reduce : virtual collective::tree::Tree {
     template <typename Arg> class Op = NoneOp,
     typename... Params
   >
-  PendingSendType reduce(Node root, Params&&... params) {
-    using Tuple = typename FuncTraits<decltype(f)>::TupleType;
-    using OpT = Op<Tuple>;
-    return reduce<OpT, f>(root, std::forward<Params>(params)...);
-  }
+  PendingSendType reduce(Node root, Params&&... params);
 
   template <typename Op, auto f, typename... Params>
   PendingSendType reduce(Node root, Params&&... params);

--- a/src/vt/collective/reduce/reduce.impl.h
+++ b/src/vt/collective/reduce/reduce.impl.h
@@ -50,6 +50,7 @@
 #include "vt/messaging/active.h"
 #include "vt/messaging/message.h"
 #include "vt/runnable/make_runnable.h"
+#include "vt/collective/reduce/get_reduce_stamp.h"
 
 namespace vt { namespace collective { namespace reduce {
 
@@ -83,19 +84,28 @@ void Reduce::reduceRootRecv(MsgT* msg) {
     .run();
 }
 
+template <
+  auto f,
+  template <typename Arg> class Op,
+  typename... Params
+>
+Reduce::PendingSendType Reduce::reduce(Node root, Params&&... params) {
+  using Tuple = typename FuncTraits<decltype(f)>::TupleType;
+  using OpT = Op<Tuple>;
+  return reduce<OpT, f>(root, std::forward<Params>(params)...);
+}
+
 template <typename Op, auto f, typename... Params>
 Reduce::PendingSendType Reduce::reduce(Node root, Params&&... params) {
   using Tuple = typename FuncTraits<decltype(f)>::TupleType;
   using MsgT = ReduceTMsg<Tuple>;
-
-  auto msg = vt::makeMessage<MsgT>(std::tuple{std::forward<Params>(params)...});
-  auto id = detail::ReduceStamp{};
+  using GetReduceStamp = collective::reduce::GetReduceStamp<void, Params...>;
+  auto [stamp, msg] = GetReduceStamp::template getStampMsg<MsgT>(std::forward<Params>(params)...);
   auto han = auto_registry::makeAutoHandlerParam<decltype(f), f, MsgT>();
   msg->root_handler_ = han;
 
-  return reduce<Op, operators::NoCombine, MsgT>(root.get(), msg.get(), id, 1);
+  return reduce<Op, operators::NoCombine, MsgT>(root.get(), msg.get(), stamp, 1);
 }
-
 
 template <typename OpT, typename MsgT, ActiveTypedFnType<MsgT> *f>
 Reduce::PendingSendType Reduce::reduce(

--- a/src/vt/collective/reduce/reduce.impl.h
+++ b/src/vt/collective/reduce/reduce.impl.h
@@ -88,7 +88,7 @@ Reduce::PendingSendType Reduce::reduce(Node root, Params&&... params) {
   using Tuple = typename FuncTraits<decltype(f)>::TupleType;
   using MsgT = ReduceTMsg<Tuple>;
 
-  auto msg = vt::makeMessage<MsgT>(std::forward<Params>(params)...);
+  auto msg = vt::makeMessage<MsgT>(std::tuple{std::forward<Params>(params)...});
   auto id = detail::ReduceStamp{};
   auto han = auto_registry::makeAutoHandlerParam<decltype(f), f, MsgT>();
   msg->root_handler_ = han;

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -327,7 +327,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsg(
   bool deliver_to_sender,
   TagType tag
 ) {
-  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
+  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT, MsgT, true>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   setBroadcastType(msgptr->env, deliver_to_sender);
   return sendMsgImpl<MsgT>(
@@ -351,7 +351,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsg(
   MsgPtrThief<MsgT> msg,
   TagType tag
 ) {
-  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
+  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT, MsgT, true>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }
@@ -371,7 +371,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::broadcastMsgAuto(
   MsgPtrThief<MsgT> msg,
   TagType tag
 ) {
-  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
+  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT, MsgT, true>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   return sendMsgImpl<MsgT>(
     broadcast_dest, han, msgptr, tag
@@ -384,7 +384,7 @@ ActiveMessenger::PendingSendType ActiveMessenger::sendMsgAuto(
   MsgPtrThief<MsgT> msg,
   TagType tag
 ) {
-  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
+  auto const han = auto_registry::makeAutoHandlerFunctor<FunctorT, MsgT, true>();
   MsgSharedPtr<MsgT> msgptr = msg.msg_;
   return sendMsgImpl<MsgT>(dest, han, msgptr, tag);
 }

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -94,7 +94,6 @@ struct Proxy {
   { }
 
 public:
-
   /**
    * \brief Broadcast a message to all nodes to be delivered to the local object
    * instance
@@ -161,6 +160,64 @@ public:
   PendingSendType broadcast(Args&&... args) const;
 
   /**
+   * \brief All-reduce back to this objgroup. Performs a reduction using
+   * operator `Op` followed by a broadcast to `f` with the result.
+   *
+   * \param[in] args the arguments to reduce. \note The last argument optionally
+   * may be a `ReduceStamp`.
+   *
+   * \return a pending send
+   */
+  template <
+    auto f,
+    template <typename Arg> class Op = collective::NoneOp,
+    typename... Args
+  >
+  PendingSendType allreduce(
+    Args&&... args
+  ) const;
+
+  /**
+   * \brief Reduce back to a point target. Performs a reduction using operator
+   * `Op` followed by a send to `f` with the result.
+   *
+   * \param[in] args the arguments to reduce. \note The last argument optionally
+   * may be a `ReduceStamp`.
+   *
+   * \return a pending send
+   */
+  template <
+    auto f,
+    template <typename Arg> class Op = collective::NoneOp,
+    typename Target,
+    typename... Args
+  >
+  PendingSendType reduce(
+    Target target,
+    Args&&... args
+  ) const;
+
+  /**
+   * \brief Reduce back to an arbitrary callback. Performs a reduction using
+   * operator `Op` and then delivers the result to the callback `cb`.
+   *
+   * \param[in] cb the callback to trigger with the reduction result
+   * \param[in] args the arguments to reduce. \note The last argument optionally
+   * may be a `ReduceStamp`.
+   *
+   * \return a pending send
+   */
+  template <
+    template <typename Arg> class Op = collective::NoneOp,
+    typename... CBArgs,
+    typename... Args
+  >
+  PendingSendType reduce(
+    vt::Callback<CBArgs...> cb,
+    Args&&... args
+  ) const;
+
+  /**
    * \brief Reduce over the objgroup instances on each node with a callback
    * target.
    *
@@ -176,6 +233,7 @@ public:
     typename MsgT,
     ActiveTypedFnType<MsgT> *f
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   PendingSendType reduce(
     MsgPtrT msg, Callback<MsgT> cb, ReduceStamp stamp = ReduceStamp{}
   ) const;
@@ -185,6 +243,7 @@ public:
     typename MsgPtrT,
     typename MsgT = typename util::MsgPtrType<MsgPtrT>::MsgType
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   PendingSendType reduce(
     MsgPtrT msg, Callback<MsgT> cb, ReduceStamp stamp = ReduceStamp{}
   ) const {
@@ -214,13 +273,16 @@ public:
     typename MsgT = typename util::MsgPtrType<MsgPtrT>::MsgType,
     ActiveTypedFnType<MsgT> *f
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   PendingSendType reduce(MsgPtrT msg, ReduceStamp stamp = ReduceStamp{}) const;
+
   template <
     typename OpT = collective::None,
     typename FunctorT,
     typename MsgPtrT,
     typename MsgT = typename util::MsgPtrType<MsgPtrT>::MsgType
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   PendingSendType reduce(MsgPtrT msg, ReduceStamp stamp = ReduceStamp{}) const
   {
     return reduce<
@@ -246,6 +308,7 @@ public:
     typename MsgT = typename util::MsgPtrType<MsgPtrT>::MsgType,
     ActiveTypedFnType<MsgT> *f
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   PendingSendType reduce(MsgPtrT msg, ReduceStamp stamp = ReduceStamp{}) const;
 
   /**

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -54,6 +54,7 @@
 #include "vt/rdmahandle/manager.h"
 #include "vt/messaging/param_msg.h"
 #include "vt/objgroup/proxy/proxy_bits.h"
+#include "vt/collective/reduce/get_reduce_stamp.h"
 
 namespace vt { namespace objgroup { namespace proxy {
 
@@ -105,6 +106,106 @@ Proxy<ObjT>::broadcast(Params&&... params) const {
 
   // Silence nvcc warning (no longer needed for CUDA 11.7 and up)
   return typename Proxy<ObjT>::PendingSendType{std::nullptr_t{}};
+}
+
+
+template <typename ObjT>
+template <
+  auto f,
+  template <typename Arg> class Op,
+  typename... Args
+>
+typename Proxy<ObjT>::PendingSendType
+Proxy<ObjT>::allreduce(
+  Args&&... args
+) const {
+  using Tuple = typename FuncTraits<decltype(f)>::TupleType;
+  using MsgT = collective::ReduceTMsg<Tuple>;
+  using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
+  auto cb = theCB()->makeBcast<f>(*this);
+
+  ReduceStamp stamp{};
+  if constexpr (GetReduceStamp::value) {
+    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
+  }
+
+  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  msg->setCallback(cb);
+  auto proxy = Proxy<ObjT>(*this);
+  return theObjGroup()->reduce<
+    ObjT,
+    MsgT,
+    &MsgT::template msgHandler<
+      MsgT, Op<Tuple>, collective::reduce::operators::ReduceCallback<MsgT>
+    >
+  >(proxy, msg.get(), stamp);
+}
+
+template <typename ObjT>
+template <
+  auto f,
+  template <typename Arg> class Op,
+  typename Target,
+  typename... Args
+>
+typename Proxy<ObjT>::PendingSendType
+Proxy<ObjT>::reduce(
+  Target target,
+  Args&&... args
+) const {
+  using Tuple = typename FuncTraits<decltype(f)>::TupleType;
+  using MsgT = collective::ReduceTMsg<Tuple>;
+  using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
+  auto cb = theCB()->makeSend<f>(target);
+
+  ReduceStamp stamp{};
+  if constexpr (GetReduceStamp::value ) {
+    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
+  }
+
+  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  msg->setCallback(cb);
+  auto proxy = Proxy<ObjT>(*this);
+  return theObjGroup()->reduce<
+    ObjT,
+    MsgT,
+    &MsgT::template msgHandler<
+      MsgT, Op<Tuple>, collective::reduce::operators::ReduceCallback<MsgT>
+    >
+  >(proxy, msg.get(), stamp);
+}
+
+template <typename ObjT>
+template <
+  template <typename Arg> class Op,
+  typename... CBArgs,
+  typename... Args
+>
+typename Proxy<ObjT>::PendingSendType
+Proxy<ObjT>::reduce(
+  vt::Callback<CBArgs...> cb,
+  Args&&... args
+) const {
+  using CallbackT = vt::Callback<CBArgs...>;
+  using Tuple = typename CallbackT::TupleType;
+  using MsgT = collective::ReduceTMsg<Tuple>;
+  using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
+
+  ReduceStamp stamp{};
+  if constexpr (GetReduceStamp::value ) {
+    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
+  }
+
+  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  msg->setCallback(cb);
+  auto proxy = Proxy<ObjT>(*this);
+  return theObjGroup()->reduce<
+    ObjT,
+    MsgT,
+    &MsgT::template msgHandler<
+      MsgT, Op<Tuple>, collective::reduce::operators::ReduceCallback<MsgT>
+    >
+  >(proxy, msg.get(), stamp);
 }
 
 template <typename ObjT>

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -124,12 +124,7 @@ Proxy<ObjT>::allreduce(
   using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
   auto cb = theCB()->makeBcast<f>(*this);
 
-  ReduceStamp stamp{};
-  if constexpr (GetReduceStamp::value) {
-    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
-  }
-
-  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  auto [stamp, msg] = GetReduceStamp::template getStampMsg<MsgT>(std::forward<Args>(args)...);
   msg->setCallback(cb);
   auto proxy = Proxy<ObjT>(*this);
   return theObjGroup()->reduce<
@@ -158,12 +153,7 @@ Proxy<ObjT>::reduce(
   using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
   auto cb = theCB()->makeSend<f>(target);
 
-  ReduceStamp stamp{};
-  if constexpr (GetReduceStamp::value ) {
-    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
-  }
-
-  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  auto [stamp, msg] = GetReduceStamp::template getStampMsg<MsgT>(std::forward<Args>(args)...);
   msg->setCallback(cb);
   auto proxy = Proxy<ObjT>(*this);
   return theObjGroup()->reduce<
@@ -191,12 +181,7 @@ Proxy<ObjT>::reduce(
   using MsgT = collective::ReduceTMsg<Tuple>;
   using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
 
-  ReduceStamp stamp{};
-  if constexpr (GetReduceStamp::value ) {
-    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
-  }
-
-  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  auto [stamp, msg] = GetReduceStamp::template getStampMsg<MsgT>(std::forward<Args>(args)...);
   msg->setCallback(cb);
   auto proxy = Proxy<ObjT>(*this);
   return theObjGroup()->reduce<

--- a/src/vt/phase/phase_manager.cc
+++ b/src/vt/phase/phase_manager.cc
@@ -175,7 +175,7 @@ void PhaseManager::nextPhaseCollective() {
   auto proxy = objgroup::proxy::Proxy<PhaseManager>(proxy_);
 
   // Start with a reduction to sure all nodes are ready for this
-  auto cb = theCB()->makeBcast<PhaseManager, NextMsg, &PhaseManager::nextPhaseReduce>(proxy);
+  auto cb = theCB()->makeBcast<&PhaseManager::nextPhaseReduce>(proxy);
   auto msg = makeMessage<NextMsg>();
   proxy.reduce(msg.get(), cb);
 
@@ -203,7 +203,7 @@ void PhaseManager::nextPhaseCollective() {
   runHooks(PhaseHook::Start);
 
   // Start with a reduction to sure all nodes are ready for this
-  auto cb2 = theCB()->makeBcast<PhaseManager, NextMsg, &PhaseManager::nextPhaseDone>(proxy);
+  auto cb2 = theCB()->makeBcast<&PhaseManager::nextPhaseDone>(proxy);
   auto msg2 = makeMessage<NextMsg>();
   proxy.reduce(msg2.get(), cb2);
 

--- a/src/vt/phase/phase_manager.cc
+++ b/src/vt/phase/phase_manager.cc
@@ -156,8 +156,6 @@ void PhaseManager::startup() {
   runHooks(PhaseHook::Start);
 }
 
-struct NextMsg : collective::ReduceNoneMsg {};
-
 void PhaseManager::nextPhaseCollective() {
   vtAbortIf(
     in_next_phase_collective_,
@@ -175,9 +173,7 @@ void PhaseManager::nextPhaseCollective() {
   auto proxy = objgroup::proxy::Proxy<PhaseManager>(proxy_);
 
   // Start with a reduction to sure all nodes are ready for this
-  auto cb = theCB()->makeBcast<&PhaseManager::nextPhaseReduce>(proxy);
-  auto msg = makeMessage<NextMsg>();
-  proxy.reduce(msg.get(), cb);
+  proxy.allreduce<&PhaseManager::nextPhaseReduce>();
 
   theSched()->runSchedulerWhile([this]{ return not reduce_next_phase_done_; });
   reduce_next_phase_done_ = false;
@@ -203,9 +199,7 @@ void PhaseManager::nextPhaseCollective() {
   runHooks(PhaseHook::Start);
 
   // Start with a reduction to sure all nodes are ready for this
-  auto cb2 = theCB()->makeBcast<&PhaseManager::nextPhaseDone>(proxy);
-  auto msg2 = makeMessage<NextMsg>();
-  proxy.reduce(msg2.get(), cb2);
+  proxy.allreduce<&PhaseManager::nextPhaseDone>();
 
   theSched()->runSchedulerWhile([this]{ return not reduce_finished_; });
   reduce_finished_ = false;
@@ -213,11 +207,11 @@ void PhaseManager::nextPhaseCollective() {
   in_next_phase_collective_ = false;
 }
 
-void PhaseManager::nextPhaseReduce(NextMsg* msg) {
+void PhaseManager::nextPhaseReduce() {
   reduce_next_phase_done_ = true;
 }
 
-void PhaseManager::nextPhaseDone(NextMsg* msg) {
+void PhaseManager::nextPhaseDone() {
   reduce_finished_ = true;
 }
 

--- a/src/vt/phase/phase_manager.h
+++ b/src/vt/phase/phase_manager.h
@@ -57,9 +57,6 @@
 
 namespace vt { namespace phase {
 
-// fwd-decl for reduce message
-struct NextMsg;
-
 /**
  * \struct PhaseManager
  *
@@ -186,7 +183,7 @@ private:
    *
    * \param[in] msg the (empty) next phase message
    */
-  void nextPhaseReduce(NextMsg* msg);
+  void nextPhaseReduce();
 
   /**
    * \internal
@@ -194,7 +191,7 @@ private:
    *
    * \param[in] msg the (empty) next phase message
    */
-  void nextPhaseDone(NextMsg* msg);
+  void nextPhaseDone();
 
   /**
    * \internal

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.cc
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.cc
@@ -98,7 +98,7 @@ CallbackRawBaseSingle::CallbackRawBaseSingle(
 // ) : pipe_(in_pipe), cb_(SendColDirCB{in_handler,in_vrt_handler,in_index})
 //  { }
 
-void CallbackRawBaseSingle::send() {
+void CallbackRawBaseSingle::sendVoid() {
   switch (cb_.active_) {
   case CallbackEnum::SendMsgCB:
     cb_.u_.send_msg_cb_.triggerVoid(pipe_);

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -228,16 +228,6 @@ struct CallbackTyped : CallbackRawBaseSingle {
     return other.pipe_ == pipe_ && other.cb_ == cb_;
   }
 
-  // Conversion operators to typed from untyped
-  CallbackTyped(CallbackRawBaseSingle const& other) {
-    pipe_ = other.pipe_;
-    cb_   = other.cb_;
-  }
-  CallbackTyped(CallbackRawBaseSingle&& other) {
-    pipe_ = std::move(other.pipe_);
-    cb_   = std::move(other.cb_);
-  }
-
   template <typename... Params>
   void send(Params&&... params) {
     using Trait = CBTraits<Args...>;

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -48,6 +48,8 @@
 #include "vt/pipe/callback/cb_union/cb_raw.h"
 #include "vt/pipe/signal/signal.h"
 #include "vt/registry/auto/auto_registry_common.h"
+#include "vt/utils/fntraits/fntraits.h"
+#include "vt/messaging/param_msg.h"
 
 #include <cassert>
 #include <type_traits>
@@ -67,7 +69,7 @@ static struct RawSendObjGrpTagType  { } RawSendObjGrpTag  { };
 static struct RawBcastObjGrpTagType { } RawBcastObjGrpTag { };
 #pragma GCC diagnostic pop
 
-template <typename MsgT>
+template <typename... Args>
 struct CallbackTyped;
 
 struct CallbackRawBaseSingle {
@@ -126,23 +128,30 @@ struct CallbackRawBaseSingle {
   bool null()  const { return cb_.null();  }
   bool valid() const { return cb_.valid(); }
 
-  template <typename MsgT, typename... Args>
-  void send(Args... args);
+  template <typename MsgT>
+  void send(MsgT* msg) {
+    sendMsg<MsgT>(msg);
+  }
 
   template <typename MsgT>
-  void send(MsgT* msg);
+  void send(messaging::MsgPtrThief<MsgT> msg) {
+    return sendMsg(msg);
+  }
+
+  template <typename MsgT>
+  void sendMsg(MsgT* msg);
 
   template <typename MsgT>
   void sendMsg(messaging::MsgPtrThief<MsgT> msg);
 
-  void send();
+  void sendVoid();
 
   template <typename SerializerT>
   void serialize(SerializerT& s);
 
   PipeType getPipe() const { return pipe_; }
 
-  template <typename MsgT>
+  template <typename... Args>
   friend struct CallbackTyped;
 
 protected:
@@ -150,14 +159,8 @@ protected:
   GeneralCallback cb_;
 };
 
-template <typename MsgT>
+template <typename... Args>
 struct CallbackTyped : CallbackRawBaseSingle {
-  using VoidSigType   = signal::SigVoidType;
-  template <typename T, typename U=void>
-  using IsVoidType    = std::enable_if_t<std::is_same<T,VoidSigType>::value,U>;
-  template <typename T, typename U=void>
-  using IsNotVoidType = std::enable_if_t<!std::is_same<T,VoidSigType>::value,U>;
-
   CallbackTyped() = default;
   CallbackTyped(CallbackTyped const&) = default;
   CallbackTyped(CallbackTyped&&) = default;
@@ -213,7 +216,7 @@ struct CallbackTyped : CallbackRawBaseSingle {
       )
   { }
 
-  bool operator==(CallbackTyped<MsgT> const& other)   const {
+  bool operator==(CallbackTyped<Args...> const& other)   const {
     return equal(other);
   }
   bool operator==(CallbackRawBaseSingle const& other) const {
@@ -235,25 +238,44 @@ struct CallbackTyped : CallbackRawBaseSingle {
     cb_   = std::move(other.cb_);
   }
 
-  template <typename MsgU=MsgT, typename... Args>
-  void send(Args... args) {
-    static_assert(std::is_same<MsgT, MsgU>::value, "Required exact type match");
-    sendMsg(makeMessage<MsgU>(std::forward<Args>(args)...));
+  template <typename... Params>
+  void send(Params&&... params) {
+    using Trait = CBTraits<Args...>;
+    if constexpr (std::is_same_v<typename Trait::MsgT, NoMsg>) {
+      using MsgT = messaging::ParamMsg<typename Trait::TupleType>;
+      auto msg = vt::makeMessage<MsgT>(std::forward<Params>(params)...);
+      CallbackRawBaseSingle::sendMsg<MsgT>(msg);
+    } else {
+      using MsgT = typename Trait::MsgT;
+      auto msg = makeMessage<MsgT>(std::forward<Params>(params)...);
+      sendMsg(msg);
+    }
   }
 
-  template <typename MsgU>
-  IsNotVoidType<MsgU> send(MsgU* m) {
-    static_assert(std::is_same<MsgT,MsgU>::value, "Required exact type match");
-    CallbackRawBaseSingle::send<MsgU>(m);
+  void send(typename CBTraits<Args...>::MsgT* msg) {
+    using MsgT = typename CBTraits<Args...>::MsgT;
+    if constexpr (not std::is_same_v<MsgT, NoMsg>) {
+      CallbackRawBaseSingle::sendMsg<MsgT>(msg);
+    }
   }
 
-  void sendMsg(messaging::MsgPtrThief<MsgT> msg) {
+  template <typename MsgT>
+  void send(messaging::MsgPtrThief<MsgT> msg) {
     CallbackRawBaseSingle::sendMsg<MsgT>(msg);
   }
 
-  template <typename T=void, typename=IsVoidType<MsgT,T>>
-  void send() {
-    CallbackRawBaseSingle::send();
+  void sendMsg(messaging::MsgPtrThief<typename CBTraits<Args...>::MsgT> msg) {
+    using MsgT = typename CBTraits<Args...>::MsgT;
+    if constexpr (not std::is_same_v<MsgT, NoMsg>) {
+      CallbackRawBaseSingle::sendMsg<MsgT>(msg);
+    }
+  }
+
+  void sendMsg(typename CBTraits<Args...>::MsgT* msg) {
+    using MsgT = typename CBTraits<Args...>::MsgT;
+    if constexpr (not std::is_same_v<MsgT, NoMsg>) {
+      CallbackRawBaseSingle::sendMsg<MsgT>(msg);
+    }
   }
 
   template <typename SerializerT>
@@ -266,10 +288,8 @@ struct CallbackTyped : CallbackRawBaseSingle {
 
 namespace vt {
 
-using VoidMsg = pipe::signal::SigVoidType;
-
-template <typename MsgT = VoidMsg>
-using Callback = pipe::callback::cbunion::CallbackTyped<MsgT>;
+template <typename... Args>
+using Callback = pipe::callback::cbunion::CallbackTyped<Args...>;
 
 using CallbackU = pipe::callback::cbunion::CallbackRawBaseSingle;
 

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -248,7 +248,7 @@ struct CallbackTyped : CallbackRawBaseSingle {
     } else {
       using MsgT = typename Trait::MsgT;
       auto msg = makeMessage<MsgT>(std::forward<Params>(params)...);
-      sendMsg(msg);
+      sendMsg(msg.get());
     }
   }
 

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -161,6 +161,8 @@ protected:
 
 template <typename... Args>
 struct CallbackTyped : CallbackRawBaseSingle {
+  using TupleType = std::tuple<Args...>;
+
   CallbackTyped() = default;
   CallbackTyped(CallbackTyped const&) = default;
   CallbackTyped(CallbackTyped&&) = default;
@@ -226,6 +228,14 @@ struct CallbackTyped : CallbackRawBaseSingle {
   template <typename CallbackT>
   bool equal(CallbackT const& other) const {
     return other.pipe_ == pipe_ && other.cb_ == cb_;
+  }
+
+  template <typename... Params>
+  void sendTuple(std::tuple<Params...> tup) {
+    using Trait = CBTraits<Args...>;
+    using MsgT = messaging::ParamMsg<typename Trait::TupleType>;
+    auto msg = vt::makeMessage<MsgT>(std::move(tup));
+    CallbackRawBaseSingle::sendMsg<MsgT>(msg);
   }
 
   template <typename... Params>

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.impl.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.impl.h
@@ -62,13 +62,8 @@ bool CallbackRawBaseSingle::operator==(CallbackTyped<MsgT> const& other) const {
   return equal(other);
 }
 
-template <typename MsgT, typename... Args>
-void CallbackRawBaseSingle::send(Args... args) {
-  sendMsg<MsgT>(makeMessage<MsgT>(std::forward<Args>(args)...));
-}
-
 template <typename MsgT>
-void CallbackRawBaseSingle::send(MsgT* msg) {
+void CallbackRawBaseSingle::sendMsg(MsgT* msg) {
   theMsg()->setupEpochMsg(msg);
 
   switch (cb_.active_) {

--- a/src/vt/pipe/callback/handler_send/callback_send_tl.impl.h
+++ b/src/vt/pipe/callback/handler_send/callback_send_tl.impl.h
@@ -63,6 +63,8 @@ void CallbackSendTypeless::serialize(SerializerT& s) {
 
 template <typename MsgT>
 void CallbackSendTypeless::trigger(MsgT* msg, PipeType const& pipe) {
+  static_assert(not std::is_same<MsgT, NoMsg>::value, "Must not be no msg");
+
   auto const& this_node = theContext()->getNode();
   vt_debug_print(
     terse, pipe,

--- a/src/vt/pipe/pipe_manager.cc
+++ b/src/vt/pipe/pipe_manager.cc
@@ -56,10 +56,10 @@ PipeManager::PipeManager() {
   );
 }
 
-Callback<PipeManager::Void> PipeManager::makeFunc(
+Callback<> PipeManager::makeFunc(
   LifetimeEnum life, FuncVoidType fn
 ) {
-  return makeCallbackSingleAnonVoid<Callback<Void>>(life,fn);
+  return makeCallbackSingleAnonVoid(life,fn);
 }
 
 // Functions pulled out of PipeManager for header deps, forward to manager

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -66,21 +66,6 @@
 namespace vt { namespace pipe {
 
 /**
- * \internal \struct PipeFunctorTraits
- *
- * \brief Extract acceptable message type from functor
- *
- * Used to automatically extract the message type from a functor endpoint
- */
-template <typename T>
-struct PipeFunctorTraits {
-  template <typename U>
-  using FunctorNoMsgArchType = decltype(std::declval<U>().operator()());
-  using FunctorNoMsgType = detection::is_detected<FunctorNoMsgArchType,T>;
-  static constexpr auto const has_no_msg_type = FunctorNoMsgType::value;
-};
-
-/**
  * \struct PipeManager
  *
  * \brief Core VT component that provides an interface to create type-erased

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -92,12 +92,12 @@ struct PipeManager
   /**
    * \brief Make callback to an active function, objgroup, or collection
    *
-   * \param[in] node the node to target
+   * \param[in] target the node or proxy to target
    *
    * \return a callback
    */
   template <auto f, typename Target>
-  auto makeSend(Target node);
+  auto makeSend(Target target);
 
   /**
    * \brief Make callback to a functor

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -330,6 +330,12 @@ struct PipeManager
   template <typename ColT, typename MsgT, ColHanType<ColT,MsgT>* f>
   Callback<MsgT> makeBcast(ColProxyType<ColT> proxy);
 
+  template <auto f, typename ProxyT>
+  auto makeBcast(ProxyT proxy);
+
+  template <auto f, typename ProxyT>
+  auto makeSend(ProxyT proxy);
+
   /**
    * \brief Make a callback to a whole collection invoking an intrusive
    * collection member handler.

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -66,14 +66,14 @@
 namespace vt { namespace pipe {
 
 /**
- * \internal \struct FunctorTraits
+ * \internal \struct PipeFunctorTraits
  *
  * \brief Extract acceptable message type from functor
  *
  * Used to automatically extract the message type from a functor endpoint
  */
 template <typename T>
-struct FunctorTraits {
+struct PipeFunctorTraits {
   template <typename U>
   using FunctorNoMsgArchType = decltype(std::declval<U>().operator()());
   using FunctorNoMsgType = detection::is_detected<FunctorNoMsgArchType,T>;
@@ -103,6 +103,52 @@ struct PipeManager
   PipeManager();
 
   std::string name() override { return "PipeManager"; }
+
+  /**
+   * \brief Make callback to an active function, objgroup, or collection
+   *
+   * \param[in] node the node to target
+   *
+   * \return a callback
+   */
+  template <auto f, typename Target>
+  auto makeSend(Target node);
+
+  /**
+   * \brief Make callback to a functor
+   *
+   * \param[in] node the node to target
+   *
+   * \return a callback
+   */
+  template <typename FunctorT>
+  auto makeSend(NodeType node);
+
+  /**
+   * \brief Make callback to an active function
+   *
+   * \return a callback
+   */
+  template <auto f>
+  auto makeBcast();
+
+  /**
+   * \brief Make callback to a functor
+   *
+   * \return a callback
+   */
+  template <typename FunctorT>
+  auto makeBcast();
+
+  /**
+   * \brief Make callback to an objgroup or collection
+   *
+   * \param[in] proxy the proxy to target
+   *
+   * \return a callback
+   */
+  template <auto f, typename ProxyT>
+  auto makeBcast(ProxyT proxy);
 
   /**
    * \brief Make callback to a function (including lambdas) with a context
@@ -229,32 +275,8 @@ struct PipeManager
    * \return the new callback
    */
   template <typename MsgT, ActiveTypedFnType<MsgT>* f>
+  [[deprecated("Replace with call to makeSend<auto f>")]]
   Callback<MsgT> makeSend(NodeType const& node);
-
-  /**
-   * \brief Make a callback to a functor handler to be invoked on a certain
-   * node with a message.
-   *
-   * \param[in] node node to invoke callback on
-   *
-   * \return the new callback
-   */
-  template <typename FunctorT, typename MsgT = GetMsgType<FunctorT>>
-  Callback<MsgT> makeSend(NodeType const& node);
-
-  /**
-   * \brief Make a callback to a void functor handler to be invoked on a certain
-   * node.
-   *
-   * \param[in] node node to invoke callback on
-   *
-   * \return the new callback
-   */
-  template <
-    typename FunctorT,
-    typename = std::enable_if_t<FunctorTraits<FunctorT>::has_no_msg_type>
-  >
-  Callback<> makeSend(NodeType const& node);
 
   /**
    * \brief Make a callback to a particular collection element invoking a
@@ -265,6 +287,7 @@ struct PipeManager
    * \return the new callback
    */
   template <typename ColT, typename MsgT, ColHanType<ColT,MsgT>* f>
+  [[deprecated("Replace with call to makeSend<auto f>")]]
   Callback<MsgT> makeSend(typename ColT::ProxyType proxy);
 
   /**
@@ -276,6 +299,7 @@ struct PipeManager
    * \return the new callback
    */
   template <typename ColT, typename MsgT, ColMemType<ColT,MsgT> f>
+  [[deprecated("Replace with call to makeSend<auto f>")]]
   Callback<MsgT> makeSend(typename ColT::ProxyType proxy);
 
   /**
@@ -287,6 +311,7 @@ struct PipeManager
    * \return the new callback
    */
   template <typename ObjT, typename MsgT, ObjMemType<ObjT,MsgT> f>
+  [[deprecated("Replace with call to makeSend<auto f>")]]
   Callback<MsgT> makeSend(objgroup::proxy::ProxyElm<ObjT> proxy);
 
   /**
@@ -296,28 +321,8 @@ struct PipeManager
    * \return the new callback
    */
   template <typename MsgT, ActiveTypedFnType<MsgT>* f>
+  [[deprecated("Replace with call to makeBcast<auto f>")]]
   Callback<MsgT> makeBcast();
-
-  /**
-   * \brief Make a callback to a functor handler with a message to be broadcast
-   * to all nodes.
-   *
-   * \return the new callback
-   */
-  template <typename FunctorT, typename MsgT = GetMsgType<FunctorT>>
-  Callback<MsgT> makeBcast();
-
-  /**
-   * \brief Make a void callback to a functor handler to be broadcast to all
-   * nodes.
-   *
-   * \return the new callback
-   */
-  template <
-    typename FunctorT,
-    typename = std::enable_if_t<FunctorTraits<FunctorT>::has_no_msg_type>
-  >
-  Callback<> makeBcast();
 
   /**
    * \brief Make a callback to a whole collection invoking a non-intrusive
@@ -328,13 +333,8 @@ struct PipeManager
    * \return the new callback
    */
   template <typename ColT, typename MsgT, ColHanType<ColT,MsgT>* f>
+  [[deprecated("Replace with call to makeBcast<auto f>")]]
   Callback<MsgT> makeBcast(ColProxyType<ColT> proxy);
-
-  template <auto f, typename ProxyT>
-  auto makeBcast(ProxyT proxy);
-
-  template <auto f, typename ProxyT>
-  auto makeSend(ProxyT proxy);
 
   /**
    * \brief Make a callback to a whole collection invoking an intrusive
@@ -345,6 +345,7 @@ struct PipeManager
    * \return the new callback
    */
   template <typename ColT, typename MsgT, ColMemType<ColT,MsgT> f>
+  [[deprecated("Replace with call to makeBcast<auto f>")]]
   Callback<MsgT> makeBcast(ColProxyType<ColT> proxy);
 
   /**
@@ -356,6 +357,7 @@ struct PipeManager
    * \return the new callback
    */
   template <typename ObjT, typename MsgT, ObjMemType<ObjT,MsgT> f>
+  [[deprecated("Replace with call to makeBcast<auto f>")]]
   Callback<MsgT> makeBcast(objgroup::proxy::Proxy<ObjT> proxy);
 
 public:

--- a/src/vt/pipe/pipe_manager.h
+++ b/src/vt/pipe/pipe_manager.h
@@ -169,7 +169,7 @@ struct PipeManager
    * \return a new callback
    */
   template <typename ContextT>
-  Callback<Void> makeFunc(
+  Callback<> makeFunc(
     LifetimeEnum life, ContextT* ctx, FuncCtxType<ContextT> fn
   );
 
@@ -218,7 +218,7 @@ struct PipeManager
    *
    * \return the new callback
    */
-  Callback<Void> makeFunc(LifetimeEnum life, FuncVoidType fn);
+  Callback<> makeFunc(LifetimeEnum life, FuncVoidType fn);
 
   /**
    * \brief Make a callback to a active message handler to be invoked on a
@@ -254,7 +254,7 @@ struct PipeManager
     typename FunctorT,
     typename = std::enable_if_t<FunctorTraits<FunctorT>::has_no_msg_type>
   >
-  Callback<Void> makeSend(NodeType const& node);
+  Callback<> makeSend(NodeType const& node);
 
   /**
    * \brief Make a callback to a particular collection element invoking a
@@ -317,7 +317,7 @@ struct PipeManager
     typename FunctorT,
     typename = std::enable_if_t<FunctorTraits<FunctorT>::has_no_msg_type>
   >
-  Callback<Void> makeBcast();
+  Callback<> makeBcast();
 
   /**
    * \brief Make a callback to a whole collection invoking a non-intrusive

--- a/src/vt/pipe/pipe_manager.impl.h
+++ b/src/vt/pipe/pipe_manager.impl.h
@@ -103,19 +103,33 @@ Callback<MsgT> PipeManager::makeSend(NodeType const& node) {
   return makeCallbackSingle<f, false>(node);
 }
 
-template <typename FunctorT, typename MsgT>
-Callback<MsgT> PipeManager::makeSend(NodeType const& node) {
-  return makeCallbackFunctorSend<FunctorT,MsgT>(node);
+template <typename FunctorT>
+auto PipeManager::makeSend(NodeType node) {
+  return makeCallbackFunctor<FunctorT, false>(node);
 }
 
-template <typename FunctorT, typename not_used_>
-Callback<> PipeManager::makeSend(NodeType const& node) {
-  return makeCallbackFunctorSendVoid<FunctorT>(node);
+template <typename FunctorT>
+auto PipeManager::makeBcast() {
+  return makeCallbackFunctor<FunctorT, true>();
 }
 
-template <auto f, typename ProxyT>
-auto PipeManager::makeSend(ProxyT proxy) {
-  return makeCallbackProxy<f, false>(proxy);
+template <auto f>
+auto PipeManager::makeBcast() {
+  return makeCallbackSingle<f, true>();
+}
+
+template <auto f, typename Target>
+auto PipeManager::makeSend(Target target) {
+  if constexpr (
+    std::is_same_v<Target, NodeType> or
+    std::is_same_v<Target, int> or
+    std::is_same_v<Target, vt::Node>
+  ) {
+    return makeCallbackSingle<f, false>(target);
+  } else {
+    // target is a proxy
+    return makeCallbackProxy<f, false>(target);
+  }
 }
 
 template <typename ColT, typename MsgT, PipeManager::ColHanType<ColT,MsgT>* f>
@@ -141,16 +155,6 @@ auto PipeManager::makeBcast(ProxyT proxy) {
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 Callback<MsgT> PipeManager::makeBcast() {
   return makeCallbackSingle<f, true>();
-}
-
-template <typename FunctorT, typename MsgT>
-Callback<MsgT> PipeManager::makeBcast() {
-  return makeCallbackFunctorBcast<FunctorT,MsgT>();
-}
-
-template <typename FunctorT, typename not_used_>
-Callback<> PipeManager::makeBcast() {
-  return makeCallbackFunctorBcastVoid<FunctorT>();
 }
 
 template <typename ColT, typename MsgT, PipeManager::ColHanType<ColT,MsgT>* f>

--- a/src/vt/pipe/pipe_manager.impl.h
+++ b/src/vt/pipe/pipe_manager.impl.h
@@ -113,6 +113,11 @@ Callback<> PipeManager::makeSend(NodeType const& node) {
   return makeCallbackFunctorSendVoid<FunctorT>(node);
 }
 
+template <auto f, typename ProxyT>
+auto PipeManager::makeSend(ProxyT proxy) {
+  return makeCallbackProxy<f, false>(proxy);
+}
+
 template <typename ColT, typename MsgT, PipeManager::ColHanType<ColT,MsgT>* f>
 Callback<MsgT> PipeManager::makeSend(typename ColT::ProxyType proxy) {
   return makeCallbackProxy<f, false>(proxy);
@@ -126,6 +131,11 @@ Callback<MsgT> PipeManager::makeSend(typename ColT::ProxyType proxy) {
 template <typename ObjT, typename MsgT, PipeManager::ObjMemType<ObjT,MsgT> f>
 Callback<MsgT> PipeManager::makeSend(objgroup::proxy::ProxyElm<ObjT> proxy) {
   return makeCallbackProxy<f, false>(proxy);
+}
+
+template <auto f, typename ProxyT>
+auto PipeManager::makeBcast(ProxyT proxy) {
+  return makeCallbackProxy<f, true>(proxy);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>

--- a/src/vt/pipe/pipe_manager.impl.h
+++ b/src/vt/pipe/pipe_manager.impl.h
@@ -80,27 +80,27 @@ void PipeManager::triggerSendBack(PipeType const& pipe, MsgT* data) {
 }
 
 template <typename C>
-Callback<PipeManager::Void> PipeManager::makeFunc(
+Callback<> PipeManager::makeFunc(
   LifetimeEnum life, C* ctx, FuncCtxType<C> fn
 ) {
-  return makeCallbackSingleAnon<C,Callback<Void>>(life,ctx,fn);
+  return makeCallbackSingleAnon<C>(life,ctx,fn);
 }
 
 template <typename MsgT, typename C>
 Callback<MsgT> PipeManager::makeFunc(
   LifetimeEnum life, C* ctx, FuncMsgCtxType<MsgT, C> fn
 ) {
-  return makeCallbackSingleAnon<MsgT,C,Callback<MsgT>>(life,ctx,fn);
+  return makeCallbackSingleAnon<MsgT,C>(life,ctx,fn);
 }
 
 template <typename MsgT>
 Callback<MsgT> PipeManager::makeFunc(LifetimeEnum life, FuncMsgType<MsgT> fn) {
-  return makeCallbackSingleAnon<MsgT,Callback<MsgT>>(life,fn);
+  return makeCallbackSingleAnon<MsgT>(life,fn);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 Callback<MsgT> PipeManager::makeSend(NodeType const& node) {
-  return makeCallbackSingleSend<MsgT,f>(node);
+  return makeCallbackSingle<f, false>(node);
 }
 
 template <typename FunctorT, typename MsgT>
@@ -109,28 +109,28 @@ Callback<MsgT> PipeManager::makeSend(NodeType const& node) {
 }
 
 template <typename FunctorT, typename not_used_>
-Callback<PipeManager::Void> PipeManager::makeSend(NodeType const& node) {
+Callback<> PipeManager::makeSend(NodeType const& node) {
   return makeCallbackFunctorSendVoid<FunctorT>(node);
 }
 
 template <typename ColT, typename MsgT, PipeManager::ColHanType<ColT,MsgT>* f>
 Callback<MsgT> PipeManager::makeSend(typename ColT::ProxyType proxy) {
-  return makeCallbackSingleProxySend<ColT,MsgT,f>(proxy);
+  return makeCallbackProxy<f, false>(proxy);
 }
 
 template <typename ColT, typename MsgT, PipeManager::ColMemType<ColT,MsgT> f>
 Callback<MsgT> PipeManager::makeSend(typename ColT::ProxyType proxy) {
-  return makeCallbackSingleProxySend<ColT,MsgT,f>(proxy);
+  return makeCallbackProxy<f, false>(proxy);
 }
 
 template <typename ObjT, typename MsgT, PipeManager::ObjMemType<ObjT,MsgT> f>
 Callback<MsgT> PipeManager::makeSend(objgroup::proxy::ProxyElm<ObjT> proxy) {
-  return makeCallbackObjGrpSend<ObjT,MsgT,f>(proxy);
+  return makeCallbackProxy<f, false>(proxy);
 }
 
 template <typename MsgT, ActiveTypedFnType<MsgT>* f>
 Callback<MsgT> PipeManager::makeBcast() {
-  return makeCallbackSingleBcast<MsgT,f>();
+  return makeCallbackSingle<f, true>();
 }
 
 template <typename FunctorT, typename MsgT>
@@ -139,23 +139,23 @@ Callback<MsgT> PipeManager::makeBcast() {
 }
 
 template <typename FunctorT, typename not_used_>
-Callback<PipeManager::Void> PipeManager::makeBcast() {
+Callback<> PipeManager::makeBcast() {
   return makeCallbackFunctorBcastVoid<FunctorT>();
 }
 
 template <typename ColT, typename MsgT, PipeManager::ColHanType<ColT,MsgT>* f>
 Callback<MsgT> PipeManager::makeBcast(ColProxyType<ColT> proxy) {
-  return makeCallbackSingleProxyBcastDirect<ColT,MsgT,f>(proxy);
+  return makeCallbackProxy<f, true>(proxy);
 }
 
 template <typename ColT, typename MsgT, PipeManager::ColMemType<ColT,MsgT> f>
 Callback<MsgT> PipeManager::makeBcast(ColProxyType<ColT> proxy) {
-  return makeCallbackSingleProxyBcastDirect<ColT,MsgT,f>(proxy);
+  return makeCallbackProxy<f, true>(proxy);
 }
 
 template <typename ObjT, typename MsgT, PipeManager::ObjMemType<ObjT,MsgT> f>
 Callback<MsgT> PipeManager::makeBcast(objgroup::proxy::Proxy<ObjT> proxy) {
-  return makeCallbackObjGrpBcast<ObjT,MsgT,f>(proxy);
+  return makeCallbackProxy<f, true>(proxy);
 }
 
 template <typename MsgT>

--- a/src/vt/pipe/pipe_manager_base.impl.h
+++ b/src/vt/pipe/pipe_manager_base.impl.h
@@ -85,7 +85,7 @@ void PipeManagerBase::triggerPipeTyped(PipeType const& pipe, MsgT* msg) {
   if (exists) {
     signal_holder_<SignalType>.deliverAll(pipe,msg);
   } else {
-    auto nmsg = makeMessage<MsgT>(*msg);
+    auto nmsg = makeMessage<MsgT>(std::move(*msg));
     triggerPipeUnknown<MsgT>(pipe,nmsg.get());
   }
   generalSignalTrigger(pipe);

--- a/src/vt/pipe/pipe_manager_tl.h
+++ b/src/vt/pipe/pipe_manager_tl.h
@@ -76,6 +76,9 @@ struct PipeManagerTL : virtual PipeManagerBase {
   template <typename MsgT>
   using CallbackMsgType = callback::cbunion::CallbackTyped<MsgT>;
 
+  template <typename... Args>
+  using CallbackRetType = callback::cbunion::CallbackTyped<Args...>;
+
   template <typename MsgT>
   using FnType = ActiveTypedFnType<MsgT>;
 
@@ -87,94 +90,45 @@ struct PipeManagerTL : virtual PipeManagerBase {
   /*
    *  Untyped variants of callbacks: uses union to dispatch
    */
-
-
-  template <typename T, FnType<T>* f, typename CbkT = DefType<T>>
-  CbkT makeCallbackSingleSendT(NodeType const& node);
-
   // Single active message function-handler
-  template <typename T, FnType<T>* f, typename CbkT = DefType<T>>
-  CbkT makeCallbackSingleSend(NodeType const& node);
-
-  template <typename T, FnType<T>* f, typename CbkT = DefType<T>>
-  CbkT makeCallbackSingleBcast();
+  template <auto f, bool is_bcast>
+  auto makeCallbackSingle(NodeType node = uninitialized_destination);
 
   // Single active message functor-handler
   template <
     typename FunctorT,
-    typename T = typename util::FunctorExtractor<FunctorT>::MessageType,
-    typename CbkT = DefType<T>
+    typename T = typename util::FunctorExtractor<FunctorT>::MessageType
   >
-  CbkT makeCallbackFunctorSend(NodeType const& node);
+  auto makeCallbackFunctorSend(NodeType const& node);
 
   template <
     typename FunctorT,
-    typename T = typename util::FunctorExtractor<FunctorT>::MessageType,
-    typename CbkT = DefType<T>
+    typename T = typename util::FunctorExtractor<FunctorT>::MessageType
   >
-  CbkT makeCallbackFunctorBcast();
+  auto makeCallbackFunctorBcast();
 
   // Single active message functor-handler void param
-  template <typename FunctorT, typename CbkT = DefType<V>>
-  CbkT makeCallbackFunctorSendVoid(NodeType const& node);
+  template <typename FunctorT>
+  auto makeCallbackFunctorSendVoid(NodeType const& node);
 
-  template <typename FunctorT, typename CbkT = DefType<V>>
-  CbkT makeCallbackFunctorBcastVoid();
+  template <typename FunctorT>
+  auto makeCallbackFunctorBcastVoid();
 
   // Single active message anon func-handler
-  template <typename CbkT = DefType<V>>
-  CbkT makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn);
+  auto makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn);
 
-  template <typename T, typename CbkT = DefType<T>>
-  CbkT makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<T> fn);
+  template <typename T>
+  auto makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<T> fn);
 
-  template <typename T, typename U, typename CbkT = DefType<T>>
-  CbkT makeCallbackSingleAnon(LifetimeEnum life, U* u, FuncMsgCtxType<T, U> fn);
+  template <typename T, typename U>
+  auto makeCallbackSingleAnon(LifetimeEnum life, U* u, FuncMsgCtxType<T, U> fn);
 
-  template <typename U, typename CbkT = DefType<V>>
-  CbkT makeCallbackSingleAnon(LifetimeEnum life, U* u, FuncCtxType<U> fn);
+  template <typename U>
+  auto makeCallbackSingleAnon(LifetimeEnum life, U* u, FuncCtxType<U> fn);
 
-  // Single active message collection proxy send
-  template <
-    typename ColT, typename T, ColHanType<ColT,T>* f, typename CbkT = DefType<T>
-  >
-  CbkT makeCallbackSingleProxySend(typename ColT::ProxyType proxy);
-
-  template <
-    typename ColT, typename T, ColMemType<ColT,T> f, typename CbkT = DefType<T>
-  >
-  CbkT makeCallbackSingleProxySend(typename ColT::ProxyType proxy);
-
-  // Obj group send callback
-  template <
-    typename ObjT, typename T, ObjMemType<ObjT,T> f, typename CbkT = DefType<T>
-  >
-  CbkT makeCallbackObjGrpSend(objgroup::proxy::ProxyElm<ObjT> proxy);
-
-  // Obj group bcast callback
-  template <
-    typename ObjT, typename T, ObjMemType<ObjT,T> f, typename CbkT = DefType<T>
-  >
-  CbkT makeCallbackObjGrpBcast(objgroup::proxy::Proxy<ObjT> proxy);
-
-
-  // Single active message collection proxy bcast
-  template <
-    typename ColT, typename T, ColHanType<ColT,T>* f, typename CbkT = DefType<T>
-  >
-  CbkT makeCallbackSingleProxyBcast(ColProxyType<ColT> proxy);
-
-  // Single active message collection proxy bcast direct
-  template <
-    typename ColT, typename T, ColHanType<ColT,T>* f, typename CbkT = DefType<T>
-  >
-  CbkT makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy);
-
-  // Single active message collection proxy bcast direct (member)
-  template <
-    typename ColT, typename T, ColMemType<ColT,T> f, typename CbkT = DefType<T>
-  >
-  CbkT makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy);
+  // Proxy callback
+  template <auto f, bool is_bcast, typename ProxyT>
+  auto makeCallbackProxy(ProxyT proxy);
 
   // Multi-staged callback
   template <typename=void>

--- a/src/vt/pipe/pipe_manager_tl.h
+++ b/src/vt/pipe/pipe_manager_tl.h
@@ -94,25 +94,8 @@ struct PipeManagerTL : virtual PipeManagerBase {
   template <auto f, bool is_bcast>
   auto makeCallbackSingle(NodeType node = uninitialized_destination);
 
-  // Single active message functor-handler
-  template <
-    typename FunctorT,
-    typename T = typename util::FunctorExtractor<FunctorT>::MessageType
-  >
-  auto makeCallbackFunctorSend(NodeType const& node);
-
-  template <
-    typename FunctorT,
-    typename T = typename util::FunctorExtractor<FunctorT>::MessageType
-  >
-  auto makeCallbackFunctorBcast();
-
-  // Single active message functor-handler void param
-  template <typename FunctorT>
-  auto makeCallbackFunctorSendVoid(NodeType const& node);
-
-  template <typename FunctorT>
-  auto makeCallbackFunctorBcastVoid();
+  template <typename FunctorT, bool is_bcast>
+  auto makeCallbackFunctor(NodeType node = uninitialized_destination);
 
   // Single active message anon func-handler
   auto makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn);

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -222,6 +222,9 @@ auto PipeManagerTL::makeCallbackProxy(ProxyT proxy) {
       };
     }
   }
+
+  // unnecessary, but to make nvcc happy
+  return RetType{};
 }
 
 template <auto f, bool is_bcast>
@@ -245,6 +248,9 @@ auto PipeManagerTL::makeCallbackSingle(NodeType node) {
   } else {
     return RetType{callback::cbunion::RawSendMsgTag, new_pipe_id, han, node};
   }
+
+  // unnecessary, but to make nvcc happy
+  return RetType{};
 }
 
 template <typename FunctorT, bool is_bcast>
@@ -269,6 +275,8 @@ auto PipeManagerTL::makeCallbackFunctor(NodeType node) {
     return RetType{callback::cbunion::RawSendMsgTag, new_pipe_id, han, node};
   }
 
+  // unnecessary, but to make nvcc happy
+  return RetType{};
 }
 
 inline auto PipeManagerTL::makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn) {

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -204,7 +204,7 @@ auto PipeManagerTL::makeCallbackProxy(ProxyT proxy) {
     HandlerType han = uninitialized_handler;
     if constexpr (std::is_same_v<MsgT, NoMsg>) {
       using Tuple = typename Trait::TupleType;
-      using PMsgT = messaging::ParamMsg<Tuple, ObjT>;
+      using PMsgT = messaging::ParamMsg<Tuple>;
       han = auto_registry::makeAutoHandlerObjGroupParam<
         ObjT, decltype(f), f, PMsgT
       >(ctrl);

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -64,6 +64,9 @@
 #include "vt/registry/auto/collection/auto_registry_collection.h"
 #include "vt/vrt/collection/dispatch/registry.h"
 #include "vt/objgroup/proxy/proxy_bits.h"
+#include "vt/utils/fntraits/fntraits.h"
+#include "vt/messaging/param_msg.h"
+#include "vt/vrt/collection/messages/param_col_msg.h"
 
 #include <memory>
 
@@ -135,186 +138,121 @@ void PipeManagerTL::addListenerFunctorBcast(
   );
 }
 
-template <
-  typename ColT, typename MsgT, PipeManagerTL::ColHanType<ColT,MsgT>* f,
-  typename CallbackT
->
-CallbackT
-PipeManagerTL::makeCallbackSingleProxySend(typename ColT::ProxyType proxy) {
+template <typename U>
+using hasIdx_t = typename U::IndexType;
+
+template <auto f, bool is_bcast, typename ProxyT>
+auto PipeManagerTL::makeCallbackProxy(ProxyT proxy) {
   bool const persist = true;
   bool const send_back = false;
   bool const dispatch = true;
-  auto const& pipe_id = makePipeID(persist,send_back);
-  newPipeState(pipe_id,persist,dispatch,-1,-1,0);
-  auto cb = CallbackT(callback::cbunion::RawSendColMsgTag,pipe_id);
-  auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  addListenerAny<MsgT>(
-    cb.getPipe(),
-    std::make_unique<callback::CallbackProxySend<ColT, MsgT>>(handler, proxy)
-  );
-  return cb;
+  auto const pipe_id = makePipeID(persist, send_back);
+  newPipeState(pipe_id, persist, dispatch, -1, -1, 0);
+
+  using Trait = ObjFuncTraits<decltype(f)>;
+  using ObjT = typename Trait::ObjT;
+  using MsgT = typename Trait::MsgT;
+  using RetType = typename Trait::template WrapType<CallbackRetType>;
+
+  if constexpr (detection::is_detected<hasIdx_t, ProxyT>::value) {
+    if constexpr (std::is_same_v<MsgT, NoMsg>) {
+      using Tuple = typename Trait::TupleType;
+      using PMsgT = vrt::collection::ParamColMsg<Tuple, ObjT>;
+      auto han = auto_registry::makeAutoHandlerCollectionMemParam<
+        ObjT, decltype(f), f, PMsgT
+      >();
+      if constexpr (is_bcast) {
+        auto vrt_handler = vrt::collection::makeVrtDispatch<PMsgT, ObjT>();
+        return RetType{
+          callback::cbunion::RawBcastColDirTag, pipe_id, han, vrt_handler,
+          proxy.getProxy()
+        };
+      } else {
+        auto cb = RetType(callback::cbunion::RawSendColMsgTag, pipe_id);
+        addListenerAny<PMsgT>(
+          cb.getPipe(),
+          std::make_unique<callback::CallbackProxySend<ObjT, PMsgT>>(han, proxy)
+        );
+        return cb;
+      }
+    } else {
+      HandlerType han = uninitialized_handler;
+      if constexpr (Trait::is_member) {
+        han = auto_registry::makeAutoHandlerCollectionMem<ObjT, MsgT, f>();
+      } else {
+        han = auto_registry::makeAutoHandlerCollection<ObjT, MsgT, f>();
+      }
+      if constexpr (is_bcast) {
+        auto vrt_handler = vrt::collection::makeVrtDispatch<MsgT, ObjT>();
+        return RetType{
+          callback::cbunion::RawBcastColDirTag, pipe_id, han, vrt_handler,
+          proxy.getProxy()
+        };
+      } else {
+        auto cb = RetType(callback::cbunion::RawSendColMsgTag, pipe_id);
+        addListenerAny<MsgT>(
+          cb.getPipe(),
+          std::make_unique<callback::CallbackProxySend<ObjT, MsgT>>(han, proxy)
+        );
+        return cb;
+      }
+    }
+  } else {
+    auto const proxy_bits = proxy.getProxy();
+    auto const ctrl = objgroup::proxy::ObjGroupProxy::getID(proxy_bits);
+    HandlerType han = uninitialized_handler;
+    if constexpr (std::is_same_v<MsgT, NoMsg>) {
+      using Tuple = typename Trait::TupleType;
+      using PMsgT = messaging::ParamMsg<Tuple, ObjT>;
+      han = auto_registry::makeAutoHandlerObjGroupParam<
+        ObjT, decltype(f), f, PMsgT
+      >(ctrl);
+    } else {
+      han = auto_registry::makeAutoHandlerObjGroup<ObjT,MsgT,f>(ctrl);
+    }
+    if constexpr (is_bcast) {
+      return RetType{
+        callback::cbunion::RawBcastObjGrpTag, pipe_id, han, proxy_bits
+      };
+    } else {
+      auto const dest_node = proxy.getNode();
+      return RetType{
+        callback::cbunion::RawSendObjGrpTag, pipe_id, han, proxy_bits, dest_node
+      };
+    }
+  }
 }
 
-template <
-  typename ColT, typename MsgT, PipeManagerTL::ColMemType<ColT,MsgT> f,
-  typename CallbackT
->
-CallbackT
-PipeManagerTL::makeCallbackSingleProxySend(typename ColT::ProxyType proxy) {
-  bool const persist = true;
-  bool const send_back = false;
-  bool const dispatch = true;
-  auto const& pipe_id = makePipeID(persist,send_back);
-  newPipeState(pipe_id,persist,dispatch,-1,-1,0);
-  auto cb = CallbackT(callback::cbunion::RawSendColMsgTag,pipe_id);
-  auto const& handler =
-    auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  addListenerAny<MsgT>(
-    cb.getPipe(),
-    std::make_unique<callback::CallbackProxySend<ColT, MsgT>>(handler, proxy)
-  );
-  return cb;
+template <auto f, bool is_bcast>
+auto PipeManagerTL::makeCallbackSingle(NodeType node) {
+  auto const new_pipe_id = makePipeID(true,false);
+
+  using Trait = FuncTraits<decltype(f)>;
+  using MsgT = typename Trait::MsgT;
+
+  HandlerType han = uninitialized_handler;
+  if constexpr (std::is_same_v<MsgT, NoMsg>) {
+    han = auto_registry::makeAutoHandlerParam<decltype(f), f, MsgT>();
+  } else {
+    han = auto_registry::makeAutoHandler<MsgT,f>();
+  }
+
+  using RetType = typename Trait::template WrapType<CallbackRetType>;
+  if constexpr (is_bcast) {
+    return RetType{callback::cbunion::RawBcastMsgTag, new_pipe_id, han};
+  } else {
+    return RetType{callback::cbunion::RawSendMsgTag, new_pipe_id, han, node};
+  }
 }
 
-template <
-  typename ObjT, typename MsgT, PipeManagerTL::ObjMemType<ObjT,MsgT> fn,
-  typename CallbackT
->
-CallbackT
-PipeManagerTL::makeCallbackObjGrpSend(objgroup::proxy::ProxyElm<ObjT> proxy) {
-  bool const persist = true;
-  bool const send_back = false;
-  auto const& pipe_id = makePipeID(persist,send_back);
-  auto const proxy_bits = proxy.getProxy();
-  auto const dest_node = proxy.getNode();
-  auto const ctrl = objgroup::proxy::ObjGroupProxy::getID(proxy_bits);
-  auto const han = auto_registry::makeAutoHandlerObjGroup<ObjT,MsgT,fn>(ctrl);
-  auto cb = CallbackT(
-    callback::cbunion::RawSendObjGrpTag,pipe_id,han,proxy_bits,dest_node
-  );
-  return cb;
-}
-
-template <
-  typename ObjT, typename MsgT, PipeManagerTL::ObjMemType<ObjT,MsgT> fn,
-  typename CallbackT
->
-CallbackT
-PipeManagerTL::makeCallbackObjGrpBcast(objgroup::proxy::Proxy<ObjT> proxy) {
-  bool const persist = true;
-  bool const send_back = false;
-  auto const& pipe_id = makePipeID(persist,send_back);
-  auto const proxy_bits = proxy.getProxy();
-  auto const ctrl = objgroup::proxy::ObjGroupProxy::getID(proxy_bits);
-  auto const han = auto_registry::makeAutoHandlerObjGroup<ObjT,MsgT,fn>(ctrl);
-  auto cb = CallbackT(
-    callback::cbunion::RawBcastObjGrpTag,pipe_id,han,proxy_bits
-  );
-  return cb;
-}
-
-
-// Single active message collection proxy bcast
-template <
-  typename ColT, typename MsgT, PipeManagerTL::ColHanType<ColT,MsgT>* f,
-  typename CallbackT
->
-CallbackT
-PipeManagerTL::makeCallbackSingleProxyBcast(ColProxyType<ColT> proxy) {
-  bool const persist = true;
-  bool const send_back = false;
-  bool const dispatch = true;
-  auto const& pipe_id = makePipeID(persist,send_back);
-  newPipeState(pipe_id,persist,dispatch,-1,-1,0);
-  auto cb = CallbackT(callback::cbunion::RawBcastColMsgTag,pipe_id);
-  auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  addListenerAny<MsgT>(
-    cb.getPipe(),
-    std::make_unique<callback::CallbackProxyBcast<ColT,MsgT>>(handler,proxy)
-  );
-  return cb;
-}
-
-template <
-  typename ColT, typename MsgT, PipeManagerTL::ColHanType<ColT,MsgT>* f,
-  typename CallbackT
->
-CallbackT
-PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
-  bool const persist = true;
-  bool const send_back = false;
-  auto const& pipe_id = makePipeID(persist,send_back);
-  auto const& handler = auto_registry::makeAutoHandlerCollection<ColT,MsgT,f>();
-  auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
-  auto cb = CallbackT(
-    callback::cbunion::RawBcastColDirTag, pipe_id, handler, vrt_handler,
-    proxy.getProxy()
-  );
-  return cb;
-}
-
-template <
-  typename ColT, typename MsgT, PipeManagerTL::ColMemType<ColT,MsgT> f,
-  typename CallbackT
->
-CallbackT
-PipeManagerTL::makeCallbackSingleProxyBcastDirect(ColProxyType<ColT> proxy) {
-  bool const persist = true;
-  bool const send_back = false;
-  auto const& pipe_id = makePipeID(persist,send_back);
-  auto const& handler =
-    auto_registry::makeAutoHandlerCollectionMem<ColT,MsgT,f>();
-  auto const& vrt_handler = vrt::collection::makeVrtDispatch<MsgT,ColT>();
-  auto cb = CallbackT(
-    callback::cbunion::RawBcastColDirTag, pipe_id, handler, vrt_handler,
-    proxy.getProxy()
-  );
-  return cb;
-}
-
-template <typename MsgT, ActiveTypedFnType<MsgT>* f, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackSingleSend(NodeType const& send_to_node) {
-  auto const& new_pipe_id = makePipeID(true,false);
-  auto const& handler = auto_registry::makeAutoHandler<MsgT,f>();
-  auto cb = CallbackT(
-    callback::cbunion::RawSendMsgTag,new_pipe_id,handler,send_to_node
-  );
-  return cb;
-}
-
-template <typename MsgT, ActiveTypedFnType<MsgT>* f, typename CallbackT>
-CallbackT
- PipeManagerTL::makeCallbackSingleSendT(NodeType const& send_to_node) {
-  auto const& new_pipe_id = makePipeID(true,false);
-  auto const& handler = auto_registry::makeAutoHandler<MsgT,f>();
-  auto cb = CallbackT(
-    callback::cbunion::RawSendMsgTag,new_pipe_id,handler,send_to_node
-  );
-  return cb;
-}
-
-template <typename MsgT, ActiveTypedFnType<MsgT>* f, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackSingleBcast() {
-  auto const& new_pipe_id = makePipeID(true,false);
-  auto const& handler = auto_registry::makeAutoHandler<MsgT,f>();
-  auto cb = CallbackT(
-    callback::cbunion::RawBcastMsgTag,new_pipe_id,handler
-  );
-  return cb;
-}
-
-template <typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn) {
+inline auto PipeManagerTL::makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn) {
   PipeType new_pipe_id = no_pipe;
   if (life == LifetimeEnum::Once) {
     new_pipe_id = makeCallbackFuncVoid(false,fn,true,1,1);
   } else {
     new_pipe_id = makeCallbackFuncVoid(true,fn,true);
   }
-  auto cb = CallbackT(callback::cbunion::RawAnonTag,new_pipe_id);
+  auto cb = CallbackRetType<>(callback::cbunion::RawAnonTag,new_pipe_id);
 
   vt_debug_print(
     normal, pipe,
@@ -325,9 +263,8 @@ PipeManagerTL::makeCallbackSingleAnonVoid(LifetimeEnum life, FuncVoidType fn) {
   return cb;
 }
 
-template <typename C, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackSingleAnon(
+template <typename C>
+auto PipeManagerTL::makeCallbackSingleAnon(
   LifetimeEnum life, C* ctx, FuncCtxType<C> fn
 ) {
   auto fn_closure = [ctx,fn] { fn(ctx); };
@@ -340,9 +277,8 @@ PipeManagerTL::makeCallbackSingleAnon(
   return makeCallbackSingleAnonVoid(life,fn_closure);
 }
 
-template <typename MsgT, typename C, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackSingleAnon(
+template <typename MsgT, typename C>
+auto PipeManagerTL::makeCallbackSingleAnon(
   LifetimeEnum life, C* ctx, FuncMsgCtxType<MsgT, C> fn
 ) {
   auto fn_closure = [ctx,fn](MsgT* msg) { fn(msg, ctx); };
@@ -352,12 +288,11 @@ PipeManagerTL::makeCallbackSingleAnon(
     "makeCallbackSingleAnon: created closure\n"
   );
 
-  return makeCallbackSingleAnon<MsgT,CallbackT>(life,fn_closure);
+  return makeCallbackSingleAnon<MsgT>(life,fn_closure);
 }
 
-template <typename MsgT, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<MsgT> fn) {
+template <typename MsgT>
+auto PipeManagerTL::makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<MsgT> fn) {
   PipeType new_pipe_id = no_pipe;
   if (life == LifetimeEnum::Once) {
     new_pipe_id = makeCallbackFunc<MsgT>(false,fn,true,1,1);
@@ -365,7 +300,7 @@ PipeManagerTL::makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<MsgT> fn) {
     new_pipe_id = makeCallbackFunc<MsgT>(true,fn,true);
   }
 
-  auto cb = CallbackT(callback::cbunion::RawAnonTag,new_pipe_id);
+  auto cb = CallbackRetType<MsgT>(callback::cbunion::RawAnonTag,new_pipe_id);
 
   vt_debug_print(
     normal, pipe,
@@ -376,49 +311,45 @@ PipeManagerTL::makeCallbackSingleAnon(LifetimeEnum life, FuncMsgType<MsgT> fn) {
   return cb;
 }
 
-template <typename FunctorT, typename T, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackFunctorSend(NodeType const& send_to_node) {
+template <typename FunctorT, typename T>
+auto PipeManagerTL::makeCallbackFunctorSend(NodeType const& send_to_node) {
   using MsgT = typename util::FunctorExtractor<FunctorT>::MessageType;
   auto const& new_pipe_id = makePipeID(true,false);
   auto const& handler =
     auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
-  auto cb = CallbackT(
+  auto cb = CallbackRetType<MsgT>(
     callback::cbunion::RawSendMsgTag,new_pipe_id,handler,send_to_node
   );
   return cb;
 }
 
-template <typename FunctorT, typename T, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackFunctorBcast() {
+template <typename FunctorT, typename T>
+auto PipeManagerTL::makeCallbackFunctorBcast() {
   using MsgT = typename util::FunctorExtractor<FunctorT>::MessageType;
   auto const& new_pipe_id = makePipeID(true,false);
   auto const& handler =
     auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
-  auto cb = CallbackT(
+  auto cb = CallbackRetType<MsgT>(
     callback::cbunion::RawBcastMsgTag,new_pipe_id,handler
   );
   return cb;
 }
 
-template <typename FunctorT, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackFunctorSendVoid(NodeType const& send_to_node) {
+template <typename FunctorT>
+auto PipeManagerTL::makeCallbackFunctorSendVoid(NodeType const& send_to_node) {
   auto const& new_pipe_id = makePipeID(true,false);
   auto const& handler = auto_registry::makeAutoHandlerFunctor<FunctorT,true>();
-  auto cb = CallbackT(
+  auto cb = CallbackRetType<>(
     callback::cbunion::RawSendMsgTag,new_pipe_id,handler,send_to_node
   );
   return cb;
 }
 
-template <typename FunctorT, typename CallbackT>
-CallbackT
-PipeManagerTL::makeCallbackFunctorBcastVoid() {
+template <typename FunctorT>
+auto PipeManagerTL::makeCallbackFunctorBcastVoid() {
   auto const& new_pipe_id = makePipeID(true,false);
   auto const& handler = auto_registry::makeAutoHandlerFunctor<FunctorT,true>();
-  auto cb = CallbackT(
+  auto cb = CallbackRetType<>(
     callback::cbunion::RawBcastMsgTag,new_pipe_id,handler
   );
   return cb;

--- a/src/vt/pipe/pipe_manager_tl.impl.h
+++ b/src/vt/pipe/pipe_manager_tl.impl.h
@@ -157,12 +157,14 @@ auto PipeManagerTL::makeCallbackProxy(ProxyT proxy) {
   if constexpr (detection::is_detected<hasIdx_t, ProxyT>::value) {
     if constexpr (std::is_same_v<MsgT, NoMsg>) {
       using Tuple = typename Trait::TupleType;
+      using NormMsgT = messaging::ParamMsg<Tuple>;
+      using WrapMsgT = vrt::collection::ColMsgWrap<ObjT, NormMsgT, vt::Message>;
       using PMsgT = vrt::collection::ParamColMsg<Tuple, ObjT>;
       auto han = auto_registry::makeAutoHandlerCollectionMemParam<
-        ObjT, decltype(f), f, PMsgT
+        ObjT, decltype(f), f, WrapMsgT
       >();
       if constexpr (is_bcast) {
-        auto vrt_handler = vrt::collection::makeVrtDispatch<PMsgT, ObjT>();
+        auto vrt_handler = vrt::collection::makeVrtDispatch<NormMsgT, ObjT>();
         return RetType{
           callback::cbunion::RawBcastColDirTag, pipe_id, han, vrt_handler,
           proxy.getProxy()

--- a/src/vt/pipe/pipe_manager_typed.impl.h
+++ b/src/vt/pipe/pipe_manager_typed.impl.h
@@ -117,7 +117,7 @@ PipeManagerTyped::makeCallbackSingleSendFunctorTyped(
 ) {
   auto const& new_pipe_id = makePipeID(is_persist,false);
   auto const& handler =
-    auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
+    auto_registry::makeAutoHandlerFunctor<FunctorT, MsgT, true>();
   auto container = CallbackSendType<MsgT>(new_pipe_id,handler,send_to_node);
   return container;
 }
@@ -128,7 +128,7 @@ PipeManagerTyped::makeCallbackSingleSendFunctorVoidTyped(
   bool const is_persist, NodeType const& send_to_node
 ) {
   auto const& new_pipe_id = makePipeID(is_persist,false);
-  auto const& handler = auto_registry::makeAutoHandlerFunctor<FunctorT,true>();
+  auto const& handler = auto_registry::makeAutoHandlerFunctor<FunctorT, void, false>();
   auto container = CallbackSendVoidType(new_pipe_id,handler,send_to_node);
   return container;
 }
@@ -149,7 +149,7 @@ PipeManagerTyped::CallbackBcastType<MsgT>
 PipeManagerTyped::makeCallbackSingleBcastFunctorTyped(bool const inc) {
   auto const& new_pipe_id = makePipeID(true,false);
   auto const& handler =
-    auto_registry::makeAutoHandlerFunctor<FunctorT,true,MsgT*>();
+    auto_registry::makeAutoHandlerFunctor<FunctorT, MsgT, true>();
   auto container = CallbackBcastType<MsgT>(
     new_pipe_id,handler,inc
   );
@@ -160,7 +160,7 @@ template <typename FunctorT>
 PipeManagerTyped::CallbackBcastVoidType
 PipeManagerTyped::makeCallbackSingleBcastFunctorVoidTyped(bool const inc) {
   auto const& new_pipe_id = makePipeID(true,false);
-  auto const& handler = auto_registry::makeAutoHandlerFunctor<FunctorT,true>();
+  auto const& handler = auto_registry::makeAutoHandlerFunctor<FunctorT, void, false>();
   auto container = CallbackBcastVoidType(new_pipe_id,handler,inc);
   return container;
 }

--- a/src/vt/rdma/rdma.cc
+++ b/src/vt/rdma/rdma.cc
@@ -272,7 +272,7 @@ RDMAManager::RDMAManager()
 
   if (not msg->has_bytes) {
     auto cbmsg = makeMessage<GetInfoChannel>(num_bytes);
-    msg->cb.send(cbmsg.get());
+    msg->cb.sendMsg(cbmsg);
   }
 
   theRDMA()->createDirectChannelInternal(

--- a/src/vt/registry/auto/functor/auto_registry_functor.h
+++ b/src/vt/registry/auto/functor/auto_registry_functor.h
@@ -58,7 +58,7 @@ struct RegistrarFunctor;
 AutoActiveFunctorType const& getAutoHandlerFunctor(HandlerType const handler);
 NumArgsType getAutoHandlerFunctorArgs(HandlerType const handler);
 
-template <typename FunctorT, bool is_msg, typename... Args>
+template <typename FunctorT, typename MsgT, bool is_msg_direct>
 HandlerType makeAutoHandlerFunctor();
 
 template <typename FunctorT, typename RegT, typename InfoT, typename FnT>
@@ -70,13 +70,12 @@ template <typename FunctorT, typename RegT, typename InfoT, typename FnT>
 AutoHandlerType registerActiveFunctor();
 
 template <
-  typename AdapterT, typename RegT, typename InfoT, typename FnT, bool msg,
-  typename... Args
+  typename AdapterT, typename RegT, typename InfoT, typename FnT,
+  typename MsgT
 >
 struct RunnableFunctor {
   using AdapterType = AdapterT;
-
-  static constexpr bool const IsMsgType = msg;
+  using MsgType = MsgT;
 
   static AutoHandlerType const idx;
 
@@ -84,20 +83,14 @@ struct RunnableFunctor {
 };
 
 template <
-  typename AdapterT, typename RegT, typename InfoT, typename FnT, bool msg,
-  typename... Args
+  typename AdapterT, typename RegT, typename InfoT, typename FnT,
+  typename MsgT
 >
-AutoHandlerType const RunnableFunctor<AdapterT, RegT, InfoT, FnT, msg, Args...>::idx =
+AutoHandlerType const RunnableFunctor<AdapterT, RegT, InfoT, FnT, MsgT>::idx =
   registerActiveFunctor<
-    RunnableFunctor<AdapterT, RegT, InfoT, FnT, msg, Args...>,
+    RunnableFunctor<AdapterT, RegT, InfoT, FnT, MsgT>,
     RegT, InfoT, FnT
   >();
-
-template <
-  typename AdapterT, typename RegT, typename InfoT, typename FnT, bool msg,
-  typename... Args
->
-bool const RunnableFunctor<AdapterT, RegT, InfoT, FnT, msg, Args...>::IsMsgType;
 
 }} // end namespace vt::auto_registry
 

--- a/src/vt/registry/auto/functor/auto_registry_functor_impl.h
+++ b/src/vt/registry/auto/functor/auto_registry_functor_impl.h
@@ -54,15 +54,15 @@
 
 namespace vt { namespace auto_registry {
 
-template <typename FunctorT, bool msg, typename... Args>
+template <typename FunctorT, typename MsgT, bool is_msg_direct>
 inline HandlerType makeAutoHandlerFunctor() {
-  // Arg (overload) differentiation in adapter.
-  using AdapterType = FunctorAdapterArgs<FunctorT, Args...>;
+  // Arg (overload) differentiaton in adapter.
+  using AdapterType = FunctorAdapterArgs<FunctorT, MsgT, is_msg_direct>;
   using ContainerType = AutoActiveFunctorContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveFunctorType>;
   using FuncType = ActiveFnPtrType;
   using RunType =
-    RunnableFunctor<AdapterType, ContainerType, RegInfoType, FuncType, msg>;
+    RunnableFunctor<AdapterType, ContainerType, RegInfoType, FuncType, MsgT>;
 
   constexpr bool is_auto = true;
   constexpr bool is_functor = true;

--- a/src/vt/registry/auto/map/auto_registry_map.h
+++ b/src/vt/registry/auto/map/auto_registry_map.h
@@ -56,7 +56,7 @@ using namespace mapping;
 
 AutoActiveMapType const& getAutoHandlerFunctorMap(HandlerType const han);
 
-template <typename FunctorT, typename... Args>
+template <typename FunctorT>
 HandlerType makeAutoHandlerFunctorMap();
 
 // Registration for collection index mapping functions

--- a/src/vt/registry/auto/map/auto_registry_map_impl.h
+++ b/src/vt/registry/auto/map/auto_registry_map_impl.h
@@ -62,13 +62,13 @@ using namespace mapping;
  * Functor map variants
  */
 
-template <typename FunctorT, typename... Args>
+template <typename FunctorT>
 inline HandlerType makeAutoHandlerFunctorMap() {
   using ContainerType = AutoActiveMapFunctorContainerType;
   using RegInfoType = AutoRegInfoType<AutoActiveMapFunctorType>;
   using FuncType = ActiveMapFnPtrType;
   using RunnableT = RunnableFunctor<
-    FunctorT, ContainerType, RegInfoType, FuncType, true, Args...
+    FunctorT, ContainerType, RegInfoType, FuncType, void
   >;
 
   constexpr bool is_auto = true;

--- a/src/vt/termination/termination.cc
+++ b/src/vt/termination/termination.cc
@@ -575,7 +575,7 @@ void TerminationDetector::startEpochGraphBuild() {
   graph->writeToFile(str);
   auto msg = makeMessage<MsgType>(graph);
   NodeType root = 0;
-  auto cb = vt::theCB()->makeSend<MsgType, epochGraphBuiltHandler>(root);
+  auto cb = vt::theCB()->makeSend<epochGraphBuiltHandler>(root);
 
   auto r = theTerm()->reducer();
   r->reduce<ReduceOp>(root, msg.get(), cb);

--- a/src/vt/utils/fntraits/fntraits.h
+++ b/src/vt/utils/fntraits/fntraits.h
@@ -201,12 +201,6 @@ struct ObjFuncTraitsImpl<
 template <typename Return, typename Arg, typename... Args>
 struct ObjFuncTraitsImpl<
   std::enable_if_t<
-    not (
-      std::is_convertible<Arg, vt::Message*>::value or
-      std::is_convertible<Arg, vt::ShortMessage*>::value or
-      std::is_convertible<Arg, vt::EpochMessage*>::value or
-      std::is_convertible<Arg, vt::PayloadMessage*>::value
-    ) and
     not std::is_pointer<Arg>::value
   >,
   Return(*)(Arg, Args...)

--- a/src/vt/utils/fntraits/fntraits.h
+++ b/src/vt/utils/fntraits/fntraits.h
@@ -217,6 +217,125 @@ struct FuncTraitsImpl<
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename enabled, typename... Args>
+struct FunctorTraitsImpl;
+
+template <typename FunctorT, typename Return, typename Msg>
+struct FunctorTraitsImpl<
+  std::enable_if_t<
+    std::is_convertible<Msg, vt::Message>::value or
+    std::is_convertible<Msg, vt::ShortMessage>::value or
+    std::is_convertible<Msg, vt::EpochMessage>::value or
+    std::is_convertible<Msg, vt::PayloadMessage>::value
+  >,
+  FunctorT,
+  Return(FunctorT::*)(Msg*)
+> {
+  static constexpr bool is_member = false;
+  using MsgT = Msg;
+  using ReturnT = Return;
+  template <template <typename...> class U>
+  using WrapType = U<MsgT>;
+  using FuncPtrType = Return(*)(Msg*);
+};
+
+template <typename FunctorT, typename Return>
+struct FunctorTraitsImpl<
+  std::enable_if_t<std::is_same_v<void, void>>,
+  FunctorT,
+  Return(FunctorT::*)()
+> {
+  static constexpr bool is_member = false;
+  using MsgT = NoMsg;
+  using ReturnT = Return;
+  template <template <typename...> class U>
+  using WrapType = U<>;
+  using TupleType = std::tuple<>;
+  using FuncPtrType = Return(*)();
+};
+
+template <typename FunctorT, typename Return, typename Arg, typename... Args>
+struct FunctorTraitsImpl<
+  std::enable_if_t<
+    not (
+      std::is_convertible<Arg, vt::Message*>::value or
+      std::is_convertible<Arg, vt::ShortMessage*>::value or
+      std::is_convertible<Arg, vt::EpochMessage*>::value or
+      std::is_convertible<Arg, vt::PayloadMessage*>::value
+    )
+  >,
+  FunctorT,
+  Return(FunctorT::*)(Arg, Args...)
+> {
+  static constexpr bool is_member = false;
+  using MsgT = NoMsg;
+  using Arg1 = Arg;
+  using ReturnT = Return;
+  template <template <typename...> class U>
+  using WrapType = U<std::decay_t<Arg>, std::decay_t<Args>...>;
+  using TupleType = WrapType<std::tuple>;
+  using FuncPtrType = Return(*)(Arg, Args...);
+};
+
+template <typename FunctorT, typename Return, typename Msg>
+struct FunctorTraitsImpl<
+  std::enable_if_t<
+    std::is_convertible<Msg, vt::Message>::value or
+    std::is_convertible<Msg, vt::ShortMessage>::value or
+    std::is_convertible<Msg, vt::EpochMessage>::value or
+    std::is_convertible<Msg, vt::PayloadMessage>::value
+  >,
+  FunctorT,
+  Return(FunctorT::*)(Msg*) const
+> {
+  static constexpr bool is_member = false;
+  using MsgT = Msg;
+  using ReturnT = Return;
+  template <template <typename...> class U>
+  using WrapType = U<MsgT>;
+  using FuncPtrType = Return(*)(Msg*);
+};
+
+template <typename FunctorT, typename Return>
+struct FunctorTraitsImpl<
+  std::enable_if_t<std::is_same_v<void, void>>,
+  FunctorT,
+  Return(FunctorT::*)() const
+> {
+  static constexpr bool is_member = false;
+  using MsgT = NoMsg;
+  using ReturnT = Return;
+  template <template <typename...> class U>
+  using WrapType = U<>;
+  using TupleType = std::tuple<>;
+  using FuncPtrType = Return(*)();
+};
+
+template <typename FunctorT, typename Return, typename Arg, typename... Args>
+struct FunctorTraitsImpl<
+  std::enable_if_t<
+    not (
+      std::is_convertible<Arg, vt::Message*>::value or
+      std::is_convertible<Arg, vt::ShortMessage*>::value or
+      std::is_convertible<Arg, vt::EpochMessage*>::value or
+      std::is_convertible<Arg, vt::PayloadMessage*>::value
+    )
+  >,
+  FunctorT,
+  Return(FunctorT::*)(Arg, Args...) const
+> {
+  static constexpr bool is_member = false;
+  using MsgT = NoMsg;
+  using Arg1 = Arg;
+  using ReturnT = Return;
+  template <template <typename...> class U>
+  using WrapType = U<std::decay_t<Arg>, std::decay_t<Args>...>;
+  using TupleType = WrapType<std::tuple>;
+  using FuncPtrType = Return(*)(Arg, Args...);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename enabled, typename... Args>
 struct CBTraitsImpl;
 
 template <typename Msg>
@@ -269,6 +388,9 @@ struct ObjFuncTraits : util::fntraits::detail::ObjFuncTraitsImpl<void, Args...> 
 
 template <typename... Args>
 struct FuncTraits : util::fntraits::detail::FuncTraitsImpl<void, Args...> {};
+
+template <typename... Args>
+struct FunctorTraits : util::fntraits::detail::FunctorTraitsImpl<void, Args...> {};
 
 template <typename... Args>
 struct CBTraits : util::fntraits::detail::CBTraitsImpl<void, Args...> {};

--- a/src/vt/utils/fntraits/fntraits.h
+++ b/src/vt/utils/fntraits/fntraits.h
@@ -54,10 +54,10 @@ struct ObjFuncTraitsImpl;
 template <typename Obj, typename Return, typename Msg>
 struct ObjFuncTraitsImpl<
   std::enable_if_t<
-    (std::is_convertible<Msg, vt::Message>::value or
-    std::is_convertible<Msg, vt::ShortMessage>::value or
-    std::is_convertible<Msg, vt::EpochMessage>::value or
-    std::is_convertible<Msg, vt::PayloadMessage>::value)
+    (std::is_convertible<Msg*, vt::Message*>::value or
+    std::is_convertible<Msg*, vt::ShortMessage*>::value or
+    std::is_convertible<Msg*, vt::EpochMessage*>::value or
+    std::is_convertible<Msg*, vt::PayloadMessage*>::value)
     and
     std::is_pointer<Obj>::value
   >,
@@ -118,10 +118,10 @@ struct ObjFuncTraitsImpl<
 template <typename Obj, typename Return, typename Msg>
 struct ObjFuncTraitsImpl<
   std::enable_if_t<
-    std::is_convertible<Msg, vt::Message>::value or
-    std::is_convertible<Msg, vt::ShortMessage>::value or
-    std::is_convertible<Msg, vt::EpochMessage>::value or
-    std::is_convertible<Msg, vt::PayloadMessage>::value
+    std::is_convertible<Msg*, vt::Message*>::value or
+    std::is_convertible<Msg*, vt::ShortMessage*>::value or
+    std::is_convertible<Msg*, vt::EpochMessage*>::value or
+    std::is_convertible<Msg*, vt::PayloadMessage*>::value
   >,
   Return(Obj::*)(Msg*)
 > {
@@ -171,10 +171,10 @@ struct ObjFuncTraitsImpl<
 template <typename Return, typename Msg>
 struct ObjFuncTraitsImpl<
   std::enable_if_t<
-    std::is_convertible<Msg, vt::Message>::value or
-    std::is_convertible<Msg, vt::ShortMessage>::value or
-    std::is_convertible<Msg, vt::EpochMessage>::value or
-    std::is_convertible<Msg, vt::PayloadMessage>::value
+    std::is_convertible<Msg*, vt::Message*>::value or
+    std::is_convertible<Msg*, vt::ShortMessage*>::value or
+    std::is_convertible<Msg*, vt::EpochMessage*>::value or
+    std::is_convertible<Msg*, vt::PayloadMessage*>::value
   >,
   Return(*)(Msg*)
 > {
@@ -228,10 +228,10 @@ struct FunctorTraitsImpl;
 template <typename FunctorT, typename Return, typename Msg>
 struct FunctorTraitsImpl<
   std::enable_if_t<
-    std::is_convertible<Msg, vt::Message>::value or
-    std::is_convertible<Msg, vt::ShortMessage>::value or
-    std::is_convertible<Msg, vt::EpochMessage>::value or
-    std::is_convertible<Msg, vt::PayloadMessage>::value
+    std::is_convertible<Msg*, vt::Message*>::value or
+    std::is_convertible<Msg*, vt::ShortMessage*>::value or
+    std::is_convertible<Msg*, vt::EpochMessage*>::value or
+    std::is_convertible<Msg*, vt::PayloadMessage*>::value
   >,
   FunctorT,
   Return(FunctorT::*)(Msg*)
@@ -285,10 +285,10 @@ struct FunctorTraitsImpl<
 template <typename FunctorT, typename Return, typename Msg>
 struct FunctorTraitsImpl<
   std::enable_if_t<
-    std::is_convertible<Msg, vt::Message>::value or
-    std::is_convertible<Msg, vt::ShortMessage>::value or
-    std::is_convertible<Msg, vt::EpochMessage>::value or
-    std::is_convertible<Msg, vt::PayloadMessage>::value
+    std::is_convertible<Msg*, vt::Message*>::value or
+    std::is_convertible<Msg*, vt::ShortMessage*>::value or
+    std::is_convertible<Msg*, vt::EpochMessage*>::value or
+    std::is_convertible<Msg*, vt::PayloadMessage*>::value
   >,
   FunctorT,
   Return(FunctorT::*)(Msg*) const
@@ -347,10 +347,10 @@ struct CBTraitsImpl;
 template <typename Msg>
 struct CBTraitsImpl<
   std::enable_if_t<
-    std::is_convertible<Msg, vt::Message>::value or
-    std::is_convertible<Msg, vt::ShortMessage>::value or
-    std::is_convertible<Msg, vt::EpochMessage>::value or
-    std::is_convertible<Msg, vt::PayloadMessage>::value
+    std::is_convertible<Msg*, vt::Message*>::value or
+    std::is_convertible<Msg*, vt::ShortMessage*>::value or
+    std::is_convertible<Msg*, vt::EpochMessage*>::value or
+    std::is_convertible<Msg*, vt::PayloadMessage*>::value
   >,
   Msg
 > {
@@ -369,10 +369,10 @@ template <typename Arg, typename... Args>
 struct CBTraitsImpl<
   std::enable_if_t<
     not (
-      std::is_convertible<Arg, vt::Message>::value or
-      std::is_convertible<Arg, vt::ShortMessage>::value or
-      std::is_convertible<Arg, vt::EpochMessage>::value or
-      std::is_convertible<Arg, vt::PayloadMessage>::value
+      std::is_convertible<Arg*, vt::Message*>::value or
+      std::is_convertible<Arg*, vt::ShortMessage*>::value or
+      std::is_convertible<Arg*, vt::EpochMessage*>::value or
+      std::is_convertible<Arg*, vt::PayloadMessage*>::value
     )
   >,
   Arg,

--- a/src/vt/utils/static_checks/functor.h
+++ b/src/vt/utils/static_checks/functor.h
@@ -49,17 +49,17 @@
 namespace vt { namespace util {
 
 template <typename FunctorT>
-struct FunctorTraits;
+struct SimpleFunctorTraits;
 
 template <typename FunctorT, typename ReturnT, typename MsgT>
-struct FunctorTraits<ReturnT(FunctorT::*)(MsgT*)> {
+struct SimpleFunctorTraits<ReturnT(FunctorT::*)(MsgT*)> {
   using FunctorType = FunctorT;
   using MessageType = MsgT;
   using ReturnType  = ReturnT;
 };
 
 template <typename FunctorT, typename ReturnT, typename MsgT>
-struct FunctorTraits<ReturnT(FunctorT::*)(MsgT*) const> {
+struct SimpleFunctorTraits<ReturnT(FunctorT::*)(MsgT*) const> {
   using FunctorType = FunctorT;
   using MessageType = MsgT;
   using ReturnType  = ReturnT;
@@ -68,7 +68,7 @@ struct FunctorTraits<ReturnT(FunctorT::*)(MsgT*) const> {
 template <
   typename FunctorT,
   typename FunctorFnT = decltype(&FunctorT::operator()),
-  typename Traits = FunctorTraits<FunctorFnT>,
+  typename Traits = SimpleFunctorTraits<FunctorFnT>,
   typename MessageT = typename Traits::MessageType
 >
 struct FunctorExtractor {

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -129,7 +129,7 @@ std::shared_ptr<const balance::Reassignment> BaseLB::normalizeReassignments() {
   pending_reassignment_->node_ = this_node;
 
   runInEpochCollective("Sum migrations", [&] {
-    auto cb = vt::theCB()->makeBcast<BaseLB, CountMsg, &BaseLB::finalize>(proxy_);
+    auto cb = vt::theCB()->makeBcast<&BaseLB::finalize>(proxy_);
     int32_t local_migration_count = transfers_.size();
     auto msg = makeMessage<CountMsg>(local_migration_count);
     proxy_.template reduce<collective::PlusOp<int32_t>>(msg,cb);

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -129,10 +129,8 @@ std::shared_ptr<const balance::Reassignment> BaseLB::normalizeReassignments() {
   pending_reassignment_->node_ = this_node;
 
   runInEpochCollective("Sum migrations", [&] {
-    auto cb = vt::theCB()->makeBcast<&BaseLB::finalize>(proxy_);
     int32_t local_migration_count = transfers_.size();
-    auto msg = makeMessage<CountMsg>(local_migration_count);
-    proxy_.template reduce<collective::PlusOp<int32_t>>(msg,cb);
+    proxy_.allreduce<&BaseLB::finalize, collective::PlusOp>(local_migration_count);
   });
 
   std::map<NodeType, ObjDestinationListType> migrate_other;
@@ -241,8 +239,7 @@ void BaseLB::migrateObjectTo(ObjIDType const obj_id, NodeType const to) {
   }
 }
 
-void BaseLB::finalize(CountMsg* msg) {
-  auto global_count = msg->getVal();
+void BaseLB::finalize(int32_t global_count) {
   if (migration_count_cb_) {
     migration_count_cb_(global_count);
   }

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -134,7 +134,7 @@ struct BaseLB {
   void migrateObjectTo(ObjIDType const obj_id, NodeType const node);
   void transferSend(NodeType from, TransferVecType const& transfer);
   void transferMigrations(TransferMsg<TransferVecType>* msg);
-  void finalize(CountMsg* msg);
+  void finalize(int32_t global_count);
 
   virtual void inputParams(balance::ConfigEntry* config) = 0;
   virtual void runLB(TimeType total_load) = 0;

--- a/src/vt/vrt/collection/balance/baselb/baselb_msgs.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb_msgs.h
@@ -72,16 +72,6 @@ private:
   Transfer transfer_;
 };
 
-struct CountMsg : vt::collective::ReduceTMsg<int32_t> {
-  using MessageParentType = vt::collective::ReduceTMsg<int32_t>;
-  vt_msg_serialize_prohibited();
-
-  CountMsg() = delete;
-  explicit CountMsg(int32_t in_num)
-    : vt::collective::ReduceTMsg<int32_t>(in_num)
-  {}
-};
-
 struct CommMsg : vt::Message {
   using MessageParentType = vt::Message;
   vt_msg_serialize_required();

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -192,14 +192,14 @@ void GreedyLB::loadStats() {
   }
 }
 
-void GreedyLB::collectHandler(GreedyCollectMsg* msg) {
+void GreedyLB::collectHandler(GreedyPayload payload) {
   vt_debug_print(
     normal, lb,
     "GreedyLB::collectHandler: entries size={}\n",
-    msg->getConstVal().getSample().size()
+    payload.getSample().size()
   );
 
-  for (auto&& elm : msg->getConstVal().getSample()) {
+  for (auto&& elm : payload.getSample()) {
     vt_debug_print(
       verbose, lb,
       "\t collectHandler: bin={}, num={}\n",
@@ -207,8 +207,8 @@ void GreedyLB::collectHandler(GreedyCollectMsg* msg) {
     );
   }
 
-  auto objs = std::move(msg->getVal().getSampleMove());
-  auto profile = std::move(msg->getVal().getLoadProfileMove());
+  auto objs = std::move(payload.getSampleMove());
+  auto profile = std::move(payload.getLoadProfileMove());
   runBalancer(std::move(objs),std::move(profile));
 }
 
@@ -219,10 +219,9 @@ void GreedyLB::reduceCollect() {
     TimeTypeWrapper(this_load / 1000),
     TimeTypeWrapper(this_load_begin / 1000), load_over.size()
   );
-  using MsgType = GreedyCollectMsg;
-  auto cb = vt::theCB()->makeSend<&GreedyLB::collectHandler>(proxy[0]);
-  auto msg = makeMessage<MsgType>(load_over,this_load);
-  proxy.template reduce<collective::PlusOp<GreedyPayload>>(msg.get(),cb);
+  proxy.reduce<&GreedyLB::collectHandler, collective::PlusOp>(
+    proxy[0], GreedyPayload{load_over, this_load}
+  );
 }
 
 void GreedyLB::runBalancer(

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -220,7 +220,7 @@ void GreedyLB::reduceCollect() {
     TimeTypeWrapper(this_load_begin / 1000), load_over.size()
   );
   using MsgType = GreedyCollectMsg;
-  auto cb = vt::theCB()->makeSend<GreedyLB, MsgType, &GreedyLB::collectHandler>(proxy[0]);
+  auto cb = vt::theCB()->makeSend<&GreedyLB::collectHandler>(proxy[0]);
   auto msg = makeMessage<MsgType>(load_over,this_load);
   proxy.template reduce<collective::PlusOp<GreedyPayload>>(msg.get(),cb);
 }

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.h
@@ -103,7 +103,7 @@ private:
   void recvObjs(GreedySendMsg* msg);
   void recvObjsBcast(GreedyBcastMsg* msg);
   void finishedTransferExchange();
-  void collectHandler(GreedyCollectMsg* msg);
+  void collectHandler(GreedyPayload payload);
 
   // This must stay static due to limitations in the scatter implementation
   // (does not work with objgroups)

--- a/src/vt/vrt/collection/balance/greedylb/greedylb_msgs.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb_msgs.h
@@ -106,29 +106,6 @@ protected:
   ObjSampleType sample_;
 };
 
-struct GreedyCollectMsg : GreedyLBTypes, collective::ReduceTMsg<GreedyPayload> {
-  using MessageParentType = collective::ReduceTMsg<GreedyPayload>;
-  vt_msg_serialize_required(); // prev. serialize(1)
-
-  GreedyCollectMsg() = default;
-  GreedyCollectMsg(ObjSampleType const& in_load, LoadType const& in_profile)
-    : collective::ReduceTMsg<GreedyPayload>(GreedyPayload{in_load,in_profile})
-  { }
-
-  template <typename SerializerT>
-  void serialize(SerializerT& s) {
-    MessageParentType::serialize(s);
-  }
-
-  ObjSampleType const& getModeledLoad() const {
-    return collective::ReduceTMsg<GreedyPayload>::getConstVal().getSample();
-  }
-
-  ObjSampleType&& getLoadMove() {
-    return collective::ReduceTMsg<GreedyPayload>::getVal().getSampleMove();
-  }
-};
-
 struct GreedySendMsg : GreedyLBTypes, vt::Message {
   using MessageParentType = vt::Message;
   vt_msg_serialize_required(); // vector

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -793,12 +793,10 @@ void HierarchicalLB::runLB(TimeType total_load) {
   buildHistogram();
   setupTree(min_threshold);
 
-  auto cb = vt::theCB()->makeBcast<&HierarchicalLB::setupDone>(proxy);
-  auto msg = makeMessage<SetupDoneMsg>();
-  proxy.reduce(msg.get(),cb);
+  proxy.allreduce<&HierarchicalLB::setupDone>();
 }
 
-void HierarchicalLB::setupDone(SetupDoneMsg* msg) {
+void HierarchicalLB::setupDone() {
   loadStats();
 }
 

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -793,9 +793,7 @@ void HierarchicalLB::runLB(TimeType total_load) {
   buildHistogram();
   setupTree(min_threshold);
 
-  auto cb = vt::theCB()->makeBcast<
-    HierarchicalLB, SetupDoneMsg, &HierarchicalLB::setupDone
-  >(proxy);
+  auto cb = vt::theCB()->makeBcast<&HierarchicalLB::setupDone>(proxy);
   auto msg = makeMessage<SetupDoneMsg>();
   proxy.reduce(msg.get(),cb);
 }

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
@@ -90,7 +90,7 @@ private:
 
   void downTreeHandler(LBTreeDownMsg* msg);
   void lbTreeUpHandler(LBTreeUpMsg* msg);
-  void setupDone(SetupDoneMsg* msg);
+  void setupDone();
 
   void downTreeSend(
     NodeType const node, NodeType const from, ObjSampleType const& excess,

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb_msgs.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb_msgs.h
@@ -114,8 +114,6 @@ private:
   bool final_child_ = 0;
 };
 
-struct SetupDoneMsg : vt::collective::ReduceNoneMsg { };
-
 }}}} /* end namespace vt::vrt::collection::lb */
 
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_HIERARCHICALLB_HIERLB_MSGS_H*/

--- a/src/vt/vrt/collection/balance/lb_data_restart_reader.cc
+++ b/src/vt/vrt/collection/balance/lb_data_restart_reader.cc
@@ -185,14 +185,14 @@ void LBDataRestartReader::determinePhasesToMigrate() {
   });
 
   runInEpochCollective("LBDataRestartReader::computeDistributionChanges", [&]{
-    auto cb = theCB()->makeBcast<&LBDataRestartReader::reduceDistroChanges>(proxy_);
-    auto msg = makeMessage<ReduceMsg>(std::move(local_changed_distro));
-    proxy_.reduce<collective::OrOp<std::vector<bool>>>(msg, cb);
+    proxy_.allreduce<
+      &LBDataRestartReader::reduceDistroChanges, collective::OrOp
+    >(std::move(local_changed_distro));
   });
 }
 
-void LBDataRestartReader::reduceDistroChanges(ReduceMsg* msg) {
-  changed_distro_ = std::move(msg->getMoveVal());
+void LBDataRestartReader::reduceDistroChanges(std::vector<bool> vec) {
+  changed_distro_ = std::move(vec);
 }
 
 }}}} /* end namespace vt::vrt::collection::balance */

--- a/src/vt/vrt/collection/balance/lb_data_restart_reader.cc
+++ b/src/vt/vrt/collection/balance/lb_data_restart_reader.cc
@@ -191,7 +191,7 @@ void LBDataRestartReader::determinePhasesToMigrate() {
   });
 }
 
-void LBDataRestartReader::reduceDistroChanges(std::vector<bool> vec) {
+void LBDataRestartReader::reduceDistroChanges(std::vector<bool> const& vec) {
   changed_distro_ = std::move(vec);
 }
 

--- a/src/vt/vrt/collection/balance/lb_data_restart_reader.cc
+++ b/src/vt/vrt/collection/balance/lb_data_restart_reader.cc
@@ -185,9 +185,7 @@ void LBDataRestartReader::determinePhasesToMigrate() {
   });
 
   runInEpochCollective("LBDataRestartReader::computeDistributionChanges", [&]{
-    auto cb = theCB()->makeBcast<
-      LBDataRestartReader,ReduceMsg,&LBDataRestartReader::reduceDistroChanges
-    >(proxy_);
+    auto cb = theCB()->makeBcast<&LBDataRestartReader::reduceDistroChanges>(proxy_);
     auto msg = makeMessage<ReduceMsg>(std::move(local_changed_distro));
     proxy_.reduce<collective::OrOp<std::vector<bool>>>(msg, cb);
   });

--- a/src/vt/vrt/collection/balance/lb_data_restart_reader.h
+++ b/src/vt/vrt/collection/balance/lb_data_restart_reader.h
@@ -153,9 +153,9 @@ private:
    * \brief Reduce distribution changes globally to find where migrations need
    * to occur
    *
-   * \param[in] msg the reduction message
+   * \param[in] vec the vector of booleans
    */
-  void reduceDistroChanges(ReduceMsg* msg);
+  void reduceDistroChanges(std::vector<bool> vec);
 
   /**
    * \brief Determine which phases migrations must happen to follow the

--- a/src/vt/vrt/collection/balance/lb_data_restart_reader.h
+++ b/src/vt/vrt/collection/balance/lb_data_restart_reader.h
@@ -155,7 +155,7 @@ private:
    *
    * \param[in] vec the vector of booleans
    */
-  void reduceDistroChanges(std::vector<bool> vec);
+  void reduceDistroChanges(std::vector<bool> const& vec);
 
   /**
    * \brief Determine which phases migrations must happen to follow the

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -185,9 +185,7 @@ void LBManager::defaultPostLBWork(ReassignmentMsg* msg) {
   auto proposed = std::make_shared<ProposedReassignment>(model_, reassignment);
 
   runInEpochCollective("LBManager::runLB -> computeStats", [=] {
-    auto stats_cb = vt::theCB()->makeBcast<
-      LBManager, StatsMsgType, &LBManager::statsHandler
-    >(proxy_);
+    auto stats_cb = vt::theCB()->makeBcast<&LBManager::statsHandler>(proxy_);
     before_lb_stats_ = false;
     computeStatistics(proposed, false, phase, stats_cb);
   });
@@ -233,9 +231,7 @@ LBManager::runLB(PhaseType phase, vt::Callback<ReassignmentMsg> cb) {
   }
 
   runInEpochCollective("LBManager::runLB -> computeStats", [=] {
-    auto stats_cb = vt::theCB()->makeBcast<
-      LBManager, StatsMsgType, &LBManager::statsHandler
-    >(proxy_);
+    auto stats_cb = vt::theCB()->makeBcast<&LBManager::statsHandler>(proxy_);
     before_lb_stats_ = true;
     computeStatistics(model_, false, phase, stats_cb);
   });
@@ -308,9 +304,7 @@ void LBManager::startLB(
 
     runInEpochCollective("LBManager::noLB -> computeStats", [=] {
       before_lb_stats_ = true;
-      auto stats_cb = vt::theCB()->makeBcast<
-        LBManager, StatsMsgType, &LBManager::statsHandler
-      >(proxy_);
+      auto stats_cb = vt::theCB()->makeBcast<&LBManager::statsHandler>(proxy_);
       before_lb_stats_ = true;
       computeStatistics(model_, false, phase, stats_cb);
     });

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -465,7 +465,7 @@ void LBManager::finishedLB(PhaseType phase) {
   destroyLB();
 }
 
-void LBManager::statsHandler(std::vector<balance::LoadData> in_stat_vec) {
+void LBManager::statsHandler(std::vector<balance::LoadData> const& in_stat_vec) {
   // use the raw loads if they were computed, otherwise fall back on model loads
   lb::Statistic rank_statistic = lb::Statistic::Rank_load_modeled;
   lb::Statistic obj_statistic  = lb::Statistic::Object_load_modeled;

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -465,9 +465,7 @@ void LBManager::finishedLB(PhaseType phase) {
   destroyLB();
 }
 
-void LBManager::statsHandler(StatsMsgType* msg) {
-  auto in_stat_vec = msg->getConstVal();
-
+void LBManager::statsHandler(std::vector<balance::LoadData> in_stat_vec) {
   // use the raw loads if they were computed, otherwise fall back on model loads
   lb::Statistic rank_statistic = lb::Statistic::Rank_load_modeled;
   lb::Statistic obj_statistic  = lb::Statistic::Object_load_modeled;
@@ -613,7 +611,7 @@ balance::LoadData reduceVec(
 
 void LBManager::computeStatistics(
   std::shared_ptr<LoadModel> model, bool comm_collectives, PhaseType phase,
-  vt::Callback<StatsMsgType> cb
+  vt::Callback<std::vector<balance::LoadData>> cb
 ) {
   vt_debug_print(
     normal, lb,
@@ -714,9 +712,7 @@ void LBManager::computeStatistics(
     lb::Statistic::Object_comm, std::move(obj_comm)
   ));
 
-  using ReduceOp = collective::PlusOp<std::vector<balance::LoadData>>;
-  auto msg = makeMessage<StatsMsgType>(std::move(lstats));
-  proxy_.template reduce<ReduceOp>(msg,cb);
+  proxy_.reduce<collective::PlusOp>(cb, std::move(lstats));
 }
 
 bool LBManager::isCollectiveComm(elm::CommCategory cat) const {

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -62,7 +62,7 @@
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
 struct LoadModel;
-struct NodeStatsMsg;
+struct LoadData;
 
 /**
  * \struct LBManager
@@ -75,7 +75,6 @@ struct NodeStatsMsg;
  */
 struct LBManager : runtime::component::Component<LBManager> {
   using LBProxyType      = objgroup::proxy::Proxy<lb::BaseLB>;
-  using StatsMsgType     = balance::NodeStatsMsg;
   using QuantityType     = lb::StatisticQuantityMap;
   using StatisticMapType = lb::StatisticMap;
 
@@ -257,10 +256,10 @@ public:
    */
   void computeStatistics(
     std::shared_ptr<LoadModel> model, bool comm_collectives, PhaseType phase,
-    vt::Callback<StatsMsgType> cb
+    vt::Callback<std::vector<balance::LoadData>> cb
   );
 
-  void statsHandler(StatsMsgType* msg);
+  void statsHandler(std::vector<balance::LoadData> in_stat_vec);
 
 private:
   bool isCollectiveComm(elm::CommCategory cat) const;

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -259,7 +259,7 @@ public:
     vt::Callback<std::vector<balance::LoadData>> cb
   );
 
-  void statsHandler(std::vector<balance::LoadData> in_stat_vec);
+  void statsHandler(std::vector<balance::LoadData> const& in_stat_vec);
 
 private:
   bool isCollectiveComm(elm::CommCategory cat) const;

--- a/src/vt/vrt/collection/balance/stats_msg.h
+++ b/src/vt/vrt/collection/balance/stats_msg.h
@@ -172,27 +172,6 @@ static_assert(
   "Must be trivially copyable to avoid serialization."
 );
 
-struct NodeStatsMsg : SerializeRequired<
-  collective::ReduceTMsg<std::vector<LoadData>>,
-  NodeStatsMsg
->
-{
-  using MessageParentType = SerializeRequired<
-    collective::ReduceTMsg<std::vector<LoadData>>,
-    NodeStatsMsg
-  >;
-
-  NodeStatsMsg() = default;
-  explicit NodeStatsMsg(std::vector<LoadData> ld)
-    : MessageParentType(std::move(ld))
-  { }
-
-  template <typename SerializerT>
-  void serialize(SerializerT& s) {
-    MessageParentType::serialize(s);
-  }
-};
-
 }}}} /* end namespace vt::vrt::collection::balance */
 
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_STATS_MSG_H*/

--- a/src/vt/vrt/collection/balance/temperedlb/tempered_msgs.h
+++ b/src/vt/vrt/collection/balance/temperedlb/tempered_msgs.h
@@ -142,46 +142,6 @@ private:
   ObjsType objs_  = {};
 };
 
-struct RejectionStats {
-  RejectionStats() = default;
-  RejectionStats(int n_rejected, int n_transfers)
-    : n_rejected_(n_rejected), n_transfers_(n_transfers) { }
-
-  friend RejectionStats operator+(RejectionStats a1, RejectionStats const& a2) {
-    a1.n_rejected_ += a2.n_rejected_;
-    a1.n_transfers_ += a2.n_transfers_;
-
-    return a1;
-  }
-
-  int n_rejected_ = 0;
-  int n_transfers_ = 0;
-};
-
-static_assert(
-  vt::messaging::is_byte_copyable_t<RejectionStats>::value,
-  "Must be trivially copyable to avoid serialization."
-);
-
-struct RejectionStatsMsg : NonSerialized<
-  collective::ReduceTMsg<RejectionStats>,
-  RejectionStatsMsg
->
-{
-  using MessageParentType = NonSerialized<
-    collective::ReduceTMsg<RejectionStats>,
-    RejectionStatsMsg
-  >;
-
-  RejectionStatsMsg() = default;
-  RejectionStatsMsg(int n_rejected, int n_transfers)
-    : MessageParentType(RejectionStats(n_rejected, n_transfers))
-  { }
-  RejectionStatsMsg(RejectionStats&& rs)
-    : MessageParentType(std::move(rs))
-  { }
-};
-
 }}}} /* end namespace vt::vrt::collection::balance */
 
 #endif /*INCLUDED_VT_VRT_COLLECTION_BALANCE_TEMPEREDLB_TEMPERED_MSGS_H*/

--- a/src/vt/vrt/collection/balance/temperedlb/temperedlb.cc
+++ b/src/vt/vrt/collection/balance/temperedlb/temperedlb.cc
@@ -550,7 +550,7 @@ void TemperedLB::doLBStages(TimeType start_imb) {
         runInEpochCollective("TemperedLB::doLBStages -> Rank_load_modeled", [=] {
           using ReduceOp = collective::PlusOp<std::vector<balance::LoadData>>;
           auto cb = vt::theCB()->makeBcast<
-            TemperedLB, StatsMsgType, &TemperedLB::loadStatsHandler
+            &TemperedLB::loadStatsHandler
           >(this->proxy_);
           // Perform the reduction for Rank_load_modeled -> processor load only
           auto msg = makeMessage<StatsMsgType>(
@@ -673,7 +673,7 @@ void TemperedLB::informAsync() {
 
   setup_done_ = false;
 
-  auto cb = theCB()->makeBcast<TemperedLB, ReduceMsgType, &TemperedLB::setupDone>(proxy_);
+  auto cb = theCB()->makeBcast<&TemperedLB::setupDone>(proxy_);
   auto msg = makeMessage<ReduceMsgType>();
   proxy_.reduce(msg.get(), cb);
 
@@ -729,7 +729,7 @@ void TemperedLB::informSync() {
 
   setup_done_ = false;
 
-  auto cb = theCB()->makeBcast<TemperedLB, ReduceMsgType, &TemperedLB::setupDone>(proxy_);
+  auto cb = theCB()->makeBcast<&TemperedLB::setupDone>(proxy_);
   auto msg = makeMessage<ReduceMsgType>();
   proxy_.reduce(msg.get(), cb);
 
@@ -1315,7 +1315,7 @@ void TemperedLB::decide() {
     runInEpochCollective("TemperedLB::decide -> compute rejection", [=] {
       using ReduceOp = collective::PlusOp<balance::RejectionStats>;
       auto cb = vt::theCB()->makeBcast<
-        TemperedLB, RejectionMsgType, &TemperedLB::rejectionStatsHandler
+        &TemperedLB::rejectionStatsHandler
       >(this->proxy_);
       auto msg = makeMessage<RejectionMsgType>(n_rejected, n_transfers);
       this->proxy_.template reduce<ReduceOp>(msg,cb);

--- a/src/vt/vrt/collection/balance/temperedlb/temperedlb.h
+++ b/src/vt/vrt/collection/balance/temperedlb/temperedlb.h
@@ -65,8 +65,6 @@ struct TemperedLB : BaseLB {
   using NodeSetType    = std::vector<NodeType>;
   using ObjsType       = std::unordered_map<ObjIDType, LoadType>;
   using ReduceMsgType  = vt::collective::ReduceNoneMsg;
-  using RejectionMsgType = balance::RejectionStatsMsg;
-  using StatsMsgType     = balance::NodeStatsMsg;
   using QuantityType     = std::map<lb::StatisticQuantity, double>;
   using StatisticMapType = std::unordered_map<lb::Statistic, QuantityType>;
 
@@ -115,11 +113,11 @@ protected:
 
   void lazyMigrateObjsTo(EpochType epoch, NodeType node, ObjsType const& objs);
   void inLazyMigrations(balance::LazyMigrationMsg* msg);
-  void loadStatsHandler(StatsMsgType* msg);
-  void rejectionStatsHandler(RejectionMsgType* msg);
+  void loadStatsHandler(std::vector<balance::LoadData> const& vec);
+  void rejectionStatsHandler(int n_rejected, int n_transfers);
   void thunkMigrations();
 
-  void setupDone(ReduceMsgType* msg);
+  void setupDone();
 
 private:
   uint16_t f_                                       = 0;

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
@@ -336,7 +336,7 @@ void ZoltanLB::countEdges() {
     total_ids
   );
 
-  auto cb = theCB()->makeBcast<ZoltanLB,ReduceMsg,&ZoltanLB::reduceCount>(proxy);
+  auto cb = theCB()->makeBcast<&ZoltanLB::reduceCount>(proxy);
   auto msg = makeMessage<ReduceMsg>(total_ids);
   proxy.reduce<collective::MaxOp<int>>(msg.get(),cb);
 }

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
@@ -336,13 +336,11 @@ void ZoltanLB::countEdges() {
     total_ids
   );
 
-  auto cb = theCB()->makeBcast<&ZoltanLB::reduceCount>(proxy);
-  auto msg = makeMessage<ReduceMsg>(total_ids);
-  proxy.reduce<collective::MaxOp<int>>(msg.get(),cb);
+  proxy.allreduce<&ZoltanLB::reduceCount, collective::MaxOp>(total_ids);
 }
 
-void ZoltanLB::reduceCount(ReduceMsg* msg) {
-  max_edges_per_node_ = msg->getVal();
+void ZoltanLB::reduceCount(int max_edges_per_node) {
+  max_edges_per_node_ = max_edges_per_node;
 
   vt_debug_print(
     normal, lb,

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
@@ -99,7 +99,7 @@ private:
   void combineEdges();
   void countEdges();
   void allocateEdges();
-  void reduceCount(ReduceMsg* msg);
+  void reduceCount(int max_edges_per_node);
   void allocateShareEdgeGIDs();
 
   void recvSharedEdges(CommMsg* msg);

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -780,7 +780,7 @@ messaging::PendingSend CollectionManager::broadcastNormalMsg(
   CollectionProxyWrapType<ColT> const& proxy, MsgT* msg,
   HandlerType const handler, bool instrument
 ) {
-  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
+  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(std::move(*msg));
   return broadcastMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
     proxy, wrap_msg.get(), handler, instrument
   );
@@ -986,7 +986,7 @@ messaging::PendingSend CollectionManager::sendNormalMsg(
   VirtualElmProxyType<ColT> const& proxy, MsgT* msg,
   HandlerType const handler
 ) {
-  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(*msg);
+  auto wrap_msg = makeMessage<ColMsgWrap<ColT, MsgT>>(std::move(*msg));
   return sendMsgUntypedHandler<ColMsgWrap<ColT, MsgT>, ColT>(
     proxy, wrap_msg.get(), handler
   );

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -1284,7 +1284,7 @@ template <typename ColT, typename ParamT, typename... Args>
   std::tuple<Args...>
 ) {
   using MapT = typename DefaultMap<ColT>::MapType;
-  return auto_registry::makeAutoHandlerFunctorMap<MapT,Args...>();
+  return auto_registry::makeAutoHandlerFunctorMap<MapT>();
 }
 
 template <typename IndexT>
@@ -1553,9 +1553,7 @@ void CollectionManager::finishModification(
   NodeType collective_root = 0;
   auto stamp = makeStamp<StrongUserID>(untyped_proxy);
   auto msg = makeMessage<CollectionStampMsg>(untyped_proxy, min_seq);
-  auto cb = theCB()->makeBcast<
-    CollectionStampMsg,&CollectionManager::computeReduceStamp
-  >();
+  auto cb = theCB()->makeBcast<&CollectionManager::computeReduceStamp>();
   r->reduce<collective::MinOp<SeqType>>(collective_root, msg.get(), cb, stamp);
 
   theSched()->runSchedulerWhile([untyped_proxy]{

--- a/src/vt/vrt/collection/messages/user_wrap.h
+++ b/src/vt/vrt/collection/messages/user_wrap.h
@@ -63,6 +63,7 @@ struct ColMsgWrap : CollectionMessage<ColT,BaseMsgT> {
   vt_msg_serialize_if_needed_by_parent_or_type1(UserMsgT);
 
   using UserMsgType = UserMsgT;
+  using IsWrapMsg = std::true_type;
 
   ColMsgWrap() = default;
 

--- a/src/vt/vrt/collection/reducable/reducable.h
+++ b/src/vt/vrt/collection/reducable/reducable.h
@@ -67,18 +67,79 @@ struct Reducable : BaseProxyT {
   explicit Reducable(VirtualProxyType const in_proxy);
   Reducable& operator=(Reducable const&) = default;
 
+  /**
+   * \brief All-reduce back to this collection. Performs a reduction using
+   * operator `Op` followed by a broadcast to `f` with the result.
+   *
+   * \param[in] args the arguments to reduce. \note The last argument optionally
+   * may be a `ReduceStamp`.
+   *
+   * \return a pending send
+   */
+  template <
+    auto f,
+    template <typename Arg> class Op = collective::NoneOp,
+    typename... Args
+  >
+  messaging::PendingSend allreduce(
+    Args&&... args
+  ) const;
+
+  /**
+   * \brief Reduce back to a point target. Performs a reduction using operator
+   * `Op` followed by a send to `f` with the result.
+   *
+   * \param[in] args the arguments to reduce. \note The last argument optionally
+   * may be a `ReduceStamp`.
+   *
+   * \return a pending send
+   */
+  template <
+    auto f,
+    template <typename Arg> class Op = collective::NoneOp,
+    typename Target,
+    typename... Args
+  >
+  messaging::PendingSend reduce(
+    Target target,
+    Args&&... args
+  ) const;
+
+  /**
+   * \brief Reduce back to an arbitrary callback. Performs a reduction using
+   * operator `Op` and then delivers the result to the callback `cb`.
+   *
+   * \param[in] cb the callback to trigger with the reduction result
+   * \param[in] args the arguments to reduce. \note The last argument optionally
+   * may be a `ReduceStamp`.
+   *
+   * \return a pending send
+   */
+  template <
+    template <typename Arg> class Op = collective::NoneOp,
+    typename... CBArgs,
+    typename... Args
+  >
+  messaging::PendingSend reduce(
+    vt::Callback<CBArgs...> cb,
+    Args&&... args
+  ) const;
+
   template <
     typename OpT = collective::None,
     typename MsgT,
     ActiveTypedFnType<MsgT> *f
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduce(
     MsgT *const msg, Callback<MsgT> cb, ReduceStamp stamp = ReduceStamp{}
   ) const;
+
   template <
     typename OpT = collective::None,
     typename MsgT
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduce(
     MsgT *const msg, Callback<MsgT> cb, ReduceStamp stamp = ReduceStamp{}
   ) const
@@ -98,12 +159,15 @@ struct Reducable : BaseProxyT {
     typename MsgT,
     ActiveTypedFnType<MsgT> *f
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduce(MsgT *const msg, ReduceStamp stamp = ReduceStamp{}) const;
+
   template <
     typename OpT,
     typename FunctorT,
     typename MsgT
   >
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduce(MsgT *const msg, ReduceStamp stamp = ReduceStamp{}) const
   {
     return reduce<
@@ -115,21 +179,25 @@ struct Reducable : BaseProxyT {
   }
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduce(
     MsgT *const msg, ReduceStamp stamp = ReduceStamp{},
     NodeType const& node = uninitialized_destination
   ) const;
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduceExpr(
     MsgT *const msg, ReduceIdxFuncType fn, ReduceStamp stamp = ReduceStamp{},
     NodeType const& node = uninitialized_destination
   ) const;
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduce(MsgT *const msg, ReduceStamp stamp, IndexT const& idx) const;
 
   template <typename MsgT, ActiveTypedFnType<MsgT> *f>
+  [[deprecated("Use new interface calls (allreduce/reduce) without message")]]
   messaging::PendingSend reduceExpr(
     MsgT *const msg, ReduceIdxFuncType fn, ReduceStamp stamp, IndexT const& idx
   ) const;

--- a/src/vt/vrt/collection/reducable/reducable.impl.h
+++ b/src/vt/vrt/collection/reducable/reducable.impl.h
@@ -49,6 +49,7 @@
 #include "vt/vrt/proxy/base_collection_proxy.h"
 #include "vt/pipe/callback/cb_union/cb_raw_base.h"
 #include "vt/vrt/collection/manager.h"
+#include "vt/collective/reduce/get_reduce_stamp.h"
 
 namespace vt { namespace vrt { namespace collection {
 
@@ -56,6 +57,95 @@ template <typename ColT, typename IndexT, typename BaseProxyT>
 Reducable<ColT,IndexT,BaseProxyT>::Reducable(VirtualProxyType const in_proxy)
   : BaseProxyT(in_proxy)
 { }
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <auto f, template <typename Arg> class Op, typename... Args>
+messaging::PendingSend Reducable<ColT,IndexT,BaseProxyT>::allreduce(
+  Args&&... args
+) const {
+  using Tuple = typename FuncTraits<decltype(f)>::TupleType;
+  using MsgT = collective::ReduceTMsg<Tuple>;
+  using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
+  auto cb = theCB()->makeBcast<f>(*this);
+
+  ReduceStamp stamp{};
+  if constexpr (GetReduceStamp::value) {
+    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
+  }
+
+  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  msg->setCallback(cb);
+  auto const root_node = 0;
+  auto const proxy = this->getProxy();
+  return theCollection()->reduceMsg<
+    ColT,
+    MsgT,
+    &MsgT::template msgHandler<
+      MsgT, Op<Tuple>, collective::reduce::operators::ReduceCallback<MsgT>
+    >
+  >(proxy, msg.get(), stamp, root_node);
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <auto f, template <typename Arg> class Op, typename Target, typename... Args>
+messaging::PendingSend Reducable<ColT,IndexT,BaseProxyT>::reduce(
+  Target target,
+  Args&&... args
+) const {
+  using Tuple = typename FuncTraits<decltype(f)>::TupleType;
+  using MsgT = collective::ReduceTMsg<Tuple>;
+  using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
+
+  auto cb = theCB()->makeSend<f>(target);
+
+  ReduceStamp stamp{};
+  if constexpr (GetReduceStamp::value) {
+    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
+  }
+
+  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  msg->setCallback(cb);
+  auto const root_node = 0;
+  auto const proxy = this->getProxy();
+
+  return theCollection()->reduceMsg<
+    ColT,
+    MsgT,
+    &MsgT::template msgHandler<
+      MsgT, Op<Tuple>, collective::reduce::operators::ReduceCallback<MsgT>
+    >
+  >(proxy, msg.get(), stamp, root_node);
+}
+
+template <typename ColT, typename IndexT, typename BaseProxyT>
+template <template <typename Arg> class Op, typename... CBArgs, typename... Args>
+messaging::PendingSend Reducable<ColT,IndexT,BaseProxyT>::reduce(
+  vt::Callback<CBArgs...> cb,
+  Args&&... args
+) const {
+  using CallbackT = vt::Callback<CBArgs...>;
+  using Tuple = typename CallbackT::TupleType;
+  using MsgT = collective::ReduceTMsg<Tuple>;
+  using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
+
+  ReduceStamp stamp{};
+  if constexpr (GetReduceStamp::value) {
+    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
+  }
+
+  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  msg->setCallback(cb);
+  auto const root_node = 0;
+  auto const proxy = this->getProxy();
+
+  return theCollection()->reduceMsg<
+    ColT,
+    MsgT,
+    &MsgT::template msgHandler<
+      MsgT, Op<Tuple>, collective::reduce::operators::ReduceCallback<MsgT>
+    >
+  >(proxy, msg.get(), stamp, root_node);
+}
 
 template <typename ColT, typename IndexT, typename BaseProxyT>
 template <typename OpT, typename MsgT, ActiveTypedFnType<MsgT> *f>
@@ -66,8 +156,7 @@ messaging::PendingSend Reducable<ColT,IndexT,BaseProxyT>::reduce(
   msg->setCallback(cb);
   vt_debug_print(
     normal, reduce,
-    "Reducable: valid={} {}, ptr={}\n", cb.valid(), msg->getCallback().valid(),
-    print_ptr(msg)
+    "Reducable: ptr={}\n", print_ptr(msg)
   );
   auto const root_node = 0;
   return theCollection()->reduceMsg<ColT,MsgT,f>(proxy,msg,stamp,root_node);

--- a/src/vt/vrt/collection/reducable/reducable.impl.h
+++ b/src/vt/vrt/collection/reducable/reducable.impl.h
@@ -67,13 +67,7 @@ messaging::PendingSend Reducable<ColT,IndexT,BaseProxyT>::allreduce(
   using MsgT = collective::ReduceTMsg<Tuple>;
   using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
   auto cb = theCB()->makeBcast<f>(*this);
-
-  ReduceStamp stamp{};
-  if constexpr (GetReduceStamp::value) {
-    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
-  }
-
-  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  auto [stamp, msg] = GetReduceStamp::template getStampMsg<MsgT>(std::forward<Args>(args)...);
   msg->setCallback(cb);
   auto const root_node = 0;
   auto const proxy = this->getProxy();
@@ -98,12 +92,7 @@ messaging::PendingSend Reducable<ColT,IndexT,BaseProxyT>::reduce(
 
   auto cb = theCB()->makeSend<f>(target);
 
-  ReduceStamp stamp{};
-  if constexpr (GetReduceStamp::value) {
-    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
-  }
-
-  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  auto [stamp, msg] = GetReduceStamp::template getStampMsg<MsgT>(std::forward<Args>(args)...);
   msg->setCallback(cb);
   auto const root_node = 0;
   auto const proxy = this->getProxy();
@@ -128,12 +117,7 @@ messaging::PendingSend Reducable<ColT,IndexT,BaseProxyT>::reduce(
   using MsgT = collective::ReduceTMsg<Tuple>;
   using GetReduceStamp = collective::reduce::GetReduceStamp<void, Args...>;
 
-  ReduceStamp stamp{};
-  if constexpr (GetReduceStamp::value) {
-    stamp = std::get<sizeof...(Args) - 1>(std::tie(std::forward<Args>(args)...));
-  }
-
-  auto msg = GetReduceStamp::template getMsg<MsgT>(std::forward<Args>(args)...);
+  auto [stamp, msg] = GetReduceStamp::template getStampMsg<MsgT>(std::forward<Args>(args)...);
   msg->setCallback(cb);
   auto const root_node = 0;
   auto const proxy = this->getProxy();

--- a/tests/perf/reduce.cc
+++ b/tests/perf/reduce.cc
@@ -78,7 +78,7 @@ struct NodeObj {
 
   void perfReduce(MyMsg* in_msg) {
     test_obj_->StartTimer(fmt::format("{} reduce", i));
-    auto cb = theCB()->makeBcast<NodeObj, ReduceMsg, &NodeObj::reduceComplete>(proxy_);
+    auto cb = theCB()->makeBcast<&NodeObj::reduceComplete>(proxy_);
     auto msg = makeMessage<ReduceMsg>();
     proxy_.reduce(msg.get(), cb);
   }

--- a/tests/perf/reduce.cc
+++ b/tests/perf/reduce.cc
@@ -55,15 +55,13 @@ static constexpr int num_iters = 100;
 struct MyTest : PerfTestHarness { };
 
 struct NodeObj {
-  struct ReduceMsg : vt::collective::ReduceNoneMsg { };
-
   explicit NodeObj(MyTest* test_obj) : test_obj_(test_obj) { }
 
   void initialize() { proxy_ = vt::theObjGroup()->getProxy<NodeObj>(this); }
 
   struct MyMsg : vt::Message {};
 
-  void reduceComplete(ReduceMsg* msg) {
+  void reduceComplete() {
     reduce_counter_++;
     test_obj_->StopTimer(fmt::format("{} reduce", i));
     test_obj_->GetMemoryUsage();
@@ -78,9 +76,7 @@ struct NodeObj {
 
   void perfReduce(MyMsg* in_msg) {
     test_obj_->StartTimer(fmt::format("{} reduce", i));
-    auto cb = theCB()->makeBcast<&NodeObj::reduceComplete>(proxy_);
-    auto msg = makeMessage<ReduceMsg>();
-    proxy_.reduce(msg.get(), cb);
+    proxy_.allreduce<&NodeObj::reduceComplete>();
   }
 
 private:

--- a/tests/unit/collection/test_collection_group.extended.cc
+++ b/tests/unit/collection/test_collection_group.extended.cc
@@ -127,8 +127,6 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
     }, "test_collection_group_2"
   );
 
-  auto const numElems = elem_counter;
-
   // msg constructed on the fly case
   runBcastTestHelper([proxy, my_node]{
     proxy.broadcastCollective<&ColA::memberHandler>(my_node);

--- a/tests/unit/collection/test_collection_group.extended.cc
+++ b/tests/unit/collection/test_collection_group.extended.cc
@@ -76,7 +76,7 @@ struct ColA : Collection<ColA,Index1D> {
 
   void doReduce() {
     auto const proxy = getCollectionProxy();
-    auto cb = theCB()->makeBcast<ColA, MyReduceMsg, &ColA::finishedReduce>(proxy);
+    auto cb = theCB()->makeBcast<&ColA::finishedReduce>(proxy);
     auto reduce_msg = makeMessage<MyReduceMsg>(getIndex().x());
     proxy.reduce<collective::PlusOp<int>>(reduce_msg.get(),cb);
     reduce_test = true;

--- a/tests/unit/collection/test_collection_group.extended.cc
+++ b/tests/unit/collection/test_collection_group.extended.cc
@@ -129,26 +129,12 @@ TEST_F(TestCollectionGroup, test_collection_group_2) {
 
   auto const numElems = elem_counter;
 
-  // raw msg pointer case
+  // msg constructed on the fly case
   runBcastTestHelper([proxy, my_node]{
     proxy.broadcastCollective<&ColA::memberHandler>(my_node);
   });
 
   EXPECT_EQ(elem_counter, 0);
-
-  // smart msg pointer case
-  runBcastTestHelper([proxy, my_node]{
-    proxy.broadcastCollective<&ColA::memberHandler>(my_node);
-  });
-
-  EXPECT_EQ(elem_counter, -numElems);
-
-  // msg constructed on the fly case
-  runBcastTestHelper([proxy, my_node] {
-    proxy.broadcastCollective<&ColA::memberHandler>(my_node);
-  });
-
-  EXPECT_EQ(elem_counter, -2 * numElems);
 }
 
 TEST_F(TestCollectionGroup, test_collection_group_3) {

--- a/tests/unit/collection/test_collection_group_recreate.cc
+++ b/tests/unit/collection/test_collection_group_recreate.cc
@@ -49,26 +49,25 @@
 
 namespace vt { namespace tests { namespace unit {
 
-struct MyReduceMsg : vt::collective::ReduceTMsg<int> {
-  explicit MyReduceMsg(int const in_num)
-    : vt::collective::ReduceTMsg<int>(in_num)
-  { }
-};
-
 struct MyCol : vt::Collection<MyCol,vt::Index1D> {
-  struct TestMsg : vt::CollectionMessage<MyCol> {
-    explicit TestMsg(vt::Callback<MyReduceMsg> in_cb) : cb(in_cb) { }
-    vt::Callback<MyReduceMsg> cb;
-  };
-  struct TestMsg2 : vt::CollectionMessage<MyCol> {};
-
-  void doWork(TestMsg2* msg) {}
-
-  void doReduce(TestMsg* msg) {
+  void doReduce() {
     auto const proxy = getCollectionProxy();
-    auto reduce_msg = makeMessage<MyReduceMsg>(getIndex().x());
-    proxy.reduce<collective::PlusOp<int>>(reduce_msg.get(),msg->cb);
+    int val = getIndex().x();
+    proxy.allreduce<&MyCol::checkVal, collective::PlusOp>(val);
   }
+
+  void checkVal(int val) {
+    cb_counter++;
+    fmt::print("at root: final num={} cb_counter={}\n", val, cb_counter);
+  }
+
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    Collection<MyCol,vt::Index1D>::serialize(s);
+    s | cb_counter;
+  }
+
+  int cb_counter = 0;
 };
 
 struct TestCollectionGroupRecreate : TestParallelHarness { };
@@ -85,23 +84,16 @@ TEST_F(TestCollectionGroupRecreate, test_collection_group_recreate_1) {
     "test_collection_group_recreate_1"
   );
 
-  int cb_counter = 0;
-
   /// Broadcast to do a reduction over the current group
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
-      auto cb = vt::theCB()->makeFunc<MyReduceMsg>(
-        vt::pipe::LifetimeEnum::Once, [&cb_counter](MyReduceMsg* m) {
-          cb_counter++;
-          fmt::print("at root: final num={}\n", m->getVal());
-        }
-      );
-      proxy.broadcast<MyCol::TestMsg,&MyCol::doReduce>(cb);
+      proxy.broadcast<&MyCol::doReduce>();
     }
   });
 
-  if (this_node == 0) {
-    EXPECT_EQ(cb_counter, 1);
+  auto set = theCollection()->getLocalIndices(proxy);
+  if (set.size() > 0) {
+    EXPECT_EQ(proxy[*set.begin()].tryGetLocalPtr()->cb_counter, 1);
   }
 
   /// Run RotateLB to make the previous group invalid!
@@ -118,18 +110,13 @@ TEST_F(TestCollectionGroupRecreate, test_collection_group_recreate_1) {
   // Try to do another reduction; should fail if group is not setup correctly
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
-      auto cb = vt::theCB()->makeFunc<MyReduceMsg>(
-        vt::pipe::LifetimeEnum::Once, [&cb_counter](MyReduceMsg* m) {
-          cb_counter++;
-          fmt::print("at root: final num={}\n", m->getVal());
-        }
-      );
-      proxy.broadcast<MyCol::TestMsg,&MyCol::doReduce>(cb);
+      proxy.broadcast<&MyCol::doReduce>();
     }
   });
 
-  if (this_node == 0) {
-    EXPECT_EQ(cb_counter, 2);
+  set = theCollection()->getLocalIndices(proxy);
+  if (set.size() > 0) {
+    EXPECT_EQ(proxy[*set.begin()].tryGetLocalPtr()->cb_counter, 2);
   }
 
   vt::runInEpochCollective([&]{
@@ -139,18 +126,13 @@ TEST_F(TestCollectionGroupRecreate, test_collection_group_recreate_1) {
   // Try to do another reduction; should fail if group is not setup correctly
   vt::runInEpochCollective([&]{
     if (this_node == 0) {
-      auto cb = vt::theCB()->makeFunc<MyReduceMsg>(
-        vt::pipe::LifetimeEnum::Once, [&cb_counter](MyReduceMsg* m) {
-          cb_counter++;
-          fmt::print("at root: final num={}\n", m->getVal());
-        }
-      );
-      proxy.broadcast<MyCol::TestMsg,&MyCol::doReduce>(cb);
+      proxy.broadcast<&MyCol::doReduce>();
     }
   });
 
-  if (this_node == 0) {
-    EXPECT_EQ(cb_counter, 3);
+  set = theCollection()->getLocalIndices(proxy);
+  if (set.size() > 0) {
+    EXPECT_EQ(proxy[*set.begin()].tryGetLocalPtr()->cb_counter, 3);
   }
 
 }

--- a/tests/unit/collection/test_collection_group_recreate.cc
+++ b/tests/unit/collection/test_collection_group_recreate.cc
@@ -58,7 +58,7 @@ struct MyCol : vt::Collection<MyCol,vt::Index1D> {
 
   void checkVal(int val) {
     cb_counter++;
-    fmt::print("at root: final num={} cb_counter={}\n", val, cb_counter);
+    fmt::print("final num={} cb_counter={}\n", val, cb_counter);
   }
 
   template <typename SerializerT>

--- a/tests/unit/collection/test_reduce_collection.cc
+++ b/tests/unit/collection/test_reduce_collection.cc
@@ -55,35 +55,23 @@ TEST_P(TestReduceCollection, test_reduce_op) {
 
   if (my_node == root) {
     auto reduce_case = GetParam();
-    auto size = (reduce_case == 5 ? collect_size * 4 : collect_size);
+    auto size = collect_size;
     auto const& range = Index1D(size);
     auto proxy = theCollection()->construct<MyCol>(range, "test_reduce_op");
 
     switch (reduce_case) {
     case 0: proxy.broadcast<colHanBasic>(); break;
-    case 1: proxy.broadcast<colHanVec>(); break;
+    case 1: proxy.broadcast<colHanBasicAR>(); break;
     case 2: proxy.broadcast<colHanVecProxy>(); break;
-    case 3: proxy.broadcast<colHanVecProxyCB>(); break;
+    case 3: proxy.broadcast<colHanVecProxyAR>(); break;
     case 4: proxy.broadcast<colHanNoneCB>(); break;
-
-      #if ENABLE_REDUCE_EXPR_CALLBACK
-    case 5: proxy.broadcast<colHanPartial>(); break;
-    case 6: proxy.broadcast<colHanPartialMulti>(); break;
-    case 7: proxy.broadcast<colHanPartialProxy>(); break;
-      #endif
-      default: vtAbort("Failure: should not be reached");
+    default: vtAbort("Failure: should not be reached");
     }
   }
 }
 
-#if ENABLE_REDUCE_EXPR_CALLBACK
-  INSTANTIATE_TEST_SUITE_P(
-    InstantiationName, TestReduceCollection, ::testing::Range(0, 8)
-  );
-#else
-  INSTANTIATE_TEST_SUITE_P(
-    InstantiationName, TestReduceCollection, ::testing::Range(0, 5)
-  );
-#endif
+INSTANTIATE_TEST_SUITE_P(
+  InstantiationName, TestReduceCollection, ::testing::Range(0, 5)
+);
 
 }}} // end namespace vt::tests::unit

--- a/tests/unit/collection/test_reduce_collection_race.cc
+++ b/tests/unit/collection/test_reduce_collection_race.cc
@@ -49,24 +49,20 @@ namespace vt { namespace tests { namespace unit { namespace race {
 using TestReduceCollectionRace = TestParallelHarnessParam<int>;
 
 struct MyCol : vt::Collection<MyCol, vt::Index1D> {};
-using ReduceMsg = vt::collective::ReduceTMsg<int>;
 
 static int multiplier = 0;
 
-struct ReduceFunctor {
-  void operator()(ReduceMsg* msg) {
-    auto const num_nodes = theContext()->getNumNodes();
-    auto const num_elems = num_nodes * multiplier;
-    fmt::print("reduce finished: val={}, num_elems={}\n", msg->getVal(), num_elems);
-    EXPECT_EQ(msg->getVal(), (num_elems * (num_elems-1))/2);
-  }
-};
+static void reduceTarget(MyCol* col, int val) {
+  auto const num_nodes = theContext()->getNumNodes();
+  auto const num_elems = num_nodes * multipler;
+  fmt::print("reduce finished: val={}, num_elems={}\n", val, num_elems);
+  EXPECT_EQ(val, (num_elems * (num_elems-1))/2);
+}
 
 static void handler(MyCol* col) {
   auto proxy = col->getCollectionProxy();
-  auto msg = vt::makeMessage<ReduceMsg>(static_cast<int>(col->getIndex().x()));
-  auto cb = vt::theCB()->makeSend<ReduceFunctor>(0);
-  proxy.reduce<vt::collective::PlusOp<int>>(msg.get(), cb);
+  int val = col->getIndex().x();
+  proxy.reduce<reduceTarget, vt::collective::PlusOp>(proxy[0], val);
 }
 
 TEST_P(TestReduceCollectionRace, test_reduce_race_1) {

--- a/tests/unit/collection/test_reduce_collection_race.cc
+++ b/tests/unit/collection/test_reduce_collection_race.cc
@@ -54,7 +54,7 @@ static int multiplier = 0;
 
 static void reduceTarget(MyCol* col, int val) {
   auto const num_nodes = theContext()->getNumNodes();
-  auto const num_elems = num_nodes * multipler;
+  auto const num_elems = num_nodes * multiplier;
   fmt::print("reduce finished: val={}, num_elems={}\n", val, num_elems);
   EXPECT_EQ(val, (num_elems * (num_elems-1))/2);
 }

--- a/tests/unit/collectives/test_collectives_reduce.cc
+++ b/tests/unit/collectives/test_collectives_reduce.cc
@@ -82,7 +82,7 @@ struct Hello : vt::Collection<Hello, vt::Index1D> {
     auto proxy = this->getCollectionProxy();
 
     // Create a callback for when the reduction finishes
-    auto cb = vt::theCB()->makeBcast<MyObjGroup,ReduceMsg,&MyObjGroup::handler>(objgroup_proxy);
+    auto cb = vt::theCB()->makeBcast<&MyObjGroup::handler>(objgroup_proxy);
 
     // Create and send the reduction message holding an int
     auto red_msg = vt::makeMessage<ReduceMsg>(this->getIndex().x());

--- a/tests/unit/collectives/test_collectives_reduce.cc
+++ b/tests/unit/collectives/test_collectives_reduce.cc
@@ -61,11 +61,9 @@ TEST_F(TestReduce, test_reduce_op) {
   theCollective()->global()->reduce<reducePlus>(root, msg.get());
 }
 
-using ReduceMsg = vt::collective::ReduceTMsg<int>;
-
 struct MyObjGroup {
-  void handler(ReduceMsg* msg) {
-    fmt::print("Reduce complete at {} value {}\n", vt::theContext()->getNode(), msg->getVal());
+  void handler(int val) {
+    fmt::print("Reduce complete at {} value {}\n", vt::theContext()->getNode(), val);
   }
 };
 
@@ -73,20 +71,13 @@ vt::objgroup::proxy::Proxy<MyObjGroup> objgroup_proxy;
 
 struct Hello : vt::Collection<Hello, vt::Index1D> {
 
-  using TestMsg = vt::CollectionMessage<Hello>;
-
-  void doWork(TestMsg* msg) {
+  void doWork() {
     fmt::print("{}: Hello from {}\n", vt::theContext()->getNode(), this->getIndex());
 
     // Get the proxy for the collection
     auto proxy = this->getCollectionProxy();
-
-    // Create a callback for when the reduction finishes
-    auto cb = vt::theCB()->makeBcast<&MyObjGroup::handler>(objgroup_proxy);
-
-    // Create and send the reduction message holding an int
-    auto red_msg = vt::makeMessage<ReduceMsg>(this->getIndex().x());
-    proxy.reduce<vt::collective::PlusOp<int>>(red_msg.get(),cb);
+    auto cb = theCB()->makeBcast<&MyObjGroup::handler>(objgroup_proxy);
+    proxy.reduce<vt::collective::PlusOp>(cb, getIndex().x());
   }
 };
 
@@ -113,7 +104,7 @@ TEST_F(TestReduce, test_reduce_with_no_elements_on_root_rank) {
     .wait();
 
   if (this_node == 0) {
-    proxy.broadcast<Hello::TestMsg,&Hello::doWork>();
+    proxy.broadcast<&Hello::doWork>();
   }
 }
 

--- a/tests/unit/lb/test_lb_data_comm.cc
+++ b/tests/unit/lb/test_lb_data_comm.cc
@@ -102,6 +102,9 @@ struct MyObjMsg : vt::Message { double x, y, z; };
 struct ElementInfo {
   using MapType = std::map<vt::Index1D, vt::elm::ElementIDStruct>;
   ElementInfo() = default;
+  ElementInfo(vt::Index1D idx, vt::elm::ElementIDStruct elm_id)
+    : elms(std::map<vt::Index1D, vt::elm::ElementIDStruct>{{idx, elm_id}})
+  {};
   explicit ElementInfo(MapType in_map) : elms(in_map) { }
   friend ElementInfo operator+(ElementInfo a1, ElementInfo const& a2) {
     for (auto&& x : a2.elms) a1.elms.insert(x);
@@ -112,27 +115,6 @@ struct ElementInfo {
     s | elms;
   }
   MapType elms;
-};
-struct ReduceMsg : SerializeRequired<
-  vt::collective::ReduceTMsg<ElementInfo>, ReduceMsg
-> {
-  using MessageParentType = SerializeRequired<
-    vt::collective::ReduceTMsg<ElementInfo>, ReduceMsg
-  >;
-
-  ReduceMsg() = default;
-  ReduceMsg(vt::Index1D idx, vt::elm::ElementIDStruct elm_id)
-    : MessageParentType(
-        ElementInfo{
-          std::map<vt::Index1D, vt::elm::ElementIDStruct>{{idx, elm_id}}
-        }
-      )
-  { }
-
-  template <typename SerializerT>
-  void serialize(SerializerT& s) {
-    MessageParentType::serialize(s);
-  }
 };
 struct ColProxyMsg : vt::Message {
   using ProxyType = vt::CollectionProxy<MyCol>;
@@ -263,14 +245,13 @@ auto idxToElmID = [](vt::Index1D i) -> vt::elm::ElementIDType {
   return all_elms.find(i)->second.id;
 };
 
-void recvElementIDs(ReduceMsg* msg) { all_elms = msg->getVal().elms; }
+void recvElementIDs(ElementInfo info) { all_elms = info.elms; }
 
 void doReduce(MyCol* col) {
   auto proxy = col->getCollectionProxy();
   auto index = col->getIndex();
   auto cb = theCB()->makeBcast<recvElementIDs>();
-  auto msg = makeMessage<ReduceMsg>(index, col->getElmID());
-  proxy.reduce<vt::collective::PlusOp<ElementInfo>>(msg.get(), cb);
+  proxy.reduce<vt::collective::PlusOp>(cb, ElementInfo{index, col->getElmID()});
 }
 
 // ColT -> ColT, expected communication edge on receive side
@@ -757,9 +738,6 @@ TEST_F(TestLBDataComm, test_lb_data_comm_handler_to_handler_send) {
     }
   }
   EXPECT_TRUE(found);
-
-  // Suppress warnings about that method being "declared but never referenced" from Intel icpc and Nvidia nvcc
-  (void)&ReduceMsg::serialize<checkpoint::Serializer>;
 }
 
 } /* end anon namespace */

--- a/tests/unit/lb/test_lb_data_comm.cc
+++ b/tests/unit/lb/test_lb_data_comm.cc
@@ -268,7 +268,7 @@ void recvElementIDs(ReduceMsg* msg) { all_elms = msg->getVal().elms; }
 void doReduce(MyCol* col) {
   auto proxy = col->getCollectionProxy();
   auto index = col->getIndex();
-  auto cb = theCB()->makeBcast<ReduceMsg, recvElementIDs>();
+  auto cb = theCB()->makeBcast<recvElementIDs>();
   auto msg = makeMessage<ReduceMsg>(index, col->getElmID());
   proxy.reduce<vt::collective::PlusOp<ElementInfo>>(msg.get(), cb);
 }

--- a/tests/unit/objgroup/test_objgroup.cc
+++ b/tests/unit/objgroup/test_objgroup.cc
@@ -65,36 +65,23 @@ struct TestObjGroup : TestParallelHarness {
   static int32_t total_verify_expected_;
 
   template <int test>
-  struct Verify {
-
-    Verify() = default;
-    Verify(int value) : expected_(value) {}
-    ~Verify() = default;
-
-    // check reduction results for scalar ops
-    void operator()(SysMsg* msg) {
-      auto const n = vt::theContext()->getNumNodes();
-      auto const value = msg->getConstVal();
-
-      switch (test) {
-        case 1: EXPECT_EQ(value, n * (n - 1)/2); break;
-        case 2: EXPECT_EQ(value, n * 4); break;
-        case 3: EXPECT_EQ(value, n - 1); break;
-        case 4: EXPECT_EQ(value, expected_); break;
-        default: vtAbort("Failure: should not be reached"); break;
-      }
-      total_verify_expected_++;
+  void verify(int value) {
+    auto const n = vt::theContext()->getNumNodes();
+    switch (test) {
+    case 1: EXPECT_EQ(value, n * (n - 1)/2); break;
+    case 2: EXPECT_EQ(value, n * 4); break;
+    case 3: EXPECT_EQ(value, n - 1); break;
+    default: vtAbort("Failure: should not be reached"); break;
     }
-    // check reduction result for vector append
-    void operator()(VecMsg* msg) {
-      auto final_size = msg->getConstVal().vec_.size();
-      auto n = vt::theContext()->getNumNodes();
-      EXPECT_EQ(final_size, n * 2U);
-      total_verify_expected_++;
-    }
-    // for reduction values not depending on ranks
-    int expected_ = 0;
-  };
+    total_verify_expected_++;
+  }
+
+  void verifyVec(VectorPayload vec) {
+    auto final_size = vec.vec_.size();
+    auto n = vt::theContext()->getNumNodes();
+    EXPECT_EQ(final_size, n);
+    total_verify_expected_++;
+  }
 };
 
 /*static*/ int32_t TestObjGroup::total_verify_expected_ = 0;
@@ -249,21 +236,18 @@ TEST_F(TestObjGroup, test_proxy_reduce) {
     auto proxy3 = vt::theObjGroup()->makeCollective<MyObjA>("test_proxy_reduce");
     auto proxy4 = vt::theObjGroup()->makeCollective<MyObjA>("test_proxy_reduce");
 
-    auto msg1 = vt::makeMessage<SysMsg>(my_node);
-    auto msg2 = vt::makeMessage<SysMsg>(4);
-    auto msg3 = vt::makeMessage<SysMsg>(my_node);
-    auto msg4 = vt::makeMessage<VecMsg>(my_node);
-
     // Multiple reductions should not interfere each other, even if
     // performed by the same subset of nodes within the same epoch.
     // Proxies should be able to do perform reduction
     // on any valid operator and data type.
     using namespace vt::collective;
 
-    proxy1.reduce<PlusOp<int>, Verify<1>>(msg1);
-    proxy2.reduce<PlusOp<int>, Verify<2>>(msg2);
-    proxy3.reduce< MaxOp<int>, Verify<3>>(msg3);
-    proxy4.reduce<PlusOp<VectorPayload>, Verify<4>>(msg4);
+    proxy1.reduce<&TestObjGroup::verify<1>, PlusOp>(proxy1[0], my_node);
+    proxy2.reduce<&TestObjGroup::verify<2>, PlusOp>(proxy1[0], 4);
+    proxy3.reduce<&TestObjGroup::verify<3>, MaxOp>(proxy1[0], my_node);
+    proxy4.reduce<&TestObjGroup::verifyVec, PlusOp>(
+      proxy1[0], VectorPayload{std::vector<int>{my_node}}
+    );
   });
 
   auto const root_node = 0;

--- a/tests/unit/objgroup/test_objgroup_common.h
+++ b/tests/unit/objgroup/test_objgroup_common.h
@@ -57,13 +57,6 @@ struct MyMsg : vt::Message {
   vt::NodeType from_ = vt::uninitialized_destination;
 };
 
-struct SysMsg : vt::collective::ReduceTMsg<int> {
-  SysMsg() = delete;
-  explicit SysMsg(int in_num)
-    : vt::collective::ReduceTMsg<int>(in_num)
-  {}
-};
-
 struct MyObjA {
 
   MyObjA() : id_(++next_id) {}
@@ -159,24 +152,6 @@ struct VectorPayload {
   }
 
   std::vector<int> vec_;
-};
-
-struct VecMsg : vt::collective::ReduceTMsg<VectorPayload> {
-  using MessageParentType = vt::collective::ReduceTMsg<VectorPayload>;
-  vt_msg_serialize_required(); // by VectorPayload
-
-  VecMsg() = default;
-
-  explicit VecMsg(int in_num) : ReduceTMsg<VectorPayload>() {
-    auto& vec = getVal().vec_;
-    vec.push_back(in_num);
-    vec.push_back(in_num + 1);
-  }
-
-  template <typename SerializerT>
-  void serialize(SerializerT& s) {
-    MessageParentType::serialize(s);
-  }
 };
 
 /*static*/ int MyObjA::next_id = 0;

--- a/tests/unit/pipe/test_callback_bcast.cc
+++ b/tests/unit/pipe/test_callback_bcast.cc
@@ -56,36 +56,25 @@ namespace vt { namespace tests { namespace unit { namespace bcast {
 using namespace vt;
 using namespace vt::tests::unit;
 
-struct CallbackMsg : vt::Message {
-  CallbackMsg() = default;
-  explicit CallbackMsg(Callback<> in_cb) : cb_(in_cb) { }
-
-  Callback<> cb_;
-};
-
 struct DataMsg : vt::Message {
   DataMsg() = default;
   DataMsg(int in_a, int in_b, int in_c) : a(in_a), b(in_b), c(in_c) { }
   int a = 0, b = 0, c = 0;
 };
 
-struct CallbackDataMsg : vt::Message {
-  CallbackDataMsg() = default;
-  explicit CallbackDataMsg(Callback<DataMsg> in_cb) : cb_(in_cb) { }
-
-  Callback<DataMsg> cb_;
-};
-
 static int32_t called = 0;
 
-struct TestCallbackBcast : TestParallelHarness {
-  static void testHandler(CallbackDataMsg* msg) {
-    msg->cb_.send(1,2,3);
-  }
-  static void testHandlerEmpty(CallbackMsg* msg) {
-    msg->cb_.send();
-  }
-};
+template <typename... Ts>
+void applyCallback(vt::Callback<Ts...> cb, Ts... ts) {
+  cb.send(ts...);
+}
+
+template <typename MsgT, typename... Ts>
+void applyCallbackMsg(vt::Callback<MsgT> cb, Ts... ts) {
+  cb.send(ts...);
+}
+
+using TestCallbackBcast = TestParallelHarness;
 
 static void callbackFn(DataMsg* msg) {
   EXPECT_EQ(msg->a, 1);
@@ -115,7 +104,7 @@ TEST_F(TestCallbackBcast, test_callback_bcast_1) {
   theCollective()->barrier();
 
   runInEpochCollective([&]{
-    auto cb = theCB()->makeBcast<DataMsg,callbackFn>();
+    auto cb = theCB()->makeBcast<callbackFn>();
     cb.send(1,2,3);
   });
 
@@ -157,10 +146,11 @@ TEST_F(TestCallbackBcast, test_callback_bcast_remote_1) {
   theCollective()->barrier();
 
   runInEpochCollective([&]{
-    auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
-    auto cb = theCB()->makeBcast<DataMsg,callbackFn>();
-    auto msg = makeMessage<CallbackDataMsg>(cb);
-    theMsg()->sendMsg<testHandler>(next, msg);
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeBcast<callbackFn>();
+    theMsg()->send<applyCallbackMsg<DataMsg, int, int, int>>(
+      vt::Node{next}, cb, 1, 2, 3
+    );
   });
 
   EXPECT_EQ(called, 100 * theContext()->getNumNodes());
@@ -175,10 +165,11 @@ TEST_F(TestCallbackBcast, test_callback_bcast_remote_2) {
   theCollective()->barrier();
 
   runInEpochCollective([&]{
-    auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeBcast<CallbackFunctor>();
-    auto msg = makeMessage<CallbackDataMsg>(cb);
-    theMsg()->sendMsg<testHandler>(next, msg);
+    theMsg()->send<applyCallbackMsg<DataMsg, int, int, int>>(
+      vt::Node{next}, cb, 1, 2, 3
+    );
   });
 
   EXPECT_EQ(called, 200 * theContext()->getNumNodes());
@@ -193,14 +184,140 @@ TEST_F(TestCallbackBcast, test_callback_bcast_remote_3) {
   theCollective()->barrier();
 
   runInEpochCollective([&]{
-    auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
     auto cb = theCB()->makeBcast<CallbackFunctorEmpty>();
-    auto msg = makeMessage<CallbackMsg>(cb);
-    theMsg()->sendMsg<testHandlerEmpty>(next, msg);
+    theMsg()->send<applyCallback<>>(vt::Node{next}, cb);
   });
 
   EXPECT_EQ(called, 300 * theContext()->getNumNodes());
 }
 
+static void callbackVoidFn() {
+  called = 100;
+}
+
+static void callbackParamFn(int a, int b) {
+  EXPECT_EQ(a, 10);
+  EXPECT_EQ(b, 20);
+  called = 100;
+}
+
+static void callbackParamSerFn(std::string a, int b) {
+  EXPECT_EQ(a, "hello");
+  EXPECT_EQ(b, 20);
+  called = 100;
+}
+
+struct CallbackVoidFn {
+  void operator()() {
+    called = 100;
+  }
+};
+
+struct CallbackParamFn {
+  void operator()(int a, int b) {
+    EXPECT_EQ(a, 10);
+    EXPECT_EQ(b, 20);
+    called = 100;
+  }
+};
+
+struct CallbackParamSerFn {
+  void operator()(std::string a, int b) {
+    EXPECT_EQ(a, "hello");
+    EXPECT_EQ(b, 20);
+    called = 100;
+  }
+};
+
+TEST_F(TestCallbackBcast, test_callback_bcast_param_1) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+
+  called = 0;
+
+  runInEpochCollective([this_node, num_nodes]{
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeBcast<callbackVoidFn>();
+    theMsg()->send<applyCallback<>>(vt::Node{next}, cb);
+  });
+
+  EXPECT_EQ(called, 100);
+}
+
+TEST_F(TestCallbackBcast, test_callback_bcast_param_2) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+
+  called = 0;
+
+  runInEpochCollective([this_node, num_nodes]{
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeBcast<callbackParamFn>();
+    theMsg()->send<applyCallback<int, int>>(vt::Node{next}, cb, 10, 20);
+  });
+
+  EXPECT_EQ(called, 100);
+}
+
+TEST_F(TestCallbackBcast, test_callback_bcast_param_3) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+
+  called = 0;
+
+  runInEpochCollective([this_node, num_nodes]{
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeBcast<callbackParamSerFn>();
+    theMsg()->send<applyCallback<std::string, int>>(vt::Node{next}, cb, "hello", 20);
+  });
+
+  EXPECT_EQ(called, 100);
+}
+
+TEST_F(TestCallbackBcast, test_callback_bcast_param_4) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+
+  called = 0;
+
+  runInEpochCollective([this_node, num_nodes]{
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeBcast<CallbackVoidFn>();
+    theMsg()->send<applyCallback<>>(vt::Node{next}, cb);
+  });
+
+  EXPECT_EQ(called, 100);
+}
+
+TEST_F(TestCallbackBcast, test_callback_bcast_param_5) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+
+  called = 0;
+
+  runInEpochCollective([this_node, num_nodes]{
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeBcast<CallbackParamFn>();
+    theMsg()->send<applyCallback<int, int>>(vt::Node{next}, cb, 10, 20);
+  });
+
+  EXPECT_EQ(called, 100);
+}
+
+TEST_F(TestCallbackBcast, test_callback_bcast_param_6) {
+  auto const& this_node = theContext()->getNode();
+  auto const& num_nodes = theContext()->getNumNodes();
+
+  called = 0;
+
+  runInEpochCollective([this_node, num_nodes]{
+    NodeType next = this_node + 1 < num_nodes ? this_node + 1 : 0;
+    auto cb = theCB()->makeBcast<CallbackParamSerFn>();
+    theMsg()->send<applyCallback<std::string, int>>(vt::Node{next}, cb, "hello", 20);
+  });
+
+  EXPECT_EQ(called, 100);
+}
 
 }}}} // end namespace vt::tests::unit::bcast

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -55,8 +55,6 @@ namespace vt { namespace tests { namespace unit { namespace send {
 using namespace vt;
 using namespace vt::tests::unit;
 
-struct TestColMsg;
-
 struct CallbackMsg : vt::Message {
   CallbackMsg() = default;
   explicit CallbackMsg(Callback<> in_cb) : cb_(in_cb) { }
@@ -90,9 +88,15 @@ struct TestCol : vt::Collection<TestCol, vt::Index1D> {
   TestCol() = default;
   virtual ~TestCol() = default;
 
-  void check(TestColMsg* msg) {
+  void check() {
     if (this->getIndex().x() % 2 == 0) {
       EXPECT_EQ(val, 29);
+    } else if (this->getIndex().x() % 3 == 0) {
+      EXPECT_EQ(val, 15);
+    } else if (this->getIndex().x() % 5 == 0) {
+      EXPECT_EQ(val, 21);
+    } else if (this->getIndex().x() % 7 == 0) {
+      EXPECT_EQ(val, 99);
     } else {
       EXPECT_EQ(val, 13);
     }
@@ -112,6 +116,18 @@ struct TestCol : vt::Collection<TestCol, vt::Index1D> {
     val = 13;
   }
 
+  void cb4(int a, int b) {
+    EXPECT_EQ(a, 8);
+    EXPECT_EQ(b, 9);
+    val = 15;
+  }
+
+  void cb5(std::string str, int a) {
+    EXPECT_EQ(a, 8);
+    EXPECT_EQ(str, "hello");
+    val = 21;
+  }
+
 public:
   int32_t val = 17;
 };
@@ -120,123 +136,42 @@ static void cb3(TestCol* col, DataMsg* msg) {
   EXPECT_EQ(msg->a, 8);
   EXPECT_EQ(msg->b, 9);
   EXPECT_EQ(msg->c, 10);
-  col->val = 13;
+  col->val = 99;
 }
-
-struct TestColMsg : ::vt::CollectionMessage<TestCol> {};
 
 TEST_F(TestCallbackSendCollection, test_callback_send_collection_1) {
   auto const& this_node = theContext()->getNode();
-  auto const& range = Index1D(32);
 
-  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
+  auto proxy = makeCollection<TestCol>("test_callback_send_collection_1")
+    .bulkInsert(Index1D(32))
+    .wait();
 
-  if (this_node == 0) {
-    proxy = theCollection()->construct<TestCol>(
-      range, "test_callback_send_collection_1"
-    );
-  }
-
-  runInEpochCollective([this_node, proxy]{
+  runInEpochCollective([&]{
     if (this_node == 0) {
       for (auto i = 0; i < 32; i++) {
         if (i % 2 == 0) {
-          auto cb =
-            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb1>(proxy(i));
+          auto cb = theCB()->makeSend<&TestCol::cb1>(proxy(i));
+          cb.send(8, 9, 10);
+        } else if (i % 3 == 0) {
+          auto cb = theCB()->makeSend<&TestCol::cb4>(proxy(i));
+          cb.send(8, 9);
+        } else if (i % 5 == 0) {
+          auto cb = theCB()->makeSend<&TestCol::cb5>(proxy(i));
+          cb.send("hello", 8);
+        } else if (i % 7 == 0) {
+          auto cb = theCB()->makeSend<cb3>(proxy(i));
           cb.send(8, 9, 10);
         } else {
-          auto cb =
-            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb2>(proxy(i));
+          auto cb = theCB()->makeSend<&TestCol::cb2>(proxy(i));
           cb.send(8, 9, 10);
         }
       }
     }
   });
 
-  runInEpochCollective([this_node, proxy]{
-    if (this_node == 0) {
-      proxy.broadcast<TestColMsg, &TestCol::check>();
-    }
+  runInEpochCollective([&]{
+    proxy.broadcastCollective<&TestCol::check>();
   });
 }
-
-TEST_F(TestCallbackSendCollection, test_callback_send_collection_2) {
-  auto const& this_node = theContext()->getNode();
-  auto const& num_nodes = theContext()->getNumNodes();
-
-  if (num_nodes < 2) {
-    return;
-  }
-
-  auto const& range = Index1D(32);
-
-  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
-
-  if (this_node == 0) {
-    proxy = theCollection()->construct<TestCol>(
-      range, "test_callback_send_collection_2"
-    );
-  }
-
-  runInEpochCollective([this_node, num_nodes, proxy]{
-    if (this_node == 0) {
-      for (auto i = 0; i < 32; i++) {
-        auto next = this_node + 1 < num_nodes ? this_node + 1 : 0;
-        if (i % 2 == 0) {
-          auto cb =
-            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb1>(proxy(i));
-          auto msg = makeMessage<CallbackDataMsg>(cb);
-          theMsg()->sendMsg<testHandler>(next, msg);
-        } else {
-          auto cb =
-            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb2>(proxy(i));
-          auto msg = makeMessage<CallbackDataMsg>(cb);
-          theMsg()->sendMsg<testHandler>(next, msg);
-        }
-      }
-    }
-  });
-
-  runInEpochCollective([this_node, proxy]{
-    if (this_node == 0) {
-      proxy.broadcast<TestColMsg, &TestCol::check>();
-    }
-  });
-}
-
-TEST_F(TestCallbackSendCollection, test_callback_send_collection_3) {
-  auto const& this_node = theContext()->getNode();
-  auto const& range = Index1D(32);
-
-  vt::CollectionProxy<TestCol, vt::Index1D> proxy;
-
-  if (this_node == 0) {
-    proxy = theCollection()->construct<TestCol>(
-      range, "test_callback_send_collection_3"
-    );
-  }
-
-  runInEpochCollective([this_node, proxy]{
-    if (this_node == 0) {
-      for (auto i = 0; i < 32; i++) {
-        if (i % 2 == 0) {
-          auto cb =
-            theCB()->makeSend<TestCol, DataMsg, &TestCol::cb1>(proxy(i));
-          cb.send(8, 9, 10);
-        } else {
-          auto cb = theCB()->makeSend<TestCol, DataMsg, cb3>(proxy(i));
-          cb.send(8, 9, 10);
-        }
-      }
-    }
-  });
-
-  runInEpochCollective([this_node, proxy]{
-    if (this_node == 0) {
-      proxy.broadcast<TestColMsg, &TestCol::check>();
-    }
-  });
-}
-
 
 }}}} // end namespace vt::tests::unit::send

--- a/tests/unit/pipe/test_callback_send_collection.extended.cc
+++ b/tests/unit/pipe/test_callback_send_collection.extended.cc
@@ -55,34 +55,13 @@ namespace vt { namespace tests { namespace unit { namespace send {
 using namespace vt;
 using namespace vt::tests::unit;
 
-struct CallbackMsg : vt::Message {
-  CallbackMsg() = default;
-  explicit CallbackMsg(Callback<> in_cb) : cb_(in_cb) { }
-
-  Callback<> cb_;
-};
-
 struct DataMsg : vt::Message {
   DataMsg() = default;
   DataMsg(int in_a, int in_b, int in_c) : a(in_a), b(in_b), c(in_c) { }
   int a = 0, b = 0, c = 0;
 };
 
-struct CallbackDataMsg : vt::Message {
-  CallbackDataMsg() = default;
-  explicit CallbackDataMsg(Callback<DataMsg> in_cb) : cb_(in_cb) { }
-
-  Callback<DataMsg> cb_;
-};
-
-struct TestCallbackSendCollection : TestParallelHarness {
-  static void testHandler(CallbackDataMsg* msg) {
-    msg->cb_.send(8,9,10);
-  }
-  static void testHandlerEmpty(CallbackMsg* msg) {
-    msg->cb_.send();
-  }
-};
+using TestCallbackSendCollection = TestParallelHarness;
 
 struct TestCol : vt::Collection<TestCol, vt::Index1D> {
   TestCol() = default;

--- a/tests/unit/termination/test_term_chaining.cc
+++ b/tests/unit/termination/test_term_chaining.cc
@@ -173,7 +173,7 @@ struct TestTermChaining : TestParallelHarness {
     EpochType epoch2 = theTerm()->makeEpochCollective();
     vt::theMsg()->pushEpoch(epoch2);
     auto msg2 = makeMessage<ChainReduceMsg>(theContext()->getNode());
-    auto cb = vt::theCB()->makeSend<ChainReduceMsg, test_handler_reduce>( 0 );
+    auto cb = vt::theCB()->makeSend<test_handler_reduce>( 0 );
     chain.add(epoch2, theCollective()->global()->reduce< vt::collective::None >(0, msg2.get(), cb));
     vt::theMsg()->popEpoch(epoch2);
     vt::theTerm()->finishedEpoch(epoch2);
@@ -195,7 +195,7 @@ struct TestTermChaining : TestParallelHarness {
     EpochType epoch2 = theTerm()->makeEpochRooted();
     vt::theMsg()->pushEpoch(epoch2);
     auto msg2 = makeMessage<ChainReduceMsg>(theContext()->getNode());
-    auto cb = vt::theCB()->makeSend<ChainReduceMsg, test_handler_reduce>( 0 );
+    auto cb = vt::theCB()->makeSend<test_handler_reduce>( 0 );
     chain.add(epoch2, theCollective()->global()->reduce< vt::collective::None >(0, msg2.get(), cb));
     vt::theMsg()->popEpoch(epoch2);
     vt::theTerm()->finishedEpoch(epoch2);

--- a/tests/unit/termination/test_term_dep_send_chain.cc
+++ b/tests/unit/termination/test_term_dep_send_chain.cc
@@ -365,7 +365,7 @@ struct MyObjGroup {
       auto num = vt::theContext()->getNumNodes();
       auto next = node + 1 < num ? node + 1 : 0;
       auto proxy = frontend_proxy_(next);
-      auto c = vt::theCB()->makeSend<MyObjGroup,OpIdxMsg,&MyObjGroup::op4Impl>(proxy);
+      auto c = vt::theCB()->makeSend<&MyObjGroup::op4Impl>(proxy);
       return backend_proxy_(idx).template send<ProxyMsg, &MyCol::op4>(c);
     });
   }

--- a/tutorial/tutorial_1g.h
+++ b/tutorial/tutorial_1g.h
@@ -105,27 +105,27 @@ static inline void activeMessageCallback() {
     NodeType const cb_node = 0;
 
     // Example lambda callback (void)
-    auto void_fn = [=]{
-      ::fmt::print("{}: triggering void function callback\n", this_node);
+    auto fn = [=](DataMsg* msg){
+      ::fmt::print("{}: triggering function callback\n", this_node);
     };
 
     // Example of a void lambda callback
     {
-      auto cb = ::vt::theCB()->makeFunc(vt::pipe::LifetimeEnum::Once, void_fn);
+      auto cb = ::vt::theCB()->makeFunc<DataMsg>(vt::pipe::LifetimeEnum::Once, fn);
       auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
       ::vt::theMsg()->sendMsg<getCallbackHandler>(to_node, msg);
     }
 
     // Example of active message handler callback with send node
     {
-      auto cb = ::vt::theCB()->makeSend<DataMsg,callbackHandler>(cb_node);
+      auto cb = ::vt::theCB()->makeSend<callbackHandler>(cb_node);
       auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
       ::vt::theMsg()->sendMsg<getCallbackHandler>(to_node, msg);
     }
 
     // Example of active message handler callback with broadcast
     {
-      auto cb = ::vt::theCB()->makeBcast<DataMsg,callbackBcastHandler>();
+      auto cb = ::vt::theCB()->makeBcast<callbackBcastHandler>();
       auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
       ::vt::theMsg()->sendMsg<getCallbackHandler>(to_node, msg);
     }

--- a/tutorial/tutorial_1g.h
+++ b/tutorial/tutorial_1g.h
@@ -46,44 +46,23 @@
 namespace vt { namespace tutorial {
 
 /// [Tutorial1G]
-//              VT Base Message
-//             \----------------/
-//              \              /
-struct DataMsg : ::vt::Message { };
-
-struct MsgWithCallback : ::vt::Message {
-  MsgWithCallback() = default;
-  explicit MsgWithCallback(Callback<DataMsg> in_cb) : cb(in_cb) {}
-
-  Callback<DataMsg> cb;
-};
-
 
 // Forward declaration for the active message handler
-static void getCallbackHandler(MsgWithCallback* msg);
+static void getCallbackHandler(Callback<int> cb);
 
 // An active message handler used as the target for a callback
-static void callbackHandler(DataMsg* msg) {
+static void callbackHandler(int data) {
   NodeType const cur_node = ::vt::theContext()->getNode();
-  ::fmt::print("{}: triggering active message callback\n", cur_node);
+  ::fmt::print("{}: triggering active message callback: {}\n", cur_node, data);
 }
 
 // An active message handler used as the target for a callback
-static void callbackBcastHandler(DataMsg* msg) {
+static void callbackBcastHandler(int data) {
   NodeType const cur_node = ::vt::theContext()->getNode();
-  ::fmt::print("{}: triggering active message callback bcast\n", cur_node);
+  ::fmt::print(
+    "{}: triggering active message callback bcast: {}\n", cur_node, data
+  );
 }
-
-// A simple context object
-struct MyContext { };
-static MyContext ctx = {};
-
-// A message handler with context used as the target for a callback
-static void callbackCtx(DataMsg* msg, MyContext* cbctx) {
-  NodeType const cur_node = ::vt::theContext()->getNode();
-  ::fmt::print("{}: triggering context callback\n", cur_node);
-}
-
 
 // Tutorial code to demonstrate using a callback
 static inline void activeMessageCallback() {
@@ -104,50 +83,27 @@ static inline void activeMessageCallback() {
     // Node that we want to callback to execute on
     NodeType const cb_node = 0;
 
-    // Example lambda callback (void)
-    auto fn = [=](DataMsg* msg){
-      ::fmt::print("{}: triggering function callback\n", this_node);
-    };
-
-    // Example of a void lambda callback
-    {
-      auto cb = ::vt::theCB()->makeFunc<DataMsg>(vt::pipe::LifetimeEnum::Once, fn);
-      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<getCallbackHandler>(to_node, msg);
-    }
-
     // Example of active message handler callback with send node
     {
       auto cb = ::vt::theCB()->makeSend<callbackHandler>(cb_node);
-      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<getCallbackHandler>(to_node, msg);
+      ::vt::theMsg()->send<getCallbackHandler>(Node{to_node}, cb);
     }
 
     // Example of active message handler callback with broadcast
     {
       auto cb = ::vt::theCB()->makeBcast<callbackBcastHandler>();
-      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<getCallbackHandler>(to_node, msg);
-    }
-
-    // Example of context callback
-    {
-      auto cb = ::vt::theCB()->makeFunc<DataMsg,MyContext>(
-        vt::pipe::LifetimeEnum::Once, &ctx, callbackCtx
-      );
-      auto msg = ::vt::makeMessage<MsgWithCallback>(cb);
-      ::vt::theMsg()->sendMsg<getCallbackHandler>(to_node, msg);
+      ::vt::theMsg()->send<getCallbackHandler>(Node{to_node}, cb);
     }
   }
 }
 
 // Message handler for to receive callback and invoke it
-static void getCallbackHandler(MsgWithCallback* msg) {
+static void getCallbackHandler(Callback<int> cb) {
   auto const cur_node = ::vt::theContext()->getNode();
   ::fmt::print("getCallbackHandler: triggered on node={}\n", cur_node);
 
   // Send the callback a message
-  msg->cb.send();
+  cb.send(29 + cur_node);
 }
 /// [Tutorial1G]
 

--- a/tutorial/tutorial_2b.h
+++ b/tutorial/tutorial_2b.h
@@ -82,9 +82,11 @@ void ReduceCol::reduceHandler() {
   proxy.allreduce<&ReduceCol::reduceTarget>(val);
 }
 
+int number_of_elements = 32;
+
 void ReduceCol::reduceTarget(int value) {
   fmt::print("collection reduce value={}\n", value);
-  assert(32 * 100 == value);
+  assert(number_of_elements * 100 == value);
 
 }
 
@@ -99,8 +101,8 @@ static inline void collectionReduce() {
    */
 
   if (this_node == 0) {
-    // Range of 32 elements for the collection
-    auto range = vt::Index1D(32);
+    // Range of `number_of_elements` elements for the collection
+    auto range = vt::Index1D(number_of_elements);
 
     // Construct the collection in a rooted manner. By default, the elements
     // will be block mapped to the nodes

--- a/tutorial/tutorial_2b.h
+++ b/tutorial/tutorial_2b.h
@@ -79,7 +79,7 @@ void ReduceCol::reduceHandler() {
   int val = 100;
 
   // Invoke the reduce!
-  proxy.allreduce<&ReduceCol::reduceTarget>(val);
+  proxy.allreduce<&ReduceCol::reduceTarget, collective::PlusOp>(val);
 }
 
 int number_of_elements = 32;


### PR DESCRIPTION
Fixes #276

This replaces the current proxy.reduce syntax with three calls that are symmetrical across object groups and collections.

```C++
proxy.allreduce<&MyCol::handler, collective::PlusOp>(value1, value2);
proxy.reduce<&MyCol::handler, collective::PlusOp>(proxy[1], value1, value2);
proxy.reduce<collective::PlusOp>(some_callback, value1, value2);
```