### PR TITLE
#2364: fix documentation build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,10 +14,10 @@ jobs:
     env:
       REPO: lifflander1/vt
       ARCH: amd64
-      UBUNTU: 18.04
+      UBUNTU: 22.04
       COMPILER_TYPE: gnu
-      COMPILER: gcc-8
-      HOST_COMPILER: gcc-8
+      COMPILER: gcc-11
+      HOST_COMPILER: gcc-11
       BUILD_TYPE: release
       ULIMIT_CORE: 0
       VT_LB: 1

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -184,7 +184,8 @@ then
     git clone "https://${token}@github.com/DARMA-tasking/DARMA-tasking.github.io"
     git clone https://github.com/mosra/m.css
     cd m.css
-    git checkout master
+    git checkout 699abdd5
+    sed -i '2600d' documentation/doxygen.py # remove incorrect assertion
     cd ../
 
     "$MCSS/documentation/doxygen.py" Doxyfile-mcss

--- a/ci/docker/ubuntu-gnu-docs.dockerfile
+++ b/ci/docker/ubuntu-gnu-docs.dockerfile
@@ -1,5 +1,6 @@
 ARG arch=amd64
-FROM ${arch}/ubuntu:18.04 as base
+ARG ubuntu=22.04
+FROM ${arch}/ubuntu:${ubuntu} as base
 
 ARG proxy=""
 ARG compiler=gcc-8


### PR DESCRIPTION
fixes #2364 

2742e9e7fd0efb2695a7ce64ca9ffa4956b748e6 is a drive-by change to update Ubuntu version.
98595cc2fdaace8fc5456fc8112673e267741f67 is the actual fix, removing faulty assertion and pinning the library version to the latest.

Issue reported in `m.css`:
https://github.com/mosra/m.css/issues/251

Successful documentation build on this branch:
https://github.com/DARMA-tasking/vt/actions/runs/11581967895/job/32243909262?pr=2367