### PR TITLE
#2446: Add fmt dir cmake variable in build script

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -171,6 +171,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -Dvt_debug_verbose="${VT_DEBUG_VERBOSE:-0}" \
       -Dvt_tests_num_nodes="${VT_TESTS_NUM_NODES:-}" \
       -Dvt_external_fmt="${VT_EXTERNAL_FMT:-0}" \
+      -Dfmt_DIR="${FMT_DIR}" \
       -DLIBUNWIND_ROOT="${LIBUNWIND_ROOT:-/usr}" \
       -Dvt_no_color_enabled="${VT_NO_COLOR_ENABLED:-0}" \
       -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-17}" \


### PR DESCRIPTION
Added a line in the cmake command to specify the fmt directory for an external installation. Fixes #2446.