### PR TITLE
#2378: update `.clang-format` to match style guidelines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ ColumnLimit: 80
 UseTab: Never
 
 AccessModifierOffset: -2
-AlignAfterOpenBracket: AlwaysBreak
+AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveAssignments: None
 AlignConsecutiveDeclarations: None
 AlignConsecutiveMacros: None
@@ -89,4 +89,4 @@ SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: c++14
+Standard: c++17

--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -1,0 +1,16 @@
+name: PR checks (clang-format)
+
+on: pull_request
+
+jobs:
+  check:
+    name: Run clang-format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run clang-format
+        shell: bash
+        run: git clang-format-16 --diff ${{ github.base_ref }}

--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -12,5 +12,48 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run clang-format
-        shell: bash
-        run: git clang-format-16 --diff ${{ github.base_ref }}
+        run: |
+          {
+            echo 'CLANG_FORMAT_DIFF<<EOF'
+            git clang-format-16 --diff origin/${{ github.base_ref }} || true
+            echo EOF
+          } >> "$GITHUB_ENV"
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            let commentId = -1
+            for await (const { data: comments } of github.paginate.iterator(
+              github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number
+              }
+            )) {
+              const foundComment = comments.find((comment) =>
+                comment.body.startsWith(
+                  '`clang-format` output for this changeset:'
+                )
+              )
+              if (foundComment) {
+                commentId = foundComment.id
+                break
+              }
+            }
+
+            const { CLANG_FORMAT_DIFF } = process.env
+            const commentBody = '`clang-format` output for this changeset:\n```diff\n' + CLANG_FORMAT_DIFF + '\n```'
+            if (commentId === -1) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody
+              })
+            } else {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body: commentBody
+              })
+            }


### PR DESCRIPTION
fixes #2378 

- update our `.clang-format` file to better match project's style guidelines
- add a CI check to run `clang-format` on the PR changes and post a comment with the output (see https://github.com/DARMA-tasking/vt/pull/2379#issuecomment-2683363054 for an example)

The new `PR checks (clang-format)` workflow will NOT fail when the style is not applied, for now this is purely informative.

---
Misc notes:
- Official style guidelines: https://github.com/DARMA-tasking/vt/wiki/Code-Style-Guidelines
- It is possible to disable formatting for a section of code with:
```
// clang-format off
...
// clang-format on
```