### PR TITLE
#2448: ci: bake: enable local output and use it for caching

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: ~/ccache
+          path: docker-output/build/ccache
           key: ${{ matrix.target }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: ${{ matrix.target }}-${{ github.ref }}
 

--- a/ci/docker/vt.dockerfile
+++ b/ci/docker/vt.dockerfile
@@ -40,7 +40,16 @@ ARG VT_UNITY_BUILD_ENABLED
 ARG VT_WERROR_ENABLED
 ARG VT_ZOLTAN_ENABLED
 
-RUN --mount=target=/vt --mount=type=cache,target=/build/ccache \
+RUN --mount=target=/vt \
+<<EOF
+if [ -d vt/docker-output/build/ccache ]; then
+    cp -r vt/docker-output/build/ccache /build
+    ccache -c
+    ccache -s
+fi
+EOF
+
+RUN --mount=target=/vt \
         /vt/ci/build_cpp.sh /vt /build && \
         /vt/ci/test_cpp.sh /vt /build  && \
         /vt/ci/build_vt_sample.sh /vt /build

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -167,6 +167,12 @@ target "vt-build" {
   target = "build"
   context = "."
   dockerfile = "ci/docker/vt.dockerfile"
+  output = [
+    {
+      type = "local"
+      dest = "docker-output"
+    }
+  ]
   platforms = [
     "linux/amd64",
     # "linux/arm64"


### PR DESCRIPTION
fixes #2448

This is pretty simple and straightforward approach, with the main downside being that local output means exporting entire container (while we are only interested in `/build/ccache`). Using `docker cp` would probably achieve the same result with an additional step in `build-docker-images.yml`.

Other possibilities:
- look for the cache location for type=cache mounts: https://stackoverflow.com/a/79489859
- copy files from container to host: https://stackoverflow.com/a/51186557