### PR TITLE
2212 add message properties for generated messages

### DIFF
--- a/src/vt/collective/reduce/reduce_manager.cc
+++ b/src/vt/collective/reduce/reduce_manager.cc
@@ -46,12 +46,12 @@
 
 namespace vt { namespace collective { namespace reduce {
 
+static std::unique_ptr<Reduce> makeReduceScope(detail::ReduceScope const& scope) {
+  return std::make_unique<Reduce>(scope);
+}
+
 ReduceManager::ReduceManager()
-  : reducers_( // default cons reducer for non-group
-      [](detail::ReduceScope const& scope) {
-        return std::make_unique<Reduce>(scope);
-      }
-    )
+  : reducers_(makeReduceScope)
 {
   // insert the default reducer scope
   reducers_.make(

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -766,7 +766,8 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   PendingSendType send(Node dest, Params&&... params) {
     using Tuple = typename FuncTraits<decltype(f)>::TupleType;
     using MsgT = ParamMsg<Tuple>;
-    auto msg = vt::makeMessage<MsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<MsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     auto han = auto_registry::makeAutoHandlerParam<decltype(f), f, MsgT>();
     return sendMsg<MsgT>(dest.get(), han, msg, no_tag);
   }
@@ -782,7 +783,8 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
   PendingSendType broadcast(Params&&... params) {
     using Tuple = typename FuncTraits<decltype(f)>::TupleType;
     using MsgT = ParamMsg<Tuple>;
-    auto msg = vt::makeMessage<MsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<MsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     auto han = auto_registry::makeAutoHandlerParam<decltype(f), f, MsgT>();
     constexpr bool deliver_to_sender = true;
     return broadcastMsg<MsgT>(han, msg, deliver_to_sender, no_tag);

--- a/src/vt/messaging/active.impl.h
+++ b/src/vt/messaging/active.impl.h
@@ -512,4 +512,6 @@ inline EpochType ActiveMessenger::setupEpochMsg(MsgSharedPtr<MsgT> const& msg) {
 
 }} //end namespace vt::messaging
 
+#include "vt/messaging/param_msg.impl.h"
+
 #endif /*INCLUDED_VT_MESSAGING_ACTIVE_IMPL_H*/

--- a/src/vt/messaging/param_msg.h
+++ b/src/vt/messaging/param_msg.h
@@ -91,8 +91,8 @@ struct MsgProps {
     return std::move(*this);
   }
 
-  template <typename MsgT>
-  void apply(MsgT& msg);
+  template <typename MsgPtrT>
+  void apply(MsgPtrT msg);
 
 private:
   bool as_location_msg_ = false;

--- a/src/vt/messaging/param_msg.h
+++ b/src/vt/messaging/param_msg.h
@@ -160,7 +160,7 @@ struct ParamMsg<
   void setParams(Param&& p, Params&&... in_params) {
     if constexpr (std::is_same_v<Param, MsgProps>) {
       params = TupleType{std::forward<Params>(in_params)...};
-      p.apply(*this);
+      p.apply(this);
     } else {
       params = TupleType{std::forward<Param>(p), std::forward<Params>(in_params)...};
     }
@@ -190,7 +190,7 @@ struct ParamMsg<
   void setParams(Param&& p, Params&&... in_params) {
     if constexpr (std::is_same_v<Param, MsgProps>) {
       params = std::make_unique<TupleType>(std::forward<Params>(in_params)...);
-      p.apply(*this);
+      p.apply(this);
     } else {
       params = std::make_unique<TupleType>(
         std::forward<Param>(p), std::forward<Params>(in_params)...

--- a/src/vt/messaging/param_msg.h
+++ b/src/vt/messaging/param_msg.h
@@ -46,7 +46,101 @@
 
 #include "vt/messaging/message/message_serialize.h"
 
-namespace vt { namespace messaging {
+namespace vt {
+
+struct MsgProps {
+
+  MsgProps() = default;
+
+  MsgProps&& asLocationMsg(bool set = true) {
+    as_location_msg_ = set;
+    return std::move(*this);
+  }
+
+  MsgProps&& asTerminationMsg(bool set = true) {
+    as_termination_msg_ = set;
+    return std::move(*this);
+  }
+
+  MsgProps&& asCollectionMsg(bool set = true) {
+    as_collection_msg_ = set;
+    return std::move(*this);
+  }
+
+  MsgProps&& asSerializationMsg(bool set = true) {
+    as_serial_msg_ = set;
+    return std::move(*this);
+  }
+
+  MsgProps&& withEpoch(EpochType in_ep) {
+    ep_ = in_ep;
+    return std::move(*this);
+  }
+
+  MsgProps&& withPriority(PriorityType in_priority) {
+#if vt_check_enabled(priorities)
+    priority_ = in_priority;
+#endif
+    return std::move(*this);
+  }
+
+  MsgProps&& withPriorityLevel(PriorityLevelType in_priority_level) {
+#if vt_check_enabled(priorities)
+    priority_level_ = in_priority_level;
+#endif
+    return std::move(*this);
+  }
+
+  template <typename MsgT>
+  void apply(MsgT& msg);
+
+private:
+  bool as_location_msg_ = false;
+  bool as_termination_msg_ = false;
+  bool as_serial_msg_ = false;
+  bool as_collection_msg_ = false;
+  EpochType ep_ = no_epoch;
+  PriorityType priority_ = no_priority;
+  PriorityLevelType priority_level_ = no_priority_level;
+};
+
+} /* end namespace vt */
+
+namespace vt::messaging::detail {
+
+template <typename enabled_, typename... Params>
+struct GetTraits;
+
+template <>
+struct GetTraits<std::enable_if_t<std::is_same_v<void, void>>> {
+  using TupleType = std::tuple<>;
+};
+
+template <typename Param, typename... Params>
+struct GetTraits<
+  std::enable_if_t<std::is_same_v<MsgProps, Param>>, Param, Params...
+>  {
+  using TupleType = std::tuple<Params...>;
+};
+
+template <typename Param, typename... Params>
+struct GetTraits<
+  std::enable_if_t<not std::is_same_v<MsgProps, Param>>, Param, Params...
+>  {
+  using TupleType = std::tuple<Param, Params...>;
+};
+
+template <typename Tuple>
+struct GetTraitsTuple;
+
+template <typename... Params>
+struct GetTraitsTuple<std::tuple<Params...>> {
+  using TupleType = typename GetTraits<void, Params...>::TupleType;
+};
+
+} /* end namespace vt::messaging::detail */
+
+namespace vt::messaging {
 
 template <typename Tuple, typename enabled = void>
 struct ParamMsg;
@@ -56,15 +150,24 @@ struct ParamMsg<
   Tuple, std::enable_if_t<is_byte_copyable_t<Tuple>::value>
 > : vt::Message
 {
+  using TupleType = typename detail::GetTraitsTuple<Tuple>::TupleType;
+
   ParamMsg() = default;
 
-  template <typename... Params>
-  explicit ParamMsg(Params&&... in_params)
-    : params(std::forward<Params>(in_params)...)
-  { }
+  void setParams() { }
 
-  Tuple params;
-  Tuple& getTuple() { return params; }
+  template <typename Param, typename... Params>
+  void setParams(Param&& p, Params&&... in_params) {
+    if constexpr (std::is_same_v<Param, MsgProps>) {
+      params = TupleType{std::forward<Params>(in_params)...};
+      p.apply(*this);
+    } else {
+      params = TupleType{std::forward<Param>(p), std::forward<Params>(in_params)...};
+    }
+  }
+
+  TupleType params;
+  TupleType& getTuple() { return params; }
 };
 
 template <typename Tuple>
@@ -75,16 +178,29 @@ struct ParamMsg<
   using MessageParentType = vt::Message;
   vt_msg_serialize_if_needed_by_parent_or_type1(Tuple); // by tup
 
+  using TupleType = typename detail::GetTraitsTuple<Tuple>::TupleType;
+
   ParamMsg() = default;
 
-  template <typename... Params>
-  explicit ParamMsg(Params&&... in_params)
-    : params(std::make_unique<Tuple>(std::forward<Params>(in_params)...))
-  { }
+  void setParams() {
+    params = std::make_unique<TupleType>();
+  }
 
-  std::unique_ptr<Tuple> params;
+  template <typename Param, typename... Params>
+  void setParams(Param&& p, Params&&... in_params) {
+    if constexpr (std::is_same_v<Param, MsgProps>) {
+      params = std::make_unique<TupleType>(std::forward<Params>(in_params)...);
+      p.apply(*this);
+    } else {
+      params = std::make_unique<TupleType>(
+        std::forward<Param>(p), std::forward<Params>(in_params)...
+      );
+    }
+  }
 
-  Tuple& getTuple() { return *params.get(); }
+  std::unique_ptr<TupleType> params;
+
+  TupleType& getTuple() { return *params.get(); }
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -93,6 +209,6 @@ struct ParamMsg<
   }
 };
 
-}} /* end namespace vt::messaging */
+} /* end namespace vt::messaging */
 
 #endif /*INCLUDED_VT_MESSAGING_PARAM_MSG_H*/

--- a/src/vt/messaging/param_msg.h
+++ b/src/vt/messaging/param_msg.h
@@ -100,8 +100,10 @@ private:
   bool as_serial_msg_ = false;
   bool as_collection_msg_ = false;
   EpochType ep_ = no_epoch;
+#if vt_check_enabled(priorities)
   PriorityType priority_ = no_priority;
   PriorityLevelType priority_level_ = no_priority_level;
+#endif
 };
 
 } /* end namespace vt */

--- a/src/vt/messaging/param_msg.h
+++ b/src/vt/messaging/param_msg.h
@@ -160,7 +160,7 @@ struct ParamMsg<
 
   template <typename Param, typename... Params>
   void setParams(Param&& p, Params&&... in_params) {
-    if constexpr (std::is_same_v<Param, MsgProps>) {
+    if constexpr (std::is_same_v<std::decay_t<Param>, MsgProps>) {
       params = TupleType{std::forward<Params>(in_params)...};
       p.apply(this);
     } else {
@@ -190,7 +190,7 @@ struct ParamMsg<
 
   template <typename Param, typename... Params>
   void setParams(Param&& p, Params&&... in_params) {
-    if constexpr (std::is_same_v<Param, MsgProps>) {
+    if constexpr (std::is_same_v<std::decay_t<Param>, MsgProps>) {
       params = std::make_unique<TupleType>(std::forward<Params>(in_params)...);
       p.apply(this);
     } else {

--- a/src/vt/messaging/param_msg.impl.h
+++ b/src/vt/messaging/param_msg.impl.h
@@ -78,4 +78,3 @@ void MsgProps::apply(MsgPtrT msg) {
 } /* end namespace vt */
 
 #endif /*INCLUDED_VT_MESSAGING_PARAM_MSG_IMPL_H*/
-

--- a/src/vt/messaging/param_msg.impl.h
+++ b/src/vt/messaging/param_msg.impl.h
@@ -48,8 +48,8 @@
 
 namespace vt {
 
-template <typename MsgT>
-void MsgProps::apply(MsgT& msg) {
+template <typename MsgPtrT>
+void MsgProps::apply(MsgPtrT msg) {
   if (as_location_msg_) {
     theMsg()->markAsLocationMessage(msg);
   }

--- a/src/vt/messaging/param_msg.impl.h
+++ b/src/vt/messaging/param_msg.impl.h
@@ -1,0 +1,81 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               param_msg.impl.h
+//                       DARMA/vt => Virtual Transport
+//
+// Copyright 2019-2021 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#if !defined INCLUDED_VT_MESSAGING_PARAM_MSG_IMPL_H
+#define INCLUDED_VT_MESSAGING_PARAM_MSG_IMPL_H
+
+#include "vt/messaging/param_msg.h"
+
+namespace vt {
+
+template <typename MsgT>
+void MsgProps::apply(MsgT& msg) {
+  if (as_location_msg_) {
+    theMsg()->markAsLocationMessage(msg);
+  }
+  if (as_termination_msg_) {
+    theMsg()->markAsTermMessage(msg);
+  }
+  if (as_serial_msg_) {
+    theMsg()->markAsSerialMsgMessage(msg);
+  }
+  if (as_collection_msg_) {
+    theMsg()->markAsCollectionMessage(msg);
+  }
+  if (ep_ != no_epoch) {
+    envelopeSetEpoch(msg->env, ep_);
+  }
+#if vt_check_enabled(priorities)
+  if (priority_ != no_priority) {
+    envelopeSetPriority(msg->env, priority_);
+  }
+  if (priority_level_ != no_priority_level) {
+    envelopeSetPriorityLevel(msg->env, priority_level_);
+  }
+#endif
+}
+
+} /* end namespace vt */
+
+#endif /*INCLUDED_VT_MESSAGING_PARAM_MSG_IMPL_H*/
+

--- a/src/vt/messaging/pending_send.h
+++ b/src/vt/messaging/pending_send.h
@@ -153,6 +153,15 @@ struct PendingSend final {
    */
   void release();
 
+  /**
+   * \internal \brief Get the message stored in the pending send
+   *
+   * \note Used for testing purposes
+   *
+   * \return a reference to the message
+   */
+  MsgPtr<BaseMsgType>& getMsg() { return msg_; }
+
 private:
 
   /**

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -118,7 +118,8 @@ Proxy<ObjT>::multicast(GroupType type, Params&&... params) const{
   if constexpr (std::is_same_v<MsgT, NoMsg>) {
     using Tuple = typename ObjFuncTraits<decltype(f)>::TupleType;
     using SendMsgT = messaging::ParamMsg<Tuple>;
-    auto msg = vt::makeMessage<SendMsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<SendMsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     vt::envelopeSetGroup(msg->env, type);
     auto const ctrl = proxy::ObjGroupProxy::getID(proxy_);
     auto const han = auto_registry::makeAutoHandlerObjGroupParam<

--- a/src/vt/objgroup/proxy/proxy_objgroup.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup.impl.h
@@ -94,7 +94,8 @@ Proxy<ObjT>::broadcast(Params&&... params) const {
   if constexpr (std::is_same_v<MsgT, NoMsg>) {
     using Tuple = typename ObjFuncTraits<decltype(f)>::TupleType;
     using SendMsgT = messaging::ParamMsg<Tuple>;
-    auto msg = vt::makeMessage<SendMsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<SendMsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     auto const ctrl = proxy::ObjGroupProxy::getID(proxy_);
     auto const han = auto_registry::makeAutoHandlerObjGroupParam<
       ObjT, decltype(f), f, SendMsgT

--- a/src/vt/objgroup/proxy/proxy_objgroup_elm.impl.h
+++ b/src/vt/objgroup/proxy/proxy_objgroup_elm.impl.h
@@ -85,7 +85,8 @@ ProxyElm<ObjT>::send(Params&&... params) const {
   if constexpr (std::is_same_v<MsgT, NoMsg>) {
     using Tuple = typename ObjFuncTraits<decltype(f)>::TupleType;
     using SendMsgT = messaging::ParamMsg<Tuple>;
-    auto msg = vt::makeMessage<SendMsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<SendMsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     auto const ctrl = proxy::ObjGroupProxy::getID(proxy_);
     auto const han = auto_registry::makeAutoHandlerObjGroupParam<
       ObjT, decltype(f), f, SendMsgT

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -234,7 +234,8 @@ struct CallbackTyped : CallbackRawBaseSingle {
   void sendTuple(std::tuple<Params...> tup) {
     using Trait = CBTraits<Args...>;
     using MsgT = messaging::ParamMsg<typename Trait::TupleType>;
-    auto msg = vt::makeMessage<MsgT>(std::move(tup));
+    auto msg = vt::makeMessage<MsgT>();
+    msg->setParams(std::move(tup));
     CallbackRawBaseSingle::sendMsg<MsgT>(msg);
   }
 
@@ -243,7 +244,8 @@ struct CallbackTyped : CallbackRawBaseSingle {
     using Trait = CBTraits<Args...>;
     if constexpr (std::is_same_v<typename Trait::MsgT, NoMsg>) {
       using MsgT = messaging::ParamMsg<typename Trait::TupleType>;
-      auto msg = vt::makeMessage<MsgT>(std::forward<Params>(params)...);
+      auto msg = vt::makeMessage<MsgT>();
+      msg->setParams(std::forward<Params>(params)...);
       CallbackRawBaseSingle::sendMsg<MsgT>(msg);
     } else {
       using MsgT = typename Trait::MsgT;

--- a/src/vt/pipe/callback/cb_union/cb_raw_base.h
+++ b/src/vt/pipe/callback/cb_union/cb_raw_base.h
@@ -232,8 +232,7 @@ struct CallbackTyped : CallbackRawBaseSingle {
 
   template <typename... Params>
   void sendTuple(std::tuple<Params...> tup) {
-    using Trait = CBTraits<Args...>;
-    using MsgT = messaging::ParamMsg<typename Trait::TupleType>;
+    using MsgT = messaging::ParamMsg<std::tuple<std::decay_t<Params>...>>;
     auto msg = vt::makeMessage<MsgT>();
     msg->setParams(std::move(tup));
     CallbackRawBaseSingle::sendMsg<MsgT>(msg);
@@ -243,7 +242,7 @@ struct CallbackTyped : CallbackRawBaseSingle {
   void send(Params&&... params) {
     using Trait = CBTraits<Args...>;
     if constexpr (std::is_same_v<typename Trait::MsgT, NoMsg>) {
-      using MsgT = messaging::ParamMsg<typename Trait::TupleType>;
+      using MsgT = messaging::ParamMsg<std::tuple<std::decay_t<Params>...>>;
       auto msg = vt::makeMessage<MsgT>();
       msg->setParams(std::forward<Params>(params)...);
       CallbackRawBaseSingle::sendMsg<MsgT>(msg);

--- a/src/vt/vrt/collection/broadcast/broadcastable.impl.h
+++ b/src/vt/vrt/collection/broadcast/broadcastable.impl.h
@@ -185,7 +185,8 @@ Broadcastable<ColT, IndexT, BaseProxyT>::broadcast(Params&&... params) const {
   if constexpr (std::is_same_v<MsgT, NoMsg>) {
     using Tuple = typename ObjFuncTraits<decltype(f)>::TupleType;
     using SendMsgT = ParamColMsg<Tuple, ColT>;
-    auto msg = vt::makeMessage<SendMsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<SendMsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     auto han = auto_registry::makeAutoHandlerCollectionMemParam<
       ColT, decltype(f), f, SendMsgT
     >();
@@ -210,7 +211,8 @@ Broadcastable<ColT, IndexT, BaseProxyT>::broadcastCollective(Params&&... params)
   if constexpr (std::is_same_v<MsgT, NoMsg>) {
     using Tuple = typename ObjFuncTraits<decltype(f)>::TupleType;
     using SendMsgT = ParamColMsg<Tuple, ColT>;
-    auto msg = vt::makeMessage<SendMsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<SendMsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     auto han = auto_registry::makeAutoHandlerCollectionMemParam<
       ColT, decltype(f), f, SendMsgT
     >();

--- a/src/vt/vrt/collection/messages/param_col_msg.h
+++ b/src/vt/vrt/collection/messages/param_col_msg.h
@@ -68,7 +68,7 @@ struct ParamColMsg<
 
   template <typename Param, typename... Params>
   void setParams(Param&& p, Params&&... in_params) {
-    if constexpr (std::is_same_v<Param, MsgProps>) {
+    if constexpr (std::is_same_v<std::decay_t<Param>, MsgProps>) {
       params = TupleType{std::forward<Params>(in_params)...};
       p.apply(this);
     } else {
@@ -99,7 +99,7 @@ struct ParamColMsg<
 
   template <typename Param, typename... Params>
   void setParams(Param&& p, Params&&... in_params) {
-    if constexpr (std::is_same_v<Param, MsgProps>) {
+    if constexpr (std::is_same_v<std::decay_t<Param>, MsgProps>) {
       params = std::make_unique<TupleType>(std::forward<Params>(in_params)...);
       p.apply(this);
     } else {

--- a/src/vt/vrt/collection/messages/param_col_msg.h
+++ b/src/vt/vrt/collection/messages/param_col_msg.h
@@ -70,7 +70,7 @@ struct ParamColMsg<
   void setParams(Param&& p, Params&&... in_params) {
     if constexpr (std::is_same_v<Param, MsgProps>) {
       params = TupleType{std::forward<Params>(in_params)...};
-      p.apply(*this);
+      p.apply(this);
     } else {
       params = TupleType{std::forward<Param>(p), std::forward<Params>(in_params)...};
     }
@@ -101,7 +101,7 @@ struct ParamColMsg<
   void setParams(Param&& p, Params&&... in_params) {
     if constexpr (std::is_same_v<Param, MsgProps>) {
       params = std::make_unique<TupleType>(std::forward<Params>(in_params)...);
-      p.apply(*this);
+      p.apply(this);
     } else {
       params = std::make_unique<TupleType>(
         std::forward<Param>(p), std::forward<Params>(in_params)...

--- a/src/vt/vrt/collection/messages/param_col_msg.h
+++ b/src/vt/vrt/collection/messages/param_col_msg.h
@@ -46,6 +46,7 @@
 
 #include "vt/vrt/collection/messages/user.h"
 #include "vt/messaging/message/message_serialize.h"
+#include "vt/messaging/param_msg.h"
 
 namespace vt { namespace vrt { namespace collection {
 
@@ -58,15 +59,25 @@ struct ParamColMsg<
   ColT,
   std::enable_if_t<messaging::is_byte_copyable_t<Tuple>::value>
 > : CollectionMessage<ColT, vt::Message> {
+
+  using TupleType = typename messaging::detail::GetTraitsTuple<Tuple>::TupleType;
+
   ParamColMsg() = default;
 
-  template <typename... Params>
-  explicit ParamColMsg(Params&&... in_params)
-    : params(std::forward<Params>(in_params)...)
-  { }
+  void setParams() { }
 
-  Tuple params;
-  Tuple& getTuple() { return params; }
+  template <typename Param, typename... Params>
+  void setParams(Param&& p, Params&&... in_params) {
+    if constexpr (std::is_same_v<Param, MsgProps>) {
+      params = TupleType{std::forward<Params>(in_params)...};
+      p.apply(*this);
+    } else {
+      params = TupleType{std::forward<Param>(p), std::forward<Params>(in_params)...};
+    }
+  }
+
+  TupleType params;
+  TupleType& getTuple() { return params; }
 };
 
 template <typename Tuple, typename ColT>
@@ -78,16 +89,29 @@ struct ParamColMsg<
   using MessageParentType = CollectionMessage<ColT, vt::Message>;
   vt_msg_serialize_if_needed_by_parent_or_type1(Tuple); // by params
 
+  using TupleType = typename messaging::detail::GetTraitsTuple<Tuple>::TupleType;
+
   ParamColMsg() = default;
 
-  template <typename... Params>
-  explicit ParamColMsg(Params&&... in_params)
-    : params(std::make_unique<Tuple>(std::forward<Params>(in_params)...))
-  { }
+  void setParams() {
+    params = std::make_unique<TupleType>();
+  }
+
+  template <typename Param, typename... Params>
+  void setParams(Param&& p, Params&&... in_params) {
+    if constexpr (std::is_same_v<Param, MsgProps>) {
+      params = std::make_unique<TupleType>(std::forward<Params>(in_params)...);
+      p.apply(*this);
+    } else {
+      params = std::make_unique<TupleType>(
+        std::forward<Param>(p), std::forward<Params>(in_params)...
+      );
+    }
+  }
 
   std::unique_ptr<Tuple> params;
 
-  Tuple& getTuple() { return *params.get(); }
+  TupleType& getTuple() { return *params.get(); }
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {

--- a/src/vt/vrt/collection/send/sendable.impl.h
+++ b/src/vt/vrt/collection/send/sendable.impl.h
@@ -139,7 +139,8 @@ messaging::PendingSend Sendable<ColT,IndexT,BaseProxyT>::send(Params&&... params
   if constexpr (std::is_same_v<MsgT, NoMsg>) {
     using Tuple = typename FnTrait::TupleType;
     using SendMsgT = ParamColMsg<Tuple, ColT>;
-    auto msg = vt::makeMessage<SendMsgT>(std::forward<Params>(params)...);
+    auto msg = vt::makeMessage<SendMsgT>();
+    msg->setParams(std::forward<Params>(params)...);
     auto han = auto_registry::makeAutoHandlerCollectionMemParam<
       ColT, decltype(f), f, SendMsgT
     >();

--- a/tests/unit/active/test_active_send.cc
+++ b/tests/unit/active/test_active_send.cc
@@ -242,4 +242,21 @@ TEST_F(TestActiveSend, test_active_message_serialization) {
   EXPECT_EQ(handler_count, num_msg_sent);
 }
 
+void testPropertiesHandler(int a, double b) {
+  // do nothing
+}
+
+TEST_F(TestActiveSend, test_active_message_properties) {
+  auto const this_node = theContext()->getNode();
+  auto const num_nodes = theContext()->getNumNodes();
+  NodeType const next_node = (this_node + 1) % num_nodes;
+
+  if (num_nodes > 1) {
+    auto ps = theMsg()->send<testPropertiesHandler>(
+      vt::Node{next_node}, MsgProps().asTerminationMsg(), 10, 20.0
+    );
+    EXPECT_TRUE(messaging::envelopeIsTerm(ps.getMsg()->env));
+  }
+}
+
 }}}} // end namespace vt::tests::unit::send


### PR DESCRIPTION
Fixes #2212

- Adds message properties to generated/synthesized messages that are parameterized.
- I had to move the parameters going into `ParamMsg` from the constructor to a method `setParams` so I could safely modify the message is `MsgProps` are passed. Otherwise, I would have to save the `MsgProps` to apply them after the constructor finishes.