### PR TITLE
#2516: Migrate extended tests from Azure to Github

### DIFF
--- a/.github/workflows/spawn-extended-tests-label.yml
+++ b/.github/workflows/spawn-extended-tests-label.yml
@@ -1,4 +1,3 @@
-
 name: Spawn extended tests (intel-18, nvcc-10.1, nvcc-11)
 
 on:
@@ -6,37 +5,71 @@ on:
     types:
       - labeled
 
+concurrency:
+  group: extended-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  build_intel_18_extended:
+  extended-tests:
     if: github.event.label.name == 'runextendedtests'
-    name: Invoke Azure Pipeline
+    name: Invoke Github Pipeline
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - vt-build-amd64-ubuntu-20-04-gcc-9-cuda-11-4-3-cpp
+          - vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp
+          - vt-build-amd64-ubuntu-24-04-icpx-cpp
+
     steps:
-      - name: Azure Pipelines Action
-        uses: Azure/pipelines@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore ccache
+        id: ccache-archive
+        uses: actions/cache@v4
         with:
-          azure-devops-project-url: https://dev.azure.com/DARMA-tasking/DARMA
-          azure-pipeline-name: 'PR tests extended (intel 18.03, ubuntu, mpich)'
-          azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-  build_nvcc_10_extended:
-    if: github.event.label.name == 'runextendedtests'
-    name: Invoke Azure Pipeline
-    runs-on: ubuntu-latest
-    steps:
-      - name: Azure Pipelines Action
-        uses: Azure/pipelines@v1
+          path: ccache-archive
+          key: extended-${{ matrix.target }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            extended-${{ matrix.target }}-${{ github.ref }}-
+            extended-${{ matrix.target }}-
+
+      - name: Inject ccache
+        uses: reproducible-containers/buildkit-cache-dance@v3
         with:
-          azure-devops-project-url: https://dev.azure.com/DARMA-tasking/DARMA
-          azure-pipeline-name: 'PR tests extended (nvidia cuda 10.1, ubuntu, mpich)'
-          azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-  build_nvcc_11_extended:
-    if: github.event.label.name == 'runextendedtests'
-    name: Invoke Azure Pipeline
-    runs-on: ubuntu-latest
-    steps:
-      - name: Azure Pipelines Action
-        uses: Azure/pipelines@v1
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              "ccache-archive": {
+                "target": "/build/ccache",
+                "id": "${{ matrix.target }}-extended"
+              }
+            }
+          skip-extraction: ${{ steps.ccache-archive.outputs.cache-hit }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
-          azure-devops-project-url: https://dev.azure.com/DARMA-tasking/DARMA
-          azure-pipeline-name: 'PR tests extended (nvidia cuda 11.0, ubuntu, mpich)'
-          azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and run extended tests
+        id: build-image
+        uses: docker/bake-action@v6
+        with:
+          source: .
+          targets: ${{ matrix.target }}
+          files: docker-bake.hcl
+          push: false
+          set: |
+            *.args.CACHE_ID=${{ matrix.target }}-extended
+            *.args.VT_EXTENDED_TESTS_ENABLED=1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GIT_BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/src/vt/topos/location/location.impl.h
+++ b/src/vt/topos/location/location.impl.h
@@ -53,6 +53,7 @@
 #include "vt/context/context.h"
 #include "vt/messaging/active.h"
 #include "vt/runnable/make_runnable.h"
+#include "vt/termination/term_common.h"
 
 #include <cstdint>
 #include <memory>
@@ -627,14 +628,27 @@ void EntityLocationCoord<EntityID>::routeMsgNode(
       }
 
       auto ask_node = msg->getAskNode();
+      auto const route_epoch = msg->getRouteEpoch();
 
       if (ask_node != uninitialized_destination) {
         auto delivered_node = theContext()->getNode();
-        // Tie the eager update to the same epoch as the routed message
-        auto epoch_local = theMsg()->getEpochContextMsg(msg);
+        // Tie the eager update to the same epoch as the routed message. Prefer
+        // the epoch explicitly carried in the message (set at origination for
+        // messages that cannot hold an epoch in their envelope); otherwise fall
+        // back to the envelope-derived epoch used by epoch-carrying messages.
+        auto epoch_local = route_epoch != no_epoch ?
+          route_epoch : theMsg()->getEpochContextMsg(msg);
         theMsg()->pushEpoch(epoch_local);
         sendEagerUpdate(hid, ask_node, home_node, delivered_node);
         theMsg()->popEpoch(epoch_local);
+      }
+
+      // Release the caller's epoch that was manually held at origination for a
+      // message that could not carry it in its envelope. The eager update above
+      // is produced on this same epoch before the consume below, so the epoch
+      // stays alive until the origin processes the cache update.
+      if (route_epoch != no_epoch) {
+        theTerm()->consume(route_epoch);
       }
     };
 
