### PR TITLE
#2320:  simulate_replay fails to link related to dumpStack

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -151,6 +151,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dvt_debug_verbose="${VT_DEBUG_VERBOSE:-0}" \
       -Dvt_tests_num_nodes="${VT_TESTS_NUM_NODES:-}" \
       -Dvt_external_fmt="${VT_EXTERNAL_FMT:-0}" \
+      -D libunwind_ROOT_DIR="${LIBUNWIND_ROOT_DIR:-/usr}" \
       -Dvt_no_color_enabled="${VT_NO_COLOR_ENABLED:-0}" \
       -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-17}" \
       -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -151,7 +151,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dvt_debug_verbose="${VT_DEBUG_VERBOSE:-0}" \
       -Dvt_tests_num_nodes="${VT_TESTS_NUM_NODES:-}" \
       -Dvt_external_fmt="${VT_EXTERNAL_FMT:-0}" \
-      -D libunwind_ROOT_DIR="${LIBUNWIND_ROOT_DIR:-/usr}" \
+      -Dlibunwind_ROOT_DIR="${LIBUNWIND_ROOT_DIR:-/usr}" \
       -Dvt_no_color_enabled="${VT_NO_COLOR_ENABLED:-0}" \
       -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-17}" \
       -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -151,7 +151,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dvt_debug_verbose="${VT_DEBUG_VERBOSE:-0}" \
       -Dvt_tests_num_nodes="${VT_TESTS_NUM_NODES:-}" \
       -Dvt_external_fmt="${VT_EXTERNAL_FMT:-0}" \
-      -Dlibunwind_ROOT_DIR="${LIBUNWIND_ROOT_DIR:-/usr}" \
+      -DLIBUNWIND_ROOT="${LIBUNWIND_ROOT:-/usr}" \
       -Dvt_no_color_enabled="${VT_NO_COLOR_ENABLED:-0}" \
       -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-17}" \
       -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \

--- a/cmake-modules/Findlibunwind.cmake
+++ b/cmake-modules/Findlibunwind.cmake
@@ -1,0 +1,70 @@
+# This file downloaded from https://raw.githubusercontent.com/m-a-d-n-e-s-s/madness/master/cmake/modules/FindLibunwind.cmake
+#
+# - Try to find Libunwind
+# Input variables:
+#  LIBUNWIND_ROOT_DIR     - The libunwind install directory
+#  LIBUNWIND_INCLUDE_DIR  - The libunwind include directory
+#  LIBUNWIND_LIBRARY      - The libunwind library directory
+# Output variables:
+#  LIBUNWIND_FOUND        - System has libunwind
+#  LIBUNWIND_INCLUDE_DIRS - The libunwind include directories
+#  LIBUNWIND_LIBRARIES    - The libraries needed to use libunwind
+#  LIBUNWIND_VERSION      - The version string for libunwind
+
+include(FindPackageHandleStandardArgs)
+
+if(NOT DEFINED LIBUNWIND_FOUND)
+
+  # Set default sarch paths for libunwind
+  if(LIBUNWIND_ROOT_DIR)
+    set(LIBUNWIND_INCLUDE_DIR ${LIBUNWIND_ROOT_DIR}/include CACHE PATH "The include directory for libunwind")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      set(LIBUNWIND_LIBRARY ${LIBUNWIND_ROOT_DIR}/lib64;${LIBUNWIND_ROOT_DIR}/lib CACHE PATH "The library directory for libunwind")
+    else()
+      set(LIBUNWIND_LIBRARY ${LIBUNWIND_ROOT_DIR}/lib CACHE PATH "The library directory for libunwind")
+    endif()
+  endif()
+
+  find_path(LIBUNWIND_INCLUDE_DIRS NAMES libunwind.h
+      HINTS ${LIBUNWIND_INCLUDE_DIR})
+
+  find_library(LIBUNWIND_LIBRARIES unwind
+      HINTS ${LIBUNWIND_LIBRARY})
+
+  # Get libunwind version
+  if(EXISTS "${LIBUNWIND_INCLUDE_DIRS}/libunwind-common.h")
+    file(READ "${LIBUNWIND_INCLUDE_DIRS}/libunwind-common.h" _libunwind_version_header)
+    string(REGEX REPLACE ".*define[ \t]+UNW_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1"
+        LIBUNWIND_MAJOR_VERSION "${_libunwind_version_header}")
+    string(REGEX REPLACE ".*define[ \t]+UNW_VERSION_MINOR[ \t]+([0-9]+).*" "\\1"
+        LIBUNWIND_MINOR_VERSION "${_libunwind_version_header}")
+    string(REGEX REPLACE ".*define[ \t]+UNW_VERSION_EXTRA[ \t]+([0-9]*).*" "\\1"
+        LIBUNWIND_MICRO_VERSION "${_libunwind_version_header}")
+    if(LIBUNWIND_MICRO_VERSION)
+      set(LIBUNWIND_VERSION "${LIBUNWIND_MAJOR_VERSION}.${LIBUNWIND_MINOR_VERSION}.${LIBUNWIND_MICRO_VERSION}")
+    else()
+      set(LIBUNWIND_VERSION "${LIBUNWIND_MAJOR_VERSION}.${LIBUNWIND_MINOR_VERSION}")
+    endif()
+    unset(_libunwind_version_header)
+  endif()
+
+  # handle the QUIETLY and REQUIRED arguments and set LIBUNWIND_FOUND to TRUE
+  # if all listed variables are TRUE
+  find_package_handle_standard_args(Libunwind
+      FOUND_VAR LIBUNWIND_FOUND
+      VERSION_VAR LIBUNWIND_VERSION
+      REQUIRED_VARS LIBUNWIND_LIBRARIES LIBUNWIND_INCLUDE_DIRS)
+
+  mark_as_advanced(LIBUNWIND_INCLUDE_DIR LIBUNWIND_LIBRARY
+      LIBUNWIND_INCLUDE_DIRS LIBUNWIND_LIBRARIES)
+
+endif()
+
+if(LIBUNWIND_FOUND)
+  if(NOT TARGET LIBUNWIND::LIBUNWIND)
+    add_library(LIBUNWIND::LIBUNWIND UNKNOWN IMPORTED)
+    set_target_properties(LIBUNWIND::LIBUNWIND PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${LIBUNWIND_INCLUDE_DIRS}"
+        IMPORTED_LOCATION "${LIBUNWIND_LIBRARIES}" )
+  endif()
+endif()

