### PR TITLE
#2321: Build system is mixing the system googletest headers with our internal googletest

### DIFF
--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -165,6 +165,9 @@ function(link_target_with_vt)
     target_link_libraries(
       ${ARG_TARGET} PUBLIC ${ARG_BUILD_TYPE} ${ZLIB_LIBRARIES}
     )
+    target_include_directories(
+      ${ARG_TARGET} PUBLIC $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIRS}>
+    )
   endif()
 
   if (NOT DEFINED ARG_LINK_FMT AND ${ARG_DEFAULT_LINK_SET} OR ARG_LINK_FMT)

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -165,9 +165,6 @@ function(link_target_with_vt)
     target_link_libraries(
       ${ARG_TARGET} PUBLIC ${ARG_BUILD_TYPE} ${ZLIB_LIBRARIES}
     )
-    target_include_directories(
-      ${ARG_TARGET} PUBLIC $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIRS}>
-    )
   endif()
 
   if (NOT DEFINED ARG_LINK_FMT AND ${ARG_DEFAULT_LINK_SET} OR ARG_LINK_FMT)

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -90,7 +90,7 @@ function(link_target_with_vt)
     if (${ARG_DEBUG_LINK})
       message(STATUS "link_target_with_vt: gtest=${ARG_LINK_GTEST}")
     endif()
-    target_link_libraries(${ARG_TARGET} PRIVATE gtest)
+    target_link_libraries(${ARG_TARGET} PRIVATE ${GOOGLETEST_LIBRARY})
   endif()
 
   if (NOT DEFINED ARG_LINK_UNWIND AND ${ARG_DEFAULT_LINK_SET} OR ARG_LINK_UNWIND)

--- a/cmake/load_packages.cmake
+++ b/cmake/load_packages.cmake
@@ -7,7 +7,7 @@ include(cmake/load_local_packages.cmake)
 include(cmake/load_mpi_package.cmake)
 
 # ZLIB package
-include(cmake/load_zlib_package.cmake)
+find_package(ZLIB REQUIRED)
 
 # Perl is used to build the PMPI wrappers
 find_package(Perl)

--- a/cmake/load_zlib_package.cmake
+++ b/cmake/load_zlib_package.cmake
@@ -4,8 +4,6 @@
 #
 
 find_package(ZLIB REQUIRED)
-if(ZLIB_FOUND)
-  include_directories(${ZLIB_INCLUDE_DIRS})
-else()
+if(NOT ZLIB_FOUND)
   message("zlib is required for tracing")
-endif(ZLIB_FOUND)
+endif(NOT ZLIB_FOUND)

--- a/cmake/load_zlib_package.cmake
+++ b/cmake/load_zlib_package.cmake
@@ -1,9 +1,0 @@
-
-#
-#  Load Zlib settings (required)
-#
-
-find_package(ZLIB REQUIRED)
-if(NOT ZLIB_FOUND)
-  message("zlib is required for tracing")
-endif(NOT ZLIB_FOUND)


### PR DESCRIPTION
Fixes #2321 

---

### Explanation

The problem was in `load_zlib_package.cmake`:

```cmake
# Original load_zlib_package.cmake
find_package(ZLIB REQUIRED)
if(ZLIB FOUND)
    include_directories(${ZLIB_INCLUDE_DIRS})
...
```

The `zlib` includes found by CMake were in a directory that also contained `gtest` includes.

- By setting `include_directories`, this directory was added as an include dir for every target that vt builds. This is what caused the conflict when we tried to build the in-house gtest.

To fix this, I removed the call to `include_directories`; the correct includes will be propagated correctly, as @cz4rs [pointed out](https://github.com/DARMA-tasking/vt/pull/2329#discussion_r1681420310)