### PR TITLE
#2254: startup: add missing mpi header include

### DIFF
--- a/src/vt/collective/startup.h
+++ b/src/vt/collective/startup.h
@@ -47,6 +47,7 @@
 #include "vt/config.h"
 #include "vt/runtime/runtime_headers.h"
 #include "vt/configs/arguments/argv_container.h"
+#include <mpi.h>
 
 namespace vt {
 


### PR DESCRIPTION
Fixes #2254.