--- a/cmake-modules/Findlibunwind.cmake
+++ b/cmake-modules/Findlibunwind.cmake
@@ -2,7 +2,7 @@
 #
 # - Try to find Libunwind
 # Input variables:
-#  LIBUNWIND_ROOT_DIR     - The libunwind install directory
+#  libunwind_ROOT_DIR     - The libunwind install directory
 #  LIBUNWIND_INCLUDE_DIR  - The libunwind include directory
 #  LIBUNWIND_LIBRARY      - The libunwind library directory
 # Output variables:
@@ -16,20 +16,26 @@ include(FindPackageHandleStandardArgs)
 if(NOT DEFINED LIBUNWIND_FOUND)
 
   # Set default sarch paths for libunwind
-  if(LIBUNWIND_ROOT_DIR)
-    set(LIBUNWIND_INCLUDE_DIR ${LIBUNWIND_ROOT_DIR}/include CACHE PATH "The include directory for libunwind")
+  if(libunwind_ROOT_DIR)
+    set(LIBUNWIND_INCLUDE_DIR ${libunwind_ROOT_DIR}/include CACHE PATH "The include directory for libunwind")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
-      set(LIBUNWIND_LIBRARY ${LIBUNWIND_ROOT_DIR}/lib64;${LIBUNWIND_ROOT_DIR}/lib CACHE PATH "The library directory for libunwind")
+      set(LIBUNWIND_LIBRARY ${libunwind_ROOT_DIR}/lib64;${libunwind_ROOT_DIR}/lib CACHE PATH "The library directory for libunwind")
     else()
-      set(LIBUNWIND_LIBRARY ${LIBUNWIND_ROOT_DIR}/lib CACHE PATH "The library directory for libunwind")
+      set(LIBUNWIND_LIBRARY ${libunwind_ROOT_DIR}/lib CACHE PATH "The library directory for libunwind")
     endif()
   endif()
 
+  # First, try searching in libunwind_ROOT ("/usr" by default)
   find_path(LIBUNWIND_INCLUDE_DIRS NAMES libunwind.h
-      HINTS ${LIBUNWIND_INCLUDE_DIR})
-
+      HINTS ${LIBUNWIND_INCLUDE_DIR}
+      NO_DEFAULT_PATH)
   find_library(LIBUNWIND_LIBRARIES unwind
-      HINTS ${LIBUNWIND_LIBRARY})
+      HINTS ${LIBUNWIND_LIBRARY}
+      NO_DEFAULT_PATH)
+
+  # If that fails, use CMake's default path
+  find_path(LIBUNWIND_INCLUDE_DIRS NAMES libunwind.h)
+  find_library(LIBUNWIND_LIBRARIES unwind)
 
   # Get libunwind version
   if(EXISTS "${LIBUNWIND_INCLUDE_DIRS}/libunwind-common.h")

