### PR TITLE
#2323: Fix an issue with magistrate target when it's included as a vt's subdirectory

### DIFF
--- a/cmake/load_local_packages.cmake
+++ b/cmake/load_local_packages.cmake
@@ -7,6 +7,8 @@ include(cmake/local_package.cmake)
 
 if (EXISTS "${PROJECT_LIB_DIR}/checkpoint")
   add_subdirectory(${PROJECT_LIB_DIR}/checkpoint)
+elseif(EXISTS "${PROJECT_LIB_DIR}/magistrate")
+  add_subdirectory(${PROJECT_LIB_DIR}/magistrate)
 else()
   # find these required packages locally
   find_package_local(magistrate)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -316,9 +316,9 @@ export(
   NAMESPACE                 vt::runtime::
 )
 
-if (EXISTS "${PROJECT_LIB_DIR}/checkpoint")
+if (EXISTS "${PROJECT_LIB_DIR}/checkpoint" OR EXISTS "${PROJECT_LIB_DIR}/magistrate")
   install(
-    TARGETS                 checkpoint
+    TARGETS                 magistrate
     EXPORT                  ${VIRTUAL_TRANSPORT_LIBRARY}
   )
 endif()


### PR DESCRIPTION
Fixes #2323