### PR TITLE
#2467: Create a helper script for reproducing CI builds locally

### DIFF
--- a/.env
+++ b/.env
@@ -1,13 +1,9 @@
 REPO=lifflander1/vt
-ARCH=amd64
-UBUNTU=22.04
+IMAGE=wf-amd64-ubuntu-22.04-gcc-12-cpp
 ULIMIT_CORE=0
-COMPILER=gcc-12
-HOST_COMPILER=gcc-12
-COMPILER_TYPE=gnu
 PROXY=
 TOKEN=
-DISTINCT_DIR="${ARCH}-${UBUNTU}-${HOST_COMPILER}-${COMPILER}-cache"
+DISTINCT_DIR="${IMAGE}-cache"
 
 # Change this path to save the volume content on disk.
 # Example: /your/path/${DISTINCT_DIR}/

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+bake_target=${1}
+
+docker buildx bake --print "$bake_target" | \
+  jq -r --arg t "$bake_target" '.target[$t].args | to_entries.[] | join("=")' \
+  >> .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@
 # Volume will be created automatically for each combination of parameters.
 volumes:
   ubuntu-cpp:
-    name: "${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-cache"
+    name: "${IMAGE}-cache"
 
 # Define basic rules for ccache used across multiple services. The beauty of
 # docker compose with cached volumes is that similarly configured builds will
@@ -103,6 +103,7 @@ x-vtopts: &vtopts
   VT_INCLUSION_TYPE: ${VT_INCLUSION:-TPL}
   VT_KOKKOS_ENABLED: ${VT_KOKKOS_ENABLED:-0}
   VT_LB_ENABLED: ${VT_LB:-1}
+  VT_LDMS_ENABLED: ${VT_LDMS_ENABLED:-0}
   VT_MIMALLOC_ENABLED: ${VT_MIMALLOC:-0}
   VT_MPI_GUARD_ENABLED: ${VT_MPI_GUARD:-1}
   VT_NO_COLOR_ENABLED: ${VT_NO_COLOR:-0}
@@ -120,11 +121,11 @@ x-vtopts: &vtopts
 
 services:
   ##############################################################################
-  # C++ builds of VT on ubuntu/alpine platform from container baseline
+  # C++ builds of VT on any platform from container baseline
   # Ubuntu gcc-12 debug build:
-  #   docker compose run -e CMAKE_BUILD_TYPE=debug ubuntu-cpp
-  ubuntu-cpp:
-    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-cpp
+  #   docker compose run -e CMAKE_BUILD_TYPE=debug vt-cpp
+  vt-cpp:
+    image: ${REPO}:${IMAGE}
     ulimits: &ulimits
       core: ${ULIMIT_CORE}
     environment:
@@ -139,48 +140,17 @@ services:
         /vt/ci/build_vt_sample.sh /vt /build"
 
   ##############################################################################
-  # C++ builds of VTK and VT on ubuntu/alpine platform from container baseline
-  # Ubuntu gcc-12 debug build:
-  #   docker compose run -e CMAKE_BUILD_TYPE=debug ubuntu-vtk-cpp
-  ubuntu-cpp-vtk:
-    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-vtk-cpp
-    ulimits: *ulimits
-    environment:
-      <<: [*ccache, *vtopts]
-    volumes: *ubuntu-volumes
-    command: *vt-cpp-command
-
-  ##############################################################################
-  # C++ build/test/clean target for VT on ubuntu platform from container
-  # baseline.
-  #
-  # Example:
-  #   docker compose run ubuntu-cpp-clean
-  ubuntu-cpp-clean:
-    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-cpp
-    ulimits: *ulimits
-    environment:
-      <<: [*ccache, *vtopts]
-    volumes: *ubuntu-volumes
-    command: &vt-build-test-clean-cpp-command >
-      /bin/bash -c "
-        /vt/ci/build_cpp.sh /vt /build &&
-        /vt/ci/test_cpp.sh  /vt /build &&
-        /vt/ci/build_vt_sample.sh /vt /build &&
-        /vt/ci/clean_cpp.sh /vt /build"
-
-  ##############################################################################
-  # Interactive C++ setup of VT on ubuntu platform from container baseline.
+  # Interactive C++ setup of VT on any platform from container baseline.
   #
   # After running:
