### PR TITLE
#2275: Improve `PerfTestHarness`

### DIFF
--- a/tests/perf/common/test_harness.cc
+++ b/tests/perf/common/test_harness.cc
@@ -235,6 +235,10 @@ std::string PerfTestHarness::OutputMemoryUse() const {
     auto const node = per_node_mem.first;
     auto const& memory_use = per_node_mem.second;
 
+    if(memory_use.empty()){
+      continue;
+    }
+
     std::size_t cur_min = std::numeric_limits<std::size_t>::max();
     std::size_t cur_max = 0;
 
@@ -317,11 +321,15 @@ void PerfTestHarness::DumpResults() {
     );
 
     auto const time_file_data = OutputTimeResults();
-    auto const memory_file = OutputMemoryUse();
-
     if (gen_file_) {
-      OutputToFile(fmt::format("{}_mem", name_), memory_file);
       OutputToFile(fmt::format("{}_time", name_), time_file_data);
+    }
+
+    if(print_memory_use_) {
+      auto const memory_file = OutputMemoryUse();
+      if (gen_file_) {
+        OutputToFile(fmt::format("{}_mem", name_), memory_file);
+      }
     }
   }
 }
@@ -443,6 +451,7 @@ void PerfTestHarness::SpinScheduler() {
 void PerfTestHarness::GetMemoryUsage() {
   // Memory footprint from PerfTestHarness' internal data structs are included
   memory_use_[current_run_].push_back(mem_tracker_.getUsage());
+  print_memory_use_ = true;
 }
 
 }}}} // namespace vt::tests::perf::common

--- a/tests/perf/common/test_harness.cc
+++ b/tests/perf/common/test_harness.cc
@@ -454,4 +454,12 @@ void PerfTestHarness::GetMemoryUsage() {
   print_memory_use_ = true;
 }
 
+void PerfTestHarness::DisableGlobalTimer() {
+  print_total_time_ = false;
+}
+
+bool PerfTestHarness::ShouldOutputGlobalTimer() const {
+  return print_total_time_;
+}
+
 }}}} // namespace vt::tests::perf::common

