### PR TITLE
#2308: Update `build_cpp.sh` to use `-DKokkos_ROOT`

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -90,7 +90,7 @@ else
         cd build
         cmake -G "${CMAKE_GENERATOR:-Ninja}" \
               -DCMAKE_INSTALL_PREFIX="$MAGISTRATE_BUILD/install" \
-              -Dkokkos_DIR="$KOKKOS_INSTALL" \
+              -DKokkos_ROOT="$KOKKOS_INSTALL" \
               "$CHECKPOINT"
         cmake --build . ${dashj} --target install
     fi


### PR DESCRIPTION
Fixes #2308 