### PR TITLE
#2416: remove a few unnecessary template keyword uses

### DIFF
--- a/src/vt/pipe/callback/callback_base_tl.h
+++ b/src/vt/pipe/callback/callback_base_tl.h
@@ -64,7 +64,7 @@ struct CallbackBaseTL {
 
   void triggerVoid(PipeType const& pipe) {
     auto cb = static_cast<CallbackT&>(*this);
-    return cb.template triggerVoid(pipe);
+    return cb.triggerVoid(pipe);
   }
 };
 

--- a/src/vt/runtime/component/component_pack.impl.h
+++ b/src/vt/runtime/component/component_pack.impl.h
@@ -54,7 +54,7 @@ template <typename T, typename Tuple, size_t... I>
 std::unique_ptr<T> tupleConsImpl(
   Tuple&& tup, [[maybe_unused]] std::index_sequence<I...> seq
 ) {
-  return T::template staticInit(std::get<I>(std::forward<Tuple>(tup))...);
+  return T::staticInit(std::get<I>(std::forward<Tuple>(tup))...);
 }
 
 template <typename T, typename Tuple>


### PR DESCRIPTION
Fixes #2416

I didn't audit all of the codebase for this, but this appears to be all that clang 20 warns on