### PR TITLE
#2461: Fix code coverage pipeline

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/cache@v4
         id: ccache-archive
         with:
-          path: build/ccache
+          path: ccache-archive
           key: ${{ matrix.target }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             ${{ matrix.target }}-${{ github.ref }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -65,3 +65,4 @@ jobs:
           push: ${{ github.ref == 'refs/heads/develop' }}
         env:
           GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,22 +39,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+
       - uses: actions/cache@v4
+        id: ccache-archive
         with:
-          path: docker-output/build/ccache
+          path: build/ccache
           key: ${{ matrix.target }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             ${{ matrix.target }}-${{ github.ref }}
             ${{ matrix.target }}-
+
+      - name: Inject ccache
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              "ccache-archive": {
+                "target": "/build/ccache",
+                "id": "${{ matrix.target }}"
+              }
+            }
+          skip-extraction: ${{ steps.ccache-archive.outputs.cache-hit }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Build
         uses: docker/bake-action@v6
@@ -63,6 +78,7 @@ jobs:
           targets: ${{ matrix.target }}
           files: docker-bake.hcl
           push: ${{ github.ref == 'refs/heads/develop' }}
+          set: |
+            *.args.CACHE_ID=${{ matrix.target }}
         env:
           GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -82,3 +82,25 @@ jobs:
             *.args.CACHE_ID=${{ matrix.target }}
         env:
           GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+
+      - name: Retrieve build artifacts
+        if: ${{ matrix.target == 'vt-build-amd64-ubuntu-22-04-gcc-11-cpp' }}
+        run: |
+          # We rely on the persistence of data on cache mounts with identical IDs and builders.
+          # This allows us to copy build artifacts from the "bake" step and use the Codecov action within the GitHub environment.
+
+          echo "
+          FROM ubuntu:latest
+          RUN --mount=type=cache,id=BUILD-${{ matrix.target }},target=/build/vt \
+          mkdir -p /vt \
+          && cp -p -R /build/vt/. /vt/ || true
+          " >> tmp_dockerfile
+
+          docker buildx build --builder ${{ steps.setup-buildx.outputs.name }} -f tmp_dockerfile --output type=local,dest=build .
+
+      - name: Upload coverage
+        if: ${{ matrix.target == 'vt-build-amd64-ubuntu-22-04-gcc-11-cpp' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: build/vt/coverage.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/ci/docker/vt.dockerfile
+++ b/ci/docker/vt.dockerfile
@@ -54,6 +54,7 @@ EOF
 ENV GIT_BRANCH=${GIT_BRANCH}
 
 RUN --mount=target=/vt,rw \
+    --mount=type=secret,id=CODECOV_TOKEN,env=CODECOV_TOKEN \
         if [ "${VT_TEST_SPACK}" = "1" ]; then \
             apt update -y -q && apt install -y -q libssl-dev unzip && \
             /vt/ci/test_spack_package.sh; \

--- a/ci/docker/vt.dockerfile
+++ b/ci/docker/vt.dockerfile
@@ -42,19 +42,13 @@ ARG VT_UNITY_BUILD_ENABLED
 ARG VT_WERROR_ENABLED
 ARG VT_ZOLTAN_ENABLED
 
-RUN --mount=target=/vt \
-<<EOF
-if [ -d vt/docker-output/build/ccache ]; then
-    cp -r vt/docker-output/build/ccache /build
-    ccache -c
-    ccache -s
-fi
-EOF
+ARG IMAGE
+ARG CACHE_ID=${IMAGE}
 
 ENV GIT_BRANCH=${GIT_BRANCH}
 
-RUN --mount=target=/vt,rw \
-    --mount=type=secret,id=CODECOV_TOKEN,env=CODECOV_TOKEN \
+RUN --mount=type=cache,id=${CACHE_ID},target=/build/ccache \
+    --mount=target=/vt,rw \
         if [ "${VT_TEST_SPACK}" = "1" ]; then \
             apt update -y -q && apt install -y -q libssl-dev unzip && \
             /vt/ci/test_spack_package.sh; \

--- a/ci/docker/vt.dockerfile
+++ b/ci/docker/vt.dockerfile
@@ -48,6 +48,7 @@ ARG CACHE_ID=${IMAGE}
 ENV GIT_BRANCH=${GIT_BRANCH}
 
 RUN --mount=type=cache,id=${CACHE_ID},target=/build/ccache \
+    --mount=type=cache,id=BUILD-${CACHE_ID},target=/build/vt \
     --mount=target=/vt,rw \
         if [ "${VT_TEST_SPACK}" = "1" ]; then \
             apt update -y -q && apt install -y -q libssl-dev unzip && \

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -14,6 +14,10 @@ ctest --output-on-failure -L 'unit_test|example' | tee cmake-output.log
 
 if test "${VT_CODE_COVERAGE:-0}" -eq 1
 then
+    if [ -z "$CODECOV_TOKEN" ]; then
+        echo "Error: CODECOV_TOKEN is not set"
+        exit 1
+    fi
     export CODECOV_TOKEN="$CODECOV_TOKEN"
     lcov --capture --directory . --output-file coverage.info
     lcov --remove coverage.info '/usr/*' --output-file coverage.info

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -23,7 +23,7 @@ then
     lcov --remove coverage.info '/usr/*' --output-file coverage.info
     lcov --list coverage.info
     pushd "$VT"
-    bash <(curl -s https://codecov.io/bash) -f "${VT_BUILD}/coverage.info" || echo "Codecov did not collect coverage reports"
+    bash <(curl -s https://codecov.io/bash) -r DARMA-tasking/vt -f "${VT_BUILD}/coverage.info" || echo "Codecov did not collect coverage reports"
     popd
 fi
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -14,17 +14,10 @@ ctest --output-on-failure -L 'unit_test|example' | tee cmake-output.log
 
 if test "${VT_CODE_COVERAGE:-0}" -eq 1
 then
-    if [ -z "$CODECOV_TOKEN" ]; then
-        echo "Error: CODECOV_TOKEN is not set"
-        exit 1
-    fi
     export CODECOV_TOKEN="$CODECOV_TOKEN"
     lcov --capture --directory . --output-file coverage.info
     lcov --remove coverage.info '/usr/*' --output-file coverage.info
     lcov --list coverage.info
-    pushd "$VT"
-    bash <(curl -s https://codecov.io/bash) -r DARMA-tasking/vt -f "${VT_BUILD}/coverage.info" || echo "Codecov did not collect coverage reports"
-    popd
 fi
 
 if test "${VT_CI_TEST_LB_SCHEMA:-0}" -eq 1

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -174,12 +174,7 @@ target "vt-build" {
   target = "build"
   context = "."
   dockerfile = "ci/docker/vt.dockerfile"
-  output = [
-    {
-      type = "local"
-      dest = "docker-output"
-    }
-  ]
+
   platforms = [
     "linux/amd64",
     # "linux/arm64"
@@ -187,21 +182,6 @@ target "vt-build" {
   ulimits = [
     "core=0"
   ]
-
-  secret = ["id=CODECOV_TOKEN,env=CODECOV_TOKEN"]
-  # FIXME: verify that caching works as intended
-  # cache-from = [
-  #   {
-  #     type = "local",
-  #     src = "~/ccache"
-  #   }
-  # ]
-  # cache-to = [
-  #   {
-  #     type = "local",
-  #     dest = "~/ccache"
-  #   }
-  # ]
 }
 
 target "vt-build-all" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -187,6 +187,8 @@ target "vt-build" {
   ulimits = [
     "core=0"
   ]
+
+  secret = ["id=CODECOV_TOKEN,env=CODECOV_TOKEN"]
   # FIXME: verify that caching works as intended
   # cache-from = [
   #   {


### PR DESCRIPTION
Fixes #2461

1. Fixes code coverage 
- Use the same approach as https://github.com/DARMA-tasking/magistrate/pull/395
2. Uses cache mount for `ccache` instead of manual copy inside dockerfile