### PR TITLE
2227 Add user LB info to load models

### DIFF
--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -191,8 +191,12 @@ std::shared_ptr<const balance::Reassignment> BaseLB::normalizeReassignments() {
       auto const raw_load_summary = getObjectRawLoads(
         load_model_, obj_id, {PhaseOffset::NEXT_PHASE, PhaseOffset::WHOLE_PHASE}
       );
+      auto const obj_user_data = getObjectUserData(
+        load_model_, obj_id, {PhaseOffset::NEXT_PHASE, PhaseOffset::WHOLE_PHASE}
+      );
+
       depart_map[dest].push_back(
-        std::make_tuple(obj_id, load_summary, raw_load_summary)
+        std::make_tuple(obj_id, load_summary, raw_load_summary, obj_user_data)
       );
     }
 
@@ -230,8 +234,9 @@ void BaseLB::notifyNewHostNodeOfObjectsArriving(
     auto const obj_id = std::get<0>(arrival);
     auto const& load_summary = std::get<1>(arrival);
     auto const& raw_load_summary = std::get<2>(arrival);
+    auto const& obj_user_data = std::get<3>(arrival);
     pending_reassignment_->arrive_[obj_id] = std::make_tuple(
-      load_summary, raw_load_summary
+      load_summary, raw_load_summary, obj_user_data
     );
   }
 }

--- a/src/vt/vrt/collection/balance/baselb/baselb.cc
+++ b/src/vt/vrt/collection/balance/baselb/baselb.cc
@@ -103,7 +103,6 @@ void BaseLB::importProcessorData(
 
   comm_data = &comm_in;
   base_stats_ = &in_stats;
-  user_data_ = &in_data_map;
 }
 
 void BaseLB::getArgs(PhaseType phase) {

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -169,7 +169,6 @@ protected:
 
   TimeType start_time_                                = TimeType{0.0};
   ElementCommType const* comm_data                    = nullptr;
-  balance::DataMapType const* user_data_              = nullptr;
   objgroup::proxy::Proxy<BaseLB> proxy_               = {};
   PhaseType phase_                                    = 0;
   std::unique_ptr<balance::ConfigEntry> config_entry_ = nullptr;

--- a/src/vt/vrt/collection/balance/baselb/baselb.h
+++ b/src/vt/vrt/collection/balance/baselb/baselb.h
@@ -78,7 +78,7 @@ struct BaseLB {
   using StatisticMapType = std::unordered_map<lb::Statistic, QuantityType>;
   using LoadSummary      = balance::LoadSummary;
   using ObjLoadListType  = std::vector<
-    std::tuple<ObjIDType, LoadSummary, LoadSummary>
+    std::tuple<ObjIDType, LoadSummary, LoadSummary, balance::ElmUserDataType>
   >;
   using ObjDestinationListType = std::vector<std::tuple<ObjIDType, NodeType>>;
 

--- a/src/vt/vrt/collection/balance/lb_common.cc
+++ b/src/vt/vrt/collection/balance/lb_common.cc
@@ -97,6 +97,26 @@ LoadSummary getObjectRawLoads(
   return ret;
 }
 
+ElmUserDataType getObjectUserData(
+  std::shared_ptr<LoadModel> model, ElementIDStruct object, PhaseOffset when
+) {
+  return getObjectUserData(model.get(), object, when);
+}
+
+ElmUserDataType getObjectUserData(
+  LoadModel* model, ElementIDStruct object, PhaseOffset when
+) {
+  ElmUserDataType ret;
+
+  if (model->hasUserData()) {
+    ret = model->getUserData(
+      object, {when.phases, PhaseOffset::WHOLE_PHASE}
+    );
+  }
+
+  return ret;
+}
+
 LoadSummary getNodeLoads(std::shared_ptr<LoadModel> model, PhaseOffset when)
 {
   LoadSummary ret;

--- a/src/vt/vrt/collection/balance/lb_common.h
+++ b/src/vt/vrt/collection/balance/lb_common.h
@@ -112,14 +112,14 @@ struct LoadSummary {
   }
 };
 
+/// User-defined LB values
+using UserDataValueType = std::variant<int, double, std::string>;
+using ElmUserDataType = std::unordered_map<std::string, UserDataValueType>;
+
 using LoadMapType         = std::unordered_map<ElementIDStruct, LoadSummary>;
 using SubphaseLoadMapType = std::unordered_map<ElementIDStruct, std::vector<LoadType>>;
-
 /// User-defined LB values map
-using DataMapType         = std::unordered_map<
-  ElementIDStruct,
-  std::unordered_map<std::string, std::variant<int, double, std::string>>
->;
+using DataMapType         = std::unordered_map<ElementIDStruct, ElmUserDataType>;
 
 struct Reassignment {
   // Include the subject node so that these structures can be formed
@@ -130,7 +130,7 @@ struct Reassignment {
   int32_t global_migration_count;
   std::unordered_map<ElementIDStruct, NodeType> depart_;
   std::unordered_map<
-    ElementIDStruct, std::tuple<LoadSummary, LoadSummary>
+    ElementIDStruct, std::tuple<LoadSummary, LoadSummary, ElmUserDataType>
   > arrive_;
 };
 
@@ -172,6 +172,14 @@ LoadSummary getObjectRawLoads(
 );
 
 LoadSummary getObjectRawLoads(
+  LoadModel* model, ElementIDStruct object, PhaseOffset when
+);
+
+ElmUserDataType getObjectUserData(
+  std::shared_ptr<LoadModel> model, ElementIDStruct object, PhaseOffset when
+);
+
+ElmUserDataType getObjectUserData(
   LoadModel* model, ElementIDStruct object, PhaseOffset when
 );
 

--- a/src/vt/vrt/collection/balance/lb_data_holder.cc
+++ b/src/vt/vrt/collection/balance/lb_data_holder.cc
@@ -290,6 +290,19 @@ LBDataHolder::LBDataHolder(nlohmann::json const& j)
                 }
               }
             }
