### PR TITLE
#2385: Print in VT header when verbose prints are enabled at compile-time

### DIFF
--- a/src/vt/configs/features/features_featureswitch.h
+++ b/src/vt/configs/features/features_featureswitch.h
@@ -64,5 +64,6 @@
                                           "debug prints disabled)"
 #define vt_feature_str_trace_enabled      "Tracing Projections"
 #define vt_feature_str_zoltan             "Zoltan for load balancing"
+#define vt_feature_str_debug_verbose      "Verbose Prints"
 
 #endif /*INCLUDED_VT_CONFIGS_FEATURES_FEATURES_FEATURESWITCH_H*/

--- a/src/vt/runtime/runtime_banner.cc
+++ b/src/vt/runtime/runtime_banner.cc
@@ -139,6 +139,9 @@ void Runtime::printStartupBanner() {
 #if vt_check_enabled(diagnostics)
   features.push_back(vt_feature_str_diagnostics);
 #endif
+#if vt_check_enabled(debug_verbose)
+  features.push_back(vt_feature_str_debug_verbose);
+#endif
 
   std::string dirty = "";
   if (vt_git_clean_status == "DIRTY") {


### PR DESCRIPTION
Fixes #2385 

Note: In following with the existing logic for printing compile-time options, there is no print when verbose prints are disabled.