### PR TITLE
#2437: [CI] fix documentation build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,10 +14,10 @@ jobs:
     env:
       REPO: lifflander1/vt
       ARCH: amd64
-      UBUNTU: 22.04
+      UBUNTU: 20.04
       COMPILER_TYPE: gnu
-      COMPILER: gcc-11
-      HOST_COMPILER: gcc-11
+      COMPILER: gcc-9
+      HOST_COMPILER: gcc-9
       BUILD_TYPE: release
       ULIMIT_CORE: 0
       VT_LB: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,7 @@ services:
   # Build documentation for VT in the container on ubuntu platform from
   # container baseline.
   ubuntu-docs:
-    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}
+    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-cpp
     ulimits: *ulimits
     environment:
       <<: *ccache
@@ -267,7 +267,7 @@ services:
   # Interactive build documentation for VT in the container on ubuntu platform
   # from container baseline.
   ubuntu-docs-interactive:
-    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}
+    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-cpp
     ulimits: *ulimits
     environment:
       <<: *ccache


### PR DESCRIPTION
Use the image that actually has Doxygen installed and fix the image name format for docs build.

fixes #2437 