+
+            if (task.find("user_defined") != task.end()) {
+              for (auto const& [key, value] : task["user_defined"].items()) {
+                if (value.is_string()) {
+                  user_defined_lb_info_[id][elm][key] =
+                    value.template get<std::string>();
+                }
+                if (value.is_number()) {
+                  user_defined_lb_info_[id][elm][key] =
+                    value.template get<double>();
+                }
+              }
+            }
           }
         }
       }

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -164,7 +164,8 @@ void LBManager::setLoadModel(std::shared_ptr<LoadModel> model) {
   model_ = model;
   auto nlb_data = theNodeLBData();
   model_->setLoads(nlb_data->getNodeLoad(),
-                   nlb_data->getNodeComm());
+                   nlb_data->getNodeComm(),
+                   nlb_data->getUserData());
 }
 
 template <typename LB>

--- a/src/vt/vrt/collection/balance/model/comm_overhead.cc
+++ b/src/vt/vrt/collection/balance/model/comm_overhead.cc
@@ -55,9 +55,10 @@ CommOverhead::CommOverhead(
 { }
 
 void CommOverhead::setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-                            std::unordered_map<PhaseType, CommMapType> const* proc_comm) {
+                            std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+                            std::unordered_map<PhaseType, DataMapType> const* user_data) {
   proc_comm_ = proc_comm;
-  ComposedModel::setLoads(proc_load, proc_comm);
+  ComposedModel::setLoads(proc_load, proc_comm, user_data);
 }
 
 LoadType

--- a/src/vt/vrt/collection/balance/model/comm_overhead.h
+++ b/src/vt/vrt/collection/balance/model/comm_overhead.h
@@ -66,7 +66,8 @@ struct CommOverhead : public ComposedModel {
   );
 
   void setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-                std::unordered_map<PhaseType, CommMapType> const* proc_comm) override;
+                std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+                std::unordered_map<PhaseType, DataMapType> const* user_data) override;
 
   LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
 

