### PR TITLE
2504 fix CI failures

### DIFF
--- a/src/vt/topos/location/location.impl.h
+++ b/src/vt/topos/location/location.impl.h
@@ -547,7 +547,7 @@ void EntityLocationCoord<EntityID>::sendEagerUpdate(
   if (ask_node != this_node) {
     vtAssert(ask_node != uninitialized_destination, "Ask node must be valid");
     proxy_[ask_node].template send<&ThisType::handleEagerUpdate>(
-      id, home_node, deliver_node
+      MsgProps().asLocationMsg(), id, home_node, deliver_node
     );
   }
 }
@@ -574,14 +574,14 @@ void EntityLocationCoord<EntityID>::routeMsgNode(
 
   if (to_node != this_node) {
     // Get the current ask node, which is the from node for the first hop
-    auto ask_node = msg->getAskNode();
-    if (ask_node != uninitialized_destination) {
-      // Insert into the ask list for a later update when information is known
-      loc_asks_[id].insert(ask_node);
+    auto prev_ask = msg->getAskNode();
+    if (prev_ask != uninitialized_destination) {
+      // Record previous asker for cascaded updates
+      loc_asks_[id].insert(prev_ask);
+    } else {
+      // Set initial ask node to the sender for direct eager update later
+      msg->setAskNode(this_node);
     }
-
-    // Update the new asking node, as this node is will be the next to ask
-    msg->setAskNode(this_node);
 
     auto m = msg; //copy for msg thief
     // send to the node discovered by the location manager
@@ -630,7 +630,11 @@ void EntityLocationCoord<EntityID>::routeMsgNode(
 
       if (ask_node != uninitialized_destination) {
         auto delivered_node = theContext()->getNode();
+        // Tie the eager update to the same epoch as the routed message
+        auto epoch_local = theMsg()->getEpochContextMsg(msg);
+        theMsg()->pushEpoch(epoch_local);
         sendEagerUpdate(hid, ask_node, home_node, delivered_node);
+        theMsg()->popEpoch(epoch_local);
       }
     };
 

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
@@ -563,7 +563,7 @@ std::unique_ptr<ZoltanLB::Graph> ZoltanLB::makeGraph() {
 
         vt_debug_print(
           verbose, lb,
-          "edge_id={:x} from={:x}, to={:x}\n",
+          "edge_id={} from={}, to={}\n",
           iter->first.edge_id_,
           iter->first.fromObj(), iter->first.toObj()
         );

--- a/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
+++ b/src/vt/vrt/collection/balance/zoltanlb/zoltanlb.cc
@@ -369,7 +369,7 @@ void ZoltanLB::allocateShareEdgeGIDs() {
 
       vt_debug_print(
         verbose, lb,
-        "allocate: local edge_id={:x}, from={:x}, to={:x}\n",
+        "allocate: local edge_id={:x}, from={}, to={}\n",
         key.edge_id_.id,
         key.fromObj(),
         key.toObj()
@@ -386,7 +386,7 @@ void ZoltanLB::allocateShareEdgeGIDs() {
 
         vt_debug_print(
           verbose, lb,
-          "allocate: remote edge_id={:x}, from={:x}, to={:x}\n",
+          "allocate: remote edge_id={:x}, from={}, to={}\n",
           key.edge_id_.id,
           key.fromObj(),
           key.toObj()


### PR DESCRIPTION
Fixes #2504

This fixes two issues;
1. the format specifiers for the ZoltanLB (conditionally compiled) do not conform to the compile-time specification with the new FMT that VT is now using for all vt_debug_print
2. Location manager: Fixes the test failure and potential performance issue with cache updates. With this change, we now connect eager location updates to the message’s epoch and send the first update directly back to the original sender, rather than cascading via all the intermediate hops. This fixes the first iteration cache miss (in the test) by ensuring the origin sees the cache update before epoch termination.