-  #   docker compose run ubuntu-cpp-interactive
+  #   docker compose run vt-cpp-interactive
   #
   # You will get a command line where you can run the build command:
   #   $ /vt/ci/build_cpp.sh /vt /build
   #   $ /vt/ci/test_cpp.sh  /vt /build
   #   $ /vt/ci/build_vt_sample.sh /vt /build
-  ubuntu-cpp-interactive:
-    image: ${REPO}:wf-${ARCH}-ubuntu-${UBUNTU}-${COMPILER}-cpp
+  vt-cpp-interactive:
+    image: ${REPO}:${IMAGE}
     ulimits: *ulimits
     environment:
       <<: [*ccache, *vtopts]


### PR DESCRIPTION
fixes #2467 

Intended use:
```
vt  ./ci/setup_env.sh vt-build-amd64-ubuntu-20-04-gcc-9-ldms-cpp
```

This will append configuration of provided target to `.env`, which can be followed up with `docker-compose run vt-cpp-interactive` etc.

```
vt  docker-compose run vt-cpp-interactive
Creating vt_vt-cpp-interactive_run ... done
root@a77be49ce002:/# env | sort
BUILD_SHARED_LIBS=0
CC=gcc-9
CCACHE_COMPILERCHECK=content
CCACHE_COMPRESS=1
CCACHE_COMPRESSLEVEL=5
CCACHE_DIR=/build/ccache
CCACHE_MAXSIZE=700M
CMAKE_BUILD_TYPE=release
CMAKE_CXX_STANDARD=17
CODECOV_TOKEN=
CXX=g++-9
(...)
LD_LIBRARY_PATH=/opt/ldms/lib
(...)
MPI_EXTRA_FLAGS=
PATH=/usr/lib/ccache:/opt/cmake/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
(...)
UBSAN_OPTIONS=
VTK_DIR=/opt/vtk/build
VT_ASAN_ENABLED=0
VT_BUILD_TRACE_ONLY=0
VT_CI_BUILD=1
VT_CI_TEST_LB_SCHEMA=0
VT_CODE_COVERAGE=0
VT_DEBUG_VERBOSE=0
VT_DIAGNOSTICS_ENABLED=1
VT_DIAGNOSTICS_RUNTIME_ENABLED=0
VT_DOXYGEN_ENABLED=0
VT_EXTENDED_TESTS_ENABLED=1
VT_EXTERNAL_FMT=0
VT_FCONTEXT_ENABLED=0
VT_INCLUSION_TYPE=TPL
VT_KOKKOS_ENABLED=0
VT_LB_ENABLED=1
VT_LDMS_ENABLED=1
VT_MIMALLOC_ENABLED=0
VT_MPI_GUARD_ENABLED=1
VT_NO_COLOR_ENABLED=0
VT_PERF_ENABLED=0
VT_POOL_ENABLED=1
VT_PRODUCTION_BUILD_ENABLED=0
VT_TESTS_NUM_NODES=4
VT_TRACE_ENABLED=0
VT_TRACE_RUNTIME_ENABLED=0
VT_TV_ENABLED=0
VT_UBSAN_ENABLED=0
VT_UNITY_BUILD_ENABLED=0
VT_WERROR_ENABLED=1
VT_ZOLTAN_ENABLED=0
WF_SETUP_ID=amd64-ubuntu-20.04-gcc-9-ldms-cpp
ZOLTAN_DIR=/opt/trilinos/bin
```

This seems simpler than playing around with docker bake and trying to remove `docker-compose.yml` completely.

---

Issues / possible improvements:
- `docker-compose` will not respect the changes you make in `.env` after first `docker-compose run`
  - i.e. run provided commands, check single variable in `.env` and run `docker-compose` again 
- we could try to provide auto completion (forwarding targets from docker bake?)
- the variables in `docker-compose.yml` need revisiting to make sure they are in sync with `docker-bake.hcl` and that nothing is missing
- can we drop defaults from `docker-compose.yml`? for example use `  VT_LDMS_ENABLED: ${VT_LDMS_ENABLED}` instead of `  VT_LDMS_ENABLED: ${VT_LDMS_ENABLED:-0}` to rely on defaults in `build_cpp.sh` instead