### PR TITLE
#2225: fix missing `<cstdint>` include

### DIFF
--- a/src/vt/configs/error/stack_out.h
+++ b/src/vt/configs/error/stack_out.h
@@ -44,6 +44,7 @@
 #if !defined INCLUDED_VT_CONFIGS_ERROR_STACK_OUT_H
 #define INCLUDED_VT_CONFIGS_ERROR_STACK_OUT_H
 
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <tuple>

--- a/src/vt/utils/compress/decompressor_base.h
+++ b/src/vt/utils/compress/decompressor_base.h
@@ -45,6 +45,7 @@
 #define INCLUDED_VT_UTILS_COMPRESS_DECOMPRESSOR_BASE_H
 
 #include <string>
+#include <cstdint>
 #include <cstdlib>
 
 namespace vt { namespace util { namespace compress {


### PR DESCRIPTION
fixes #2225 

Stumbled upon this when working on NimbleSM :slightly_smiling_face: 