### PR TITLE
2094: Allow ObjGroup broadcast to selected nodes

### DIFF
--- a/examples/hello_world/objgroup.cc
+++ b/examples/hello_world/objgroup.cc
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
   vt::theGroup()->newGroupCollective(
     this_node % 2, [proxy, this_node](::vt::GroupType type) {
       if (this_node == 0) {
-        proxy.broadcastToGroup<&MyObjGroup::handler>(type, 122, 244);
+        proxy.multicast<&MyObjGroup::handler>(type, 122, 244);
       }
     });
 
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
       }
     }
 
-    proxy.broadcastToNodes<&MyObjGroup::handler>(
+    proxy.multicast<&MyObjGroup::handler>(
       std::make_unique<List>(range), 20, 40
     );
   }

--- a/examples/hello_world/objgroup.cc
+++ b/examples/hello_world/objgroup.cc
@@ -75,8 +75,8 @@ int main(int argc, char** argv) {
   if (this_node == 0) {
     using namespace ::vt::group::region;
 
-    List list(List::ListType{0, 2, 4});
-    proxy.broadcastToNodes<&MyObjGroup::handler>(std::move(list), 20, 40, 60);
+    Region::RegionUPtrType list = std::make_unique<List>(List::ListType{0, 2, 4});
+    proxy.broadcastToNodes<&MyObjGroup::handler>(std::move(list), 20, 40);
   }
   vt::theCollective()->barrier();
 

--- a/examples/hello_world/objgroup.cc
+++ b/examples/hello_world/objgroup.cc
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
   auto proxy =
     vt::theObjGroup()->makeCollective<MyObjGroup>("examples_hello_world");
 
-  // Create group of odd nodes and broadcast to them (from root node)
+  // Create group of odd nodes and multicast to them (from root node)
   vt::theGroup()->newGroupCollective(
     this_node % 2, [proxy, this_node](::vt::GroupType type) {
       if (this_node == 0) {
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
 
     using namespace ::vt::group::region;
 
-    // Create list of nodes and broadcast to them
+    // Create list of nodes and multicast to them
     List::ListType range;
     for (vt::NodeType node = 0; node < num_nodes; ++node) {
       if (node % 2 == 0) {

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -124,6 +124,16 @@ void GroupManager::deleteGroupCollective(GroupType group_id) {
   }
 }
 
+std::optional<GroupType>
+GroupManager::GetTempGroupForRange(const region::Region::ListType& range) {
+  const auto it = temporary_groups_.find(range);
+  if (it != temporary_groups_.end()) {
+    return it->second;
+  }
+
+  return {};
+}
+
 bool GroupManager::inGroup(GroupType const group) {
   auto iter = local_collective_group_info_.find(group);
   vtAssert(iter != local_collective_group_info_.end(), "Must exist");

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -68,6 +68,7 @@
 #include <unordered_map>
 #include <cstdlib>
 #include <functional>
+#include <optional>
 
 #include <mpi.h>
 
@@ -120,6 +121,12 @@ struct GroupManager : runtime::component::Component<GroupManager> {
    */
   void setupDefaultGroup();
 
+  void AddNewTempGroup(const region::Region::ListType& key, GroupType value) {
+    temporary_groups_[key] = value;
+  }
+
+  std::optional<GroupType>
+  GetTempGroupForRange(const region::Region::ListType& range);
   /**
    * \brief Create a new rooted group.
    *
@@ -431,6 +438,7 @@ private:
   ActionContainerType   continuation_actions_         = {};
   ActionListType        cleanup_actions_              = {};
   CollectiveScopeType   collective_scope_;
+  std::unordered_map<region::Region::ListType, GroupType, region::ListHash> temporary_groups_ = {};
 };
 
 /**

--- a/src/vt/group/group_manager.h
+++ b/src/vt/group/group_manager.h
@@ -121,12 +121,22 @@ struct GroupManager : runtime::component::Component<GroupManager> {
    */
   void setupDefaultGroup();
 
-  void AddNewTempGroup(const region::Region::ListType& key, GroupType value) {
-    temporary_groups_[key] = value;
+  /**
+   * \internal \brief Cache group created by multicast. This allows for reusing the same group.
+   *
+   * \param[in] range list of nodes that are part of given group
+   * \param[in] group group to cache
+   */
+  void AddNewTempGroup(const region::Region::ListType& range, GroupType group) {
+    temporary_groups_[range] = group;
   }
 
+  /**
+   * \internal \brief Return (if any) group associated with given range of nodes
+   */
   std::optional<GroupType>
   GetTempGroupForRange(const region::Region::ListType& range);
+
   /**
    * \brief Create a new rooted group.
    *
@@ -438,7 +448,8 @@ private:
   ActionContainerType   continuation_actions_         = {};
   ActionListType        cleanup_actions_              = {};
   CollectiveScopeType   collective_scope_;
-  std::unordered_map<region::Region::ListType, GroupType, region::ListHash> temporary_groups_ = {};
+  std::unordered_map<region::Region::ListType, GroupType, region::ListHash>
+    temporary_groups_ = {};
 };
 
 /**

--- a/src/vt/group/region/group_region.h
+++ b/src/vt/group/region/group_region.h
@@ -64,7 +64,7 @@ struct Region {
   using ListType = std::vector<BoundType>;
   using ApplyFnType = std::function<void(RegionUPtrType)>;
 
-  virtual ~Region(){}
+  virtual ~Region() = default;
   virtual SizeType getSize() const = 0;
   virtual void sort() = 0;
   virtual bool contains(NodeType const& node) = 0;
@@ -75,6 +75,17 @@ struct Region {
   virtual RegionUPtrType tail() const = 0;
   virtual SplitRegionType split() const = 0;
   virtual void splitN(int nsplits, ApplyFnType apply) const = 0;
+};
+
+struct ListHash {
+    size_t operator()(const Region::ListType& v) const {
+        std::hash<Region::BoundType> hasher;
+        size_t seed = 0;
+        for (const auto i : v) {
+            seed ^= hasher(i) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        }
+        return seed;
+    }
 };
 
 struct List;

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -41,6 +41,7 @@
 //@HEADER
 */
 
+#include "vt/group/region/group_list.h"
 #if !defined INCLUDED_VT_OBJGROUP_PROXY_PROXY_OBJGROUP_H
 #define INCLUDED_VT_OBJGROUP_PROXY_PROXY_OBJGROUP_H
 
@@ -158,6 +159,12 @@ public:
    */
   template <auto fn, typename... Args>
   PendingSendType broadcast(Args&&... args) const;
+
+  template <auto fn, typename... Args>
+  PendingSendType broadcastToGroup(GroupType type, Args&&... args) const;
+
+  template <auto fn, typename... Args>
+  PendingSendType broadcastToNodes(group::region::List&& nodes, Args&&... args) const;
 
   /**
    * \brief All-reduce back to this objgroup. Performs a reduction using

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -161,24 +161,24 @@ public:
   PendingSendType broadcast(Args&&... args) const;
 
   /**
-   * \brief Broadcast a message to nodes that are part of given group to be delivered to the local object
+   * \brief Multicast a message to nodes that are part of given group to be delivered to the local object
    * instance
    *
-   * \param[in] type group to broadcast
+   * \param[in] type group to multicast
    * \param[in] args args to pass to the message constructor
    */
   template <auto fn, typename... Args>
-  PendingSendType broadcastToGroup(GroupType type, Args&&... args) const;
+  PendingSendType multicast(GroupType type, Args&&... args) const;
 
   /**
-   * \brief Broadcast a message to nodes specified by the region to be delivered to the local object
+   * \brief Multicast a message to nodes specified by the region to be delivered to the local object
    * instance
    *
-   * \param[in] nodes region of nodes to broadcast to
+   * \param[in] nodes region of nodes to multicast to
    * \param[in] args args to pass to the message constructor
    */
   template <auto fn, typename... Args>
-  PendingSendType broadcastToNodes(group::region::Region::RegionUPtrType&& nodes, Args&&... args) const;
+  PendingSendType multicast(group::region::Region::RegionUPtrType&& nodes, Args&&... args) const;
 
   /**
    * \brief All-reduce back to this objgroup. Performs a reduction using

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -41,7 +41,6 @@
 //@HEADER
 */
 
-#include "vt/group/region/group_list.h"
 #if !defined INCLUDED_VT_OBJGROUP_PROXY_PROXY_OBJGROUP_H
 #define INCLUDED_VT_OBJGROUP_PROXY_PROXY_OBJGROUP_H
 
@@ -60,6 +59,7 @@
 #include "vt/rdmahandle/handle_set.fwd.h"
 #include "vt/messaging/pending_send.h"
 #include "vt/utils/fntraits/fntraits.h"
+#include "vt/group/region/group_list.h"
 
 namespace vt { namespace objgroup { namespace proxy {
 
@@ -160,9 +160,23 @@ public:
   template <auto fn, typename... Args>
   PendingSendType broadcast(Args&&... args) const;
 
+  /**
+   * \brief Broadcast a message to nodes that are part of given group to be delivered to the local object
+   * instance
+   *
+   * \param[in] type group to broadcast
+   * \param[in] args args to pass to the message constructor
+   */
   template <auto fn, typename... Args>
   PendingSendType broadcastToGroup(GroupType type, Args&&... args) const;
 
+  /**
+   * \brief Broadcast a message to nodes specified by the region to be delivered to the local object
+   * instance
+   *
+   * \param[in] nodes region of nodes to broadcast to
+   * \param[in] args args to pass to the message constructor
+   */
   template <auto fn, typename... Args>
   PendingSendType broadcastToNodes(group::region::Region::RegionUPtrType&& nodes, Args&&... args) const;
 

--- a/src/vt/objgroup/proxy/proxy_objgroup.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.h
@@ -164,7 +164,7 @@ public:
   PendingSendType broadcastToGroup(GroupType type, Args&&... args) const;
 
   template <auto fn, typename... Args>
-  PendingSendType broadcastToNodes(group::region::List&& nodes, Args&&... args) const;
+  PendingSendType broadcastToNodes(group::region::Region::RegionUPtrType&& nodes, Args&&... args) const;
 
   /**
    * \brief All-reduce back to this objgroup. Performs a reduction using

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -112,7 +112,7 @@ Proxy<ObjT>::broadcast(Params&&... params) const {
 template <typename ObjT>
 template <auto f, typename... Params>
 typename Proxy<ObjT>::PendingSendType
-Proxy<ObjT>::broadcastToGroup(GroupType type, Params&&... params) const{
+Proxy<ObjT>::multicast(GroupType type, Params&&... params) const{
   using MsgT = typename ObjFuncTraits<decltype(f)>::MsgT;
   if constexpr (std::is_same_v<MsgT, NoMsg>) {
     using Tuple = typename ObjFuncTraits<decltype(f)>::TupleType;
@@ -136,7 +136,7 @@ Proxy<ObjT>::broadcastToGroup(GroupType type, Params&&... params) const{
 
 template <typename ObjT>
 template <auto f, typename... Params>
-typename Proxy<ObjT>::PendingSendType Proxy<ObjT>::broadcastToNodes(
+typename Proxy<ObjT>::PendingSendType Proxy<ObjT>::multicast(
   group::region::Region::RegionUPtrType&& nodes, Params&&... params) const {
   // This will work for list-type ranges only
   nodes->sort();
@@ -148,7 +148,7 @@ typename Proxy<ObjT>::PendingSendType Proxy<ObjT>::broadcastToNodes(
     theGroup()->AddNewTempGroup(range, groupID.value());
   }
 
-  return broadcastToGroup<f>(groupID.value(), std::forward<Params>(params)...);
+  return multicast<f>(groupID.value(), std::forward<Params>(params)...);
 }
 
 template <typename ObjT>

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -139,7 +139,7 @@ Proxy<ObjT>::broadcastToGroup(GroupType type, Params&&... params) const{
 template <typename ObjT>
 template <auto f, typename... Params>
 typename Proxy<ObjT>::PendingSendType
-Proxy<ObjT>::broadcastToNodes(group::region::List&& nodes, Params&&... params) const{
+Proxy<ObjT>::broadcastToNodes(group::region::Region::RegionUPtrType&& nodes, Params&&... params) const{
   // TODO: Should we cache it?
   const auto groupType = theGroup()->newGroup(std::move(nodes), [](GroupType type){});
   return broadcastToGroup<f>(groupType, std::forward<Params>(params)...);

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -138,7 +138,11 @@ template <typename ObjT>
 template <auto f, typename... Params>
 typename Proxy<ObjT>::PendingSendType Proxy<ObjT>::multicast(
   group::region::Region::RegionUPtrType&& nodes, Params&&... params) const {
-  // This will work for list-type ranges only
+  vtAssert(
+    not dynamic_cast<group::region::ShallowList*>(nodes.get()),
+    "multicast: range of nodes is not supported for ShallowList!"
+  );
+
   nodes->sort();
   auto& range = nodes->makeList();
 


### PR DESCRIPTION
Fixes #2094 

*******
```c++
#include "common/test_harness.h"
#include <vt/transport.h>

#include <fmt-vt/core.h>

using namespace vt;
using namespace vt::tests::perf::common;

struct MyTest : PerfTestHarness { };

struct NodeObj {
  void handler(int, int b) {
  }
};

VT_PERF_TEST(MyTest, test_objgroup_send) {
  using namespace ::vt::group::region;

  const auto num_nodes = vt::theContext()->getNumNodes();

  auto proxy = vt::theObjGroup()->makeCollective<NodeObj>(
    "test_objgroup_local_send");

  List::ListType range;
  for(NodeType n = 0; n < num_nodes - 1; ++n){
    range.push_back(n);
  }

  if (theContext()->getNode() == 0) {

    for(auto& node : range){
      proxy[node].send<&NodeObj::handler>(10, 20);
    }

    for(auto& node : range){
      proxy[node].send<&NodeObj::handler>(10, 20);
    }
  }

  vt::theCollective()->barrier();
}

VT_PERF_TEST(MyTest, test_objgroup_multicast) {
  using namespace ::vt::group::region;

  const auto num_nodes = vt::theContext()->getNumNodes();

  auto proxy = vt::theObjGroup()->makeCollective<NodeObj>(
    "test_objgroup_local_send");

  List::ListType range;
  for(NodeType n = 0; n < num_nodes - 1; ++n){
    range.push_back(n);
  }

  if (theContext()->getNode() == 0) {
    proxy.multicast<&NodeObj::handler>(
      std::make_unique<List>(range), 10, 20);

    proxy.multicast<&NodeObj::handler>(
      std::make_unique<List>(range), 10, 20);
  }

  vt::theCollective()->barrier();
}

VT_PERF_TEST_MAIN()
```
*******
### SEND
![image](https://github.com/DARMA-tasking/vt/assets/9077677/56f565df-0fd9-4883-b4c3-4665c2e2c8dc)

*******
### MULTICAST
![image](https://github.com/DARMA-tasking/vt/assets/9077677/7df217ac-8c95-4e1e-8629-697735209c46)
