### PR TITLE
#2478: runtime: free the MPI error handler properly to avoid leaking

### DIFF
--- a/src/vt/runtime/runtime.cc
+++ b/src/vt/runtime/runtime.cc
@@ -541,6 +541,7 @@ bool Runtime::finalize(bool const force_now, bool const disable_sig) {
     }
 
     MPI_Barrier(comm);
+    MPI_Errhandler_free(&err_handler_);
 
     theContext = nullptr; // used in some state checks
     context = nullptr;    // "use" to avoid warning
@@ -1077,9 +1078,8 @@ namespace {
 }
 
 void Runtime::initializeErrorHandlers() {
-  MPI_Errhandler err_handler = 0;
-  MPI_Comm_create_errhandler(&mpiErrorHandler, &err_handler);
-  MPI_Comm_set_errhandler(theContext->getComm(), err_handler);
+  MPI_Comm_create_errhandler(&mpiErrorHandler, &err_handler_);
+  MPI_Comm_set_errhandler(theContext->getComm(), err_handler_);
 }
 
 void Runtime::initializeOptionalComponents() {

--- a/src/vt/runtime/runtime.h
+++ b/src/vt/runtime/runtime.h
@@ -458,6 +458,7 @@ protected:
   std::unique_ptr<component::ComponentPack> p_;
   std::unique_ptr<arguments::ArgConfig> arg_config_;
   arguments::AppConfig const* app_config_;   /**< App config during startup */
+  MPI_Errhandler err_handler_ = 0;
 };
 
 }} /* end namespace vt::runtime */


### PR DESCRIPTION
Fixes #2478

Could not get ASAN to trigger this leak.