### PR TITLE
#2491: debug: convert first argument of string concat to a explicit string

### DIFF
--- a/src/vt/configs/debug/debug_print.h
+++ b/src/vt/configs/debug/debug_print.h
@@ -78,7 +78,10 @@
   vt_print_colorize_impl(::vt::debug::bd_green(), "vt", ":")
 
 #define vt_proc_print_colorize(proc)                                    \
-  vt_print_colorize_impl(::vt::debug::blue(), "[" + std::to_string(proc) + "]", "")
+  vt_print_colorize_impl(                                               \
+    ::vt::debug::blue(), std::string("[") + std::to_string(proc) + "]", \
+    ""                                                                  \
+  )
 
 #define vt_debug_argument_option(opt)                                   \
   ::vt::debug::preConfig()->vt_debug_ ## opt


### PR DESCRIPTION
Fixes #2491

The current code is triggering a compiler bug with C++20 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651). This works around the bug by converting the first argument to operator+ to a std::string first.