### PR TITLE
#2319: fix undefined reference to `makeLB` in collection_extended

### DIFF
--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.cc
@@ -173,19 +173,6 @@ void LBManager::setLoadModel(std::shared_ptr<LoadModel> model) {
                    nlb_data->getUserData());
 }
 
-template <typename LB>
-LBManager::LBProxyType
-LBManager::makeLB(std::string const& lb_name) {
-  auto proxy = theObjGroup()->makeCollective<LB>(lb_name);
-  auto strat = proxy.get();
-  strat->init(proxy);
-  auto base_proxy = proxy.template castToBase<lb::BaseLB>();
-
-  destroy_lb_ = [proxy]{ proxy.destroyCollective(); };
-
-  return base_proxy;
-}
-
 void LBManager::defaultPostLBWork(ReassignmentMsg* msg) {
   auto reassignment = msg->reassignment;
   auto phase = msg->phase;

--- a/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
+++ b/src/vt/vrt/collection/balance/lb_invoke/lb_manager.h
@@ -231,7 +231,16 @@ public:
    * \return objgroup proxy to the new load balancer
    */
   template <typename LB>
-  LBProxyType makeLB(std::string const& lb_name = {});
+  LBProxyType makeLB(std::string const& lb_name = {}) {
+    auto proxy = theObjGroup()->makeCollective<LB>(lb_name);
+    auto strat = proxy.get();
+    strat->init(proxy);
+    auto base_proxy = proxy.template castToBase<lb::BaseLB>();
+
+    destroy_lb_ = [proxy]{ proxy.destroyCollective(); };
+
+    return base_proxy;
+  }
 
 protected:
   /**


### PR DESCRIPTION
Reproduced with Intel `2023.2.0` and `2024.2.0`. Our Azure builds are using `2022.2.1`, so maybe we need to update them.

Explicit instantiation also solves this.

fixes #2319 