@@ -766,6 +780,22 @@ void EntityLocationCoord<EntityID>::routePreparedMsg(
   auto const msg_size = sizeof(*msg);
   bool const use_eager = useEagerProtocol(msg);
   auto const epoch = theMsg()->getEpochContextMsg(msg);
+
+  // Messages whose envelope cannot hold an epoch (e.g. short messages) lose the
+  // caller's epoch as soon as they hop to another node: getEpochContextMsg
+  // collapses to the "any epoch" sentinel even when the caller is inside a real
+  // collective epoch. Detect that case at origination and manually hold the
+  // caller's epoch across the whole route (including the eager cache update that
+  // comes back to the origin), releasing it at final delivery. This keeps the
+  // routed message and its cache update enclosed by the caller's epoch, exactly
+  // as an epoch-carrying (long) message already is via its envelope.
+  if (msg->getRouteEpoch() == no_epoch and epoch == term::any_epoch_sentinel) {
+    auto const cur_epoch = theMsg()->getEpoch();
+    if (cur_epoch != term::any_epoch_sentinel and cur_epoch != no_epoch) {
+      msg->setRouteEpoch(cur_epoch);
+      theTerm()->produce(cur_epoch);
+    }
+  }
 
   vt_debug_print(
     verbose, location,

--- a/src/vt/topos/location/message/msg.h
+++ b/src/vt/topos/location/message/msg.h
@@ -48,11 +48,68 @@
 #include "vt/topos/location/location_common.h"
 #include "vt/messaging/message.h"
 
+#include <type_traits>
+#include <utility>
+
 namespace vt { namespace location {
 
+namespace detail {
+
+/// True if envelope type \c EnvT is able to carry an epoch (has an \c epoch
+/// member); such envelopes propagate the caller's epoch across location hops
+/// on their own, so no epoch needs to be carried in the message payload.
+template <typename EnvT, typename = void>
+struct EnvelopeHasEpoch : std::false_type {};
+
+template <typename EnvT>
+struct EnvelopeHasEpoch<
+  EnvT, std::void_t<decltype(std::declval<EnvT&>().epoch)>
+> : std::true_type {};
+
+/**
+ * \struct RouteEpochField
+ *
+ * \brief Storage for the caller's epoch carried by a routed location message.
+ *
+ * Messages whose envelope can hold an epoch (e.g. epoch/collection messages)
+ * propagate the caller's epoch across nodes via the envelope, so this stores
+ * nothing and is an empty base (no size cost on the common path). Messages
+ * whose envelope cannot hold an epoch (e.g. short messages) capture the
+ * caller's epoch here at origination so routing and the eager cache update
+ * stay enclosed by that epoch.
+ */
+template <bool CarryEpoch>
+struct RouteEpochField {
+  void setRouteEpoch(EpochType const&) {}
+  EpochType getRouteEpoch() const { return no_epoch; }
+  template <typename SerializerT>
+  void serializeRouteEpoch(SerializerT&) {}
+};
+
+template <>
+struct RouteEpochField<true> {
+  void setRouteEpoch(EpochType const& epoch) { route_epoch_ = epoch; }
+  EpochType getRouteEpoch() const { return route_epoch_; }
+  template <typename SerializerT>
+  void serializeRouteEpoch(SerializerT& s) { s | route_epoch_; }
+
+private:
+  EpochType route_epoch_ = no_epoch;
+};
+
+} /* end namespace detail */
+
 template <typename EntityID, typename ActiveMessageT>
-struct EntityMsg : ActiveMessageT {
+struct EntityMsg
+  : ActiveMessageT,
+    detail::RouteEpochField<
+      not detail::EnvelopeHasEpoch<typename ActiveMessageT::EnvelopeType>::value
+    >
+{
   using MessageParentType = ActiveMessageT;
+  using RouteEpochFieldType = detail::RouteEpochField<
+    not detail::EnvelopeHasEpoch<typename ActiveMessageT::EnvelopeType>::value
+  >;
   vt_msg_serialize_if_needed_by_parent();
 
   EntityMsg() = default;
@@ -73,8 +130,6 @@ struct EntityMsg : ActiveMessageT {
   int16_t getHops() const { return hops_; }
   void setAskNode(NodeType const& node) { ask_node_ = node; }
   NodeType getAskNode() const { return ask_node_; }
-  void setRouteEpoch(EpochType const& epoch) { route_epoch_ = epoch; }
-  EpochType getRouteEpoch() const { return route_epoch_; }
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -85,7 +140,7 @@ struct EntityMsg : ActiveMessageT {
     s | handler_;
     s | hops_;
     s | ask_node_;
-    s | route_epoch_;
+    RouteEpochFieldType::serializeRouteEpoch(s);
   }
 
 private:
@@ -95,10 +150,6 @@ private:
   HandlerType handler_ = uninitialized_handler;
   int16_t hops_ = 0;
   NodeType ask_node_ =  uninitialized_destination;
-  // The caller's epoch, captured at origination for messages whose envelope
-  // cannot carry an epoch across location hops (e.g. short messages). Used to
-  // keep routing and eager cache updates enclosed by the caller's epoch.
-  EpochType route_epoch_ = no_epoch;
 };
 
 }}  // end namespace vt::location

--- a/src/vt/topos/location/message/msg.h
+++ b/src/vt/topos/location/message/msg.h
@@ -73,6 +73,8 @@ struct EntityMsg : ActiveMessageT {
   int16_t getHops() const { return hops_; }
   void setAskNode(NodeType const& node) { ask_node_ = node; }
   NodeType getAskNode() const { return ask_node_; }
+  void setRouteEpoch(EpochType const& epoch) { route_epoch_ = epoch; }
+  EpochType getRouteEpoch() const { return route_epoch_; }
 
   template <typename SerializerT>
   void serialize(SerializerT& s) {
@@ -83,6 +85,7 @@ struct EntityMsg : ActiveMessageT {
     s | handler_;
     s | hops_;
     s | ask_node_;
+    s | route_epoch_;
   }
 
 private:
@@ -92,6 +95,10 @@ private:
   HandlerType handler_ = uninitialized_handler;
   int16_t hops_ = 0;
   NodeType ask_node_ =  uninitialized_destination;
+  // The caller's epoch, captured at origination for messages whose envelope
+  // cannot carry an epoch across location hops (e.g. short messages). Used to
+  // keep routing and eager cache updates enclosed by the caller's epoch.
+  EpochType route_epoch_ = no_epoch;
 };
 
 }}  // end namespace vt::location


### PR DESCRIPTION
Fixes #2516.

We can delete the obsolete `AZURE_DEVOPS_TOKEN` repository secret after migration.

