### PR TITLE
#2132: utils: close meminfo -- although it seems unecessary since destructor should?

### DIFF
--- a/src/vt/utils/memory/memory_usage.cc
+++ b/src/vt/utils/memory/memory_usage.cc
@@ -271,6 +271,7 @@ std::size_t StatM::getUsage() {
           huge_page_bytes *= 1024;
         }
       }
+      meminfo.close();
     }
 
     return ((npages - huge_pages) * sysconf(_SC_PAGE_SIZE)) +


### PR DESCRIPTION
Fixes #2132