--- a/cmake-modules/Findlibunwind.cmake
+++ b/cmake-modules/Findlibunwind.cmake
@@ -1,10 +1,12 @@
-# This file downloaded from https://raw.githubusercontent.com/m-a-d-n-e-s-s/madness/master/cmake/modules/FindLibunwind.cmake
+# This file was downloaded from https://raw.githubusercontent.com/m-a-d-n-e-s-s/madness/master/cmake/modules/FindLibunwind.cmake
+# and modified on August 2 2024
 #
 # - Try to find Libunwind
 # Input variables:
 #  libunwind_ROOT_DIR     - The libunwind install directory
 #  LIBUNWIND_INCLUDE_DIR  - The libunwind include directory
 #  LIBUNWIND_LIBRARY      - The libunwind library directory
+#
 # Output variables:
 #  LIBUNWIND_FOUND        - System has libunwind
 #  LIBUNWIND_INCLUDE_DIRS - The libunwind include directories
@@ -15,7 +17,7 @@ include(FindPackageHandleStandardArgs)
 
 if(NOT DEFINED LIBUNWIND_FOUND)
 
-  # Set default sarch paths for libunwind
+  # Set default search paths for libunwind
   if(libunwind_ROOT_DIR)
     set(LIBUNWIND_INCLUDE_DIR ${libunwind_ROOT_DIR}/include CACHE PATH "The include directory for libunwind")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -54,7 +56,7 @@ if(NOT DEFINED LIBUNWIND_FOUND)
     unset(_libunwind_version_header)
   endif()
 