--- a/tests/perf/common/test_harness.h
+++ b/tests/perf/common/test_harness.h
@@ -167,6 +167,12 @@ struct PerfTestHarness : TestHarnessBase {
    */
   void GetMemoryUsage();
 
+  void
+  DisableGlobalTimer();
+
+  bool
+  ShouldOutputGlobalTimer() const;
+
 private:
   std::string OutputMemoryUse() const;
   std::string OutputTimeResults();
@@ -175,6 +181,7 @@ protected:
   bool gen_file_ = false;
   bool verbose_ = false;
   bool print_memory_use_ = false;
+  bool print_total_time_ = true;
   uint32_t num_runs_ = 20;
   uint32_t current_run_ = 0;
   std::vector<char*> custom_args_ = {};

--- a/tests/perf/common/test_harness.h
+++ b/tests/perf/common/test_harness.h
@@ -174,6 +174,7 @@ private:
 protected:
   bool gen_file_ = false;
   bool verbose_ = false;
+  bool print_memory_use_ = false;
   uint32_t num_runs_ = 20;
   uint32_t current_run_ = 0;
   std::vector<char*> custom_args_ = {};

--- a/tests/perf/common/test_harness.h
+++ b/tests/perf/common/test_harness.h
@@ -167,11 +167,18 @@ struct PerfTestHarness : TestHarnessBase {
    */
   void GetMemoryUsage();
 
-  void
-  DisableGlobalTimer();
+/**
+ * \brief Disables the global timer (execution time of VT_PERF_TEST).
+ * Useful for tests that use custom timers.
+ */
+void DisableGlobalTimer();
 
-  bool
-  ShouldOutputGlobalTimer() const;
+/**
+ * \brief Returns information whether global timer (execution time of VT_PERF_TEST)
+ * is disabled.
+ */
+bool ShouldOutputGlobalTimer() const;
+
 
 private:
   std::string OutputMemoryUse() const;

--- a/tests/perf/common/test_harness_macros.h
+++ b/tests/perf/common/test_harness_macros.h
@@ -121,8 +121,8 @@ struct PerfTestRegistry{
       if (rank == 0) {                                                       \
         fmt::print(                                                          \
           "{}{}RUNNING TEST:{} {} (Number of runs = {}) ...\n",              \
-          test_num > 0 ? "\n\n\n\n" : "", vt::debug::bold(), vt::debug::reset(), \
-          vt::debug::reg(test->GetName()),                                   \
+          test_num > 0 ? "\n\n\n\n" : "", vt::debug::bold(),                 \
+          vt::debug::reset(), vt::debug::reg(test->GetName()),               \
           vt::debug::reg(fmt::format("{}", num_runs)));                      \
       }                                                                      \
       for (uint32_t run_num = 1; run_num <= num_runs; ++run_num) {           \
@@ -131,7 +131,10 @@ struct PerfTestRegistry{
         timer.Start();                                                       \
         test->TestFunc();                                                    \
         PerfTestHarness::SpinScheduler();                                    \
-        test->AddResult({test->GetName(), timer.Stop()});                    \
+                                                                             \
+        if (test->ShouldOutputGlobalTimer()) {                               \
+          test->AddResult({test->GetName(), timer.Stop()});                  \
+        }                                                                    \
                                                                              \
         if (run_num == num_runs) {                                           \
           test->SyncResults();                                               \

--- a/tests/perf/common/test_harness_macros.h
+++ b/tests/perf/common/test_harness_macros.h
@@ -106,40 +106,43 @@ struct PerfTestRegistry{
   } StructName##TestName##_registerer;                                     \
   void StructName##TestName::TestFunc()
 
-#define VT_PERF_TEST_MAIN()                                                      \
-  int main(int argc, char** argv) {                                              \
-    using namespace vt::tests::perf::common;                                     \
-    MPI_Init(&argc, &argv);                                                      \
-    int rank;                                                                    \
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);                                        \
-    for (const auto& test_base : PerfTestRegistry::GetTests()) {                 \
-      auto* test = dynamic_cast<PerfTestHarness*>(test_base.get());              \
-      test->Initialize(argc, argv);                                              \
-      auto const num_runs = test->GetNumRuns();                                  \
-      StopWatch timer;                                                           \
-      if (rank == 0) {                                                           \
-        fmt::print("{}RUNNING TEST:{} {} (Number of runs = {}) ...\n",           \
-          vt::debug::bold(), vt::debug::reset(), vt::debug::reg(test->GetName()),\
-          vt::debug::reg(fmt::format("{}", num_runs)));                          \
-      }                                                                          \
-      for (uint32_t run_num = 1; run_num <= num_runs; ++run_num) {               \
-        test->SetUp();                                                           \
-                                                                                 \
-        timer.Start();                                                           \
-        test->TestFunc();                                                        \
-        PerfTestHarness::SpinScheduler();                                        \
-        test->AddResult({test->GetName(), timer.Stop()});                        \
-                                                                                 \
-        if (run_num == num_runs) {                                               \
-          test->SyncResults();                                                   \
-        }                                                                        \
-                                                                                 \
-        test->TearDown();                                                        \
-      }                                                                          \
-      test->DumpResults();                                                       \
-    }                                                                            \
-    MPI_Finalize();                                                              \
-    return 0;                                                                    \
+#define VT_PERF_TEST_MAIN()                                                  \
+  int main(int argc, char** argv) {                                          \
+    using namespace vt::tests::perf::common;                                 \
+    MPI_Init(&argc, &argv);                                                  \
+    int rank;                                                                \
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);                                    \
+    auto& tests = PerfTestRegistry::GetTests();                              \
+    for (uint32_t test_num = 0; test_num < tests.size(); ++test_num) {       \
+      auto* test = dynamic_cast<PerfTestHarness*>(tests.at(test_num).get()); \
+      test->Initialize(argc, argv);                                          \
+      auto const num_runs = test->GetNumRuns();                              \
+      StopWatch timer;                                                       \
+      if (rank == 0) {                                                       \
+        fmt::print(                                                          \
+          "{}{}RUNNING TEST:{} {} (Number of runs = {}) ...\n",              \
+          test_num > 0 ? "\n\n\n\n" : "", vt::debug::bold(), vt::debug::reset(), \
+          vt::debug::reg(test->GetName()),                                   \
+          vt::debug::reg(fmt::format("{}", num_runs)));                      \
+      }                                                                      \
+      for (uint32_t run_num = 1; run_num <= num_runs; ++run_num) {           \
+        test->SetUp();                                                       \
+                                                                             \
+        timer.Start();                                                       \
+        test->TestFunc();                                                    \
+        PerfTestHarness::SpinScheduler();                                    \
+        test->AddResult({test->GetName(), timer.Stop()});                    \
+                                                                             \
+        if (run_num == num_runs) {                                           \
+          test->SyncResults();                                               \
+        }                                                                    \
+                                                                             \
+        test->TearDown();                                                    \
+      }                                                                      \
+      test->DumpResults();                                                   \
+    }                                                                        \
+    MPI_Finalize();                                                          \
+    return 0;                                                                \
   }
 
 }}}} // namespace vt::tests::perf::common


### PR DESCRIPTION
Fixes #2275
--------------
## Memory usage
### Before
![image](https://github.com/DARMA-tasking/vt/assets/9077677/7b0d5a87-26ec-4b4d-b436-e36eaecaee19)

### After
![image](https://github.com/DARMA-tasking/vt/assets/9077677/5f11a368-e73e-41a7-a836-1f4d8da965d7)

<br><br>
---------------
## Multiple tests in a single file
### Before
![image](https://github.com/DARMA-tasking/vt/assets/9077677/d3d7bebd-e31d-4598-8b02-92ec8a6dc47a)

### After
![image](https://github.com/DARMA-tasking/vt/assets/9077677/47b4fb50-151c-4745-9469-a72970c2fff3)

<br><br>
---------------
## Disable global timer (when using custom timers)
### Before
![image](https://github.com/DARMA-tasking/vt/assets/9077677/a5db4e25-6b19-4ae2-9902-39c58c95e069)

### After
![image](https://github.com/DARMA-tasking/vt/assets/9077677/110bbf45-469b-48f3-9a56-881c533e130c)
