### PR TITLE
#2368: avoid regression in Doxygen 1.9.1

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -185,7 +185,6 @@ then
     git clone https://github.com/mosra/m.css
     cd m.css
     git checkout 699abdd5
-    sed -i '2600d' documentation/doxygen.py # remove incorrect assertion
     cd ../
 
     "$MCSS/documentation/doxygen.py" Doxyfile-mcss

--- a/ci/deps/doxygen.sh
+++ b/ci/deps/doxygen.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+if test $# -ne 1
+then
+    echo "usage: ./$0 <doxygen-version>"
+    exit 1
+fi
+
+doxygen_version=$1
+doxygen_tar_name=doxygen-"${doxygen_version}".linux.bin.tar.gz
+
+echo "${doxygen_tar_name}"
+
+wget https://sourceforge.net/projects/doxygen/files/rel-"${doxygen_version}"/"${doxygen_tar_name}"
+
+tar xzf "${doxygen_tar_name}" --one-top-level=doxygen --strip-components=1

--- a/ci/docker/ubuntu-gnu-docs.dockerfile
+++ b/ci/docker/ubuntu-gnu-docs.dockerfile
@@ -13,23 +13,22 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
-    ca-certificates \
-    curl \
-    git \
-    mpich \
-    libmpich-dev \
-    wget \
-    ${compiler} \
-    zlib1g \
-    zlib1g-dev \
-    ninja-build \
-    doxygen \
-    python3 \
-    python3-jinja2 \
-    python3-pygments \
-    texlive-font-utils \
-    ghostscript \
-    ccache && \
+        ${compiler} \
+        ca-certificates \
+        ccache \
+        curl \
+        ghostscript \
+        git \
+        libmpich-dev \
+        mpich \
+        ninja-build \
+        python3 \
+        python3-jinja2 \
+        python3-pygments \
+        texlive-font-utils \
+        wget \
+        zlib1g \
+        zlib1g-dev &&\
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -45,6 +44,11 @@ COPY ./ci/deps/cmake.sh cmake.sh
 RUN ./cmake.sh 3.23.4 ${arch}
 
 ENV PATH=/cmake/bin/:$PATH
+
+COPY ./ci/deps/doxygen.sh doxygen.sh
+RUN ./doxygen.sh 1.8.16
+
+ENV PATH=/doxygen/bin/:$PATH
 
 FROM base as build
 COPY . /vt


### PR DESCRIPTION
fixes #2368 

Pin Doxygen version to `1.8.16` and remove the workaround from #2367.

---

Successful run from this branch: https://github.com/DARMA-tasking/vt/actions/runs/11780656704/job/32811716629.

Examples of the affected pages:
- https://darma-tasking.github.io/docs/html/structvt_1_1rdma_1_1_handle.html
- https://darma-tasking.github.io/docs/html/structvt_1_1rdma_1_1_handle_3_01_t_00_01_e_00_01_index_t_00_01typename_01std_1_1enable__if__t_3_d15dac1b5db6e2bc0fb0b8aca42b1456.html
