### PR TITLE
#2457: Don't install fmt files when we're using external fmt for `vt-trace`

### DIFF
--- a/cmake/trace_only_functions.cmake
+++ b/cmake/trace_only_functions.cmake
@@ -92,10 +92,16 @@ function(create_trace_only_target)
   # we don't use INSTALL_DIR/include/ as include directory
   # we use INSTALL_DIR/include/vt-trace instead
   # so we have to install FMT lib aswell
-  install(
-    FILES "${CMAKE_CURRENT_SOURCE_DIR}/../lib/fmt/include/fmt-vt/core.h"
-    DESTINATION "include/vt-trace/fmt"
-  )
+  if (NOT vt_external_fmt)
+    install(
+      FILES
+      "${CMAKE_CURRENT_SOURCE_DIR}/../lib/fmt/include/fmt-vt/core.h"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../lib/fmt/include/fmt-vt/format.h"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../lib/fmt/include/fmt-vt/base.h"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../lib/fmt/include/fmt-vt/ostream.h"
+      DESTINATION "include/vt-trace/fmt"
+    )
+  endif()
 
   install(
     FILES "${CMAKE_CURRENT_SOURCE_DIR}/../lib/EngFormat-Cpp/include/EngFormat-Cpp/eng_format.hpp"


### PR DESCRIPTION
Fixes #2457 

We don't want to copy bundled `fmt` files if we're using external `fmt`. 


Also in case of bundled fmt, we want to also copy the rest of the headers but do we actually need to copy the files at all? We link against `fmt` target that is configured to install fmt files (to a parent directory, for vt-runtime export set), so it makes sense that a single location for multiple targets should be fine :thinking: 