-  # handle the QUIETLY and REQUIRED arguments and set LIBUNWIND_FOUND to TRUE
+  # Handle the QUIETLY and REQUIRED arguments and set LIBUNWIND_FOUND to TRUE
   # if all listed variables are TRUE
   find_package_handle_standard_args(Libunwind
       FOUND_VAR LIBUNWIND_FOUND

--- a/cmake-modules/Findlibunwind.cmake
+++ b/cmake-modules/Findlibunwind.cmake
@@ -1,5 +1,6 @@
 
-# Users can pass LIBUNWIND_ROOT, LIBUNWIND_INCLUDE_DIR, and LIBUNWIND_LIBRARY as CMake variables
+# Users can pass LIBUNWIND_ROOT, LIBUNWIND_INCLUDE_DIR, and LIBUNWIND_LIBRARY as CMake variables.
+# If LIBUNWIND_ROOT is provided, the INCLUDE_DIR and LIBRARY variables may be omitted.
 #
 # LIBUNWIND_FOUND, LIBUNWIND_INCLUDE_DIRS, and LIBUNWIND_LIBRARIES are outputs
 

--- a/cmake-modules/Findlibunwind.cmake
+++ b/cmake-modules/Findlibunwind.cmake
@@ -4,8 +4,8 @@
 # LIBUNWIND_FOUND, LIBUNWIND_INCLUDE_DIRS, and LIBUNWIND_LIBRARIES are outputs
 
 if(LIBUNWIND_ROOT)
-    set(LIBUNWIND_INCLUDE_DIR ${LIBUNWIND_ROOT}/include CACHE PATH "The include directory for libunwind")
-    set(LIBUNWIND_LIBRARY ${LIBUNWIND_ROOT}/lib64;${LIBUNWIND_ROOT}/lib CACHE PATH "The library directory for libunwind")
+    set(LIBUNWIND_INCLUDE_DIR ${LIBUNWIND_INCLUDE_DIR};${LIBUNWIND_ROOT}/include)
+    set(LIBUNWIND_LIBRARY ${LIBUNWIND_LIBRARY};${LIBUNWIND_ROOT}/lib64;${LIBUNWIND_ROOT}/lib)
 endif()
 
 # First, check only in the hinted paths

--- a/cmake/check_system_functions.cmake
+++ b/cmake/check_system_functions.cmake
@@ -10,7 +10,7 @@ check_include_files(mach/mach.h vt_has_mach_mach_h)
 check_include_files(sys/resource.h vt_has_sys_resource_h)
 check_include_files(unistd.h vt_has_unistd_h)
 check_include_files(inttypes.h vt_has_inttypes_h)
-check_include_files(libunwind.h vt_has_libunwind_h)
+# check_include_files(libunwind.h vt_has_libunwind)
 check_include_files(execinfo.h vt_has_execinfo_h)
 
 check_function_exists(mstats vt_has_mstats)

--- a/cmake/check_system_functions.cmake
+++ b/cmake/check_system_functions.cmake
@@ -10,7 +10,6 @@ check_include_files(mach/mach.h vt_has_mach_mach_h)
 check_include_files(sys/resource.h vt_has_sys_resource_h)
 check_include_files(unistd.h vt_has_unistd_h)
 check_include_files(inttypes.h vt_has_inttypes_h)
-# check_include_files(libunwind.h vt_has_libunwind)
 check_include_files(execinfo.h vt_has_execinfo_h)
 
 check_function_exists(mstats vt_has_mstats)

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -100,7 +100,7 @@ function(link_target_with_vt)
       endif()
       if (NOT DEFINED APPLE)
         target_link_libraries(
-          ${ARG_TARGET} PUBLIC ${ARG_BUILD_TYPE} unwind
+          ${ARG_TARGET} PUBLIC ${ARG_BUILD_TYPE} ${LIBUNWIND_LIBRARIES}
         )
       endif()
     endif()

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -94,7 +94,7 @@ function(link_target_with_vt)
   endif()
 
   if (NOT DEFINED ARG_LINK_UNWIND AND ${ARG_DEFAULT_LINK_SET} OR ARG_LINK_UNWIND)
-    if (vt_has_libunwind_h)
+    if (vt_has_libunwind)
       if (${ARG_DEBUG_LINK})
         message(STATUS "link_target_with_vt: unwind=${ARG_LINK_UNWIND}")
       endif()

--- a/cmake/link_vt.cmake
+++ b/cmake/link_vt.cmake
@@ -94,7 +94,7 @@ function(link_target_with_vt)
   endif()
 
   if (NOT DEFINED ARG_LINK_UNWIND AND ${ARG_DEFAULT_LINK_SET} OR ARG_LINK_UNWIND)
-    if (vt_has_libunwind)
+    if (vt_feature_cmake_libunwind)
       if (${ARG_DEBUG_LINK})
         message(STATUS "link_target_with_vt: unwind=${ARG_LINK_UNWIND}")
       endif()

--- a/cmake/load_libunwind.cmake
+++ b/cmake/load_libunwind.cmake
@@ -1,7 +1,7 @@
 set(vt_feature_cmake_libunwind "0")
 
-if(NOT DEFINED libunwind_ROOT_DIR)
-    set(libunwind_ROOT_DIR "/usr")
+if(NOT DEFINED LIBUNWIND_ROOT)
+    set(LIBUNWIND_ROOT "/usr")
 endif()
 
 find_package(libunwind)

--- a/cmake/load_libunwind.cmake
+++ b/cmake/load_libunwind.cmake
@@ -1,7 +1,7 @@
-set(vt_has_libunwind 0)
+set(vt_feature_cmake_libunwind "0")
 
 find_package(libunwind)
 
-if(libunwind_FOUND)
-    set(vt_has_libunwind 1)
+if(LIBUNWIND_FOUND)
+    set(vt_feature_cmake_libunwind "1")
 endif()

--- a/cmake/load_libunwind.cmake
+++ b/cmake/load_libunwind.cmake
@@ -1,5 +1,9 @@
 set(vt_feature_cmake_libunwind "0")
 
+if(NOT DEFINED libunwind_ROOT_DIR)
+    set(libunwind_ROOT_DIR "/usr")
+endif()
+
 find_package(libunwind)
 
 if(LIBUNWIND_FOUND)

--- a/cmake/load_libunwind.cmake
+++ b/cmake/load_libunwind.cmake
@@ -1,0 +1,7 @@
+set(vt_has_libunwind 0)
+
+find_package(libunwind)
+
+if(libunwind_FOUND)
+    set(vt_has_libunwind 1)
+endif()

--- a/cmake/load_packages.cmake
+++ b/cmake/load_packages.cmake
@@ -15,6 +15,9 @@ find_package(Perl)
 # Doxygen package
 include(cmake/load_doxygen.cmake)
 
+# Optionally link with libunwind
+include(cmake/load_libunwind.cmake)
+
 # Optionally link with Zoltan
 include(cmake/load_zoltan_package.cmake)
 

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -66,6 +66,7 @@
 #define vt_feature_cmake_debug_verbose       @vt_feature_cmake_debug_verbose@
 #define vt_feature_cmake_rdma_tests          @vt_feature_cmake_rdma_tests@
 #define vt_feature_cmake_external_fmt        @vt_feature_cmake_external_fmt@
+#define vt_feature_cmake_libunwind           @vt_feature_cmake_libunwind@
 
 #define vt_detected_max_num_nodes @cmake_detected_max_num_nodes@
 
@@ -89,7 +90,6 @@
 #cmakedefine vt_has_unistd_h
 #cmakedefine vt_has_inttypes_h
 #cmakedefine vt_has_sysconf
-#cmakedefine vt_has_libunwind
 #cmakedefine vt_has_execinfo_h
 
 #if vt_feature_cmake_external_fmt

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -89,7 +89,7 @@
 #cmakedefine vt_has_unistd_h
 #cmakedefine vt_has_inttypes_h
 #cmakedefine vt_has_sysconf
-#cmakedefine vt_has_libunwind_h
+#cmakedefine vt_has_libunwind
 #cmakedefine vt_has_execinfo_h
 
 #if vt_feature_cmake_external_fmt

--- a/src/vt/configs/error/stack_out.cc
+++ b/src/vt/configs/error/stack_out.cc
@@ -47,7 +47,7 @@
 
 #include <cxxabi.h>
 
-#if defined(vt_has_libunwind)
+#if vt_check_enabled(libunwind)
 # define UNW_LOCAL_ONLY
 # include <libunwind.h>
 #elif defined(vt_has_execinfo_h)
@@ -59,7 +59,7 @@ namespace vt { namespace debug { namespace stack {
 
 DumpStackType dumpStack(int skip) {
   DumpStackType stack;
-  #if defined(vt_has_libunwind)
+  #if vt_check_enabled(libunwind)
 
     unw_cursor_t cursor;
     unw_context_t context;

--- a/src/vt/configs/error/stack_out.cc
+++ b/src/vt/configs/error/stack_out.cc
@@ -152,7 +152,8 @@ DumpStackType dumpStack(int skip) {
     std::free(symbols);
 
     return stack;
-  #else //neither libnunwind.h or libexecinfo.h is available
+  #else // neither libunwind.h nor libexecinfo.h is available
+    (void)skip;
     return stack;
   #endif
 }

--- a/src/vt/configs/error/stack_out.cc
+++ b/src/vt/configs/error/stack_out.cc
@@ -47,7 +47,7 @@
 
 #include <cxxabi.h>
 
-#if defined(vt_has_libunwind_h)
+#if defined(vt_has_libunwind)
 # define UNW_LOCAL_ONLY
 # include <libunwind.h>
 #elif defined(vt_has_execinfo_h)
@@ -59,7 +59,7 @@ namespace vt { namespace debug { namespace stack {
 
 DumpStackType dumpStack(int skip) {
   DumpStackType stack;
-  #if defined(vt_has_libunwind_h)
+  #if defined(vt_has_libunwind)
 
     unw_cursor_t cursor;
     unw_context_t context;

--- a/src/vt/configs/features/features_defines.h
+++ b/src/vt/configs/features/features_defines.h
@@ -73,6 +73,7 @@
 #define vt_feature_production_build    0 || vt_feature_cmake_production_build
 #define vt_feature_debug_verbose       0 || vt_feature_cmake_debug_verbose
 #define vt_feature_fmt_external        0 || vt_feature_cmake_external_fmt
+#define vt_feature_libunwind           0 || vt_feature_cmake_libunwind
 
 #define vt_check_enabled(test_option) (vt_feature_ ## test_option != 0)
 

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -49,7 +49,7 @@
 
 namespace vt { namespace tests { namespace unit {
 
-#if defined(vt_has_libunwind_h) || defined(vt_has_execinfo_h)
+#if defined(vt_has_libunwind) || defined(vt_has_execinfo_h)
 
   struct TestStackDumping : TestParallelHarness {};
 

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -49,7 +49,7 @@
 
 namespace vt { namespace tests { namespace unit {
 
-#if defined(vt_has_libunwind) || defined(vt_has_execinfo_h)
+#if vt_check_enabled(libunwind) || defined(vt_has_execinfo_h)
 
   struct TestStackDumping : TestParallelHarness {};
 


### PR DESCRIPTION
Fixes #2320

### Problem

The issue was that there were two versions of libunwind available, and we were trying to link with the wrong one.

### Solution

I've added a `Findlibunwind.cmake` module so we can use `find_package(libunwind)` instead of `check_include_file`.

This gives us more control over which libunwind is found. Specifically, we can provide `HINTS` that point to the desired `libunwind` installation (usually, we want the one installed in `/usr`)
- I've added a `libunwind_ROOT_DIR` CMake variable that users can optionally provide during configuration. (This directory becomes the `HINT` passed to `find_package`)
- If `libunwind` isn't found in the suggested directory, it searches using CMake's default path instead.