--- a/src/vt/vrt/collection/balance/model/composed_model.cc
+++ b/src/vt/vrt/collection/balance/model/composed_model.cc
@@ -46,8 +46,9 @@
 namespace vt { namespace vrt { namespace collection { namespace balance {
 
 void ComposedModel::setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-                             std::unordered_map<PhaseType, CommMapType> const* proc_comm) {
-  base_->setLoads(proc_load, proc_comm);
+                             std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+                             std::unordered_map<PhaseType, DataMapType> const* user_data) {
+  base_->setLoads(proc_load, proc_comm, user_data);
 }
 
 void ComposedModel::updateLoads(PhaseType last_completed_phase) {
@@ -70,6 +71,14 @@ bool ComposedModel::hasRawLoad() const {
 
 LoadType ComposedModel::getRawLoad(ElementIDStruct object, PhaseOffset when) const {
   return base_->getRawLoad(object, when);
+}
+
+bool ComposedModel::hasUserData() const {
+  return base_->hasUserData();
+}
+
+ElmUserDataType ComposedModel::getUserData(ElementIDStruct object, PhaseOffset when) const {
+  return base_->getUserData(object, when);
 }
 
 unsigned int ComposedModel::getNumPastPhasesNeeded(unsigned int look_back) const

--- a/src/vt/vrt/collection/balance/model/composed_model.h
+++ b/src/vt/vrt/collection/balance/model/composed_model.h
@@ -65,7 +65,8 @@ public:
   explicit ComposedModel(std::shared_ptr<LoadModel> base) : base_(base) {}
 
   void setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-                std::unordered_map<PhaseType, CommMapType> const* proc_comm) override;
+                std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+                std::unordered_map<PhaseType, DataMapType> const* user_data) override;
 
   void updateLoads(PhaseType last_completed_phase) override;
 
@@ -73,6 +74,8 @@ public:
   LoadType getModeledComm(ElementIDStruct object, PhaseOffset when) const override;
   bool hasRawLoad() const override;
   LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  bool hasUserData() const override;
+  ElmUserDataType getUserData(ElementIDStruct object, PhaseOffset when) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 
   ObjectIterator begin() const override;

--- a/src/vt/vrt/collection/balance/model/load_model.h
+++ b/src/vt/vrt/collection/balance/model/load_model.h
@@ -102,7 +102,7 @@ struct LoadMapObjectIterator : public ObjectIteratorImpl {
 
 struct DualLoadMapObjectIterator : public ObjectIteratorImpl {
   using DualLoadMapType = std::unordered_map<
-    ElementIDStruct, std::tuple<LoadSummary, LoadSummary>
+    ElementIDStruct, std::tuple<LoadSummary, LoadSummary, ElmUserDataType>
   >;
   using map_iterator_type = DualLoadMapType::const_iterator;
   using iterator_category = std::iterator_traits<map_iterator_type>::iterator_category;
@@ -196,7 +196,8 @@ struct LoadModel
    */
   virtual void setLoads(
     std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-    std::unordered_map<PhaseType, CommMapType> const* proc_comm
+    std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+    std::unordered_map<PhaseType, DataMapType> const* user_data
   ) = 0;
 
   /**
@@ -245,6 +246,26 @@ struct LoadModel
       "LoadModel::getRawLoad() called on a model that does not implement it"
     );
     return 0.0;
+  };
+
+  /**
+   * \brief Whether or not the model is based on the RawData model
+   */
+  virtual bool hasUserData() const { return false; }
+
+  /**
+   * \brief Provide the given object's user data during a specified interval
+   *
+   * \param[in] object The object whose user data is desired
+   * \param[in] when The interval in which the user data is desired
+   *
+   * \return The user data associated with the object
+   */
+  virtual ElmUserDataType getUserData(ElementIDStruct object, PhaseOffset when) const {
+    vtAbort(
+      "LoadModel::getUserData() called on a model that does not implement it"
+    );
+    return ElmUserDataType{};
   };
 
   /**

--- a/src/vt/vrt/collection/balance/model/naive_persistence.cc
+++ b/src/vt/vrt/collection/balance/model/naive_persistence.cc
@@ -66,6 +66,14 @@ LoadType NaivePersistence::getRawLoad(ElementIDStruct object, PhaseOffset offset
   return ComposedModel::getRawLoad(object, offset);
 }
 
+ElmUserDataType NaivePersistence::getUserData(ElementIDStruct object, PhaseOffset offset) const
+{
+  if (offset.phases >= 0)
+    offset.phases = -1;
+
+  return ComposedModel::getUserData(object, offset);
+}
+
 unsigned int NaivePersistence::getNumPastPhasesNeeded(unsigned int look_back) const
 {
   return ComposedModel::getNumPastPhasesNeeded(std::max(1u, look_back));

--- a/src/vt/vrt/collection/balance/model/naive_persistence.h
+++ b/src/vt/vrt/collection/balance/model/naive_persistence.h
@@ -62,6 +62,7 @@ struct NaivePersistence : public ComposedModel {
   explicit NaivePersistence(std::shared_ptr<balance::LoadModel> base);
   LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   LoadType getRawLoad(ElementIDStruct object, PhaseOffset offset) const override;
+  ElmUserDataType getUserData(ElementIDStruct object, PhaseOffset when) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 }; // class NaivePersistence
 

--- a/src/vt/vrt/collection/balance/model/per_collection.h
+++ b/src/vt/vrt/collection/balance/model/per_collection.h
@@ -74,13 +74,16 @@ struct PerCollection : public ComposedModel
   void addModel(CollectionID proxy, std::shared_ptr<LoadModel> model);
 
   void setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-                std::unordered_map<PhaseType, CommMapType> const* proc_comm) override;
+                std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+                std::unordered_map<PhaseType, DataMapType> const* user_data) override;
 
   void updateLoads(PhaseType last_completed_phase) override;
 
   LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   bool hasRawLoad() const override;
   LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  bool hasUserData() const override;
+  ElmUserDataType getUserData(ElementIDStruct object, PhaseOffset when) const override;
   unsigned int getNumPastPhasesNeeded(unsigned int look_back) const override;
 
 private:

--- a/src/vt/vrt/collection/balance/model/proposed_reassignment.cc
+++ b/src/vt/vrt/collection/balance/model/proposed_reassignment.cc
@@ -121,4 +121,18 @@ LoadType ProposedReassignment::getRawLoad(ElementIDStruct object, PhaseOffset wh
   return ComposedModel::getRawLoad(object, when);
 }
 
+ElmUserDataType ProposedReassignment::getUserData(ElementIDStruct object, PhaseOffset when) const
+{
+  auto a = reassignment_->arrive_.find(object);
+  if (a != reassignment_->arrive_.end()) {
+    return std::get<2>(a->second);
+  }
+
+  // Check this *after* arrivals to handle hypothetical self-migration
+  vtAssert(reassignment_->depart_.find(object) == reassignment_->depart_.end(),
+           "Departing object should not appear as a user data query subject");
+
+  return ComposedModel::getUserData(object, when);
+}
+
 }}}}

--- a/src/vt/vrt/collection/balance/model/proposed_reassignment.h
+++ b/src/vt/vrt/collection/balance/model/proposed_reassignment.h
@@ -59,6 +59,7 @@ struct ProposedReassignment : public ComposedModel {
   int getNumObjects() const override;
   LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  ElmUserDataType getUserData(ElementIDStruct object, PhaseOffset when) const override;
 
 private:
   std::shared_ptr<const Reassignment> reassignment_;

--- a/src/vt/vrt/collection/balance/model/raw_data.cc
+++ b/src/vt/vrt/collection/balance/model/raw_data.cc
@@ -51,10 +51,12 @@ void RawData::updateLoads(PhaseType last_completed_phase) {
 }
 
 void RawData::setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-                       std::unordered_map<PhaseType, CommMapType> const* proc_comm)
+                       std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+                       std::unordered_map<PhaseType, DataMapType> const* user_data)
 {
   proc_load_ = proc_load;
   proc_comm_ = proc_comm;
+  user_data_ = user_data;
 }
 
 ObjectIterator RawData::begin() const {
@@ -108,6 +110,23 @@ LoadType RawData::getRawLoad(ElementIDStruct object, PhaseOffset offset) const {
     return phase_data.at(object).get(offset);
   } else {
     return 0.0;
+  }
+}
+
+ElmUserDataType RawData::getUserData(ElementIDStruct object, PhaseOffset offset) const {
+  vtAssert(offset.phases < 0,
+           "RawData makes no predictions. Compose with NaivePersistence or some longer-range forecasting model as needed");
+
+  auto phase = getNumCompletedPhases() + offset.phases;
+  if (user_data_->find(phase) != user_data_->end()) {
+    auto& phase_data = user_data_->at(phase);
+    if (phase_data.find(object) != phase_data.end()) {
+      return phase_data.at(object);
+    } else {
+      return ElmUserDataType{};
+    }
+  } else {
+    return ElmUserDataType{};
   }
 }
 

--- a/src/vt/vrt/collection/balance/model/raw_data.h
+++ b/src/vt/vrt/collection/balance/model/raw_data.h
@@ -62,9 +62,12 @@ struct RawData : public LoadModel {
   LoadType getModeledLoad(ElementIDStruct object, PhaseOffset when) const override;
   bool hasRawLoad() const override { return true; }
   LoadType getRawLoad(ElementIDStruct object, PhaseOffset when) const override;
+  bool hasUserData() const override { return user_data_ != nullptr; }
+  ElmUserDataType getUserData(ElementIDStruct object, PhaseOffset when) const override;
 
   void setLoads(std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-                std::unordered_map<PhaseType, CommMapType> const* proc_comm) override;
+                std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+                std::unordered_map<PhaseType, DataMapType> const* user_data) override;
 
   ObjectIterator begin() const override;
 
@@ -76,6 +79,7 @@ struct RawData : public LoadModel {
   // Observer pointers to the underlying data. In operation, these would be owned by NodeLBData
   std::unordered_map<PhaseType, LoadMapType>         const* proc_load_;
   std::unordered_map<PhaseType, CommMapType>         const* proc_comm_;
+  std::unordered_map<PhaseType, DataMapType>         const* user_data_;
   PhaseType last_completed_phase_ = ~0;
 }; // class RawData
 

--- a/src/vt/vrt/collection/balance/model/weighted_messages.h
+++ b/src/vt/vrt/collection/balance/model/weighted_messages.h
@@ -66,10 +66,11 @@ struct WeightedMessages : public ComposedModel {
 
   void setLoads(
     std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-    std::unordered_map<PhaseType, CommMapType> const* proc_comm
+    std::unordered_map<PhaseType, CommMapType> const* proc_comm,
+    std::unordered_map<PhaseType, DataMapType> const* user_data
   ) override {
     proc_comm_ = proc_comm;
-    ComposedModel::setLoads(proc_load, proc_comm);
+    ComposedModel::setLoads(proc_load, proc_comm, user_data);
   }
 
   LoadType getModeledComm(ElementIDStruct object, PhaseOffset when) const override;

--- a/src/vt/vrt/collection/balance/workload_replay.cc
+++ b/src/vt/vrt/collection/balance/workload_replay.cc
@@ -82,7 +82,10 @@ void replayWorkloads(
   // remember vt's base load model
   auto base_load_model = theLBManager()->getBaseLoadModel();
   // force it to use our given workloads, not anything it may have collected
-  base_load_model->setLoads(&(workloads->node_data_), &(workloads->node_comm_));
+  base_load_model->setLoads(
+    &(workloads->node_data_), &(workloads->node_comm_),
+    &(workloads->user_defined_lb_info_)
+  );
   // point the load model at the workloads for the relevant phase
   runInEpochCollective("WorkloadReplayDriver -> updateLoads", [=] {
     base_load_model->updateLoads(initial_phase);
@@ -104,7 +107,8 @@ void replayWorkloads(
 
     // force it to use our given workloads, not anything it may have collected
     base_load_model->setLoads(
-      &(workloads->node_data_), &(workloads->node_comm_)
+      &(workloads->node_data_), &(workloads->node_comm_),
+      &(workloads->user_defined_lb_info_)
     );
 
     // point the load model at the workloads for the relevant phase
@@ -151,7 +155,8 @@ void replayWorkloads(
 
       // force it to use our given workloads, not anything it may have collected
       pre_lb_load_model->setLoads(
-        &(workloads->node_data_), &(workloads->node_comm_)
+        &(workloads->node_data_), &(workloads->node_comm_),
+        &(workloads->user_defined_lb_info_)
       );
     }
 

--- a/tests/unit/collection/test_model_comm_overhead.nompi.cc
+++ b/tests/unit/collection/test_model_comm_overhead.nompi.cc
@@ -67,10 +67,12 @@ using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::SubphaseLoadMapType;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
 using ProcSubphaseLoadMap = std::unordered_map<PhaseType, SubphaseLoadMapType>;
 using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+using UserDataMap = std::unordered_map<PhaseType, DataMapType>;
 
 static auto num_phases = 0;
 
@@ -81,7 +83,8 @@ struct StubModel : LoadModel {
 
   void setLoads(
     ProcLoadMap const* proc_load,
-    ProcCommMap const*) override {
+    ProcCommMap const*,
+    UserDataMap const*) override {
     proc_load_ = proc_load;
   }
 
@@ -153,7 +156,7 @@ TEST_F(TestModelCommOverhead, test_model_comm_overhead_1) {
   auto test_model = std::make_shared<CommOverhead>(
     std::make_shared<StubModel>(), per_msg_weight, per_byte_weight
   );
-  test_model->setLoads(&proc_load, &proc_comm);
+  test_model->setLoads(&proc_load, &proc_comm, nullptr);
 
   std::unordered_map<PhaseType, LoadType> expected_work = {
     {0, LoadType{296}}, {1, LoadType{295.5}}

--- a/tests/unit/collection/test_model_linear_model.nompi.cc
+++ b/tests/unit/collection/test_model_linear_model.nompi.cc
@@ -65,6 +65,7 @@ using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::SubphaseLoadMapType;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 struct StubModel : LoadModel {
 
@@ -73,7 +74,8 @@ struct StubModel : LoadModel {
 
   void setLoads(
     std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-    std::unordered_map<PhaseType, CommMapType> const*) override {
+    std::unordered_map<PhaseType, CommMapType> const*,
+    std::unordered_map<PhaseType, DataMapType> const*) override {
     proc_load_ = proc_load;
   }
 
@@ -109,7 +111,7 @@ TEST_F(TestLinearModel, test_model_linear_model_1) {
         {ElementIDStruct{1,this_node}, {LoadType{10}, {}}},
         {ElementIDStruct{2,this_node}, {LoadType{40}, {}}}
     }}};
-  test_model->setLoads(&proc_loads, nullptr);
+  test_model->setLoads(&proc_loads, nullptr, nullptr);
   test_model->updateLoads(0);
 
   // Work loads to be added in each test iteration

--- a/tests/unit/collection/test_model_multiple_phases.nompi.cc
+++ b/tests/unit/collection/test_model_multiple_phases.nompi.cc
@@ -63,6 +63,7 @@ using vt::vrt::collection::balance::SubphaseLoadMapType;
 using vt::vrt::collection::balance::CommMapType;
 using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 struct StubModel : LoadModel {
 
@@ -71,7 +72,8 @@ struct StubModel : LoadModel {
 
   void setLoads(
     std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-    std::unordered_map<PhaseType, CommMapType> const*) override {
+    std::unordered_map<PhaseType, CommMapType> const*,
+    std::unordered_map<PhaseType, DataMapType> const*) override {
     proc_load_ = proc_load;
   }
 
@@ -115,7 +117,7 @@ TEST_F(TestModelMultiplePhases, test_model_multiple_phases_1) {
   auto test_model =
     std::make_shared<MultiplePhases>(std::make_shared<StubModel>(), 4);
 
-  test_model->setLoads(&proc_loads, nullptr);
+  test_model->setLoads(&proc_loads, nullptr, nullptr);
   test_model->updateLoads(3);
 
   for (auto&& obj : *test_model) {

--- a/tests/unit/collection/test_model_naive_persistence.nompi.cc
+++ b/tests/unit/collection/test_model_naive_persistence.nompi.cc
@@ -63,6 +63,7 @@ using vt::vrt::collection::balance::SubphaseLoadMapType;
 using vt::vrt::collection::balance::CommMapType;
 using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 static int32_t getIndexFromPhase(int32_t phase) {
   return std::max(0, -1 * phase - 1);
@@ -75,7 +76,8 @@ struct StubModel : LoadModel {
 
   void setLoads(
     std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-    std::unordered_map<PhaseType, CommMapType> const*) override {
+    std::unordered_map<PhaseType, CommMapType> const*,
+    std::unordered_map<PhaseType, DataMapType> const*) override {
     proc_load_ = proc_load;
   }
 
@@ -118,7 +120,7 @@ TEST_F(TestModelNaivePersistence, test_model_naive_persistence_1) {
   auto test_model =
     std::make_shared<NaivePersistence>(std::make_shared<StubModel>());
 
-  test_model->setLoads(&proc_loads, nullptr);
+  test_model->setLoads(&proc_loads, nullptr, nullptr);
   test_model->updateLoads(3);
 
   for (auto it = test_model->begin(); it != test_model->end(); ++it) {

--- a/tests/unit/collection/test_model_norm.nompi.cc
+++ b/tests/unit/collection/test_model_norm.nompi.cc
@@ -64,10 +64,12 @@ using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::SubphaseLoadMapType;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
 using ProcSubphaseLoadMap = std::unordered_map<PhaseType, SubphaseLoadMapType>;
 using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+using UserDataMap = std::unordered_map<PhaseType, DataMapType>;
 
 constexpr auto num_subphases = 3;
 
@@ -78,7 +80,8 @@ struct StubModel : LoadModel {
 
   void setLoads(
     ProcLoadMap const* proc_load,
-    ProcCommMap const*) override {
+    ProcCommMap const*,
+    UserDataMap const*) override {
     proc_load_ = proc_load;
   }
 
@@ -111,7 +114,7 @@ TEST_F(TestModelNorm, test_model_norm_1) {
        {ElementIDStruct{2,this_node}, {LoadType{150}, {LoadType{40}, LoadType{50}, LoadType{60}}}}}}};
 
   auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
-  test_model->setLoads(&proc_load, nullptr);
+  test_model->setLoads(&proc_load, nullptr, nullptr);
   test_model->updateLoads(0);
 
   // ONLY because this is built on top of the StubModel do we expect false
@@ -143,7 +146,7 @@ TEST_F(TestModelNorm, test_model_norm_2) {
 
   // finite 'power' value
   auto test_model = std::make_shared<Norm>(std::make_shared<StubModel>(), 3.0);
-  test_model->setLoads(&proc_load, nullptr);
+  test_model->setLoads(&proc_load, nullptr, nullptr);
   test_model->updateLoads(0);
 
   std::array<LoadType, 2> expected_norms = {
@@ -173,7 +176,7 @@ TEST_F(TestModelNorm, test_model_norm_3) {
   // infinite 'power' value
   auto test_model = std::make_shared<Norm>(
     std::make_shared<StubModel>(), std::numeric_limits<double>::infinity());
-  test_model->setLoads(&proc_load, nullptr);
+  test_model->setLoads(&proc_load, nullptr, nullptr);
   test_model->updateLoads(0);
 
   std::array<LoadType, 2> expected_norms = {LoadType{30}, LoadType{60}};

--- a/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
+++ b/tests/unit/collection/test_model_persistence_median_last_n.nompi.cc
@@ -65,6 +65,7 @@ using vt::vrt::collection::balance::SubphaseLoadMapType;
 using vt::vrt::collection::balance::CommMapType;
 using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 struct StubModel : LoadModel {
 
@@ -73,7 +74,8 @@ struct StubModel : LoadModel {
 
   void setLoads(
     std::unordered_map<PhaseType, LoadMapType> const* proc_load,
-    std::unordered_map<PhaseType, CommMapType> const*) override {
+    std::unordered_map<PhaseType, CommMapType> const*,
+    std::unordered_map<PhaseType, DataMapType> const*) override {
     proc_load_ = proc_load;
   }
 
@@ -105,7 +107,7 @@ TEST_F(TestModelPersistenceMedianLastN, test_model_persistence_median_last_n_1) 
 
   std::unordered_map<PhaseType, LoadMapType> proc_loads(num_total_phases);
 
-  test_model->setLoads(&proc_loads, nullptr);
+  test_model->setLoads(&proc_loads, nullptr, nullptr);
 
   // Work loads to be added in each test iteration
   std::vector<LoadMapType> load_holder{

--- a/tests/unit/collection/test_model_raw_data.nompi.cc
+++ b/tests/unit/collection/test_model_raw_data.nompi.cc
@@ -62,6 +62,8 @@ using vt::vrt::collection::balance::LoadModel;
 using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::SubphaseLoadMapType;
+using vt::vrt::collection::balance::ElmUserDataType;
+using vt::vrt::collection::balance::DataMapType;
 
 TEST_F(TestRawData, test_model_raw_data_scalar) {
   NodeType this_node = 0;
@@ -69,8 +71,9 @@ TEST_F(TestRawData, test_model_raw_data_scalar) {
     std::make_shared<RawData>();
 
   std::unordered_map<PhaseType, LoadMapType> proc_loads;
-  test_model->setLoads(&proc_loads, nullptr);
+  test_model->setLoads(&proc_loads, nullptr, nullptr);
   EXPECT_TRUE(test_model->hasRawLoad());
+  EXPECT_FALSE(test_model->hasUserData());  // because passed a nullptr
 
   ElementIDStruct id1{1,this_node};
   ElementIDStruct id2{2,this_node};
@@ -114,6 +117,71 @@ TEST_F(TestRawData, test_model_raw_data_scalar) {
 
       auto sub_raw_load_val = test_model->getRawLoad(obj, PhaseOffset{-1, 0});
       EXPECT_EQ(sub_raw_load_val, load_holder[iter][obj].subphase_loads[0]);
+    }
+    EXPECT_EQ(objects_seen, 2);
+  }
+}
+
+TEST_F(TestRawData, test_model_raw_user_data) {
+  NodeType this_node = 0;
+  auto test_model =
+    std::make_shared<RawData>();
+
+  std::unordered_map<PhaseType, LoadMapType> proc_loads;
+  std::unordered_map<PhaseType, DataMapType> user_data;
+  test_model->setLoads(&proc_loads, nullptr, &user_data);
+  EXPECT_TRUE(test_model->hasRawLoad());
+  EXPECT_TRUE(test_model->hasUserData());
+
+  ElementIDStruct id1{1,this_node};
+  ElementIDStruct id2{2,this_node};
+
+  // Work loads to be added in each test iteration
+  std::vector<LoadMapType> load_holder{
+    LoadMapType{{id1, {LoadType{5}, {LoadType{5}}}},   {id2, {LoadType{10}, {LoadType{10}}}}},
+    LoadMapType{{id1, {LoadType{30}, {LoadType{30}}}},  {id2, {LoadType{100}, {LoadType{100}}}}},
+    LoadMapType{{id1, {LoadType{50}, {LoadType{50}}}},  {id2, {LoadType{40}, {LoadType{40}}}}},
+    LoadMapType{{id1, {LoadType{2}, {LoadType{2}}}},   {id2, {LoadType{50}, {LoadType{50}}}}},
+    LoadMapType{{id1, {LoadType{60}, {LoadType{60}}}},  {id2, {LoadType{20}, {LoadType{20}}}}},
+    LoadMapType{{id1, {LoadType{100}, {LoadType{100}}}}, {id2, {LoadType{10}, {LoadType{10}}}}},
+  };
+  std::vector<DataMapType> user_holder{
+    DataMapType{{id1, ElmUserDataType{{"init",4}}},   {id2, ElmUserDataType{{"init",12}}}},
+    DataMapType{},
+    DataMapType{{id1, ElmUserDataType{{"tag", 100}}}, {id2, ElmUserDataType{{"tag", 200}}}},
+    DataMapType{{id1, ElmUserDataType{{"tag", 101}}}},
+    DataMapType{},
+    DataMapType{{id2, ElmUserDataType{{"x", 1}, {"y", 2}}}}
+  };
+
+  for (size_t iter = 0; iter < load_holder.size(); ++iter) {
+    proc_loads[iter] = load_holder[iter];
+    user_data[iter] = user_holder[iter];
+    test_model->updateLoads(iter);
+
+    EXPECT_EQ(test_model->getNumObjects(), 2);
+    EXPECT_EQ(test_model->getNumCompletedPhases(), iter+1);
+    EXPECT_EQ(test_model->getNumSubphases(), 1);
+
+    EXPECT_EQ(test_model->getNumPastPhasesNeeded(iter), iter);
+    EXPECT_EQ(test_model->getNumPastPhasesNeeded(2*iter), 2*iter);
+
+    int objects_seen = 0;
+    for (auto&& obj : *test_model) {
+      EXPECT_TRUE(obj.id == 1 || obj.id == 2);
+      objects_seen++;
+
+      auto user_dict = test_model->getUserData(obj, PhaseOffset{-1, PhaseOffset::WHOLE_PHASE});
+      EXPECT_EQ(user_dict.size(), user_holder[iter][obj].size());
+      if (user_dict.size(), user_holder[iter][obj].size()) {
+        for (auto &u : user_holder[iter][obj]) {
+          auto it = user_dict.find(u.first);
+          EXPECT_TRUE(it != user_dict.end());
+          if (it != user_dict.end()) {
+            EXPECT_EQ(it->second, u.second);
+          }
+        }
+      }
     }
     EXPECT_EQ(objects_seen, 2);
   }

--- a/tests/unit/collection/test_model_select_subphases.nompi.cc
+++ b/tests/unit/collection/test_model_select_subphases.nompi.cc
@@ -63,10 +63,12 @@ using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::SelectSubphases;
 using vt::vrt::collection::balance::SubphaseLoadMapType;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
 using ProcSubphaseLoadMap = std::unordered_map<PhaseType, SubphaseLoadMapType>;
 using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+using UserDataMap = std::unordered_map<PhaseType, DataMapType>;
 
 constexpr auto num_subphases = 3;
 
@@ -77,7 +79,8 @@ struct StubModel : LoadModel {
 
   void setLoads(
     ProcLoadMap const* proc_load,
-    ProcCommMap const*) override {
+    ProcCommMap const*,
+    UserDataMap const*) override {
     proc_load_ = proc_load;
   }
 
@@ -124,7 +127,7 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_1) {
 
   EXPECT_EQ(test_model->getNumSubphases(), subphases.size());
 
-  test_model->setLoads(&proc_load, nullptr);
+  test_model->setLoads(&proc_load, nullptr, nullptr);
   test_model->updateLoads(0);
 
   std::unordered_map<ElementIDStruct, std::vector<LoadType>> expected_values = {
@@ -173,7 +176,7 @@ TEST_F(TestModelSelectSubphases, test_model_select_subphases_2) {
 
   EXPECT_EQ(test_model->getNumSubphases(), subphases.size());
 
-  test_model->setLoads(&proc_load, nullptr);
+  test_model->setLoads(&proc_load, nullptr, nullptr);
   test_model->updateLoads(0);
 
   std::unordered_map<ElementIDStruct, LoadType> expected_values = {

--- a/tests/unit/collection/test_model_weighted_communication_volume.nompi.cc
+++ b/tests/unit/collection/test_model_weighted_communication_volume.nompi.cc
@@ -67,9 +67,11 @@ using vt::vrt::collection::balance::LoadModel;
 using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
 using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+using UserDataMap = std::unordered_map<PhaseType, DataMapType>;
 
 static auto num_phases = 0;
 
@@ -77,7 +79,10 @@ struct StubModel : LoadModel {
   StubModel() = default;
   virtual ~StubModel() = default;
 
-  void setLoads(ProcLoadMap const* proc_load, ProcCommMap const* proc_comm) override {
+  void setLoads(
+    ProcLoadMap const* proc_load,
+    ProcCommMap const* proc_comm,
+    UserDataMap const*) override {
     proc_load_ = proc_load;
     proc_comm_ = proc_comm;
   }
@@ -155,7 +160,7 @@ TEST_F(TestModelWeightedCommunicationVolume, test_model) {
   auto test_model = std::make_shared<WeightedCommunicationVolume>(
     weighted_messages_model, alpha, beta, gamma
   );
-  test_model->setLoads(&proc_load, &proc_comm);
+  test_model->setLoads(&proc_load, &proc_comm, nullptr);
 
   std::unordered_map<PhaseType, LoadType> expected_work = {
     {0, LoadType{125.0}}, {1, LoadType{22.5}}

--- a/tests/unit/collection/test_model_weighted_messages.nompi.cc
+++ b/tests/unit/collection/test_model_weighted_messages.nompi.cc
@@ -65,9 +65,11 @@ using vt::vrt::collection::balance::LoadModel;
 using vt::vrt::collection::balance::ObjectIterator;
 using vt::vrt::collection::balance::PhaseOffset;
 using vt::vrt::collection::balance::LoadMapObjectIterator;
+using vt::vrt::collection::balance::DataMapType;
 
 using ProcLoadMap = std::unordered_map<PhaseType, LoadMapType>;
 using ProcCommMap = std::unordered_map<PhaseType, CommMapType>;
+using UserDataMap = std::unordered_map<PhaseType, DataMapType>;
 
 static auto num_phases = 0;
 
@@ -75,7 +77,10 @@ struct StubModel : LoadModel {
   StubModel() = default;
   virtual ~StubModel() = default;
 
-  void setLoads(ProcLoadMap const* proc_load, ProcCommMap const*) override {
+  void setLoads(
+    ProcLoadMap const* proc_load,
+    ProcCommMap const*,
+    UserDataMap const*) override {
     proc_load_ = proc_load;
   }
 
@@ -147,7 +152,7 @@ TEST_F(TestModelWeightedMessages, test_model) {
   auto test_model = std::make_shared<WeightedMessages>(
     std::make_shared<StubModel>(), per_msg_weight, per_byte_weight
   );
-  test_model->setLoads(&proc_load, &proc_comm);
+  test_model->setLoads(&proc_load, &proc_comm, nullptr);
 
   std::unordered_map<PhaseType, LoadType> expected_comm = {
     {0, LoadType{146}}, {1, LoadType{280.5}}


### PR DESCRIPTION
This PR adds access to the user-defined LB info to the load models so that load balancers can access it whether running on a live application or replaying from json files.

I have confirmed that, with the appropriate changes to #2203, TemperedLB can access the user-defined LB info for local objects that were loaded from a json file for a different rank, while still being able to access info provided live by a running application. I will comment on #2203 what changes are necessary.

Closes #2227
