### PR TITLE
#2168: LB: Consistently use `LoadType` for load related variables

### DIFF
--- a/src/vt/configs/types/types_type.h
+++ b/src/vt/configs/types/types_type.h
@@ -101,6 +101,8 @@ using GroupType               = uint64_t;
 using MsgSizeType             = int64_t;
 /// Used for hold a phase for load balancing
 using PhaseType               = uint64_t;
+/// LoadType used for load balancing
+using LoadType                = double;
 /// Used for hold a sub-phase for load balancing
 using SubphaseType            = uint16_t;
 /// Used for hold the identifier for a pipe (callbacks)

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -66,7 +66,7 @@ std::shared_ptr<const balance::Reassignment> BaseLB::startLB(
   balance::LoadModel* model,
   StatisticMapType const& in_stats,
   ElementCommType const& in_comm_lb_data,
-  TimeType total_load,
+  LoadType total_load,
   balance::DataMapType const& in_data_map
 ) {
   start_time_ = timing::getCurrentTime();
@@ -86,7 +86,7 @@ std::shared_ptr<const balance::Reassignment> BaseLB::startLB(
 }
 
 /*static*/
-BaseLB::LoadType BaseLB::loadMilli(LoadType const& load) {
+LoadType BaseLB::loadMilli(LoadType const& load) {
   // Convert `load` in seconds to milliseconds, typically for binning purposes
   return load * 1000;
 }
@@ -251,7 +251,7 @@ void BaseLB::finalize(int32_t global_count) {
 
   auto const& this_node = theContext()->getNode();
   if (this_node == 0) {
-    TimeTypeWrapper const total_time = timing::getCurrentTime() - start_time_;
+    auto const total_time = timing::getCurrentTime() - start_time_;
     vt_debug_print(
       terse, lb,
       "BaseLB::finalize: LB total time={}\n",

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -68,12 +68,11 @@ struct CommMsg;
 
 struct BaseLB {
   using ObjIDType        = balance::ElementIDStruct;
-  using ElementLoadType  = std::unordered_map<ObjIDType,TimeType>;
+  using ElementLoadType  = std::unordered_map<ObjIDType,LoadType>;
   using ElementCommType  = elm::CommMapType;
   using TransferDestType = std::tuple<ObjIDType,NodeType>;
   using TransferVecType  = std::vector<TransferDestType>;
   using TransferType     = std::map<NodeType, TransferVecType>;
-  using LoadType         = double;
   using MigrationCountCB = std::function<void(int32_t)>;
   using QuantityType     = std::map<lb::StatisticQuantity, double>;
   using StatisticMapType = std::unordered_map<lb::Statistic, QuantityType>;
@@ -119,7 +118,7 @@ struct BaseLB {
     balance::LoadModel *model,
     StatisticMapType const& in_stats,
     ElementCommType const& in_comm_lb_data,
-    TimeType total_load,
+    LoadType total_load,
     balance::DataMapType const& in_data_map
   );
 
@@ -154,7 +153,7 @@ struct BaseLB {
   void finalize(int32_t global_count);
 
   virtual void inputParams(balance::ConfigEntry* config) = 0;
-  virtual void runLB(TimeType total_load) = 0;
+  virtual void runLB(LoadType total_load) = 0;
 
   StatisticMapType const* getStats() const {
     return base_stats_;

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.cc
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.cc
@@ -143,7 +143,7 @@ void GreedyLB::inputParams(balance::ConfigEntry* config) {
   strat_ = strategy_converter_.getFromConfig(config, strat_);
 }
 
-void GreedyLB::runLB(TimeType total_load) {
+void GreedyLB::runLB(LoadType total_load) {
   this_load = loadMilli(total_load);
   buildHistogram();
   loadStats();

--- a/src/vt/vrt/collection/balance/greedylb/greedylb.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb.h
@@ -72,16 +72,15 @@ enum struct DataDistStrategy : uint8_t {
 };
 
 struct GreedyLB : LoadSamplerBaseLB {
-  using ElementLoadType  = std::unordered_map<ObjIDType,TimeType>;
+  using ElementLoadType  = std::unordered_map<ObjIDType,LoadType>;
   using TransferType     = std::map<NodeType, std::vector<ObjIDType>>;
-  using LoadType         = double;
   using LoadProfileType  = std::unordered_map<NodeType,LoadType>;
 
   GreedyLB() = default;
   virtual ~GreedyLB() {}
 
   void init(objgroup::proxy::Proxy<GreedyLB> in_proxy);
-  void runLB(TimeType total_load) override;
+  void runLB(LoadType total_load) override;
   void inputParams(balance::ConfigEntry* config) override;
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp();

--- a/src/vt/vrt/collection/balance/greedylb/greedylb_types.h
+++ b/src/vt/vrt/collection/balance/greedylb/greedylb_types.h
@@ -59,13 +59,11 @@ struct GreedyLBTypes {
   using ObjBinType = int32_t;
   using ObjBinListType = std::list<ObjIDType>;
   using ObjSampleType = std::map<ObjBinType, ObjBinListType>;
-  using LoadType = double;
   using LoadProfileType = std::unordered_map<NodeType,LoadType>;
 };
 
 struct GreedyRecord {
   using ObjType = GreedyLBTypes::ObjIDType;
-  using LoadType = GreedyLBTypes::LoadType;
 
   GreedyRecord(ObjType const& in_obj, LoadType const& in_load)
     : obj_(in_obj), load_(in_load)
@@ -76,19 +74,19 @@ struct GreedyRecord {
 
 private:
   GreedyLBTypes::ObjIDType obj_ = { elm::no_element_id, uninitialized_destination };
-  LoadType load_ = 0.0f;
+  LoadType load_ = 0.0;
 };
 
 struct GreedyProc {
   GreedyProc() = default;
   GreedyProc(
-    NodeType const& in_node, GreedyLBTypes::LoadType const& in_load
+    NodeType const& in_node, LoadType const& in_load
   ) : node_(in_node), load_(in_load) {}
 
-  GreedyLBTypes::LoadType getModeledLoad() const { return load_; }
+  LoadType getModeledLoad() const { return load_; }
 
   NodeType node_ = uninitialized_destination;
-  GreedyLBTypes::LoadType load_ = 0.0f;
+  LoadType load_ = 0.0;
   std::vector<GreedyLBTypes::ObjIDType> recs_;
 };
 

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.cc
@@ -788,7 +788,7 @@ void HierarchicalLB::clearObj(ObjSampleType& objs) {
   }
 }
 
-void HierarchicalLB::runLB(TimeType total_load) {
+void HierarchicalLB::runLB(LoadType total_load) {
   this_load = loadMilli(total_load);
   buildHistogram();
   setupTree(min_threshold);

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb.h
@@ -65,15 +65,14 @@ namespace vt { namespace vrt { namespace collection { namespace lb {
 struct HierarchicalLB : LoadSamplerBaseLB {
   using ChildPtrType = std::unique_ptr<HierLBChild>;
   using ChildMapType = std::unordered_map<NodeType,ChildPtrType>;
-  using ElementLoadType = std::unordered_map<ObjIDType,TimeType>;
+  using ElementLoadType = std::unordered_map<ObjIDType,LoadType>;
   using TransferType = std::map<NodeType, std::vector<ObjIDType>>;
-  using LoadType = double;
 
   HierarchicalLB() = default;
   virtual ~HierarchicalLB() {}
 
   void init(objgroup::proxy::Proxy<HierarchicalLB> in_proxy);
-  void runLB(TimeType total_load) override;
+  void runLB(LoadType total_load) override;
   void inputParams(balance::ConfigEntry* config) override;
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp();

--- a/src/vt/vrt/collection/balance/hierarchicallb/hierlb_msgs.h
+++ b/src/vt/vrt/collection/balance/hierarchicallb/hierlb_msgs.h
@@ -56,8 +56,6 @@ struct LBTreeUpMsg : HierLBTypes, ::vt::Message {
   using MessageParentType = ::vt::Message;
   vt_msg_serialize_required(); // prev. serialize(1)
 
-  using LoadType = double;
-
   LBTreeUpMsg() = default;
   LBTreeUpMsg(
     LoadType const in_child_load, NodeType const in_child,
@@ -88,8 +86,6 @@ private:
 struct LBTreeDownMsg : HierLBTypes, ::vt::Message {
   using MessageParentType = ::vt::Message;
   vt_msg_serialize_required(); // prev. serialize(1)
-
-  using LoadType = double;
 
   LBTreeDownMsg() = default;
   LBTreeDownMsg(

--- a/src/vt/vrt/collection/balance/lb_common.h
+++ b/src/vt/vrt/collection/balance/lb_common.h
@@ -85,10 +85,10 @@ struct PhaseOffset {
 };
 
 struct LoadSummary {
-  TimeType whole_phase_load = 0.0;
-  std::vector<TimeType> subphase_loads = {};
+  LoadType whole_phase_load = 0.0;
+  std::vector<LoadType> subphase_loads = {};
 
-  TimeType get(PhaseOffset when) const
+  LoadType get(PhaseOffset when) const
   {
     if (when.subphase == PhaseOffset::WHOLE_PHASE)
       return whole_phase_load;
@@ -113,7 +113,7 @@ struct LoadSummary {
 };
 
 using LoadMapType         = std::unordered_map<ElementIDStruct, LoadSummary>;
-using SubphaseLoadMapType = std::unordered_map<ElementIDStruct, std::vector<TimeType>>;
+using SubphaseLoadMapType = std::unordered_map<ElementIDStruct, std::vector<LoadType>>;
 
 /// User-defined LB values map
 using DataMapType         = std::unordered_map<

--- a/src/vt/vrt/collection/balance/lb_data_holder.cc
+++ b/src/vt/vrt/collection/balance/lb_data_holder.cc
@@ -135,7 +135,7 @@ std::unique_ptr<nlohmann::json> LBDataHolder::toJson(PhaseType phase) const {
   if (node_data_.find(phase) != node_data_.end()) {
     for (auto&& elm : node_data_.at(phase)) {
       ElementIDStruct id = elm.first;
-      TimeType time = elm.second.whole_phase_load;
+      LoadType time = elm.second.whole_phase_load;
       j["tasks"][i]["resource"] = "cpu";
       j["tasks"][i]["node"] = id.getCurrNode();
       j["tasks"][i]["time"] = time;

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -641,7 +641,7 @@ void LBManager::computeStatistics(
     total_load_from_model += work;
   }
 
-  TimeType total_load_raw = 0.;
+  LoadType total_load_raw = 0.;
   std::vector<balance::LoadData> obj_load_raw;
   if (model->hasRawLoad()) {
     for (auto elm : *model) {

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -287,7 +287,7 @@ private:
   std::shared_ptr<LoadModel> strategy_specific_model_;
   std::unordered_map<std::string, LBProxyType> lb_instances_;
   StatisticMapType stats;
-  TimeType total_load_from_model = 0.;
+  LoadType total_load_from_model = 0.;
   std::unique_ptr<lb::PhaseInfo> last_phase_info_ = nullptr;
   bool before_lb_stats_ = true;
   /// The appender for outputting statistics in JSON format

--- a/src/vt/vrt/collection/balance/model/comm_overhead.cc
+++ b/src/vt/vrt/collection/balance/model/comm_overhead.cc
@@ -47,8 +47,8 @@
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
 CommOverhead::CommOverhead(
-  std::shared_ptr<balance::LoadModel> base, TimeType in_per_msg_weight,
-  TimeType in_per_byte_weight
+  std::shared_ptr<balance::LoadModel> base, LoadType in_per_msg_weight,
+  LoadType in_per_byte_weight
 ) : ComposedModel(base),
     per_msg_weight_(in_per_msg_weight),
     per_byte_weight_(in_per_byte_weight)
@@ -60,14 +60,14 @@ void CommOverhead::setLoads(std::unordered_map<PhaseType, LoadMapType> const* pr
   ComposedModel::setLoads(proc_load, proc_comm);
 }
 
-TimeType
+LoadType
 CommOverhead::getModeledLoad(ElementIDStruct object, PhaseOffset offset) const {
   auto work = ComposedModel::getModeledLoad(object, offset);
 
   auto phase = getNumCompletedPhases() + offset.phases;
   auto& comm = proc_comm_->at(phase);
 
-  TimeType overhead = 0.;
+  LoadType overhead = 0.;
   for (auto&& c : comm) {
     // find messages that go off-node and are sent to this object
     if (c.first.offNode() and c.first.toObj() == object) {

--- a/src/vt/vrt/collection/balance/model/comm_overhead.h
+++ b/src/vt/vrt/collection/balance/model/comm_overhead.h
@@ -61,19 +61,19 @@ struct CommOverhead : public ComposedModel {
    * \param[in] in_per_byte_weight weight to add per byte received
    */
   explicit CommOverhead(
-    std::shared_ptr<balance::LoadModel> base, TimeType in_per_msg_weight,
-    TimeType in_per_byte_weight
+    std::shared_ptr<balance::LoadModel> base, LoadType in_per_msg_weight,
+    LoadType in_per_byte_weight
   );
 
   void setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
                 std::unordered_map<PhaseType, CommMapType> const* proc_comm) override;
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
 
 private:
   std::unordered_map<PhaseType, CommMapType> const* proc_comm_; /**< Underlying comm data */
-  TimeType per_msg_weight_ = 0.001;           /**< Cost per message */
-  TimeType per_byte_weight_ = 0.000001;       /**< Cost per bytes */
+  LoadType per_msg_weight_ = 0.001;           /**< Cost per message */
+  LoadType per_byte_weight_ = 0.000001;       /**< Cost per bytes */
 }; // class CommOverhead
 
 }}}} // end namespace

--- a/src/vt/vrt/collection/balance/model/composed_model.cc
+++ b/src/vt/vrt/collection/balance/model/composed_model.cc
@@ -54,12 +54,12 @@ void ComposedModel::updateLoads(PhaseType last_completed_phase) {
   base_->updateLoads(last_completed_phase);
 }
 
-TimeType
+LoadType
 ComposedModel::getModeledLoad(ElementIDStruct object, PhaseOffset when) const {
   return base_->getModeledLoad(object, when);
 }
 
-TimeType
+LoadType
 ComposedModel::getModeledComm(ElementIDStruct object, PhaseOffset when) const {
   return base_->getModeledComm(object, when);
 }
@@ -68,7 +68,7 @@ bool ComposedModel::hasRawLoad() const {
   return base_->hasRawLoad();
 }
 
-TimeType ComposedModel::getRawLoad(ElementIDStruct object, PhaseOffset when) const {
+LoadType ComposedModel::getRawLoad(ElementIDStruct object, PhaseOffset when) const {
   return base_->getRawLoad(object, when);
 }
 

--- a/src/vt/vrt/collection/balance/model/composed_model.h
+++ b/src/vt/vrt/collection/balance/model/composed_model.h
@@ -69,10 +69,10 @@ public:
 
   void updateLoads(PhaseType last_completed_phase) override;
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
-  TimeType getModeledComm(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledComm(ElementIDStruct object, PhaseOffset when) const override;
   bool hasRawLoad() const override;
-  TimeType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 
   ObjectIterator begin() const override;

--- a/src/vt/vrt/collection/balance/model/linear_model.cc
+++ b/src/vt/vrt/collection/balance/model/linear_model.cc
@@ -48,7 +48,7 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-TimeType LinearModel::getModeledLoad(ElementIDStruct object, PhaseOffset when) const {
+LoadType LinearModel::getModeledLoad(ElementIDStruct object, PhaseOffset when) const {
   using util::stats::LinearRegression;
 
   // Retrospective queries don't call for a prediction

--- a/src/vt/vrt/collection/balance/model/linear_model.h
+++ b/src/vt/vrt/collection/balance/model/linear_model.h
@@ -69,7 +69,7 @@ struct LinearModel : ComposedModel {
       past_len_(in_past_len)
   { }
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 
 private:

--- a/src/vt/vrt/collection/balance/model/load_model.h
+++ b/src/vt/vrt/collection/balance/model/load_model.h
@@ -225,7 +225,7 @@ struct LoadModel
    * The `updateLoads` method must have been called before any call to
    * this.
    */
-  virtual TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const = 0;
+  virtual LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const = 0;
 
   /**
    * \brief Whether or not the model is based on the RawData model
@@ -240,7 +240,7 @@ struct LoadModel
    *
    * \return How much computation time the object required
    */
-  virtual TimeType getRawLoad(ElementIDStruct object, PhaseOffset when) const {
+  virtual LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const {
     vtAbort(
       "LoadModel::getRawLoad() called on a model that does not implement it"
     );
@@ -259,7 +259,7 @@ struct LoadModel
    * The `updateLoads` method must have been called before any call to
    * this.
    */
-  virtual TimeType getModeledComm(ElementIDStruct object, PhaseOffset when) const {
+  virtual LoadType getModeledComm(ElementIDStruct object, PhaseOffset when) const {
     return {};
   }
 

--- a/src/vt/vrt/collection/balance/model/multiple_phases.cc
+++ b/src/vt/vrt/collection/balance/model/multiple_phases.cc
@@ -45,13 +45,13 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-TimeType
+LoadType
 MultiplePhases::getModeledLoad(ElementIDStruct object, PhaseOffset when) const {
   // Retrospective queries don't call for a prediction
   if (when.phases < 0)
     return ComposedModel::getModeledLoad(object, when);
 
-  TimeType sum = 0.0;
+  LoadType sum = 0.0;
   for (int i = 0; i < future_phase_block_size_; ++i) {
     PhaseOffset p{future_phase_block_size_*when.phases + i,
                   when.subphase};

--- a/src/vt/vrt/collection/balance/model/multiple_phases.h
+++ b/src/vt/vrt/collection/balance/model/multiple_phases.h
@@ -79,7 +79,7 @@ struct MultiplePhases : ComposedModel {
     , future_phase_block_size_(in_future_phase_block_size)
   { }
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
 
 private:
   int future_phase_block_size_ = 0;

--- a/src/vt/vrt/collection/balance/model/naive_persistence.cc
+++ b/src/vt/vrt/collection/balance/model/naive_persistence.cc
@@ -50,7 +50,7 @@ NaivePersistence::NaivePersistence(std::shared_ptr<balance::LoadModel> base)
   : ComposedModel(base)
 { }
 
-TimeType
+LoadType
 NaivePersistence::getModeledLoad(ElementIDStruct object, PhaseOffset offset) const {
   if (offset.phases >= 0)
     offset.phases = -1;
@@ -58,7 +58,7 @@ NaivePersistence::getModeledLoad(ElementIDStruct object, PhaseOffset offset) con
   return ComposedModel::getModeledLoad(object, offset);
 }
 
-TimeType NaivePersistence::getRawLoad(ElementIDStruct object, PhaseOffset offset) const
+LoadType NaivePersistence::getRawLoad(ElementIDStruct object, PhaseOffset offset) const
 {
   if (offset.phases >= 0)
     offset.phases = -1;

--- a/src/vt/vrt/collection/balance/model/naive_persistence.h
+++ b/src/vt/vrt/collection/balance/model/naive_persistence.h
@@ -60,8 +60,8 @@ struct NaivePersistence : public ComposedModel {
    * \param[in] base: The source of underlying load numbers to return; must not be null
    */
   explicit NaivePersistence(std::shared_ptr<balance::LoadModel> base);
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
-  TimeType getRawLoad(ElementIDStruct object, PhaseOffset offset) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getRawLoad(ElementIDStruct object, PhaseOffset offset) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 }; // class NaivePersistence
 

--- a/src/vt/vrt/collection/balance/model/norm.cc
+++ b/src/vt/vrt/collection/balance/model/norm.cc
@@ -55,7 +55,7 @@ Norm::Norm(std::shared_ptr<balance::LoadModel> base, double power)
   vtAssert(power >= 0.0, "Reciprocal loads make no sense");
 }
 
-TimeType Norm::getModeledLoad(ElementIDStruct object, PhaseOffset offset) const {
+LoadType Norm::getModeledLoad(ElementIDStruct object, PhaseOffset offset) const {
   if (offset.subphase != PhaseOffset::WHOLE_PHASE)
     return ComposedModel::getModeledLoad(object, offset);
 

--- a/src/vt/vrt/collection/balance/model/norm.h
+++ b/src/vt/vrt/collection/balance/model/norm.h
@@ -64,7 +64,7 @@ public:
    */
   Norm(std::shared_ptr<balance::LoadModel> base, double power);
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
 
 private:
   const double power_;

--- a/src/vt/vrt/collection/balance/model/per_collection.cc
+++ b/src/vt/vrt/collection/balance/model/per_collection.cc
@@ -68,7 +68,7 @@ void PerCollection::updateLoads(PhaseType last_completed_phase) {
   ComposedModel::updateLoads(last_completed_phase);
 }
 
-TimeType
+LoadType
 PerCollection::getModeledLoad(ElementIDStruct object, PhaseOffset when) const {
   // See if some specific model has been given for the object in question
   auto mi = models_.find(theNodeLBData()->getCollectionProxyForElement(object));
@@ -90,7 +90,7 @@ bool PerCollection::hasRawLoad() const {
   return has_raw_load and ComposedModel::hasRawLoad();
 }
 
-TimeType PerCollection::getRawLoad(ElementIDStruct object, PhaseOffset when) const {
+LoadType PerCollection::getRawLoad(ElementIDStruct object, PhaseOffset when) const {
   // See if some specific model has been given for the object in question
   auto mi = models_.find(theNodeLBData()->getCollectionProxyForElement(object));
   if (mi != models_.end())

--- a/src/vt/vrt/collection/balance/model/per_collection.h
+++ b/src/vt/vrt/collection/balance/model/per_collection.h
@@ -78,9 +78,9 @@ struct PerCollection : public ComposedModel
 
   void updateLoads(PhaseType last_completed_phase) override;
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   bool hasRawLoad() const override;
-  TimeType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 
 private:

--- a/src/vt/vrt/collection/balance/model/persistence_median_last_n.cc
+++ b/src/vt/vrt/collection/balance/model/persistence_median_last_n.cc
@@ -54,7 +54,7 @@ PersistenceMedianLastN::PersistenceMedianLastN(std::shared_ptr<LoadModel> base, 
   vtAssert(n > 0, "Cannot take a median over no phases");
 }
 
-TimeType PersistenceMedianLastN::getModeledLoad(
+LoadType PersistenceMedianLastN::getModeledLoad(
   ElementIDStruct object, PhaseOffset when
 ) const {
   // Retrospective queries don't call for a prospective calculation
@@ -62,10 +62,10 @@ TimeType PersistenceMedianLastN::getModeledLoad(
     return ComposedModel::getModeledLoad(object, when);
 
   unsigned int phases = std::min(n_, getNumCompletedPhases());
-  std::vector<TimeType> times(phases);
+  std::vector<LoadType> times(phases);
   for (unsigned int i = 1; i <= phases; ++i) {
     PhaseOffset p{-1*static_cast<int>(i), when.subphase};
-    TimeType t = ComposedModel::getModeledLoad(object, p);
+    LoadType t = ComposedModel::getModeledLoad(object, p);
     times[i-1] = t;
   }
 

--- a/src/vt/vrt/collection/balance/model/persistence_median_last_n.h
+++ b/src/vt/vrt/collection/balance/model/persistence_median_last_n.h
@@ -65,7 +65,7 @@ struct PersistenceMedianLastN : public ComposedModel
    */
   PersistenceMedianLastN(std::shared_ptr<LoadModel> base, unsigned int n);
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 
 private:

--- a/src/vt/vrt/collection/balance/model/proposed_reassignment.cc
+++ b/src/vt/vrt/collection/balance/model/proposed_reassignment.cc
@@ -93,7 +93,7 @@ int ProposedReassignment::getNumObjects() const
   return base - departing + arriving;
 }
 
-TimeType
+LoadType
 ProposedReassignment::getModeledLoad(ElementIDStruct object, PhaseOffset when) const {
   auto a = reassignment_->arrive_.find(object);
   if (a != reassignment_->arrive_.end()) {
@@ -107,7 +107,7 @@ ProposedReassignment::getModeledLoad(ElementIDStruct object, PhaseOffset when) c
   return ComposedModel::getModeledLoad(object, when);
 }
 
-TimeType ProposedReassignment::getRawLoad(ElementIDStruct object, PhaseOffset when) const
+LoadType ProposedReassignment::getRawLoad(ElementIDStruct object, PhaseOffset when) const
 {
   auto a = reassignment_->arrive_.find(object);
   if (a != reassignment_->arrive_.end()) {

--- a/src/vt/vrt/collection/balance/model/proposed_reassignment.h
+++ b/src/vt/vrt/collection/balance/model/proposed_reassignment.h
@@ -57,8 +57,8 @@ struct ProposedReassignment : public ComposedModel {
 
   ObjectIterator begin() const override;
   int getNumObjects() const override;
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
-  TimeType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
 
 private:
   std::shared_ptr<const Reassignment> reassignment_;

--- a/src/vt/vrt/collection/balance/model/raw_data.cc
+++ b/src/vt/vrt/collection/balance/model/raw_data.cc
@@ -94,11 +94,11 @@ int RawData::getNumSubphases() const {
   return subphases;
 }
 
-TimeType RawData::getModeledLoad(ElementIDStruct object, PhaseOffset offset) const {
+LoadType RawData::getModeledLoad(ElementIDStruct object, PhaseOffset offset) const {
   return getRawLoad(object, offset);
 }
 
-TimeType RawData::getRawLoad(ElementIDStruct object, PhaseOffset offset) const {
+LoadType RawData::getRawLoad(ElementIDStruct object, PhaseOffset offset) const {
   vtAssert(offset.phases < 0,
            "RawData makes no predictions. Compose with NaivePersistence or some longer-range forecasting model as needed");
 

--- a/src/vt/vrt/collection/balance/model/raw_data.h
+++ b/src/vt/vrt/collection/balance/model/raw_data.h
@@ -59,9 +59,9 @@ namespace vt { namespace vrt { namespace collection { namespace balance {
 struct RawData : public LoadModel {
   RawData() = default;
   void updateLoads(PhaseType last_completed_phase) override;
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   bool hasRawLoad() const override { return true; }
-  TimeType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
 
   void setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
                 std::unordered_map<PhaseType, CommMapType> const* proc_comm) override;

--- a/src/vt/vrt/collection/balance/model/select_subphases.cc
+++ b/src/vt/vrt/collection/balance/model/select_subphases.cc
@@ -58,11 +58,11 @@ SelectSubphases::SelectSubphases(std::shared_ptr<LoadModel> base, std::vector<un
   //vtAssert(subphases_.size() < base_subphases, "...");
 }
 
-TimeType
+LoadType
 SelectSubphases::getModeledLoad(ElementIDStruct object, PhaseOffset when) const {
   if (when.subphase == PhaseOffset::WHOLE_PHASE) {
     // Sum up the selected subphases as if they represent the entire phase
-    TimeType sum = 0.0;
+    LoadType sum = 0.0;
     for (auto s : subphases_) {
       PhaseOffset p{when.phases, s};
       sum += ComposedModel::getModeledLoad(object, p);

--- a/src/vt/vrt/collection/balance/model/select_subphases.h
+++ b/src/vt/vrt/collection/balance/model/select_subphases.h
@@ -68,7 +68,7 @@ public:
    */
   SelectSubphases(std::shared_ptr<LoadModel> base, std::vector<unsigned int> subphases);
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   int getNumSubphases() const override;
 
   std::vector<unsigned int> subphases_;

--- a/src/vt/vrt/collection/balance/model/weighted_communication_volume.cc
+++ b/src/vt/vrt/collection/balance/model/weighted_communication_volume.cc
@@ -46,7 +46,7 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-TimeType WeightedCommunicationVolume::getModeledLoad(
+LoadType WeightedCommunicationVolume::getModeledLoad(
     ElementIDStruct object, PhaseOffset when
 ) const {
   return alpha_ * ComposedModel::getModeledLoad(object, when) +

--- a/src/vt/vrt/collection/balance/model/weighted_communication_volume.h
+++ b/src/vt/vrt/collection/balance/model/weighted_communication_volume.h
@@ -67,7 +67,7 @@ public:
       beta_(beta),
       gamma_(gamma) { }
 
-  TimeType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
 
 private:
   double alpha_;

--- a/src/vt/vrt/collection/balance/model/weighted_messages.cc
+++ b/src/vt/vrt/collection/balance/model/weighted_messages.cc
@@ -45,12 +45,12 @@
 
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
-TimeType
+LoadType
 WeightedMessages::getModeledComm(ElementIDStruct object, PhaseOffset when) const {
   auto phase = getNumCompletedPhases() + when.phases;
   auto& comm = proc_comm_->at(phase);
 
-  TimeType incoming = 0., outgoing = 0.;
+  LoadType incoming = 0., outgoing = 0.;
   for (auto&& c : comm) {
     if (
       c.first.commCategory() == elm::CommCategory::SendRecv and

--- a/src/vt/vrt/collection/balance/model/weighted_messages.h
+++ b/src/vt/vrt/collection/balance/model/weighted_messages.h
@@ -59,7 +59,7 @@ struct WeightedMessages : public ComposedModel {
    */
   explicit WeightedMessages(
     std::shared_ptr<balance::LoadModel> base,
-    TimeType in_per_msg_weight = 0.0, TimeType in_per_byte_weight = 1.0
+    LoadType in_per_msg_weight = 0.0, LoadType in_per_byte_weight = 1.0
   ) : ComposedModel(base),
       per_msg_weight_(in_per_msg_weight),
       per_byte_weight_(in_per_byte_weight) { }
@@ -72,14 +72,14 @@ struct WeightedMessages : public ComposedModel {
     ComposedModel::setLoads(proc_load, proc_comm);
   }
 
-  TimeType getModeledComm(ElementIDStruct object, PhaseOffset when) const override;
+  LoadType getModeledComm(ElementIDStruct object, PhaseOffset when) const override;
 
 private:
   // observer pointer to the underlying comm data
   std::unordered_map<PhaseType, CommMapType> const* proc_comm_;
 
-  TimeType per_msg_weight_;
-  TimeType per_byte_weight_;
+  LoadType per_msg_weight_;
+  LoadType per_byte_weight_;
 };
 
 }}}} // namespace vt::vrt::collection::balance

--- a/src/vt/vrt/collection/balance/offlinelb/offlinelb.cc
+++ b/src/vt/vrt/collection/balance/offlinelb/offlinelb.cc
@@ -54,7 +54,7 @@ void OfflineLB::init(objgroup::proxy::Proxy<OfflineLB> in_proxy) {
   proxy_ = in_proxy;
 }
 
-void OfflineLB::runLB(TimeType) {
+void OfflineLB::runLB(LoadType) {
   auto const& distro = theLBDataReader()->getDistro(phase_ + 1);
   for (auto&& elm : distro) {
     migrateObjectTo(elm, theContext()->getNode());

--- a/src/vt/vrt/collection/balance/offlinelb/offlinelb.h
+++ b/src/vt/vrt/collection/balance/offlinelb/offlinelb.h
@@ -61,7 +61,7 @@ struct OfflineLB : BaseLB {
   virtual ~OfflineLB() = default;
 
   void init(objgroup::proxy::Proxy<OfflineLB> in_proxy);
-  void runLB(TimeType) override;
+  void runLB(LoadType) override;
   void inputParams(balance::ConfigEntry* config) override { }
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp() {

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.cc
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.cc
@@ -95,7 +95,7 @@ void RandomLB::inputParams(balance::ConfigEntry* config) {
   randomize_seed_ = config->getOrDefault<bool>("randomize_seed", randomize_seed_);
 }
 
-void RandomLB::runLB(TimeType) {
+void RandomLB::runLB(LoadType) {
   auto const this_node = theContext()->getNode();
   auto const num_nodes = static_cast<int32_t>(theContext()->getNumNodes());
 

--- a/src/vt/vrt/collection/balance/randomlb/randomlb.h
+++ b/src/vt/vrt/collection/balance/randomlb/randomlb.h
@@ -55,7 +55,7 @@ struct RandomLB : BaseLB {
   RandomLB() = default;
 
   void init(objgroup::proxy::Proxy<RandomLB> in_proxy);
-  void runLB(TimeType) override;
+  void runLB(LoadType) override;
   void inputParams(balance::ConfigEntry* config) override;
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp();

--- a/src/vt/vrt/collection/balance/rotatelb/rotatelb.cc
+++ b/src/vt/vrt/collection/balance/rotatelb/rotatelb.cc
@@ -61,7 +61,7 @@ RotateLB::getInputKeysWithHelp() {
 
 void RotateLB::inputParams(balance::ConfigEntry* config) { }
 
-void RotateLB::runLB(TimeType) {
+void RotateLB::runLB(LoadType) {
   auto const& this_node = theContext()->getNode();
   auto const& num_nodes = theContext()->getNumNodes();
   auto const next_node = this_node + 1 > num_nodes-1 ? 0 : this_node + 1;
@@ -76,7 +76,7 @@ void RotateLB::runLB(TimeType) {
   }
 
   for (auto obj : *load_model_) {
-    TimeTypeWrapper const load = load_model_->getModeledLoad(
+    LoadType const load = load_model_->getModeledLoad(
       obj, {balance::PhaseOffset::NEXT_PHASE, balance::PhaseOffset::WHOLE_PHASE}
     );
     vt_debug_print(

--- a/src/vt/vrt/collection/balance/rotatelb/rotatelb.h
+++ b/src/vt/vrt/collection/balance/rotatelb/rotatelb.h
@@ -66,7 +66,7 @@ struct RotateLB : BaseLB {
   virtual ~RotateLB() {}
 
   void init(objgroup::proxy::Proxy<RotateLB> in_proxy);
-  void runLB(TimeType) override;
+  void runLB(LoadType) override;
   void inputParams(balance::ConfigEntry* config) override;
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp();

--- a/src/vt/vrt/collection/balance/stats_msg.h
+++ b/src/vt/vrt/collection/balance/stats_msg.h
@@ -62,7 +62,7 @@ struct LoadData {
   using isByteCopyable = std::true_type;
 
   LoadData() = default;
-  LoadData(lb::Statistic in_stat, TimeType const y)
+  LoadData(lb::Statistic in_stat, LoadType const y)
     : max_(y), sum_(y), min_(y), avg_(y), M2_(0.0f), M3_(0.0f), M4_(0.0f),
       N_(1), P_(y not_eq 0.0f), stat_(in_stat)
   {
@@ -118,12 +118,12 @@ struct LoadData {
     return a1;
   }
 
-  TimeType max() const { return max_; }
-  TimeType sum() const { return sum_; }
-  TimeType min() const { return min_; }
-  TimeType avg() const { return avg_; }
-  TimeType var() const { return N_ > 0 ? M2_ * (1.0f / N_) : 0.0; }
-  TimeType skew() const {
+  LoadType max() const { return max_; }
+  LoadType sum() const { return sum_; }
+  LoadType min() const { return min_; }
+  LoadType avg() const { return avg_; }
+  LoadType var() const { return N_ > 0 ? M2_ * (1.0f / N_) : 0.0; }
+  LoadType skew() const {
     static const double min_sqrt = std::sqrt(std::numeric_limits<double>::min());
     if (N_ == 1 or M2_ < min_sqrt) { // 1.e-150
       return 0.0;
@@ -135,7 +135,7 @@ struct LoadData {
       return nvar_inv * std::sqrt( var_inv ) * M3_;
     }
   }
-  TimeType krte() const {
+  LoadType krte() const {
     if (N_ == 1 or M2_ < 1.e-150) {
       return 0.0;
     } else {
@@ -146,22 +146,22 @@ struct LoadData {
       return nvar_inv * var_inv * M4_ - 3.;
     }
   }
-  TimeType I() const { return avg() > 0.0 ? (max() / avg()) - 1.0f : 0.0; }
-  TimeType stdv() const { return std::sqrt(var()); }
+  LoadType I() const { return avg() > 0.0 ? (max() / avg()) - 1.0f : 0.0; }
+  LoadType stdv() const { return std::sqrt(var()); }
   int32_t  npr() const { return P_; }
 
   static_assert(
-    std::is_same<TimeType, double>::value == true,
-    "TimeType must be a double"
+    std::is_same<LoadType, double>::value == true,
+    "LoadType must be a double"
   );
 
-  TimeType max_ = 0.0;
-  TimeType sum_ = 0.0;
-  TimeType min_ = 0.0;
-  TimeType avg_ = 0.0;
-  TimeType M2_  = 0.0;
-  TimeType M3_  = 0.0;
-  TimeType M4_  = 0.0;
+  LoadType max_ = 0.0;
+  LoadType sum_ = 0.0;
+  LoadType min_ = 0.0;
+  LoadType avg_ = 0.0;
+  LoadType M2_  = 0.0;
+  LoadType M3_  = 0.0;
+  LoadType M4_  = 0.0;
   int32_t  N_ = 0;
   int32_t  P_ = 0;
   lb::Statistic stat_ = lb::Statistic::Rank_load_modeled;

--- a/src/vt/vrt/collection/balance/temperedlb/criterion.h
+++ b/src/vt/vrt/collection/balance/temperedlb/criterion.h
@@ -53,23 +53,19 @@ enum struct CriterionEnum : uint8_t {
   ModifiedGrapevine = 1
 };
 
-struct CriterionBase {
-  using LoadType = double;
-};
-
-struct GrapevineCriterion : CriterionBase {
+struct GrapevineCriterion {
   bool operator()(LoadType, LoadType under, LoadType obj, LoadType avg) const {
     return not (under + obj > avg);
   }
 };
 
-struct ModifiedGrapevineCriterion : CriterionBase {
+struct ModifiedGrapevineCriterion  {
   bool operator()(LoadType over, LoadType under, LoadType obj, LoadType) const {
     return obj < over - under;
   }
 };
 
-struct Criterion : CriterionBase {
+struct Criterion {
   explicit Criterion(CriterionEnum const criterion)
     : criterion_(criterion)
   { }

--- a/src/vt/vrt/collection/balance/temperedlb/tempered_msgs.h
+++ b/src/vt/vrt/collection/balance/temperedlb/tempered_msgs.h
@@ -55,7 +55,7 @@ struct LoadMsg : vt::Message {
   using MessageParentType = vt::Message;
   vt_msg_serialize_required(); // node_load_
 
-  using NodeLoadType = std::unordered_map<NodeType, lb::BaseLB::LoadType>;
+  using NodeLoadType = std::unordered_map<NodeType, LoadType>;
 
   LoadMsg() = default;
   LoadMsg(NodeType in_from_node, NodeLoadType const& in_node_load)
@@ -66,7 +66,7 @@ struct LoadMsg : vt::Message {
     return node_load_;
   }
 
-  void addNodeLoad(NodeType node, lb::BaseLB::LoadType load) {
+  void addNodeLoad(NodeType node, LoadType load) {
     node_load_[node] = load;
   }
 
@@ -117,7 +117,7 @@ struct LazyMigrationMsg : SerializeRequired<
     vt::Message,
     LazyMigrationMsg
   >;
-  using ObjsType = std::unordered_map<lb::BaseLB::ObjIDType, lb::BaseLB::LoadType>;
+  using ObjsType = std::unordered_map<lb::BaseLB::ObjIDType, LoadType>;
 
   LazyMigrationMsg() = default;
   LazyMigrationMsg(NodeType in_to_node, ObjsType const& in_objs)

--- a/src/vt/vrt/collection/balance/temperedlb/temperedlb.cc
+++ b/src/vt/vrt/collection/balance/temperedlb/temperedlb.cc
@@ -420,7 +420,7 @@ void TemperedLB::inputParams(balance::ConfigEntry* config) {
   }
 }
 
-void TemperedLB::runLB(TimeType total_load) {
+void TemperedLB::runLB(LoadType total_load) {
   bool should_lb = false;
 
   this_load = total_load;
@@ -457,8 +457,8 @@ void TemperedLB::runLB(TimeType total_load) {
     vt_debug_print(
       terse, temperedlb,
       "TemperedLB::runLB: avg={}, max={}, pole={}, imb={}, load={}, should_lb={}\n",
-      TimeTypeWrapper(avg), TimeTypeWrapper(max), TimeTypeWrapper(pole), imb,
-      TimeTypeWrapper(load), should_lb
+      LoadType(avg), LoadType(max), LoadType(pole), imb,
+      LoadType(load), should_lb
     );
 
     if (!should_lb) {
@@ -474,10 +474,10 @@ void TemperedLB::runLB(TimeType total_load) {
   }
 }
 
-void TemperedLB::doLBStages(TimeType start_imb) {
+void TemperedLB::doLBStages(LoadType start_imb) {
   decltype(this->cur_objs_) best_objs;
   LoadType best_load = 0;
-  TimeType best_imb = start_imb + 10;
+  LoadType best_imb = start_imb + 10;
   uint16_t best_trial = 0;
 
   auto this_node = theContext()->getNode();
@@ -489,7 +489,7 @@ void TemperedLB::doLBStages(TimeType start_imb) {
     load_info_.clear();
     is_overloaded_ = is_underloaded_ = false;
 
-    TimeType best_imb_this_trial = start_imb + 10;
+    LoadType best_imb_this_trial = start_imb + 10;
 
     for (iter_ = 0; iter_ < num_iters_; iter_++) {
       bool first_iter = iter_ == 0;
@@ -515,8 +515,8 @@ void TemperedLB::doLBStages(TimeType start_imb) {
         normal, temperedlb,
         "TemperedLB::doLBStages: (before) running trial={}, iter={}, "
         "num_iters={}, load={}, new_load={}\n",
-        trial_, iter_, num_iters_, TimeTypeWrapper(this_load),
-        TimeTypeWrapper(this_new_load_)
+        trial_, iter_, num_iters_, LoadType(this_load),
+        LoadType(this_new_load_)
       );
 
       if (isOverloaded(this_new_load_)) {
@@ -542,8 +542,8 @@ void TemperedLB::doLBStages(TimeType start_imb) {
         verbose, temperedlb,
         "TemperedLB::doLBStages: (after) running trial={}, iter={}, "
         "num_iters={}, load={}, new_load={}\n",
-        trial_, iter_, num_iters_, TimeTypeWrapper(this_load),
-        TimeTypeWrapper(this_new_load_)
+        trial_, iter_, num_iters_, LoadType(this_load),
+        LoadType(this_new_load_)
       );
 
       if (rollback_ || theConfig()->vt_debug_temperedlb || (iter_ == num_iters_ - 1)) {
@@ -619,9 +619,9 @@ void TemperedLB::loadStatsHandler(std::vector<balance::LoadData> const& vec) {
       terse, temperedlb,
       "TemperedLB::loadStatsHandler: trial={} iter={} max={} min={} "
       "avg={} pole={} imb={:0.4f}\n",
-      trial_, iter_, TimeTypeWrapper(in.max()),
-      TimeTypeWrapper(in.min()), TimeTypeWrapper(in.avg()),
-      TimeTypeWrapper(stats.at(
+      trial_, iter_, LoadType(in.max()),
+      LoadType(in.min()), LoadType(in.avg()),
+      LoadType(stats.at(
         lb::Statistic::Object_load_modeled
       ).at(lb::StatisticQuantity::max)),
       in.I()
@@ -652,7 +652,7 @@ void TemperedLB::informAsync() {
     "TemperedLB::informAsync: starting inform phase: trial={}, iter={}, "
     "k_max={}, is_underloaded={}, is_overloaded={}, load={}\n",
     trial_, iter_, k_max_, is_underloaded_, is_overloaded_,
-    TimeTypeWrapper(this_new_load_)
+    LoadType(this_new_load_)
   );
 
   vtAssert(k_max_ > 0, "Number of rounds (k) must be greater than zero");
@@ -993,7 +993,7 @@ std::vector<NodeType> TemperedLB::makeUnderloaded() const {
 }
 
 std::vector<NodeType> TemperedLB::makeSufficientlyUnderloaded(
-  TimeType load_to_accommodate
+  LoadType load_to_accommodate
 ) const {
   std::vector<NodeType> sufficiently_under = {};
   for (auto&& elm : load_info_) {
@@ -1031,8 +1031,8 @@ TemperedLB::selectObject(
 /*static*/
 std::vector<TemperedLB::ObjIDType> TemperedLB::orderObjects(
   ObjectOrderEnum obj_ordering,
-  std::unordered_map<ObjIDType, TimeType> cur_objs,
-  LoadType this_new_load, TimeType target_max_load
+  std::unordered_map<ObjIDType, LoadType> cur_objs,
+  LoadType this_new_load, LoadType target_max_load
 ) {
   // define the iteration order
   std::vector<ObjIDType> ordered_obj_ids(cur_objs.size());
@@ -1090,8 +1090,8 @@ std::vector<TemperedLB::ObjIDType> TemperedLB::orderObjects(
         vt_debug_print(
           normal, temperedlb,
           "TemperedLB::decide: over_avg={}, single_obj_load={}\n",
-          TimeTypeWrapper(over_avg),
-          TimeTypeWrapper(cur_objs[ordered_obj_ids[0]])
+          LoadType(over_avg),
+          LoadType(cur_objs[ordered_obj_ids[0]])
         );
       }
     }
@@ -1151,8 +1151,8 @@ std::vector<TemperedLB::ObjIDType> TemperedLB::orderObjects(
         vt_debug_print(
           normal, temperedlb,
           "TemperedLB::decide: over_avg={}, marginal_obj_load={}\n",
-          TimeTypeWrapper(over_avg),
-          TimeTypeWrapper(cur_objs[ordered_obj_ids[0]])
+          LoadType(over_avg),
+          LoadType(cur_objs[ordered_obj_ids[0]])
         );
       }
     }
@@ -1250,9 +1250,9 @@ void TemperedLB::decide() {
           selected_load,
           obj_id.id,
           obj_id.getHomeNode(),
-          TimeTypeWrapper(obj_load),
-          TimeTypeWrapper(target_max_load_),
-          TimeTypeWrapper(this_new_load_),
+          LoadType(obj_load),
+          LoadType(target_max_load_),
+          LoadType(this_new_load_),
           eval
         );
 
@@ -1341,7 +1341,7 @@ void TemperedLB::migrate() {
   vtAssertExpr(false);
 }
 
-TimeType TemperedLB::getModeledValue(const elm::ElementIDStruct& obj) {
+LoadType TemperedLB::getModeledValue(const elm::ElementIDStruct& obj) {
   return load_model_->getModeledLoad(
     obj, {balance::PhaseOffset::NEXT_PHASE, balance::PhaseOffset::WHOLE_PHASE}
   );

--- a/src/vt/vrt/collection/balance/temperedlb/temperedlb.h
+++ b/src/vt/vrt/collection/balance/temperedlb/temperedlb.h
@@ -75,19 +75,19 @@ struct TemperedLB : BaseLB {
 
 public:
   void init(objgroup::proxy::Proxy<TemperedLB> in_proxy);
-  void runLB(TimeType total_load) override;
+  void runLB(LoadType total_load) override;
   void inputParams(balance::ConfigEntry* config) override;
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp();
 
   static std::vector<ObjIDType> orderObjects(
     ObjectOrderEnum obj_ordering,
-    std::unordered_map<ObjIDType, TimeType> cur_objs,
-    LoadType this_new_load, TimeType target_max_load
+    std::unordered_map<ObjIDType, LoadType> cur_objs,
+    LoadType this_new_load, LoadType target_max_load
   );
 
 protected:
-  void doLBStages(TimeType start_imb);
+  void doLBStages(LoadType start_imb);
   void informAsync();
   void informSync();
   void decide();
@@ -109,7 +109,7 @@ protected:
   ElementLoadType::iterator selectObject(
     LoadType size, ElementLoadType& load, std::set<ObjIDType> const& available
   );
-  virtual TimeType getModeledValue(const elm::ElementIDStruct& obj);
+  virtual LoadType getModeledValue(const elm::ElementIDStruct& obj);
 
   void lazyMigrateObjsTo(EpochType epoch, NodeType node, ObjsType const& objs);
   void inLazyMigrations(balance::LazyMigrationMsg* msg);
@@ -165,10 +165,10 @@ private:
   std::unordered_set<NodeType> selected_            = {};
   std::unordered_set<NodeType> underloaded_         = {};
   std::unordered_set<NodeType> new_underloaded_     = {};
-  std::unordered_map<ObjIDType, TimeType> cur_objs_ = {};
+  std::unordered_map<ObjIDType, LoadType> cur_objs_ = {};
   LoadType this_new_load_                           = 0.0;
-  TimeType new_imbalance_                           = 0.0;
-  TimeType target_max_load_                         = 0.0;
+  LoadType new_imbalance_                           = 0.0;
+  LoadType target_max_load_                         = 0.0;
   CriterionEnum criterion_                          = CriterionEnum::ModifiedGrapevine;
   InformTypeEnum inform_type_                       = InformTypeEnum::AsyncInform;
   ObjectOrderEnum obj_ordering_                     = ObjectOrderEnum::FewestMigrations;

--- a/src/vt/vrt/collection/balance/temperedwmin/temperedwmin.cc
+++ b/src/vt/vrt/collection/balance/temperedwmin/temperedwmin.cc
@@ -110,7 +110,7 @@ void TemperedWMin::inputParams(balance::ConfigEntry* config) {
   load_model_ptr = theLBManager()->getLoadModel().get();
 }
 
-TimeType TemperedWMin::getModeledValue(const elm::ElementIDStruct& obj) {
+LoadType TemperedWMin::getModeledValue(const elm::ElementIDStruct& obj) {
   vtAssert(
     theLBManager()->getLoadModel().get() == load_model_ptr,
     "Load model must not change"

--- a/src/vt/vrt/collection/balance/temperedwmin/temperedwmin.h
+++ b/src/vt/vrt/collection/balance/temperedwmin/temperedwmin.h
@@ -64,7 +64,7 @@ public:
   void inputParams(balance::ConfigEntry* config) override;
 
 protected:
-  TimeType getModeledValue(const elm::ElementIDStruct& obj) override;
+  LoadType getModeledValue(const elm::ElementIDStruct& obj) override;
 
 private:
   std::shared_ptr<balance::LoadModel> total_work_model_ = nullptr;

--- a/src/vt/vrt/collection/balance/testserializationlb/testserializationlb.cc
+++ b/src/vt/vrt/collection/balance/testserializationlb/testserializationlb.cc
@@ -60,7 +60,7 @@ void TestSerializationLB::init(objgroup::proxy::Proxy<TestSerializationLB>) {
 
 void TestSerializationLB::inputParams(balance::ConfigEntry*) { }
 
-void TestSerializationLB::runLB(TimeType) {
+void TestSerializationLB::runLB(LoadType) {
   auto const this_node = theContext()->getNode();
   for (auto obj : *load_model_) {
     auto const load = load_model_->getModeledLoad(

--- a/src/vt/vrt/collection/balance/testserializationlb/testserializationlb.h
+++ b/src/vt/vrt/collection/balance/testserializationlb/testserializationlb.h
@@ -60,7 +60,7 @@ struct TestSerializationLB : BaseLB {
   virtual ~TestSerializationLB() {}
 
   void init(objgroup::proxy::Proxy<TestSerializationLB> in_proxy);
-  void runLB(TimeType) override;
+  void runLB(LoadType) override;
   void inputParams(balance::ConfigEntry* config) override;
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp();

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
@@ -129,7 +129,7 @@ void ZoltanLB::inputParams(balance::ConfigEntry* config) {
   }
 }
 
-void ZoltanLB::runLB(TimeType total_load) {
+void ZoltanLB::runLB(LoadType total_load) {
   auto const& this_node = theContext()->getNode();
   this_load = loadMilli(total_load);
 

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.h
@@ -64,7 +64,7 @@ struct ZoltanLB : BaseLB {
   ZoltanLB();
 
   void init(objgroup::proxy::Proxy<ZoltanLB> in_proxy);
-  void runLB(TimeType total_load) override;
+  void runLB(LoadType total_load) override;
   void inputParams(balance::ConfigEntry* config) override;
 
   static std::unordered_map<std::string, std::string> getInputKeysWithHelp();

--- a/tests/unit/collection/test_lb.extended.cc
+++ b/tests/unit/collection/test_lb.extended.cc
@@ -541,7 +541,7 @@ TEST_F(TestRestoreLBData, test_restore_lb_data_data_1) {
     for (int i=0; i<num_elms; ++i) {
       vt::Index1D idx(i);
 
-      TimeType dur = (i % 10 + 1) * 0.1;
+      LoadType dur = (i % 10 + 1) * 0.1;
       uint64_t ntocm = (i+1) % 3 + 2;
       CommBytesType ntoc = (i+1) * 100;
       uint64_t ctonm = (i+1) % 2 + 1;
@@ -551,7 +551,7 @@ TEST_F(TestRestoreLBData, test_restore_lb_data_data_1) {
       if (elm_ptr != nullptr) {
         auto elm_id = elm_ptr->getElmID();
 
-        std::vector<TimeType> dur_vec(2);
+        std::vector<LoadType> dur_vec(2);
         dur_vec[i % 2] = dur;
         lbdh.node_data_[phase][elm_id].whole_phase_load = dur;
         lbdh.node_data_[phase][elm_id].subphase_loads = dur_vec;

--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -86,7 +86,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     const auto work = proc_load_->at(0).at(id).whole_phase_load;
 
     if (phase.subphase == PhaseOffset::WHOLE_PHASE) {
@@ -122,7 +122,7 @@ TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
   // Element 3 (home node == 3)
   ElementIDStruct const elem3 = {3, 3};
 
-  ProcLoadMap proc_load = {{0, LoadMapType{{elem2, {TimeType{150}, {}}}}}};
+  ProcLoadMap proc_load = {{0, LoadMapType{{elem2, {LoadType{150}, {}}}}}};
 
   ProcCommMap proc_comm = {
     {0,
@@ -154,8 +154,8 @@ TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
   );
   test_model->setLoads(&proc_load, &proc_comm);
 
-  std::unordered_map<PhaseType, TimeType> expected_work = {
-    {0, TimeType{296}}, {1, TimeType{295.5}}
+  std::unordered_map<PhaseType, LoadType> expected_work = {
+    {0, LoadType{296}}, {1, LoadType{295.5}}
   };
 
   for (; num_phases < 2; ++num_phases) {

--- a/tests/unit/collection/test_model_linear_model.nompi.cc
+++ b/tests/unit/collection/test_model_linear_model.nompi.cc
@@ -79,7 +79,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     // Most recent phase will be at the end of vector
     return proc_load_->at(num_phases + phase.phases).at(id).whole_phase_load;
   }
@@ -106,8 +106,8 @@ TEST_F(TestLinearModel, test_model_linear_model_1) {
   // For linear regression there needs to be at least 2 phases completed
   // so we begin with 1 phase already done
   std::unordered_map<PhaseType, LoadMapType> proc_loads{{0, LoadMapType{
-        {ElementIDStruct{1,this_node}, {TimeType{10}, {}}},
-        {ElementIDStruct{2,this_node}, {TimeType{40}, {}}}
+        {ElementIDStruct{1,this_node}, {LoadType{10}, {}}},
+        {ElementIDStruct{2,this_node}, {LoadType{40}, {}}}
     }}};
   test_model->setLoads(&proc_loads, nullptr);
   test_model->updateLoads(0);
@@ -115,32 +115,32 @@ TEST_F(TestLinearModel, test_model_linear_model_1) {
   // Work loads to be added in each test iteration
   std::vector<LoadMapType> load_holder{
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{5}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{10}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{5}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{10}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{30}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{100}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{30}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{100}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{50}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{40}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{50}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{40}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{2}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{50}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{2}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{50}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{60}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{20}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{60}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{20}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{100}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{10}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{100}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{10}, {}}}},
   };
 
-  std::array<std::pair<TimeType, TimeType>, num_test_interations> expected_data{
-    std::make_pair(TimeType{0}, TimeType{-20}),   // iter 0 results
-    std::make_pair(TimeType{35}, TimeType{110}),  // iter 1 results
-    std::make_pair(TimeType{60}, TimeType{70}),   // iter 2 results
-    std::make_pair(TimeType{24.5}, TimeType{65}), // iter 3 results
-    std::make_pair(TimeType{46}, TimeType{-5}),   // iter 4 results
-    std::make_pair(TimeType{105}, TimeType{0})    // iter 5 results
+  std::array<std::pair<LoadType, LoadType>, num_test_interations> expected_data{
+    std::make_pair(LoadType{0}, LoadType{-20}),   // iter 0 results
+    std::make_pair(LoadType{35}, LoadType{110}),  // iter 1 results
+    std::make_pair(LoadType{60}, LoadType{70}),   // iter 2 results
+    std::make_pair(LoadType{24.5}, LoadType{65}), // iter 3 results
+    std::make_pair(LoadType{46}, LoadType{-5}),   // iter 4 results
+    std::make_pair(LoadType{105}, LoadType{0})    // iter 5 results
   };
 
   for (auto iter = 0; iter < num_test_interations; ++iter) {

--- a/tests/unit/collection/test_model_multiple_phases.nompi.cc
+++ b/tests/unit/collection/test_model_multiple_phases.nompi.cc
@@ -77,7 +77,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     // Here we return predicted loads for future phases
     // For the sake of the test we use values from the past phases
     return proc_load_->at(phase.phases).at(id).whole_phase_load;
@@ -100,17 +100,17 @@ TEST_F(TestModelMultiplePhases, test_model_multiple_phases_1) {
   NodeType this_node = 0;
   std::unordered_map<PhaseType, LoadMapType> proc_loads = {
     {0, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{10}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{40}, {}}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{10}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{40}, {}}}}},
     {1, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{20}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{30}, {}}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{20}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{30}, {}}}}},
     {2, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{30}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{10}, {}}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{30}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{10}, {}}}}},
     {3, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{40}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{5}, {}}}}}};
+      {ElementIDStruct{1,this_node}, {LoadType{40}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{5}, {}}}}}};
 
   auto test_model =
     std::make_shared<MultiplePhases>(std::make_shared<StubModel>(), 4);
@@ -122,7 +122,7 @@ TEST_F(TestModelMultiplePhases, test_model_multiple_phases_1) {
     auto work_val = test_model->getModeledLoad(
       obj, {PhaseOffset::NEXT_PHASE, PhaseOffset::WHOLE_PHASE}
     );
-    EXPECT_EQ(work_val, obj.id == 1 ? TimeType{100} : TimeType{85});
+    EXPECT_EQ(work_val, obj.id == 1 ? LoadType{100} : LoadType{85});
   }
 }
 

--- a/tests/unit/collection/test_model_naive_persistence.nompi.cc
+++ b/tests/unit/collection/test_model_naive_persistence.nompi.cc
@@ -81,7 +81,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     EXPECT_LE(phase.phases, -1);
     return proc_load_->at(getIndexFromPhase(phase.phases)).at(id).whole_phase_load;
   }
@@ -103,17 +103,17 @@ TEST_F(TestModelNaivePersistence, test_model_naive_persistence_1) {
   NodeType this_node = 0;
   std::unordered_map<PhaseType, LoadMapType> proc_loads = {
     {0, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{10}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{40}, {}}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{10}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{40}, {}}}}},
     {1, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{4}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{10}, {}}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{4}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{10}, {}}}}},
     {2, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{20}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{50}, {}}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{20}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{50}, {}}}}},
     {3, LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{40}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{100}, {}}}}}};
+      {ElementIDStruct{1,this_node}, {LoadType{40}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{100}, {}}}}}};
 
   auto test_model =
     std::make_shared<NaivePersistence>(std::make_shared<StubModel>());

--- a/tests/unit/collection/test_model_norm.nompi.cc
+++ b/tests/unit/collection/test_model_norm.nompi.cc
@@ -84,7 +84,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     return proc_load_->at(0).at(id).subphase_loads.at(phase.subphase);
   }
 
@@ -107,8 +107,8 @@ TEST_F(TestModelNorm, test_model_norm_1) {
   ProcLoadMap proc_load = {
     {0,
      LoadMapType{
-       {ElementIDStruct{1,this_node}, {TimeType{60}, {TimeType{10}, TimeType{20}, TimeType{30}}}},
-       {ElementIDStruct{2,this_node}, {TimeType{150}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}}};
+       {ElementIDStruct{1,this_node}, {LoadType{60}, {LoadType{10}, LoadType{20}, LoadType{30}}}},
+       {ElementIDStruct{2,this_node}, {LoadType{150}, {LoadType{40}, LoadType{50}, LoadType{60}}}}}}};
 
   auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
   test_model->setLoads(&proc_load, nullptr);
@@ -138,16 +138,16 @@ TEST_F(TestModelNorm, test_model_norm_2) {
   ProcLoadMap proc_load = {
     {0,
      LoadMapType{
-       {ElementIDStruct{1,this_node}, {TimeType{60}, {TimeType{10}, TimeType{20}, TimeType{30}}}},
-       {ElementIDStruct{2,this_node}, {TimeType{150}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}}};
+       {ElementIDStruct{1,this_node}, {LoadType{60}, {LoadType{10}, LoadType{20}, LoadType{30}}}},
+       {ElementIDStruct{2,this_node}, {LoadType{150}, {LoadType{40}, LoadType{50}, LoadType{60}}}}}}};
 
   // finite 'power' value
   auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
   test_model->setLoads(&proc_load, nullptr);
   test_model->updateLoads(0);
 
-  std::array<TimeType, 2> expected_norms = {
-    TimeType{33.019}, TimeType{73.986}};
+  std::array<LoadType, 2> expected_norms = {
+    LoadType{33.019}, LoadType{73.986}};
 
   int objects_seen = 0;
   for (auto&& obj : *test_model) {
@@ -167,8 +167,8 @@ TEST_F(TestModelNorm, test_model_norm_3) {
   ProcLoadMap proc_load = {
     {0,
      LoadMapType{
-       {ElementIDStruct{1,this_node}, {TimeType{60}, {TimeType{10}, TimeType{20}, TimeType{30}}}},
-       {ElementIDStruct{2,this_node}, {TimeType{150}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}}};
+       {ElementIDStruct{1,this_node}, {LoadType{60}, {LoadType{10}, LoadType{20}, LoadType{30}}}},
+       {ElementIDStruct{2,this_node}, {LoadType{150}, {LoadType{40}, LoadType{50}, LoadType{60}}}}}}};
 
   // infinite 'power' value
   auto test_model = std::make_shared<Norm>(
@@ -176,7 +176,7 @@ TEST_F(TestModelNorm, test_model_norm_3) {
   test_model->setLoads(&proc_load, nullptr);
   test_model->updateLoads(0);
 
-  std::array<TimeType, 2> expected_norms = {TimeType{30}, TimeType{60}};
+  std::array<LoadType, 2> expected_norms = {LoadType{30}, LoadType{60}};
 
   int objects_seen = 0;
   for (auto&& obj : *test_model) {

--- a/tests/unit/collection/test_model_per_collection.extended.cc
+++ b/tests/unit/collection/test_model_per_collection.extended.cc
@@ -74,8 +74,8 @@ struct ConstantTestModel : ComposedModel {
       proxy_(in_proxy)
   { }
 
-  TimeType getModeledLoad(ElementIDStruct, PhaseOffset) const override {
-    return static_cast<TimeType>(proxy_);
+  LoadType getModeledLoad(ElementIDStruct, PhaseOffset) const override {
+    return static_cast<LoadType>(proxy_);
   }
 
 private:
@@ -158,7 +158,7 @@ TEST_F(TestModelPerCollection, test_model_per_collection_1) {
         obj, {PhaseOffset::NEXT_PHASE, PhaseOffset::WHOLE_PHASE}
       );
       if (id_proxy_map.find(obj) != id_proxy_map.end()) {
-        EXPECT_DOUBLE_EQ(work_val, static_cast<TimeType>(id_proxy_map[obj]));
+        EXPECT_DOUBLE_EQ(work_val, static_cast<LoadType>(id_proxy_map[obj]));
       }
       if (model->hasRawLoad()) {
         auto raw_load_val = model->getRawLoad(obj, {PhaseOffset::NEXT_PHASE, PhaseOffset::WHOLE_PHASE});

--- a/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
+++ b/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
@@ -79,7 +79,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     // Most recent phase will be at the end of vector
     return proc_load_->at(num_phases + phase.phases).at(id).whole_phase_load;
   }
@@ -110,36 +110,36 @@ TEST_F(TestModelPersistenceMedianLastN, test_model_persistence_median_last_n_1) 
   // Work loads to be added in each test iteration
   std::vector<LoadMapType> load_holder{
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{10}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{40}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{10}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{40}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{4}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{10}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{4}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{10}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{20}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{100}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{20}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{100}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{50}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{40}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{50}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{40}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{2}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{50}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{2}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{50}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{60}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{20}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{60}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{20}, {}}}},
     LoadMapType{
-      {ElementIDStruct{1,this_node}, {TimeType{100}, {}}},
-      {ElementIDStruct{2,this_node}, {TimeType{10}, {}}}},
+      {ElementIDStruct{1,this_node}, {LoadType{100}, {}}},
+      {ElementIDStruct{2,this_node}, {LoadType{10}, {}}}},
   };
 
-  std::array<std::pair<TimeType, TimeType>, num_total_phases> expected_medians{
-    std::make_pair(TimeType{10}, TimeType{40}), // iter 0 results
-    std::make_pair(TimeType{7},  TimeType{25}), // iter 1 results
-    std::make_pair(TimeType{10}, TimeType{40}), // iter 2 results
-    std::make_pair(TimeType{15}, TimeType{40}), // iter 3 results
-    std::make_pair(TimeType{12}, TimeType{45}), // iter 4 results
-    std::make_pair(TimeType{35}, TimeType{45}), // iter 5 results
-    std::make_pair(TimeType{55}, TimeType{30})  // iter 6 results
+  std::array<std::pair<LoadType, LoadType>, num_total_phases> expected_medians{
+    std::make_pair(LoadType{10}, LoadType{40}), // iter 0 results
+    std::make_pair(LoadType{7},  LoadType{25}), // iter 1 results
+    std::make_pair(LoadType{10}, LoadType{40}), // iter 2 results
+    std::make_pair(LoadType{15}, LoadType{40}), // iter 3 results
+    std::make_pair(LoadType{12}, LoadType{45}), // iter 4 results
+    std::make_pair(LoadType{35}, LoadType{45}), // iter 5 results
+    std::make_pair(LoadType{55}, LoadType{30})  // iter 6 results
   };
 
   for (auto iter = 0; iter < num_total_phases; ++iter) {

--- a/tests/unit/collection/test_model_raw_data.nompi.cc
+++ b/tests/unit/collection/test_model_raw_data.nompi.cc
@@ -77,12 +77,12 @@ TEST_F(TestRawData, test_model_raw_data_scalar) {
 
   // Work loads to be added in each test iteration
   std::vector<LoadMapType> load_holder{
-    LoadMapType{{id1, {TimeType{5}, {TimeType{5}}}},   {id2, {TimeType{10}, {TimeType{10}}}}},
-    LoadMapType{{id1, {TimeType{30}, {TimeType{30}}}},  {id2, {TimeType{100}, {TimeType{100}}}}},
-    LoadMapType{{id1, {TimeType{50}, {TimeType{50}}}},  {id2, {TimeType{40}, {TimeType{40}}}}},
-    LoadMapType{{id1, {TimeType{2}, {TimeType{2}}}},   {id2, {TimeType{50}, {TimeType{50}}}}},
-    LoadMapType{{id1, {TimeType{60}, {TimeType{60}}}},  {id2, {TimeType{20}, {TimeType{20}}}}},
-    LoadMapType{{id1, {TimeType{100}, {TimeType{100}}}}, {id2, {TimeType{10}, {TimeType{10}}}}},
+    LoadMapType{{id1, {LoadType{5}, {LoadType{5}}}},   {id2, {LoadType{10}, {LoadType{10}}}}},
+    LoadMapType{{id1, {LoadType{30}, {LoadType{30}}}},  {id2, {LoadType{100}, {LoadType{100}}}}},
+    LoadMapType{{id1, {LoadType{50}, {LoadType{50}}}},  {id2, {LoadType{40}, {LoadType{40}}}}},
+    LoadMapType{{id1, {LoadType{2}, {LoadType{2}}}},   {id2, {LoadType{50}, {LoadType{50}}}}},
+    LoadMapType{{id1, {LoadType{60}, {LoadType{60}}}},  {id2, {LoadType{20}, {LoadType{20}}}}},
+    LoadMapType{{id1, {LoadType{100}, {LoadType{100}}}}, {id2, {LoadType{10}, {LoadType{10}}}}},
   };
 
   for (size_t iter = 0; iter < load_holder.size(); ++iter) {

--- a/tests/unit/collection/test_model_select_subphases.nompi.cc
+++ b/tests/unit/collection/test_model_select_subphases.nompi.cc
@@ -83,7 +83,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override {}
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     return proc_load_->at(0).at(id).subphase_loads.at(phase.subphase);
   }
 
@@ -115,8 +115,8 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_1) {
   ProcLoadMap proc_load = {
     {0,
      LoadMapType{
-       {id1, {TimeType{60}, {TimeType{10}, TimeType{20}, TimeType{30}}}},
-       {id2, {TimeType{150}, {TimeType{40}, TimeType{50}, TimeType{60}}}}}}};
+       {id1, {LoadType{60}, {LoadType{10}, LoadType{20}, LoadType{30}}}},
+       {id2, {LoadType{150}, {LoadType{40}, LoadType{50}, LoadType{60}}}}}}};
 
   std::vector<unsigned int> subphases{2, 0, 1};
   auto test_model =
@@ -127,7 +127,7 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_1) {
   test_model->setLoads(&proc_load, nullptr);
   test_model->updateLoads(0);
 
-  std::unordered_map<ElementIDStruct, std::vector<TimeType>> expected_values = {
+  std::unordered_map<ElementIDStruct, std::vector<LoadType>> expected_values = {
     {id1,
      {proc_load[0][id1].subphase_loads[subphases[0]],
       proc_load[0][id1].subphase_loads[subphases[1]],
@@ -160,9 +160,9 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_2) {
     {0,
      LoadMapType{
        {ElementIDStruct{1,this_node},
-        {TimeType{60}, {TimeType{10}, TimeType{20}, TimeType{30}}}},
+        {LoadType{60}, {LoadType{10}, LoadType{20}, LoadType{30}}}},
        {ElementIDStruct{2,this_node},
-        {TimeType{150}, {TimeType{40}, TimeType{50}, TimeType{60}}}}
+        {LoadType{150}, {LoadType{40}, LoadType{50}, LoadType{60}}}}
      }
     }
   };
@@ -176,9 +176,9 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_2) {
   test_model->setLoads(&proc_load, nullptr);
   test_model->updateLoads(0);
 
-  std::unordered_map<ElementIDStruct, TimeType> expected_values = {
-    {ElementIDStruct{1,this_node}, TimeType{50}},
-    {ElementIDStruct{2,this_node}, TimeType{110}}};
+  std::unordered_map<ElementIDStruct, LoadType> expected_values = {
+    {ElementIDStruct{1,this_node}, LoadType{50}},
+    {ElementIDStruct{2,this_node}, LoadType{110}}};
 
   int objects_seen = 0;
 

--- a/tests/unit/collection/test_model_weighted_communication_volume.nompi.cc
+++ b/tests/unit/collection/test_model_weighted_communication_volume.nompi.cc
@@ -84,7 +84,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override { }
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     const auto work = proc_load_->at(0).at(id).whole_phase_load;
 
     if (phase.subphase == PhaseOffset::WHOLE_PHASE) {
@@ -124,7 +124,7 @@ TEST_F(TestModelWeightedCommunicationVolume, test_model) {
   // Element 3 (home node == 3)
   ElementIDStruct const elem3 = {3, 3};
 
-  ProcLoadMap proc_load = {{0, LoadMapType{{elem2, {TimeType{150}, {}}}}}};
+  ProcLoadMap proc_load = {{0, LoadMapType{{elem2, {LoadType{150}, {}}}}}};
 
   ProcCommMap proc_comm = {
     {0,
@@ -157,8 +157,8 @@ TEST_F(TestModelWeightedCommunicationVolume, test_model) {
   );
   test_model->setLoads(&proc_load, &proc_comm);
 
-  std::unordered_map<PhaseType, TimeType> expected_work = {
-    {0, TimeType{125.0}}, {1, TimeType{22.5}}
+  std::unordered_map<PhaseType, LoadType> expected_work = {
+    {0, LoadType{125.0}}, {1, LoadType{22.5}}
   };
 
   for (; num_phases < 2; ++num_phases) {

--- a/tests/unit/collection/test_model_weighted_messages.nompi.cc
+++ b/tests/unit/collection/test_model_weighted_messages.nompi.cc
@@ -81,7 +81,7 @@ struct StubModel : LoadModel {
 
   void updateLoads(PhaseType) override { }
 
-  TimeType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
+  LoadType getModeledLoad(ElementIDStruct id, PhaseOffset phase) const override {
     const auto work = proc_load_->at(0).at(id).whole_phase_load;
 
     if (phase.subphase == PhaseOffset::WHOLE_PHASE) {
@@ -120,7 +120,7 @@ TEST_F(TestModelWeightedMessages, test_model) {
   // Element 3 (home node == 3)
   ElementIDStruct const elem3 = {3, 3};
 
-  ProcLoadMap proc_load = {{0, LoadMapType{{elem2, {TimeType{150}, {}}}}}};
+  ProcLoadMap proc_load = {{0, LoadMapType{{elem2, {LoadType{150}, {}}}}}};
 
   ProcCommMap proc_comm = {
     {0,
@@ -149,8 +149,8 @@ TEST_F(TestModelWeightedMessages, test_model) {
   );
   test_model->setLoads(&proc_load, &proc_comm);
 
-  std::unordered_map<PhaseType, TimeType> expected_comm = {
-    {0, TimeType{146}}, {1, TimeType{280.5}}
+  std::unordered_map<PhaseType, LoadType> expected_comm = {
+    {0, LoadType{146}}, {1, LoadType{280.5}}
   };
 
   for (; num_phases < 2; ++num_phases) {

--- a/tests/unit/lb/test_temperedlb.nompi.cc
+++ b/tests/unit/lb/test_temperedlb.nompi.cc
@@ -55,8 +55,8 @@ using ElementIDStruct = vt::vrt::collection::balance::ElementIDStruct;
 using ElementIDType = vt::vrt::collection::balance::ElementIDType;
 using ObjectOrdering = vt::vrt::collection::lb::ObjectOrderEnum;
 
-TimeType setupProblem(
-  std::unordered_map<ElementIDStruct, TimeType> &cur_objs
+LoadType setupProblem(
+  std::unordered_map<ElementIDStruct, LoadType> &cur_objs
 ) {
   // total load of 29 seconds
   cur_objs.emplace(ElementIDStruct{3,0}, 4.0);
@@ -67,7 +67,7 @@ TimeType setupProblem(
   cur_objs.emplace(ElementIDStruct{4,0}, 3.0);
 
   // compute the load for this processor
-  TimeType my_load = 0;
+  LoadType my_load = 0;
   for (auto &obj : cur_objs) {
     my_load += obj.second;
   }
@@ -76,8 +76,8 @@ TimeType setupProblem(
 
 void orderAndVerify(
   ObjectOrdering order,
-  const std::unordered_map<ElementIDStruct, TimeType>& cur_objs,
-  TimeType my_load, TimeType target_load,
+  const std::unordered_map<ElementIDStruct, LoadType>& cur_objs,
+  LoadType my_load, LoadType target_load,
   const std::vector<ElementIDType>& soln, bool use_tempered_wmin) {
   // have TemperedLB order the objects
   auto ordered_objs = use_tempered_wmin ?
@@ -94,12 +94,12 @@ void orderAndVerify(
 }
 
 void orderUsingOverloadAndVerify(
-  ObjectOrdering order, TimeType over_avg_sec /* my_load-target_load */,
+  ObjectOrdering order, LoadType over_avg_sec /* my_load-target_load */,
   const std::vector<ElementIDType> &soln, bool use_temperd_wmin = false
 ) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = setupProblem(cur_objs);
-  TimeType target_load = my_load - over_avg_sec;
+  std::unordered_map<ElementIDStruct, LoadType> cur_objs;
+  LoadType my_load = setupProblem(cur_objs);
+  LoadType target_load = my_load - over_avg_sec;
 
   orderAndVerify(
     order, cur_objs, my_load, target_load, soln, use_temperd_wmin
@@ -107,12 +107,12 @@ void orderUsingOverloadAndVerify(
 }
 
 void orderUsingTargetLoadAndVerify(
-  ObjectOrdering order, TimeType target_load_sec,
+  ObjectOrdering order, LoadType target_load_sec,
   const std::vector<ElementIDType> &soln, bool use_temperd_wmin = false
 ) {
-  std::unordered_map<ElementIDStruct, TimeType> cur_objs;
-  TimeType my_load = setupProblem(cur_objs);
-  TimeType target_load = target_load_sec;
+  std::unordered_map<ElementIDStruct, LoadType> cur_objs;
+  LoadType my_load = setupProblem(cur_objs);
+  LoadType target_load = target_load_sec;
 
   orderAndVerify(
     order, cur_objs, my_load, target_load, soln, use_temperd_wmin
@@ -123,7 +123,7 @@ void orderUsingTargetLoadAndVerify(
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_elmid) {
   ObjectOrdering order = ObjectOrdering::ElmID;
-  TimeType over_avg = 4.5;
+  LoadType over_avg = 4.5;
   // result will be independent of over_avg
   std::vector<ElementIDType> soln = {0, 1, 2, 3, 4, 5};
 
@@ -134,7 +134,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_elmid) {
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_fewestmigrations_intermediate) {
   ObjectOrdering order = ObjectOrdering::FewestMigrations;
-  TimeType over_avg = 4.5;
+  LoadType over_avg = 4.5;
   // single_obj_load will be 5.0
   // load order will be 5.0, 4.0, 3.0, 2.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {5, 3, 4, 0, 1, 2};
@@ -144,7 +144,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_fewestmigrations_intermediate) {
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_fewestmigrations_largest) {
   ObjectOrdering order = ObjectOrdering::FewestMigrations;
-  TimeType over_avg = 12.5;
+  LoadType over_avg = 12.5;
   // single_obj_load will be 9.0
   // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
   std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
@@ -154,7 +154,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_fewestmigrations_largest) {
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_fewestmigrations_smallest) {
   ObjectOrdering order = ObjectOrdering::FewestMigrations;
-  TimeType over_avg = 1.5;
+  LoadType over_avg = 1.5;
   // single_obj_load will be 2.0
   // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {0, 4, 3, 5, 1, 2};
@@ -166,7 +166,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_fewestmigrations_smallest) {
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_smallobjects_intermediate) {
   ObjectOrdering order = ObjectOrdering::SmallObjects;
-  TimeType over_avg = 4.5;
+  LoadType over_avg = 4.5;
   // marginal_obj_load will be 3.0
   // load order will be 3.0, 2.0, 4.0, 5.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {4, 0, 3, 5, 1, 2};
@@ -176,7 +176,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_smallobjects_intermediate) {
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_smallobjects_largest) {
   ObjectOrdering order = ObjectOrdering::SmallObjects;
-  TimeType target_load = 0.5;
+  LoadType target_load = 0.5;
   // marginal_obj_load will be 9.0
   // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
   std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
@@ -186,7 +186,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_smallobjects_largest) {
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_smallobjects_smallest) {
   ObjectOrdering order = ObjectOrdering::SmallObjects;
-  TimeType over_avg = 1.5;
+  LoadType over_avg = 1.5;
   // marginal_obj_load will be 2.0
   // load order will be 2.0, 3.0, 4.0, 5.0, 6.0, 9.0
   std::vector<ElementIDType> soln = {0, 4, 3, 5, 1, 2};
@@ -198,7 +198,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_smallobjects_smallest) {
 
 TEST_F(TestTemperedLB, test_temperedlb_ordering_largestobjects) {
   ObjectOrdering order = ObjectOrdering::LargestObjects;
-  TimeType over_avg = 4.5;
+  LoadType over_avg = 4.5;
   // result will be independent of over_avg
   std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};
 
@@ -209,7 +209,7 @@ TEST_F(TestTemperedLB, test_temperedlb_ordering_largestobjects) {
 
 TEST_F(TestTemperedLB, test_temperedwmin_ordering_elmid) {
   ObjectOrdering order = ObjectOrdering::ElmID;
-  TimeType over_avg = 4.5;
+  LoadType over_avg = 4.5;
   // result will be independent of over_avg
   std::vector<ElementIDType> soln = {0, 1, 2, 3, 4, 5};
 
@@ -218,7 +218,7 @@ TEST_F(TestTemperedLB, test_temperedwmin_ordering_elmid) {
 
 TEST_F(TestTemperedLB, test_temperedwmin_ordering_smallobjects_largest) {
   ObjectOrdering order = ObjectOrdering::SmallObjects;
-  TimeType target_load = 0.5;
+  LoadType target_load = 0.5;
   // marginal_obj_load will be 9.0
   // load order will be 9.0, 6.0, 5.0, 4.0, 3.0, 2.0
   std::vector<ElementIDType> soln = {2, 1, 5, 3, 4, 0};


### PR DESCRIPTION
Fixes #2168 