### PR TITLE
#2482: lib: update bundled libs cmake version requirements to avoid failure with CMake 4.0

### DIFF
--- a/lib/EngFormat-Cpp/CMakeLists.txt
+++ b/lib/EngFormat-Cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(EngFormat-Cpp CXX)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...4.0)
 
 add_library(${PROJECT_NAME} include/EngFormat-Cpp/eng_format.hpp src/eng_format.cpp)
 

--- a/lib/brotli/CMakeLists.txt
+++ b/lib/brotli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.17...4.0)
 
 cmake_policy(SET CMP0048 NEW)
 project(brotli VERSION 1.0.9)

--- a/lib/json/CMakeLists.txt
+++ b/lib/json/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...4.0)
 
 ##
 ## PROJECT

--- a/lib/libfort/CMakeLists.txt
+++ b/lib/libfort/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.23)
 
 project(libfort VERSION 0.4.1)
 

--- a/lib/libfort/CMakeLists.txt
+++ b/lib/libfort/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.0...4.0)
 
 project(libfort VERSION 0.4.1)
 

--- a/lib/mimalloc/CMakeLists.txt
+++ b/lib/mimalloc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...4.0)
 project(libmimalloc C CXX)
 
 set(CMAKE_C_STANDARD 11)

--- a/lib/yaml-cpp/CMakeLists.txt
+++ b/lib/yaml-cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # 3.5 is actually available almost everywhere, but this a good minimum
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.0)
 
 # enable MSVC_RUNTIME_LIBRARY target property
 # see https://cmake.org/cmake/help/latest/policy/CMP0091.html


### PR DESCRIPTION
Fixes #2482

This fixes the Mac build which has been consistently failing due to a much later cmake version:
```
  Compatibility with CMake < 3.5 has been removed from CMake.
```