### PR TITLE
#2138: CI: Change concurrency to use PR number instead of branch name

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
     types: comment-pr
 
-concurrency: ${{ github.event.repository.name }}-${{ github.ref }}
+concurrency: ${{ github.event.repository.name }}-${{ github.event.client_payload.pr_number }}
 
 jobs:
   comment-on-pr:


### PR DESCRIPTION
Fixes #2138 

Revert back change made in https://github.com/DARMA-tasking/vt/commit/baa8413712361f9bb01f1d30b9d2e3379f7ff3bf