### PR TITLE
#2500: Implement MPI_Improbe/MPI_Imrecv for active and data messages

### DIFF
--- a/src/vt/group/global/group_default.cc
+++ b/src/vt/group/global/group_default.cc
@@ -172,10 +172,6 @@ namespace vt { namespace group { namespace global {
   );
 
   if ((num_children > 0 || send_to_root) && (!this_node_dest || first_send)) {
-    auto const& send_tag = static_cast<messaging::MPI_TagType>(
-      messaging::MPITag::ActiveMsgTag
-    );
-
     // Send to child nodes in the spanning tree
     if (num_children > 0) {
       default_group_->spanning_tree_->foreachChild([&](NodeType child) {
@@ -189,7 +185,7 @@ namespace vt { namespace group { namespace global {
         );
 
         if (send) {
-          theMsg()->sendMsgBytesWithPut(child, base, send_tag);
+          theMsg()->sendMsgBytesWithPut(child, base);
         }
       });
     }
@@ -204,7 +200,7 @@ namespace vt { namespace group { namespace global {
         print_bool(is_root), root_node, dest, print_ptr(msg)
       );
 
-      theMsg()->sendMsgBytesWithPut(root_node, base, send_tag);
+      theMsg()->sendMsgBytesWithPut(root_node, base);
     }
   }
 

--- a/src/vt/group/group_manager.cc
+++ b/src/vt/group/group_manager.cc
@@ -314,9 +314,6 @@ EventType GroupManager::sendGroupCollective(
   bool const is_root,
   bool* const deliver
 ) {
-  auto const& send_tag = static_cast<messaging::MPI_TagType>(
-    messaging::MPITag::ActiveMsgTag
-  );
   auto const& msg = base.get();
   auto const& group = envelopeGetGroup(msg->env);
   auto iter = local_collective_group_info_.find(group);
@@ -376,7 +373,7 @@ EventType GroupManager::sendGroupCollective(
         );
 
         if (send) {
-          theMsg()->sendMsgBytesWithPut(child, base, send_tag);
+          theMsg()->sendMsgBytesWithPut(child, base);
         }
       });
 
@@ -384,7 +381,7 @@ EventType GroupManager::sendGroupCollective(
        *  Send message to the root node of the group
        */
       if (send_to_root) {
-        theMsg()->sendMsgBytesWithPut(root_node, base, send_tag);
+        theMsg()->sendMsgBytesWithPut(root_node, base);
       }
 
       if (!first_send && this_node_dest) {
@@ -422,7 +419,7 @@ EventType GroupManager::sendGroupCollective(
      *  must forward.
      */
     auto const put_event = theMsg()->sendMsgBytesWithPut(
-      root_node, base, send_tag
+      root_node, base
     );
     /*
      *  Do not deliver on this node since it is not part of the group and will
@@ -459,11 +456,7 @@ EventType GroupManager::sendGroup(
   );
 
   auto send_to_node = [&](NodeType node) -> EventType {
-    auto const& send_tag = static_cast<messaging::MPI_TagType>(
-      messaging::MPITag::ActiveMsgTag
-    );
-
-    return theMsg()->sendMsgBytesWithPut(node, base, send_tag);
+    return theMsg()->sendMsgBytesWithPut(node, base);
   };
 
   EventType ret_event = no_event;
@@ -503,9 +496,6 @@ EventType GroupManager::sendGroup(
           info.default_spanning_tree_ != nullptr, "Must have spanning tree"
         );
 
-        auto const& send_tag = static_cast<messaging::MPI_TagType>(
-          messaging::MPITag::ActiveMsgTag
-        );
         auto const& num_children = info.default_spanning_tree_->getNumChildren();
 
         // Send to child nodes in the group's spanning tree
@@ -518,7 +508,7 @@ EventType GroupManager::sendGroup(
             );
 
             if (child != this_node) {
-              theMsg()->sendMsgBytesWithPut(child, base, send_tag);
+              theMsg()->sendMsgBytesWithPut(child, base);
             }
           });
         }

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -210,9 +210,17 @@ MsgSizeType ActiveMessenger::packMsg(
   return size + ptr_bytes;
 }
 
+// Choose active message tag based on final size
+/*static*/ MPI_TagType ActiveMessenger::selectActiveTag(MsgSizeType size) {
+  if (size <= ActiveRecvBroker::caps_[0]) return static_cast<MPI_TagType>(MPITag::ActiveMsgS);
+  if (size <= ActiveRecvBroker::caps_[1]) return static_cast<MPI_TagType>(MPITag::ActiveMsgM);
+  if (size <= ActiveRecvBroker::caps_[2]) return static_cast<MPI_TagType>(MPITag::ActiveMsgL);
+  if (size <= ActiveRecvBroker::caps_[3]) return static_cast<MPI_TagType>(MPITag::ActiveMsgXL);
+  return static_cast<MPI_TagType>(MPITag::ActiveMsgTag); // fallback
+}
+
 EventType ActiveMessenger::sendMsgBytesWithPut(
-  NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base,
-  TagType const& send_tag
+  NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base
 ) {
   auto msg = base.get();
   auto const is_term = envelopeIsTerm(msg->env);
@@ -278,7 +286,9 @@ EventType ActiveMessenger::sendMsgBytesWithPut(
     }
   }
 
-  sendMsgBytes(dest, base, new_msg_size, send_tag);
+  // Choose size-class tag for the active message
+  auto const chosen_tag = selectActiveTag(new_msg_size);
+  sendMsgBytes(dest, base, new_msg_size, chosen_tag);
 
   return no_event;
 }
@@ -443,8 +453,6 @@ EventType ActiveMessenger::sendMsgBytes(
 EventType ActiveMessenger::doMessageSend(
   MsgSharedPtr<BaseMsgType>& base
 ) {
-  auto const& send_tag = static_cast<MPI_TagType>(MPITag::ActiveMsgTag);
-
   auto msg = base.get();
 
   auto const dest = envelopeGetDest(msg->env);
@@ -496,7 +504,8 @@ EventType ActiveMessenger::doMessageSend(
   // Don't go through MPI with self-send, schedule the message locally instead
   if (deliver) {
     if (dest != this_node_) {
-      sendMsgBytesWithPut(dest, base, send_tag);
+      // Compute size-class tag internally in sendMsgBytesWithPut
+      sendMsgBytesWithPut(dest, base);
     } else {
       recordLBDataCommForSend(dest, base, base.size());
 
@@ -1017,6 +1026,142 @@ void ActiveMessenger::processActiveMsg(
   }
 }
 
+// Try to process one incoming active message via Improbe/Iprobe for any size tag
+bool ActiveMessenger::tryProcessIncomingActiveMsg() {
+  struct TagEntry { MPI_TagType tag; };
+  static constexpr TagEntry active_tags[] = {
+    { static_cast<MPI_TagType>(MPITag::ActiveMsgS)  },
+    { static_cast<MPI_TagType>(MPITag::ActiveMsgM)  },
+    { static_cast<MPI_TagType>(MPITag::ActiveMsgL)  },
+    { static_cast<MPI_TagType>(MPITag::ActiveMsgXL) },
+    { static_cast<MPI_TagType>(MPITag::ActiveMsgTag) }
+  };
+
+  for (auto const& te : active_tags) {
+    CountType num_probe_bytes = 0;
+    MPI_Status stat{};
+    int flag = 0;
+
+#if MPI_VERSION >= 3
+    MPI_Message msg_handle = MPI_MESSAGE_NULL;
+    {
+      VT_ALLOW_MPI_CALLS;
+      MPI_Improbe(
+        MPI_ANY_SOURCE, te.tag, comm_, &flag, &msg_handle, &stat
+      );
+    }
+
+    if (flag == 1) {
+      MPI_Get_count(&stat, MPI_BYTE, &num_probe_bytes);
+
+      std::byte* buf = thePool()->alloc(num_probe_bytes);
+      NodeType const sender = stat.MPI_SOURCE;
+
+      MPI_Request req = MPI_REQUEST_NULL;
+
+      {
+        #if vt_check_enabled(trace_enabled)
+          std::unique_ptr<trace::TraceScopedNote> trace_note;
+          if (theConfig()->vt_trace_mpi) {
+            trace_note = std::make_unique<trace::TraceScopedNote>(trace_irecv);
+          }
+        #endif
+
+        VT_ALLOW_MPI_CALLS;
+        MPI_Imrecv(buf, num_probe_bytes, MPI_BYTE, &msg_handle, &req);
+
+        amPostedCounterGauge.incrementUpdate(num_probe_bytes, 1);
+
+        #if vt_check_enabled(trace_enabled)
+          if (theConfig()->vt_trace_mpi) {
+            auto tr_note = fmt::format(
+              "Imrecv(AM): from={}, bytes={}, tag={}",
+              stat.MPI_SOURCE, num_probe_bytes, te.tag
+            );
+            trace_note->setNote(tr_note);
+            trace_note->end();
+          }
+        #endif
+      }
+
+      InProgressIRecv recv_holder{buf, num_probe_bytes, sender, req};
+
+      int num_mpi_tests = 0;
+      auto done = recv_holder.test(num_mpi_tests);
+      amPollCount.increment(num_mpi_tests);
+
+      if (done) {
+        finishPendingActiveMsgAsyncRecv(&recv_holder);
+      } else {
+        in_progress_active_msg_irecv.emplace(std::move(recv_holder));
+      }
+
+      return true;
+    }
+#else
+    {
+      VT_ALLOW_MPI_CALLS;
+      MPI_Iprobe(
+        MPI_ANY_SOURCE, te.tag, comm_, &flag, &stat
+      );
+    }
+
+    if (flag == 1) {
+      MPI_Get_count(&stat, MPI_BYTE, &num_probe_bytes);
+
+      std::byte* buf = thePool()->alloc(num_probe_bytes);
+      NodeType const sender = stat.MPI_SOURCE;
+
+      MPI_Request req;
+
+      {
+        #if vt_check_enabled(trace_enabled)
+          std::unique_ptr<trace::TraceScopedNote> trace_note;
+          if (theConfig()->vt_trace_mpi) {
+            trace_note = std::make_unique<trace::TraceScopedNote>(trace_irecv);
+          }
+        #endif
+
+        VT_ALLOW_MPI_CALLS;
+        MPI_Irecv(
+          buf, num_probe_bytes, MPI_BYTE, sender, stat.MPI_TAG,
+          comm_, &req
+        );
+
+        amPostedCounterGauge.incrementUpdate(num_probe_bytes, 1);
+
+        #if vt_check_enabled(trace_enabled)
+          if (theConfig()->vt_trace_mpi) {
+            auto tr_note = fmt::format(
+              "Irecv(AM): from={}, bytes={}, tag={}",
+              stat.MPI_SOURCE, num_probe_bytes, stat.MPI_TAG
+            );
+            trace_note->setNote(tr_note);
+            trace_note->end();
+          }
+        #endif
+      }
+
+      InProgressIRecv recv_holder{buf, num_probe_bytes, sender, req};
+
+      int num_mpi_tests = 0;
+      auto done = recv_holder.test(num_mpi_tests);
+      amPollCount.increment(num_mpi_tests);
+
+      if (done) {
+        finishPendingActiveMsgAsyncRecv(&recv_holder);
+      } else {
+        in_progress_active_msg_irecv.emplace(std::move(recv_holder));
+      }
+
+      return true;
+    }
+#endif
+  }
+
+  return false;
+}
+
 void ActiveMessenger::prepareActiveMsgToRun(
   MsgSharedPtr<BaseMsgType> const& base, NodeType const& in_from_node,
   bool insert, ActionType cont
@@ -1069,144 +1214,6 @@ void ActiveMessenger::prepareActiveMsgToRun(
     theTerm()->consume(epoch,1,in_from_node);
     theTerm()->hangDetectRecv();
   }
-}
-
-bool ActiveMessenger::tryProcessIncomingActiveMsg() {
-  CountType num_probe_bytes;
-  MPI_Status stat;
-  int flag;
-
-#if MPI_VERSION >= 3
-  // MPI 3+: Use MPI_Improbe + MPI_Imrecv to claim message from unexpected queue
-  MPI_Message msg_handle;
-
-  {
-    VT_ALLOW_MPI_CALLS;
-
-    MPI_Improbe(
-      MPI_ANY_SOURCE, static_cast<MPI_TagType>(MPITag::ActiveMsgTag),
-      comm_, &flag, &msg_handle, &stat
-    );
-  }
-
-  if (flag == 1) {
-    MPI_Get_count(&stat, MPI_BYTE, &num_probe_bytes);
-
-    std::byte* buf = thePool()->alloc(num_probe_bytes);
-
-    NodeType const sender = stat.MPI_SOURCE;
-
-    MPI_Request req;
-
-    {
-      #if vt_check_enabled(trace_enabled)
-        std::unique_ptr<trace::TraceScopedNote> trace_note;
-        if (theConfig()->vt_trace_mpi) {
-          trace_note = std::make_unique<trace::TraceScopedNote>(trace_irecv);
-        }
-      #endif
-
-      VT_ALLOW_MPI_CALLS;
-      MPI_Imrecv(
-        buf, num_probe_bytes, MPI_BYTE,
-        &msg_handle, &req
-      );
-
-      amPostedCounterGauge.incrementUpdate(num_probe_bytes, 1);
-
-      #if vt_check_enabled(trace_enabled)
-        if (theConfig()->vt_trace_mpi) {
-          auto tr_note = fmt::format(
-            "Imrecv(AM): from={}, bytes={}",
-            stat.MPI_SOURCE, num_probe_bytes
-          );
-          trace_note->setNote(tr_note);
-          trace_note->end();
-        }
-      #endif
-    }
-
-    InProgressIRecv recv_holder{buf, num_probe_bytes, sender, req};
-
-    int num_mpi_tests = 0;
-    auto done = recv_holder.test(num_mpi_tests);
-    amPollCount.increment(num_mpi_tests);
-
-    if (done) {
-      finishPendingActiveMsgAsyncRecv(&recv_holder);
-    } else {
-      in_progress_active_msg_irecv.emplace(std::move(recv_holder));
-    }
-
-    return true;
-  } else {
-    return false;
-  }
-#else
-  // MPI < 3: Use existing MPI_Iprobe + MPI_Irecv path
-  {
-    VT_ALLOW_MPI_CALLS;
-
-    MPI_Iprobe(
-      MPI_ANY_SOURCE, static_cast<MPI_TagType>(MPITag::ActiveMsgTag),
-      comm_, &flag, &stat
-    );
-  }
-
-  if (flag == 1) {
-    MPI_Get_count(&stat, MPI_BYTE, &num_probe_bytes);
-
-    std::byte* buf = thePool()->alloc(num_probe_bytes);
-
-    NodeType const sender = stat.MPI_SOURCE;
-
-    MPI_Request req;
-
-    {
-      #if vt_check_enabled(trace_enabled)
-        std::unique_ptr<trace::TraceScopedNote> trace_note;
-        if (theConfig()->vt_trace_mpi) {
-          trace_note = std::make_unique<trace::TraceScopedNote>(trace_irecv);
-        }
-      #endif
-
-      VT_ALLOW_MPI_CALLS;
-      MPI_Irecv(
-        buf, num_probe_bytes, MPI_BYTE, sender, stat.MPI_TAG,
-        comm_, &req
-      );
-
-      amPostedCounterGauge.incrementUpdate(num_probe_bytes, 1);
-
-      #if vt_check_enabled(trace_enabled)
-        if (theConfig()->vt_trace_mpi) {
-          auto tr_note = fmt::format(
-            "Irecv(AM): from={}, bytes={}",
-            stat.MPI_SOURCE, num_probe_bytes
-          );
-          trace_note->setNote(tr_note);
-          trace_note->end();
-        }
-      #endif
-    }
-
-    InProgressIRecv recv_holder{buf, num_probe_bytes, sender, req};
-
-    int num_mpi_tests = 0;
-    auto done = recv_holder.test(num_mpi_tests);
-    amPollCount.increment(num_mpi_tests);
-
-    if (done) {
-      finishPendingActiveMsgAsyncRecv(&recv_holder);
-    } else {
-      in_progress_active_msg_irecv.emplace(std::move(recv_holder));
-    }
-
-    return true;
-  } else {
-    return false;
-  }
-#endif
 }
 
 void ActiveMessenger::finishPendingActiveMsgAsyncRecv(InProgressIRecv* irecv) {
@@ -1312,7 +1319,7 @@ bool ActiveMessenger::testPendingAsyncOps() {
 }
 
 void ActiveMessenger::ActiveRecvBroker::postSlot(ActiveMessenger* self, Slot& s) {
-  // Allocate a fresh buffer for this slot and post a wildcard Irecv for ActiveMsgTag
+  // Allocate a fresh buffer for this slot and post a Irecv for the corresponding tag
   s.buf = thePool()->alloc(s.cap);
 
   #if vt_check_enabled(trace_enabled)
@@ -1326,7 +1333,7 @@ void ActiveMessenger::ActiveRecvBroker::postSlot(ActiveMessenger* self, Slot& s)
     VT_ALLOW_MPI_CALLS;
     int const ret = MPI_Irecv(
       s.buf, s.cap, MPI_BYTE, MPI_ANY_SOURCE,
-      static_cast<MPI_TagType>(MPITag::ActiveMsgTag), self->comm_, &s.req
+      s.tag, self->comm_, &s.req
     );
     vtAssertMPISuccess(ret, "Broker MPI_Irecv");
   }
@@ -1335,7 +1342,7 @@ void ActiveMessenger::ActiveRecvBroker::postSlot(ActiveMessenger* self, Slot& s)
 
   #if vt_check_enabled(trace_enabled)
     if (theConfig()->vt_trace_mpi) {
-      auto tr_note = fmt::format("Irecv(AM Broker): anysrc, cap={}", s.cap);
+      auto tr_note = fmt::format("Irecv(AM Broker): tag={}, cap={}", s.tag, s.cap);
       trace_note->setNote(tr_note);
       trace_note->end();
     }
@@ -1346,22 +1353,21 @@ void ActiveMessenger::ActiveRecvBroker::postSlot(ActiveMessenger* self, Slot& s)
 
 void ActiveMessenger::ActiveRecvBroker::setup(ActiveMessenger* self) {
   slots_.clear();
-  slots_.reserve(num_caps_ * slots_per_size_);
+  slots_.reserve(num_caps_ * slots_per_class_);
 
-  for (int i = 0; i < num_caps_; ++i) {
-    for (int k = 0; k < slots_per_size_; ++k) {
-      slots_.emplace_back(Slot{caps_[i], nullptr, MPI_REQUEST_NULL, false});
+  for (int ci = 0; ci < num_caps_; ++ci) {
+    for (int k = 0; k < slots_per_class_; ++k) {
+      slots_.emplace_back(Slot{caps_[ci], tags_[ci], nullptr, MPI_REQUEST_NULL, false});
     }
   }
 
-  // Post all slots
   for (auto& s : slots_) {
     postSlot(self, s);
   }
 
   vt_debug_print(
     normal, active,
-    "ActiveRecvBroker::setup: posted {} slots across caps\n",
+    "ActiveRecvBroker::setup: posted {} slots across size classes\n",
     slots_.size()
   );
 }
@@ -1374,7 +1380,7 @@ bool ActiveMessenger::ActiveRecvBroker::progress(ActiveMessenger* self) {
     if (!s.posted) continue;
 
     int flag = 0;
-    MPI_Status stat;
+    MPI_Status stat{};
 
     {
       VT_ALLOW_MPI_CALLS;
@@ -1386,21 +1392,19 @@ bool ActiveMessenger::ActiveRecvBroker::progress(ActiveMessenger* self) {
       int count_bytes = 0;
       MPI_Get_count(&stat, MPI_BYTE, &count_bytes);
 
-      // If received size exceeds capacity, this indicates truncation; guard.
       if (count_bytes > s.cap) {
-        vtWarn(
-          fmt::format("ActiveRecvBroker: received {} bytes > slot cap {}. "
-                      "Consider increasing broker caps.", count_bytes, s.cap)
-        );
+        vtWarn(fmt::format(
+          "ActiveRecvBroker: received {} bytes > slot cap {} on tag {}",
+          count_bytes, s.cap, s.tag
+        ));
       }
 
       NodeType sender = stat.MPI_SOURCE;
 
-      // Dispatch completion using the existing path
       InProgressIRecv tmp(s.buf, count_bytes, sender);
       self->finishPendingActiveMsgAsyncRecv(&tmp);
 
-      // Repost the slot with a fresh buffer
+      // Repost with a fresh buffer
       postSlot(self, s);
 
       any_progress = true;
@@ -1413,9 +1417,6 @@ bool ActiveMessenger::ActiveRecvBroker::progress(ActiveMessenger* self) {
 
   return any_progress;
 }
-
-// -----------------------------------------------------------------------------
-
 
 int ActiveMessenger::progress([[maybe_unused]] TimeType current_time) {
   bool const started_irecv_active_msg = tryProcessIncomingActiveMsg();

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -162,6 +162,9 @@ void ActiveMessenger::startup() {
     );
   });
 #endif
+
+  // Set up the active receive broker to pre-post wildcard receives
+  active_broker_.setup(this);
 }
 
 /*virtual*/ ActiveMessenger::~ActiveMessenger() {}
@@ -1308,15 +1311,123 @@ bool ActiveMessenger::testPendingAsyncOps() {
   );
 }
 
+void ActiveMessenger::ActiveRecvBroker::postSlot(ActiveMessenger* self, Slot& s) {
+  // Allocate a fresh buffer for this slot and post a wildcard Irecv for ActiveMsgTag
+  s.buf = thePool()->alloc(s.cap);
+
+  #if vt_check_enabled(trace_enabled)
+    std::unique_ptr<trace::TraceScopedNote> trace_note;
+    if (theConfig()->vt_trace_mpi) {
+      trace_note = std::make_unique<trace::TraceScopedNote>(self->trace_irecv);
+    }
+  #endif
+
+  {
+    VT_ALLOW_MPI_CALLS;
+    int const ret = MPI_Irecv(
+      s.buf, s.cap, MPI_BYTE, MPI_ANY_SOURCE,
+      static_cast<MPI_TagType>(MPITag::ActiveMsgTag), self->comm_, &s.req
+    );
+    vtAssertMPISuccess(ret, "Broker MPI_Irecv");
+  }
+
+  self->amPostedCounterGauge.incrementUpdate(s.cap, 1);
+
+  #if vt_check_enabled(trace_enabled)
+    if (theConfig()->vt_trace_mpi) {
+      auto tr_note = fmt::format("Irecv(AM Broker): anysrc, cap={}", s.cap);
+      trace_note->setNote(tr_note);
+      trace_note->end();
+    }
+  #endif
+
+  s.posted = true;
+}
+
+void ActiveMessenger::ActiveRecvBroker::setup(ActiveMessenger* self) {
+  slots_.clear();
+  slots_.reserve(num_caps_ * slots_per_size_);
+
+  for (int i = 0; i < num_caps_; ++i) {
+    for (int k = 0; k < slots_per_size_; ++k) {
+      slots_.emplace_back(Slot{caps_[i], nullptr, MPI_REQUEST_NULL, false});
+    }
+  }
+
+  // Post all slots
+  for (auto& s : slots_) {
+    postSlot(self, s);
+  }
+
+  vt_debug_print(
+    normal, active,
+    "ActiveRecvBroker::setup: posted {} slots across caps\n",
+    slots_.size()
+  );
+}
+
+bool ActiveMessenger::ActiveRecvBroker::progress(ActiveMessenger* self) {
+  bool any_progress = false;
+  int tests = 0;
+
+  for (auto& s : slots_) {
+    if (!s.posted) continue;
+
+    int flag = 0;
+    MPI_Status stat;
+
+    {
+      VT_ALLOW_MPI_CALLS;
+      MPI_Test(&s.req, &flag, &stat);
+      tests++;
+    }
+
+    if (flag) {
+      int count_bytes = 0;
+      MPI_Get_count(&stat, MPI_BYTE, &count_bytes);
+
+      // If received size exceeds capacity, this indicates truncation; guard.
+      if (count_bytes > s.cap) {
+        vtWarn(
+          fmt::format("ActiveRecvBroker: received {} bytes > slot cap {}. "
+                      "Consider increasing broker caps.", count_bytes, s.cap)
+        );
+      }
+
+      NodeType sender = stat.MPI_SOURCE;
+
+      // Dispatch completion using the existing path
+      InProgressIRecv tmp(s.buf, count_bytes, sender);
+      self->finishPendingActiveMsgAsyncRecv(&tmp);
+
+      // Repost the slot with a fresh buffer
+      postSlot(self, s);
+
+      any_progress = true;
+    }
+  }
+
+  if (tests > 0) {
+    self->amPollCount.increment(tests);
+  }
+
+  return any_progress;
+}
+
+// -----------------------------------------------------------------------------
+
+
 int ActiveMessenger::progress([[maybe_unused]] TimeType current_time) {
   bool const started_irecv_active_msg = tryProcessIncomingActiveMsg();
   bool const started_irecv_data_msg = tryProcessDataMsgRecv();
   bool const received_active_msg = testPendingActiveMsgAsyncRecv();
   bool const received_data_msg = testPendingDataMsgAsyncRecv();
   bool const general_async = testPendingAsyncOps();
+  bool const broker_progress = active_broker_.progress(this);
 
   return started_irecv_active_msg or started_irecv_data_msg or
-         received_active_msg or received_data_msg or general_async;
+         received_active_msg or received_data_msg or general_async or
+         broker_progress;
 }
 
 void ActiveMessenger::registerAsyncOp(std::unique_ptr<AsyncOp> in) {

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -196,8 +196,8 @@ MsgSizeType ActiveMessenger::packMsg(
 ) {
   vt_debug_print(
     verbose, active,
-    "packMsg: msg_size={}, put_size={}, ptr={}, ptr_bytes={}\n",
-    size, ptr_bytes, print_ptr(ptr), ptr_bytes
+    "packMsg: msg_size={}, put_size={}, ptr={}\n",
+    size, ptr_bytes, print_ptr(ptr)
   );
 
   auto const can_grow = thePool()->tryGrowAllocation(reinterpret_cast<std::byte*>(msg), ptr_bytes);

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -193,8 +193,8 @@ MsgSizeType ActiveMessenger::packMsg(
 ) {
   vt_debug_print(
     verbose, active,
-    "packMsg: msg_size={}, put_size={}, ptr={}\n",
-    size, ptr_bytes, print_ptr(ptr)
+    "packMsg: msg_size={}, put_size={}, ptr={}, ptr_bytes={}\n",
+    size, ptr_bytes, print_ptr(ptr), ptr_bytes
   );
 
   auto const can_grow = thePool()->tryGrowAllocation(reinterpret_cast<std::byte*>(msg), ptr_bytes);

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -1392,6 +1392,9 @@ bool ActiveMessenger::ActiveRecvBroker::progress(ActiveMessenger* self) {
       int count_bytes = 0;
       MPI_Get_count(&stat, MPI_BYTE, &count_bytes);
 
+      // Decrease the "allocated" size to the actual used size so we know the true length of the buffer
+      thePool()->setUsedSize(s.buf, count_bytes);
+
       if (count_bytes > s.cap) {
         vtWarn(fmt::format(
           "ActiveRecvBroker: received {} bytes > slot cap {} on tag {}",

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -167,7 +167,10 @@ void ActiveMessenger::startup() {
   active_broker_.setup(this);
 }
 
-/*virtual*/ ActiveMessenger::~ActiveMessenger() {}
+/*virtual*/ ActiveMessenger::~ActiveMessenger() {
+  // Ensure broker-posted receives/buffers are cleaned up to avoid leaks
+  active_broker_.cleanup();
+}
 
 trace::TraceEventIDType ActiveMessenger::makeTraceCreationSend(
   [[maybe_unused]] HandlerType const handler,
@@ -1419,6 +1422,26 @@ bool ActiveMessenger::ActiveRecvBroker::progress(ActiveMessenger* self) {
   }
 
   return any_progress;
+}
+
+void ActiveMessenger::ActiveRecvBroker::cleanup() {
+  // Cancel any outstanding receives and free any broker-owned buffers
+  for (auto& s : slots_) {
+    if (s.posted) {
+      VT_ALLOW_MPI_CALLS;
+      int ret = MPI_Cancel(&s.req);
+      vtAssertMPISuccess(ret, "Broker MPI_Cancel");
+      ret = MPI_Request_free(&s.req);
+      vtAssertMPISuccess(ret, "Broker MPI_Request_free");
+      s.posted = false;
+    }
+    if (s.buf != nullptr) {
+      thePool()->dealloc(s.buf);
+      s.buf = nullptr;
+    }
+    s.req = MPI_REQUEST_NULL;
+  }
+  slots_.clear();
 }
 
 int ActiveMessenger::progress([[maybe_unused]] TimeType current_time) {

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -692,6 +692,45 @@ bool ActiveMessenger::recvDataMsgBuffer(
     MPI_Status stat;
     int flag;
 
+#if MPI_VERSION >= 3
+    // MPI 3+: Use MPI_Improbe to claim the first chunk immediately
+    MPI_Message first_msg_handle;
+
+    {
+      VT_ALLOW_MPI_CALLS;
+      const int probe_ret = MPI_Improbe(
+        node == uninitialized_destination ? MPI_ANY_SOURCE : node,
+        tag, comm_, &flag, &first_msg_handle, &stat
+      );
+      vtAssertMPISuccess(probe_ret, "MPI_Improbe");
+    }
+
+    if (flag == 1) {
+      MPI_Get_count(&stat, MPI_BYTE, &num_probe_bytes);
+
+      std::byte* buf = user_buf == nullptr ?
+        thePool()->alloc(num_probe_bytes) :
+        user_buf;
+
+      NodeType const sender = stat.MPI_SOURCE;
+
+      // Calculate first chunk size
+      auto const max_per_send = theConfig()->vt_max_mpi_send_size;
+      MsgSizeType first_chunk_bytes = static_cast<MsgSizeType>(
+        std::min(static_cast<std::size_t>(num_probe_bytes), max_per_send)
+      );
+
+      recvDataDirect(
+        nchunks, buf, tag, sender, num_probe_bytes, priority, dealloc_user_buf,
+        next, is_user_buf, first_msg_handle, first_chunk_bytes
+      );
+
+      return true;
+    } else {
+      return false;
+    }
+#else
+    // MPI < 3: Use existing MPI_Iprobe path
     {
       VT_ALLOW_MPI_CALLS;
       const int probe_ret = MPI_Iprobe(
@@ -719,6 +758,7 @@ bool ActiveMessenger::recvDataMsgBuffer(
     } else {
       return false;
     }
+#endif
   } else {
     vt_debug_print(
       normal, active,
@@ -756,6 +796,9 @@ void ActiveMessenger::recvDataDirect(
   int nchunks, std::byte* const buf, TagType const tag, NodeType const from,
   MsgSizeType len, PriorityType prio, ActionType dealloc,
   ContinuationDeleterType next, bool is_user_buf
+#if MPI_VERSION >= 3
+  , MPI_Message first_msg, MsgSizeType first_chunk_bytes
+#endif
 ) {
   vtAssert(nchunks > 0, "Must have at least one chunk");
 
@@ -765,7 +808,49 @@ void ActiveMessenger::recvDataDirect(
   std::byte* cbuf = buf;
   MsgSizeType remainder = len;
   auto const max_per_send = theConfig()->vt_max_mpi_send_size;
+
+#if MPI_VERSION >= 3
+  // If we have a pre-matched first message, use MPI_Imrecv for the first chunk
+  int start_chunk = 0;
+  if (first_msg != MPI_MESSAGE_NULL && first_chunk_bytes > 0) {
+    #if vt_check_enabled(trace_enabled)
+      std::unique_ptr<trace::TraceScopedNote> trace_note;
+      if (theConfig()->vt_trace_mpi) {
+        trace_note = std::make_unique<trace::TraceScopedNote>(trace_irecv);
+      }
+    #endif
+
+    {
+      VT_ALLOW_MPI_CALLS;
+      int const ret = MPI_Imrecv(
+        cbuf, first_chunk_bytes, MPI_BYTE,
+        &first_msg, &reqs[0]
+      );
+      vtAssertMPISuccess(ret, "MPI_Imrecv");
+    }
+
+    dmPostedCounterGauge.incrementUpdate(first_chunk_bytes, 1);
+
+    #if vt_check_enabled(trace_enabled)
+      if (theConfig()->vt_trace_mpi) {
+        auto tr_note = fmt::format(
+          "Imrecv(Data, first chunk): from={}, bytes={}",
+          from, first_chunk_bytes
+        );
+        trace_note->setNote(tr_note);
+        trace_note->end();
+      }
+    #endif
+
+    remainder -= first_chunk_bytes;
+    start_chunk = 1;
+  }
+
+  // Post remaining chunks using MPI_Irecv
+  for (int i = start_chunk; i < nchunks; i++) {
+#else
   for (int i = 0; i < nchunks; i++) {
+#endif
     auto sublen = static_cast<int>(
       std::min(static_cast<std::size_t>(remainder), max_per_send)
     );
@@ -988,6 +1073,74 @@ bool ActiveMessenger::tryProcessIncomingActiveMsg() {
   MPI_Status stat;
   int flag;
 
+#if MPI_VERSION >= 3
+  // MPI 3+: Use MPI_Improbe + MPI_Imrecv to claim message from unexpected queue
+  MPI_Message msg_handle;
+
+  {
+    VT_ALLOW_MPI_CALLS;
+
+    MPI_Improbe(
+      MPI_ANY_SOURCE, static_cast<MPI_TagType>(MPITag::ActiveMsgTag),
+      comm_, &flag, &msg_handle, &stat
+    );
+  }
+
+  if (flag == 1) {
+    MPI_Get_count(&stat, MPI_BYTE, &num_probe_bytes);
+
+    std::byte* buf = thePool()->alloc(num_probe_bytes);
+
+    NodeType const sender = stat.MPI_SOURCE;
+
+    MPI_Request req;
+
+    {
+      #if vt_check_enabled(trace_enabled)
+        std::unique_ptr<trace::TraceScopedNote> trace_note;
+        if (theConfig()->vt_trace_mpi) {
+          trace_note = std::make_unique<trace::TraceScopedNote>(trace_irecv);
+        }
+      #endif
+
+      VT_ALLOW_MPI_CALLS;
+      MPI_Imrecv(
+        buf, num_probe_bytes, MPI_BYTE,
+        &msg_handle, &req
+      );
+
+      amPostedCounterGauge.incrementUpdate(num_probe_bytes, 1);
+
+      #if vt_check_enabled(trace_enabled)
+        if (theConfig()->vt_trace_mpi) {
+          auto tr_note = fmt::format(
+            "Imrecv(AM): from={}, bytes={}",
+            stat.MPI_SOURCE, num_probe_bytes
+          );
+          trace_note->setNote(tr_note);
+          trace_note->end();
+        }
+      #endif
+    }
+
+    InProgressIRecv recv_holder{buf, num_probe_bytes, sender, req};
+
+    int num_mpi_tests = 0;
+    auto done = recv_holder.test(num_mpi_tests);
+    amPollCount.increment(num_mpi_tests);
+
+    if (done) {
+      finishPendingActiveMsgAsyncRecv(&recv_holder);
+    } else {
+      in_progress_active_msg_irecv.emplace(std::move(recv_holder));
+    }
+
+    return true;
+  } else {
+    return false;
+  }
+#else
+  // MPI < 3: Use existing MPI_Iprobe + MPI_Irecv path
   {
     VT_ALLOW_MPI_CALLS;
 
@@ -1050,6 +1203,7 @@ bool ActiveMessenger::tryProcessIncomingActiveMsg() {
   } else {
     return false;
   }
+#endif
 }
 
 void ActiveMessenger::finishPendingActiveMsgAsyncRecv(InProgressIRecv* irecv) {

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -786,7 +786,7 @@ void ActiveMessenger::recvDataDirect(
       vtAssertMPISuccess(ret, "MPI_Irecv");
     }
 
-    dmPostedCounterGauge.incrementUpdate(len, 1);
+    dmPostedCounterGauge.incrementUpdate(sublen, 1);
 
     #if vt_check_enabled(trace_enabled)
       if (theConfig()->vt_trace_mpi) {

--- a/src/vt/messaging/active.cc
+++ b/src/vt/messaging/active.cc
@@ -824,9 +824,10 @@ void ActiveMessenger::recvDataDirect(
   MsgSizeType remainder = len;
   auto const max_per_send = theConfig()->vt_max_mpi_send_size;
 
+  int start_chunk = 0;
+
 #if MPI_VERSION >= 3
   // If we have a pre-matched first message, use MPI_Imrecv for the first chunk
-  int start_chunk = 0;
   if (first_msg != MPI_MESSAGE_NULL && first_chunk_bytes > 0) {
     #if vt_check_enabled(trace_enabled)
       std::unique_ptr<trace::TraceScopedNote> trace_note;
@@ -860,12 +861,10 @@ void ActiveMessenger::recvDataDirect(
     remainder -= first_chunk_bytes;
     start_chunk = 1;
   }
+#endif
 
   // Post remaining chunks using MPI_Irecv
   for (int i = start_chunk; i < nchunks; i++) {
-#else
-  for (int i = 0; i < nchunks; i++) {
-#endif
     auto sublen = static_cast<int>(
       std::min(static_cast<std::size_t>(remainder), max_per_send)
     );

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1770,6 +1770,9 @@ private:
     static constexpr int slots_per_class_ = 4;
 
     void postSlot(ActiveMessenger* self, Slot& s);
+  public:
+    // Cleanup outstanding posted receives and buffers to avoid leaks at shutdown
+    void cleanup();
   };
 
 public:

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1727,6 +1727,36 @@ private:
     MsgSizeType const msg_size
   );
 
+  /**
+   * \brief Active receive broker that keeps a pool of pre-posted Irecv slots
+   * at various sizes to drain unexpected ActiveMsg traffic quickly.
+   *
+   * This broker only handles ActiveMsgTag receives to avoid interfering with
+   * data messages. Each completed slot dispatches directly
+   * to finishPendingActiveMsgAsyncRecv and is immediately reposted with a
+   * fresh buffer of the same capacity.
+   */
+  struct ActiveRecvBroker {
+    struct Slot {
+      int cap = 0;
+      std::byte* buf = nullptr;
+      MPI_Request req = MPI_REQUEST_NULL;
+      bool posted = false;
+    };
+
+    void setup(ActiveMessenger* self);
+    bool progress(ActiveMessenger* self);
+
+  private:
+    std::vector<Slot> slots_;
+    // Tunable capacities and per-size slot count; conservative defaults.
+    static constexpr int num_caps_ = 4;
+    static constexpr int caps_[num_caps_] = {256, 1024, 4096, 16384};
+    static constexpr int slots_per_size_ = 4;
+
+    void postSlot(ActiveMessenger* self, Slot& s);
+  };
+
 public:
   /**
    * \brief Get the rank-based LB data along with element ID for rank-based work
@@ -1784,6 +1814,9 @@ private:
   elm::ElementIDStruct bare_handler_dummy_elm_id_for_lb_data_ = {};
   elm::ElementLBData bare_handler_lb_data_;
   MPI_Comm comm_ = MPI_COMM_NULL;
+
+  // Active receive broker instance
+  ActiveRecvBroker active_broker_;
 };
 
 }} // end namespace vt::messaging

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -105,7 +105,13 @@ static constexpr TagType const PutPackedTag =
 
 enum class MPITag : MPI_TagType {
   ActiveMsgTag = 1,
-  DataMsgTag = 2
+  DataMsgTag   = 2,
+
+  // Size-class active message tags
+  ActiveMsgS   = 11,  // <= 512 bytes
+  ActiveMsgM   = 12,  // <= 2048 bytes
+  ActiveMsgL   = 13,  // <= 8192 bytes
+  ActiveMsgXL  = 14   // <= 32768 bytes
 };
 
 static constexpr TagType const starting_direct_buffer_tag = 1000;
@@ -1495,13 +1501,11 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    *
    * \param[in] dest the destination of the message
    * \param[in] base the message base pointer
-   * \param[in] send_tag the send tag on the message
    *
    * \return the event to test/wait for completion
    */
   EventType sendMsgBytesWithPut(
-    NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base,
-    TagType const& send_tag
+    NodeType const& dest, MsgSharedPtr<BaseMsgType> const& base
   );
 
   /**
@@ -1728,17 +1732,23 @@ private:
   );
 
   /**
-   * \brief Active receive broker that keeps a pool of pre-posted Irecv slots
-   * at various sizes to drain unexpected ActiveMsg traffic quickly.
+   * \brief Select an active message tag based on the size of the message
    *
-   * This broker only handles ActiveMsgTag receives to avoid interfering with
-   * data messages. Each completed slot dispatches directly
-   * to finishPendingActiveMsgAsyncRecv and is immediately reposted with a
-   * fresh buffer of the same capacity.
+   * \param[in] size the size of the message
+   */
+  static MPI_TagType selectActiveTag(MsgSizeType size);
+
+  /**
+   * \brief Active receive broker that keeps a pool of pre-posted Irecv slots
+   * per size-class tag to drain unexpected ActiveMsg traffic quickly.
+   *
+   * Each completed slot dispatches directly to finishPendingActiveMsgAsyncRecv
+   * and is immediately reposted with a fresh buffer of the same capacity.
    */
   struct ActiveRecvBroker {
     struct Slot {
       int cap = 0;
+      MPI_TagType tag = 0;
       std::byte* buf = nullptr;
       MPI_Request req = MPI_REQUEST_NULL;
       bool posted = false;
@@ -1747,12 +1757,17 @@ private:
     void setup(ActiveMessenger* self);
     bool progress(ActiveMessenger* self);
 
+    static constexpr int num_caps_ = 4;
+    static constexpr int caps_[num_caps_] = {512, 2048, 8192, 32768};
   private:
     std::vector<Slot> slots_;
-    // Tunable capacities and per-size slot count; conservative defaults.
-    static constexpr int num_caps_ = 4;
-    static constexpr int caps_[num_caps_] = {256, 1024, 4096, 16384};
-    static constexpr int slots_per_size_ = 4;
+    static constexpr MPI_TagType tags_[num_caps_] = {
+      static_cast<MPI_TagType>(MPITag::ActiveMsgS),
+      static_cast<MPI_TagType>(MPITag::ActiveMsgM),
+      static_cast<MPI_TagType>(MPITag::ActiveMsgL),
+      static_cast<MPI_TagType>(MPITag::ActiveMsgXL)
+    };
+    static constexpr int slots_per_class_ = 4;
 
     void postSlot(ActiveMessenger* self, Slot& s);
   };

--- a/src/vt/messaging/active.h
+++ b/src/vt/messaging/active.h
@@ -1375,11 +1375,16 @@ struct ActiveMessenger : runtime::component::PollableComponent<ActiveMessenger> 
    * \param[in] dealloc the action to deallocate the buffer
    * \param[in] next the continuation that gets passed the data when ready
    * \param[in] is_user_buf is a user buffer that require user deallocation
+   * \param[in] first_msg (MPI >= 3) pre-matched message handle for first chunk
+   * \param[in] first_chunk_bytes (MPI >= 3) size of the first matched chunk
    */
   void recvDataDirect(
     int nchunks, std::byte* const buf, TagType const tag, NodeType const from,
     MsgSizeType len, PriorityType prio, ActionType dealloc = nullptr,
     ContinuationDeleterType next = nullptr, bool is_user_buf = false
+#if MPI_VERSION >= 3
+    , MPI_Message first_msg = MPI_MESSAGE_NULL, MsgSizeType first_chunk_bytes = 0
+#endif
   );
 
   /**

--- a/src/vt/pool/header/pool_header.cc
+++ b/src/vt/pool/header/pool_header.cc
@@ -54,6 +54,7 @@ namespace vt { namespace pool {
   view.buffer = buffer;
   view.layout->prealloc.alloc_size = num_bytes;
   view.layout->prealloc.oversize = oversize;
+  view.layout->prealloc.use_size = num_bytes;
   auto buf_start = buffer + sizeof(Header);
   return buf_start;
 }
@@ -62,6 +63,12 @@ namespace vt { namespace pool {
   AllocView view;
   view.buffer = buffer - sizeof(Header);
   return view.layout->prealloc.alloc_size;
+}
+
+/*static*/ size_t HeaderManager::getHeaderUsedBytes(std::byte* buffer) {
+  AllocView view;
+  view.buffer = buffer - sizeof(Header);
+  return view.layout->prealloc.use_size;
 }
 
 /*static*/ size_t HeaderManager::getHeaderOversizeBytes(std::byte* buffer) {

--- a/src/vt/pool/header/pool_header.h
+++ b/src/vt/pool/header/pool_header.h
@@ -50,6 +50,7 @@ namespace vt { namespace pool {
 
 struct Header {
   size_t alloc_size;
+  size_t use_size;
   size_t oversize;
 };
 
@@ -67,6 +68,7 @@ struct HeaderManager {
     size_t const& num_bytes, size_t const& oversize, std::byte* buffer
   );
   static size_t getHeaderBytes(std::byte* buffer);
+  static size_t getHeaderUsedBytes(std::byte* buffer);
   static size_t getHeaderOversizeBytes(std::byte* buffer);
   static std::byte* getHeaderPtr(std::byte* buffer);
 };

--- a/src/vt/pool/pool.cc
+++ b/src/vt/pool/pool.cc
@@ -201,15 +201,15 @@ Pool::SizeType Pool::remainingSize(
   [[maybe_unused]] std::byte* const buf
 ) const {
   #if vt_check_enabled(memory_pool)
-    auto const& actual_alloc_size = HeaderManagerType::getHeaderBytes(buf);
+    auto const& actual_used_size = HeaderManagerType::getHeaderUsedBytes(buf);
     auto const& oversize = HeaderManagerType::getHeaderOversizeBytes(buf);
 
-    ePoolSize const pool_type = getPoolType(actual_alloc_size, oversize);
+    ePoolSize const pool_type = getPoolType(actual_used_size, oversize);
 
     if (pool_type == ePoolSize::Small) {
-      return small_msg->getNumBytes() - actual_alloc_size;
+      return small_msg->getNumBytes() - actual_used_size;
     } else if (pool_type == ePoolSize::Medium) {
-      return medium_msg->getNumBytes() - actual_alloc_size;
+      return medium_msg->getNumBytes() - actual_used_size;
     } else {
       return oversize;
     }
@@ -219,19 +219,19 @@ Pool::SizeType Pool::remainingSize(
 }
 
 Pool::SizeType Pool::allocatedSize(std::byte* const buf) const {
-  return HeaderManagerType::getHeaderBytes(buf) + HeaderManagerType::getHeaderOversizeBytes(buf);
+  return HeaderManagerType::getHeaderUsedBytes(buf) + HeaderManagerType::getHeaderOversizeBytes(buf);
 }
 
 void Pool::setUsedSize(std::byte* const buf, SizeType used_bytes) {
   auto *header = reinterpret_cast<Header*>(HeaderManagerType::getHeaderPtr(buf));
-  header->alloc_size = used_bytes;
+  header->use_size = used_bytes;
 }
 
 bool
 Pool::tryGrowAllocation(std::byte* buf, size_t grow_amount) {
   // For non-pooled alloc, this condition will always be true
   // since remainingSize(buf) would be 0
-  if ( remainingSize(buf) < grow_amount )
+  if (remainingSize(buf) < grow_amount)
     return false;
 
   auto *header = reinterpret_cast<Header*>(HeaderManagerType::getHeaderPtr(buf));

--- a/src/vt/pool/pool.cc
+++ b/src/vt/pool/pool.cc
@@ -222,6 +222,11 @@ Pool::SizeType Pool::allocatedSize(std::byte* const buf) const {
   return HeaderManagerType::getHeaderBytes(buf) + HeaderManagerType::getHeaderOversizeBytes(buf);
 }
 
+void Pool::setUsedSize(std::byte* const buf, SizeType used_bytes) {
+  auto *header = reinterpret_cast<Header*>(HeaderManagerType::getHeaderPtr(buf));
+  header->alloc_size = used_bytes;
+}
+
 bool
 Pool::tryGrowAllocation(std::byte* buf, size_t grow_amount) {
   // For non-pooled alloc, this condition will always be true

--- a/src/vt/pool/pool.cc
+++ b/src/vt/pool/pool.cc
@@ -235,7 +235,7 @@ Pool::tryGrowAllocation(std::byte* buf, size_t grow_amount) {
     return false;
 
   auto *header = reinterpret_cast<Header*>(HeaderManagerType::getHeaderPtr(buf));
-  header->alloc_size += grow_amount;
+  header->use_size += grow_amount;
   return true;
 }
 

--- a/src/vt/pool/pool.h
+++ b/src/vt/pool/pool.h
@@ -144,6 +144,16 @@ struct Pool : runtime::component::Component<Pool> {
   SizeType allocatedSize(std::byte* const buf) const;
 
   /**
+   * \brief Set the actual used (requested) bytes for allocation
+   *   *
+   * \param[in] buf the buffer allocated from the pool
+   * \param[in] used_size the used size to set
+   *
+   * \return the total number of allocated bytes
+   */
+  void setUsedSize(std::byte* const buf, SizeType used_bytes);
+
+  /**
    * \internal \brief Attempt to increase the size of an allocation without reallocating
    *
    * The allocation will only be grown if grow_amount is less than or equal to the remaining


### PR DESCRIPTION
Fixes #2500

Large-scale runs on HPE Cray Slingshot (libfabric CXI provider) hit non-deterministic aborts under heavy unexpected-message pressure due to hardware match-table exhaustion and Iprobe→Irecv race conditions. Switch to MPI_Improbe/MPI_Imrecv (MPI 3+) to claim messages from unexpected queue immediately.

- Updated tryProcessIncomingActiveMsg to use MPI_Improbe+MPI_Imrecv on MPI 3+
- Updated recvDataMsgBuffer to use MPI_Improbe for data messages (enqueue=false)
- Extended recvDataDirect signature with optional first_msg and first_chunk_bytes parameters
- Implemented matched-first-chunk path in recvDataDirect using MPI_Imrecv
- Added MPI_VERSION >= 3 guards for all new code paths
- Maintained backward compatibility with MPI < 3 using existing Iprobe/Irecv
- Add new broker to post Irecv so messages are not unexpected partitioned by size using tags