### PR TITLE
#2519: Update to fmt 12

### DIFF
--- a/cmake/load_bundled_libraries.cmake
+++ b/cmake/load_bundled_libraries.cmake
@@ -30,7 +30,7 @@ if(${vt_external_fmt})
   else()
     message(STATUS "vt_external_fmt = ON but neither fmt_DIR nor fmt_ROOT is provided!")
   endif()
-  find_package(fmt 10.2.1 REQUIRED)
+  find_package(fmt 12.2.0 REQUIRED)
 
 else()
   set(FMT_LIBRARY fmt)

--- a/cmake/load_bundled_libraries.cmake
+++ b/cmake/load_bundled_libraries.cmake
@@ -30,7 +30,7 @@ if(${vt_external_fmt})
   else()
     message(STATUS "vt_external_fmt = ON but neither fmt_DIR nor fmt_ROOT is provided!")
   endif()
-  find_package(fmt 12.2.0 REQUIRED)
+  find_package(fmt 10.2.1 REQUIRED)
 
 else()
   set(FMT_LIBRARY fmt)

--- a/lib/fmt/include/fmt-vt/base.h
+++ b/lib/fmt/include/fmt-vt/base.h
@@ -1,6 +1,6 @@
 // Formatting library for C++ - the base API for char/UTF-8
 //
-// Copyright (c) 2012 - present, Victor Zverovich
+// Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
 // All rights reserved.
 //
 // For the license information refer to format.h.
@@ -21,7 +21,7 @@
 #endif
 
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
-#define FMT_VERSION 110103
+#define FMT_VERSION 120200
 
 // Detect compiler versions.
 #if defined(__clang__) && !defined(__ibmxl__)
@@ -114,7 +114,9 @@
 #endif
 
 // Detect consteval, C++20 constexpr extensions and std::is_constant_evaluated.
-#if !defined(__cpp_lib_is_constant_evaluated)
+#ifdef FMT_USE_CONSTEVAL
+// Use the provided definition.
+#elif !defined(__cpp_lib_is_constant_evaluated)
 #  define FMT_USE_CONSTEVAL 0
 #elif FMT_CPLUSPLUS < 201709L
 #  define FMT_USE_CONSTEVAL 0
@@ -124,8 +126,8 @@
 #  define FMT_USE_CONSTEVAL 0
 #elif defined(__apple_build_version__) && __apple_build_version__ < 14000029L
 #  define FMT_USE_CONSTEVAL 0  // consteval is broken in Apple clang < 14.
-#elif FMT_MSC_VERSION && FMT_MSC_VERSION < 1929
-#  define FMT_USE_CONSTEVAL 0  // consteval is broken in MSVC VS2019 < 16.10.
+#elif FMT_MSC_VERSION && FMT_MSC_VERSION < 1940
+#  define FMT_USE_CONSTEVAL 0  // consteval is broken in some MSVC2022 versions.
 #elif defined(__cpp_consteval)
 #  define FMT_USE_CONSTEVAL 1
 #elif FMT_GCC_VERSION >= 1002 || FMT_CLANG_VERSION >= 1101
@@ -201,6 +203,38 @@
 #  define FMT_NODISCARD
 #endif
 
+#if FMT_GCC_VERSION || FMT_CLANG_VERSION
+#  define FMT_VISIBILITY(value) __attribute__((visibility(value)))
+#else
+#  define FMT_VISIBILITY(value)
+#endif
+
+// Detect pragmas.
+#define FMT_PRAGMA_IMPL(x) _Pragma(#x)
+#if FMT_GCC_VERSION >= 504 && !defined(__NVCOMPILER)
+// Workaround a _Pragma bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59884
+// and an nvhpc warning: https://github.com/fmtlib/fmt/pull/2582.
+#  define FMT_PRAGMA_GCC(x) FMT_PRAGMA_IMPL(GCC x)
+#else
+#  define FMT_PRAGMA_GCC(x)
+#endif
+#if FMT_CLANG_VERSION
+#  define FMT_PRAGMA_CLANG(x) FMT_PRAGMA_IMPL(clang x)
+#else
+#  define FMT_PRAGMA_CLANG(x)
+#endif
+
+#ifndef FMT_USE_OPTIMIZE_PRAGMA
+#  define FMT_USE_OPTIMIZE_PRAGMA 1
+#endif
+
+// Enable minimal optimizations for more compact code in debug mode.
+FMT_PRAGMA_GCC(push_options)
+#if FMT_USE_OPTIMIZE_PRAGMA && !defined(__OPTIMIZE__) && \
+    !defined(__CUDACC__) && !defined(FMT_MODULE)
+FMT_PRAGMA_GCC(optimize("Og"))
+#endif
+
 #ifdef FMT_DEPRECATED
 // Use the provided definition.
 #elif FMT_HAS_CPP14_ATTRIBUTE(deprecated)
@@ -223,36 +257,10 @@
 #  define FMT_INLINE inline
 #endif
 
-#if FMT_GCC_VERSION || FMT_CLANG_VERSION
-#  define FMT_VISIBILITY(value) __attribute__((visibility(value)))
-#else
-#  define FMT_VISIBILITY(value)
-#endif
-
-// Detect pragmas.
-#define FMT_PRAGMA_IMPL(x) _Pragma(#x)
-#if FMT_GCC_VERSION >= 504 && !defined(__NVCOMPILER)
-// Workaround a _Pragma bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59884
-// and an nvhpc warning: https://github.com/fmtlib/fmt/pull/2582.
-#  define FMT_PRAGMA_GCC(x) FMT_PRAGMA_IMPL(GCC x)
-#else
-#  define FMT_PRAGMA_GCC(x)
-#endif
-#if FMT_CLANG_VERSION
-#  define FMT_PRAGMA_CLANG(x) FMT_PRAGMA_IMPL(clang x)
-#else
-#  define FMT_PRAGMA_CLANG(x)
-#endif
-#if FMT_MSC_VERSION
-#  define FMT_MSC_WARNING(...) __pragma(warning(__VA_ARGS__))
-#else
-#  define FMT_MSC_WARNING(...)
-#endif
-
 #ifndef FMT_BEGIN_NAMESPACE
 #  define FMT_BEGIN_NAMESPACE \
     namespace fmt {           \
-    inline namespace v11 {
+    inline namespace v12 {
 #  define FMT_END_NAMESPACE \
     }                       \
     }
@@ -294,15 +302,8 @@
 #endif
 
 #define FMT_APPLY_VARIADIC(expr) \
-  using ignore = int[];          \
-  (void)ignore { 0, (expr, 0)... }
-
-// Enable minimal optimizations for more compact code in debug mode.
-FMT_PRAGMA_GCC(push_options)
-#if !defined(__OPTIMIZE__) && !defined(__CUDACC__) && !defined(FMT_MODULE)
-FMT_PRAGMA_GCC(optimize("Og"))
-#endif
-FMT_PRAGMA_CLANG(diagnostic push)
+  using unused = int[];          \
+  (void)unused { 0, (expr, 0)... }
 
 FMT_BEGIN_NAMESPACE
 
@@ -325,8 +326,10 @@ using underlying_t = typename std::underlying_type<T>::type;
 template <typename T> using decay_t = typename std::decay<T>::type;
 using nullptr_t = decltype(nullptr);
 
-#if FMT_GCC_VERSION && FMT_GCC_VERSION < 500
-// A workaround for gcc 4.9 to make void_t work in a SFINAE context.
+using ullong = unsigned long long;
+
+#if (FMT_GCC_VERSION && FMT_GCC_VERSION < 500) || FMT_MSC_VERSION
+// A workaround for gcc 4.9 & MSVC v141 to make void_t work in a SFINAE context.
 template <typename...> struct void_t_impl {
   using type = void;
 };
@@ -355,6 +358,9 @@ template <typename T> constexpr auto max_of(T a, T b) -> T {
   return a > b ? a : b;
 }
 
+FMT_NORETURN FMT_API void assert_fail(const char* file, int line,
+                                      const char* message);
+
 namespace detail {
 // Suppresses "unused variable" warnings with the method described in
 // https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/.
@@ -377,15 +383,7 @@ constexpr auto is_constant_evaluated(bool default_value = false) noexcept
 #endif
 }
 
-// Suppresses "conditional expression is constant" warnings.
-template <typename T> FMT_ALWAYS_INLINE constexpr auto const_check(T val) -> T {
-  return val;
-}
-
-FMT_NORETURN FMT_API void assert_fail(const char* file, int line,
-                                      const char* message);
-
-#if defined(FMT_ASSERT)
+#ifdef FMT_ASSERT
 // Use the provided definition.
 #elif defined(NDEBUG)
 // FMT_ASSERT is not empty to avoid -Wempty-body.
@@ -395,7 +393,7 @@ FMT_NORETURN FMT_API void assert_fail(const char* file, int line,
 #  define FMT_ASSERT(condition, message)                                    \
     ((condition) /* void() fails with -Winvalid-constexpr on clang 4.0.1 */ \
          ? (void)0                                                          \
-         : fmt::detail::assert_fail(__FILE__, __LINE__, (message)))
+         : ::fmt::assert_fail(__FILE__, __LINE__, (message)))
 #endif
 
 #ifdef FMT_USE_INT128
@@ -403,33 +401,20 @@ FMT_NORETURN FMT_API void assert_fail(const char* file, int line,
 #elif defined(__SIZEOF_INT128__) && !defined(__NVCC__) && \
     !(FMT_CLANG_VERSION && FMT_MSC_VERSION)
 #  define FMT_USE_INT128 1
-using int128_opt = __int128_t;  // An optional native 128-bit integer.
-using uint128_opt = __uint128_t;
-inline auto map(int128_opt x) -> int128_opt { return x; }
-inline auto map(uint128_opt x) -> uint128_opt { return x; }
+using native_int128 = __int128_t;
+using native_uint128 = __uint128_t;
+inline auto map(native_int128 x) -> native_int128 { return x; }
+inline auto map(native_uint128 x) -> native_uint128 { return x; }
 #else
 #  define FMT_USE_INT128 0
 #endif
 #if !FMT_USE_INT128
-enum class int128_opt {};
-enum class uint128_opt {};
-// Reduce template instantiations.
-inline auto map(int128_opt) -> monostate { return {}; }
-inline auto map(uint128_opt) -> monostate { return {}; }
+// Fallbacks to reduce conditional compilation and SFINAE.
+enum class native_int128 {};
+enum class native_uint128 {};
+inline auto map(native_int128) -> monostate { return {}; }
+inline auto map(native_uint128) -> monostate { return {}; }
 #endif
-
-#ifndef FMT_USE_BITINT
-#  define FMT_USE_BITINT (FMT_CLANG_VERSION >= 1500)
-#endif
-
-#if FMT_USE_BITINT
-FMT_PRAGMA_CLANG(diagnostic ignored "-Wbit-int-extension")
-template <int N> using bitint = _BitInt(N);
-template <int N> using ubitint = unsigned _BitInt(N);
-#else
-template <int N> struct bitint {};
-template <int N> struct ubitint {};
-#endif  // FMT_USE_BITINT
 
 // Casts a nonnegative integer to unsigned.
 template <typename Int>
@@ -462,12 +447,13 @@ enum { use_utf8 = !FMT_WIN32 || is_utf8_enabled };
 static_assert(!FMT_UNICODE || use_utf8,
               "Unicode support requires compiling with /utf-8");
 
-template <typename T> constexpr const char* narrow(const T*) { return nullptr; }
-constexpr FMT_ALWAYS_INLINE const char* narrow(const char* s) { return s; }
+template <typename T> constexpr auto narrow(T*) -> char* { return nullptr; }
+constexpr FMT_ALWAYS_INLINE auto narrow(const char* s) -> const char* {
+  return s;
+}
 
 template <typename Char>
-FMT_CONSTEXPR auto compare(const Char* s1, const Char* s2, std::size_t n)
-    -> int {
+FMT_CONSTEXPR auto compare(const Char* s1, const Char* s2, size_t n) -> int {
   if (!is_constant_evaluated() && sizeof(Char) == 1) return memcmp(s1, s2, n);
   for (; n != 0; ++s1, ++s2, --n) {
     if (*s1 < *s2) return -1;
@@ -495,22 +481,30 @@ struct is_back_insert_iterator<
 
 // Extracts a reference to the container from *insert_iterator.
 template <typename OutputIt>
-inline FMT_CONSTEXPR20 auto get_container(OutputIt it) ->
+inline FMT_CONSTEXPR auto get_container(OutputIt it) ->
     typename OutputIt::container_type& {
   struct accessor : OutputIt {
-    FMT_CONSTEXPR20 accessor(OutputIt base) : OutputIt(base) {}
+    constexpr accessor(OutputIt base) : OutputIt(base) {}
     using OutputIt::container;
   };
   return *accessor(it).container;
 }
+
+template <typename T, typename Enable = void>
+struct is_contiguous : std::false_type {};
+template <typename T>
+struct is_contiguous<T, void_t<decltype(std::declval<T&>().data()),
+                               decltype(std::declval<T&>().size()),
+                               decltype(std::declval<T&>()[size_t()])>>
+    : std::true_type {};
 }  // namespace detail
 
 // Parsing-related public API and forward declarations.
 FMT_BEGIN_EXPORT
 
 /**
- * An implementation of `std::basic_string_view` for pre-C++17. It provides a
- * subset of the API. `fmt::basic_string_view` is used for format strings even
+ * An implementation of `std::basic_string_view` for pre-C++17 providing a
+ * subset of the API. `fmt::basic_string_view` is used in the public API even
  * if `std::basic_string_view` is available to prevent issues when a library is
  * compiled with a different `-std` option than the client code (which is not
  * recommended).
@@ -525,21 +519,16 @@ template <typename Char> class basic_string_view {
   using iterator = const Char*;
 
   constexpr basic_string_view() noexcept : data_(nullptr), size_(0) {}
-
-  /// Constructs a string reference object from a C string and a size.
   constexpr basic_string_view(const Char* s, size_t count) noexcept
       : data_(s), size_(count) {}
 
-  constexpr basic_string_view(nullptr_t) = delete;
-
-  /// Constructs a string reference object from a C string.
 #if FMT_GCC_VERSION
   FMT_ALWAYS_INLINE
 #endif
-  FMT_CONSTEXPR20 basic_string_view(const Char* s) : data_(s) {
-#if FMT_HAS_BUILTIN(__buitin_strlen) || FMT_GCC_VERSION || FMT_CLANG_VERSION
-    if (std::is_same<Char, char>::value) {
-      size_ = __builtin_strlen(detail::narrow(s));
+  FMT_CONSTEXPR basic_string_view(const Char* s) : data_(s) {
+#if FMT_HAS_BUILTIN(__builtin_strlen) || FMT_GCC_VERSION || FMT_CLANG_VERSION
+    if (std::is_same<Char, char>::value && !detail::is_constant_evaluated()) {
+      size_ = __builtin_strlen(detail::narrow(s));  // strlen is not constexpr.
       return;
     }
 #endif
@@ -548,18 +537,14 @@ template <typename Char> class basic_string_view {
     size_ = len;
   }
 
-  /// Constructs a string reference from a `std::basic_string` or a
-  /// `std::basic_string_view` object.
-  template <typename S,
-            FMT_ENABLE_IF(detail::is_std_string_like<S>::value&& std::is_same<
-                          typename S::value_type, Char>::value)>
-  FMT_CONSTEXPR basic_string_view(const S& s) noexcept
+  template <
+      typename S,
+      FMT_ENABLE_IF(detail::is_std_string_like<S>::value&&  //
+                        std::is_same<typename S::value_type, Char>::value)>
+  constexpr basic_string_view(const S& s) noexcept
       : data_(s.data()), size_(s.size()) {}
 
-  /// Returns a pointer to the string data.
   constexpr auto data() const noexcept -> const Char* { return data_; }
-
-  /// Returns the string size.
   constexpr auto size() const noexcept -> size_t { return size_; }
 
   constexpr auto begin() const noexcept -> iterator { return data_; }
@@ -574,22 +559,19 @@ template <typename Char> class basic_string_view {
     size_ -= n;
   }
 
-  FMT_CONSTEXPR auto starts_with(basic_string_view<Char> sv) const noexcept
-      -> bool {
+  FMT_CONSTEXPR auto starts_with(basic_string_view sv) const noexcept -> bool {
     return size_ >= sv.size_ && detail::compare(data_, sv.data_, sv.size_) == 0;
   }
   FMT_CONSTEXPR auto starts_with(Char c) const noexcept -> bool {
     return size_ >= 1 && *data_ == c;
   }
   FMT_CONSTEXPR auto starts_with(const Char* s) const -> bool {
-    return starts_with(basic_string_view<Char>(s));
+    return starts_with(basic_string_view(s));
   }
 
-  // Lexicographically compare this string reference to other.
   FMT_CONSTEXPR auto compare(basic_string_view other) const -> int {
-    int result =
-        detail::compare(data_, other.data_, min_of(size_, other.size_));
-    if (result != 0) return result;
+    int cmp = detail::compare(data_, other.data_, min_of(size_, other.size_));
+    if (cmp != 0) return cmp;
     return size_ == other.size_ ? 0 : (size_ < other.size_ ? -1 : 1);
   }
 
@@ -613,27 +595,10 @@ template <typename Char> class basic_string_view {
     return lhs.compare(rhs) >= 0;
   }
 };
-
 using string_view = basic_string_view<char>;
-
-/// Specifies if `T` is an extended character type. Can be specialized by users.
-template <typename T> struct is_xchar : std::false_type {};
-template <> struct is_xchar<wchar_t> : std::true_type {};
-template <> struct is_xchar<char16_t> : std::true_type {};
-template <> struct is_xchar<char32_t> : std::true_type {};
-#ifdef __cpp_char8_t
-template <> struct is_xchar<char8_t> : std::true_type {};
-#endif
-
-// DEPRECATED! Will be replaced with an alias to prevent specializations.
-template <typename T> struct is_char : is_xchar<T> {};
-template <> struct is_char<char> : std::true_type {};
 
 template <typename T> class basic_appender;
 using appender = basic_appender<char>;
-
-// Checks whether T is a container with contiguous storage.
-template <typename T> struct is_contiguous : std::false_type {};
 
 class context;
 template <typename OutputIt, typename Char> class generic_context;
@@ -653,6 +618,8 @@ using buffered_context =
     conditional_t<std::is_same<Char, char>::value, context,
                   generic_context<basic_appender<Char>, Char>>;
 
+template <typename T> struct is_contiguous : detail::is_contiguous<T> {};
+
 template <typename Context> class basic_format_arg;
 template <typename Context> class basic_format_args;
 
@@ -666,6 +633,9 @@ struct formatter {
   // A deleted default constructor indicates a disabled formatter.
   formatter() = delete;
 };
+
+template <typename T, typename Enable = void>
+struct locking : std::false_type {};
 
 /// Reports a format error at compile time or, via a `format_error` exception,
 /// at runtime.
@@ -740,14 +710,13 @@ class basic_specs {
   };
 
   unsigned data_ = 1 << fill_size_shift;
-  static_assert(sizeof(data_) * CHAR_BIT >= 18, "");
+  static_assert(sizeof(basic_specs::data_) * CHAR_BIT >= 18, "");
 
   // Character (code unit) type is erased to prevent template bloat.
   char fill_data_[max_fill_size] = {' '};
 
   FMT_CONSTEXPR void set_fill_size(size_t size) {
-    data_ = (data_ & ~fill_size_mask) |
-            (static_cast<unsigned>(size) << fill_size_shift);
+    data_ = (data_ & ~fill_size_mask) | (unsigned(size) << fill_size_shift);
   }
 
  public:
@@ -755,21 +724,21 @@ class basic_specs {
     return static_cast<presentation_type>(data_ & type_mask);
   }
   FMT_CONSTEXPR void set_type(presentation_type t) {
-    data_ = (data_ & ~type_mask) | static_cast<unsigned>(t);
+    data_ = (data_ & ~type_mask) | unsigned(t);
   }
 
   constexpr auto align() const -> align {
     return static_cast<fmt::align>((data_ & align_mask) >> align_shift);
   }
   FMT_CONSTEXPR void set_align(fmt::align a) {
-    data_ = (data_ & ~align_mask) | (static_cast<unsigned>(a) << align_shift);
+    data_ = (data_ & ~align_mask) | (unsigned(a) << align_shift);
   }
 
   constexpr auto dynamic_width() const -> arg_id_kind {
     return static_cast<arg_id_kind>((data_ & width_mask) >> width_shift);
   }
   FMT_CONSTEXPR void set_dynamic_width(arg_id_kind w) {
-    data_ = (data_ & ~width_mask) | (static_cast<unsigned>(w) << width_shift);
+    data_ = (data_ & ~width_mask) | (unsigned(w) << width_shift);
   }
 
   FMT_CONSTEXPR auto dynamic_precision() const -> arg_id_kind {
@@ -777,11 +746,10 @@ class basic_specs {
                                     precision_shift);
   }
   FMT_CONSTEXPR void set_dynamic_precision(arg_id_kind p) {
-    data_ = (data_ & ~precision_mask) |
-            (static_cast<unsigned>(p) << precision_shift);
+    data_ = (data_ & ~precision_mask) | (unsigned(p) << precision_shift);
   }
 
-  constexpr bool dynamic() const {
+  constexpr auto dynamic() const -> bool {
     return (data_ & (width_mask | precision_mask)) != 0;
   }
 
@@ -789,7 +757,7 @@ class basic_specs {
     return static_cast<fmt::sign>((data_ & sign_mask) >> sign_shift);
   }
   FMT_CONSTEXPR void set_sign(fmt::sign s) {
-    data_ = (data_ & ~sign_mask) | (static_cast<unsigned>(s) << sign_shift);
+    data_ = (data_ & ~sign_mask) | (unsigned(s) << sign_shift);
   }
 
   constexpr auto upper() const -> bool { return (data_ & uppercase_mask) != 0; }
@@ -819,9 +787,8 @@ class basic_specs {
 
   template <typename Char> constexpr auto fill_unit() const -> Char {
     using uchar = unsigned char;
-    return static_cast<Char>(static_cast<uchar>(fill_data_[0]) |
-                             (static_cast<uchar>(fill_data_[1]) << 8) |
-                             (static_cast<uchar>(fill_data_[2]) << 16));
+    return Char(uchar(fill_data_[0]) | uchar(fill_data_[1]) << 8 |
+                uchar(fill_data_[2]) << 16);
   }
 
   FMT_CONSTEXPR void set_fill(char c) {
@@ -835,14 +802,13 @@ class basic_specs {
     set_fill_size(size);
     if (size == 1) {
       unsigned uchar = static_cast<detail::unsigned_char<Char>>(s[0]);
-      fill_data_[0] = static_cast<char>(uchar);
-      fill_data_[1] = static_cast<char>(uchar >> 8);
-      fill_data_[2] = static_cast<char>(uchar >> 16);
+      fill_data_[0] = char(uchar);
+      fill_data_[1] = char(uchar >> 8);
+      fill_data_[2] = char(uchar >> 16);
       return;
     }
     FMT_ASSERT(size <= max_fill_size, "invalid fill");
-    for (size_t i = 0; i < size; ++i)
-      fill_data_[i & 3] = static_cast<char>(s[i]);
+    for (size_t i = 0; i < size; ++i) fill_data_[i & 3] = char(s[i]);
   }
 
   FMT_CONSTEXPR void copy_fill_from(const basic_specs& specs) {
@@ -921,14 +887,53 @@ template <typename Char = char> class parse_context {
   FMT_CONSTEXPR void check_dynamic_spec(int arg_id);
 };
 
+#ifndef FMT_USE_LOCALE
+#  define FMT_USE_LOCALE (FMT_OPTIMIZE_SIZE <= 1)
+#endif
+
+// A type-erased reference to std::locale to avoid the heavy <locale> include.
+class locale_ref {
+#if FMT_USE_LOCALE
+ private:
+  const void* locale_;  // A type-erased pointer to std::locale.
+
+ public:
+  constexpr locale_ref() : locale_(nullptr) {}
+
+  template <typename Locale, FMT_ENABLE_IF(sizeof(Locale::collate) != 0)>
+  locale_ref(const Locale& loc) : locale_(&loc) {
+    // Check if std::isalpha is found via ADL to reduce the chance of misuse.
+    detail::ignore_unused(sizeof(isalpha('x', loc)));
+  }
+
+  inline explicit operator bool() const noexcept { return locale_ != nullptr; }
+#else
+ public:
+  inline explicit operator bool() const noexcept { return false; }
+#endif  // FMT_USE_LOCALE
+
+ public:
+  template <typename Locale> auto get() const -> Locale;
+};
+
 FMT_END_EXPORT
 
 namespace detail {
 
+// Specifies if `T` is a code unit type.
+template <typename T> struct is_code_unit : std::false_type {};
+template <> struct is_code_unit<char> : std::true_type {};
+template <> struct is_code_unit<wchar_t> : std::true_type {};
+template <> struct is_code_unit<char16_t> : std::true_type {};
+template <> struct is_code_unit<char32_t> : std::true_type {};
+#ifdef __cpp_char8_t
+template <> struct is_code_unit<char8_t> : bool_constant<is_utf8_enabled> {};
+#endif
+
 // Constructs fmt::basic_string_view<Char> from types implicitly convertible
 // to it, deducing Char. Explicitly convertible types such as the ones returned
 // from FMT_STRING are intentionally excluded.
-template <typename Char, FMT_ENABLE_IF(is_char<Char>::value)>
+template <typename Char, FMT_ENABLE_IF(is_code_unit<Char>::value)>
 constexpr auto to_string_view(const Char* s) -> basic_string_view<Char> {
   return s;
 }
@@ -991,9 +996,9 @@ struct type_constant : std::integral_constant<type, type::custom_type> {};
 FMT_TYPE_CONSTANT(int, int_type);
 FMT_TYPE_CONSTANT(unsigned, uint_type);
 FMT_TYPE_CONSTANT(long long, long_long_type);
-FMT_TYPE_CONSTANT(unsigned long long, ulong_long_type);
-FMT_TYPE_CONSTANT(int128_opt, int128_type);
-FMT_TYPE_CONSTANT(uint128_opt, uint128_type);
+FMT_TYPE_CONSTANT(ullong, ulong_long_type);
+FMT_TYPE_CONSTANT(native_int128, int128_type);
+FMT_TYPE_CONSTANT(native_uint128, uint128_type);
 FMT_TYPE_CONSTANT(bool, bool_type);
 FMT_TYPE_CONSTANT(Char, char_type);
 FMT_TYPE_CONSTANT(float, float_type);
@@ -1010,9 +1015,9 @@ constexpr auto is_arithmetic_type(type t) -> bool {
   return t > type::none_type && t <= type::last_numeric_type;
 }
 
-constexpr auto set(type rhs) -> int { return 1 << static_cast<int>(rhs); }
+constexpr auto set(type rhs) -> int { return 1 << int(rhs); }
 constexpr auto in(type t, int set) -> bool {
-  return ((set >> static_cast<int>(t)) & 1) != 0;
+  return ((set >> int(t)) & 1) != 0;
 }
 
 // Bitsets of types.
@@ -1032,14 +1037,20 @@ enum {
 
 struct view {};
 
-template <typename Char, typename T> struct named_arg;
+template <typename T, typename Enable = std::true_type>
+struct is_view : std::false_type {};
+template <typename T>
+struct is_view<T, bool_constant<sizeof(T) != 0>> : std::is_base_of<view, T> {};
+
+// DEPRECATED! named_arg will be moved to the fmt namespace.
+template <typename T, typename Char> struct named_arg;
 template <typename T> struct is_named_arg : std::false_type {};
 template <typename T> struct is_static_named_arg : std::false_type {};
 
-template <typename Char, typename T>
-struct is_named_arg<named_arg<Char, T>> : std::true_type {};
+template <typename T, typename Char>
+struct is_named_arg<named_arg<T, Char>> : std::true_type {};
 
-template <typename Char, typename T> struct named_arg : view {
+template <typename T, typename Char = char> struct named_arg : view {
   const Char* name;
   const T& value;
 
@@ -1052,17 +1063,27 @@ template <bool B1, bool B2, bool... Tail> constexpr auto count() -> int {
   return (B1 ? 1 : 0) + count<B2, Tail...>();
 }
 
-template <typename... Args> constexpr auto count_named_args() -> int {
-  return count<is_named_arg<Args>::value...>();
+template <typename... T> constexpr auto count_named_args() -> int {
+  return count<is_named_arg<T>::value...>();
 }
-template <typename... Args> constexpr auto count_static_named_args() -> int {
-  return count<is_static_named_arg<Args>::value...>();
+template <typename... T> constexpr auto count_static_named_args() -> int {
+  return count<is_static_named_arg<T>::value...>();
 }
 
 template <typename Char> struct named_arg_info {
   const Char* name;
   int id;
 };
+
+// named_args is non-const to suppress a bogus -Wmaybe-uninitialized in gcc 13.
+template <typename Char>
+FMT_CONSTEXPR void check_for_duplicate(named_arg_info<Char>* named_args,
+                                       int named_arg_index,
+                                       basic_string_view<Char> arg_name) {
+  for (int i = 0; i < named_arg_index; ++i) {
+    if (named_args[i].name == arg_name) report_error("duplicate named arg");
+  }
+}
 
 template <typename Char, typename T, FMT_ENABLE_IF(!is_named_arg<T>::value)>
 void init_named_arg(named_arg_info<Char>*, int& arg_index, int&, const T&) {
@@ -1071,6 +1092,7 @@ void init_named_arg(named_arg_info<Char>*, int& arg_index, int&, const T&) {
 template <typename Char, typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
 void init_named_arg(named_arg_info<Char>* named_args, int& arg_index,
                     int& named_arg_index, const T& arg) {
+  check_for_duplicate<Char>(named_args, named_arg_index, arg.name);
   named_args[named_arg_index++] = {arg.name, arg_index++};
 }
 
@@ -1084,14 +1106,15 @@ template <typename T, typename Char,
           FMT_ENABLE_IF(is_static_named_arg<T>::value)>
 FMT_CONSTEXPR void init_static_named_arg(named_arg_info<Char>* named_args,
                                          int& arg_index, int& named_arg_index) {
+  check_for_duplicate<Char>(named_args, named_arg_index, T::name);
   named_args[named_arg_index++] = {T::name, arg_index++};
 }
 
 // To minimize the number of types we need to deal with, long is translated
 // either to int or to long long depending on its size.
-enum { long_short = sizeof(long) == sizeof(int) };
+enum { long_short = sizeof(long) == sizeof(int) && FMT_BUILTIN_TYPES };
 using long_type = conditional_t<long_short, int, long long>;
-using ulong_type = conditional_t<long_short, unsigned, unsigned long long>;
+using ulong_type = conditional_t<long_short, unsigned, ullong>;
 
 template <typename T>
 using format_as_result =
@@ -1145,18 +1168,12 @@ template <typename Char> struct type_mapper {
   static auto map(long) -> long_type;
   static auto map(unsigned long) -> ulong_type;
   static auto map(long long) -> long long;
-  static auto map(unsigned long long) -> unsigned long long;
-  static auto map(int128_opt) -> int128_opt;
-  static auto map(uint128_opt) -> uint128_opt;
+  static auto map(ullong) -> ullong;
+  static auto map(native_int128) -> native_int128;
+  static auto map(native_uint128) -> native_uint128;
   static auto map(bool) -> bool;
 
-  template <int N>
-  static auto map(bitint<N>) -> conditional_t<N <= 64, long long, void>;
-  template <int N>
-  static auto map(ubitint<N>)
-      -> conditional_t<N <= 64, unsigned long long, void>;
-
-  template <typename T, FMT_ENABLE_IF(is_char<T>::value)>
+  template <typename T, FMT_ENABLE_IF(is_code_unit<T>::value)>
   static auto map(T) -> conditional_t<
       std::is_same<T, char>::value || std::is_same<T, Char>::value, Char, void>;
 
@@ -1215,9 +1232,9 @@ class compile_parse_context : public parse_context<Char> {
   using base = parse_context<Char>;
 
  public:
-  FMT_CONSTEXPR explicit compile_parse_context(basic_string_view<Char> fmt,
-                                               int num_args, const type* types,
-                                               int next_arg_id = 0)
+  constexpr explicit compile_parse_context(basic_string_view<Char> fmt,
+                                           int num_args, const type* types,
+                                           int next_arg_id = 0)
       : base(fmt, next_arg_id), num_args_(num_args), types_(types) {}
 
   constexpr auto num_args() const -> int { return num_args_; }
@@ -1236,7 +1253,6 @@ class compile_parse_context : public parse_context<Char> {
   using base::check_arg_id;
 
   FMT_CONSTEXPR void check_dynamic_spec(int arg_id) {
-    ignore_unused(arg_id);
     if (arg_id < num_args_ && types_ && !is_integral_type(types_[arg_id]))
       report_error("width/precision is not integer");
   }
@@ -1262,13 +1278,13 @@ template <typename Char = char> struct dynamic_format_specs : format_specs {
 // Converts a character to ASCII. Returns '\0' on conversion failure.
 template <typename Char, FMT_ENABLE_IF(std::is_integral<Char>::value)>
 constexpr auto to_ascii(Char c) -> char {
-  return c <= 0xff ? static_cast<char>(c) : '\0';
+  return c <= 0xff ? char(c) : '\0';
 }
 
 // Returns the number of code units in a code point or 1 on error.
 template <typename Char>
 FMT_CONSTEXPR auto code_point_length(const Char* begin) -> int {
-  if (const_check(sizeof(Char) != 1)) return 1;
+  if FMT_CONSTEXPR20 (sizeof(Char) != 1) return 1;
   auto c = static_cast<unsigned char>(*begin);
   return static_cast<int>((0x3a55000000000000ull >> (2 * (c >> 3))) & 3) + 1;
 }
@@ -1288,13 +1304,13 @@ FMT_CONSTEXPR auto parse_nonnegative_int(const Char*& begin, const Char* end,
   } while (p != end && '0' <= *p && *p <= '9');
   auto num_digits = p - begin;
   begin = p;
-  int digits10 = static_cast<int>(sizeof(int) * CHAR_BIT * 3 / 10);
-  if (num_digits <= digits10) return static_cast<int>(value);
+  int digits10 = int(sizeof(int) * CHAR_BIT * 3 / 10);
+  if (num_digits <= digits10) return int(value);
   // Check for overflow.
   unsigned max = INT_MAX;
   return num_digits == digits10 + 1 &&
                  prev * 10ull + unsigned(p[-1] - '0') <= max
-             ? static_cast<int>(value)
+             ? int(value)
              : error_value;
 }
 
@@ -1662,12 +1678,12 @@ template <typename... T> struct arg_pack {};
 template <typename Char, int NUM_ARGS, int NUM_NAMED_ARGS, bool DYNAMIC_NAMES>
 class format_string_checker {
  private:
-  type types_[max_of(1, NUM_ARGS)];
-  named_arg_info<Char> named_args_[max_of(1, NUM_NAMED_ARGS)];
+  type types_[max_of<size_t>(1, NUM_ARGS)];
+  named_arg_info<Char> named_args_[max_of<size_t>(1, NUM_NAMED_ARGS)];
   compile_parse_context<Char> context_;
 
   using parse_func = auto (*)(parse_context<Char>&) -> const Char*;
-  parse_func parse_funcs_[max_of(1, NUM_ARGS)];
+  parse_func parse_funcs_[max_of<size_t>(1, NUM_ARGS)];
 
  public:
   template <typename... T>
@@ -1706,7 +1722,17 @@ class format_string_checker {
       -> const Char* {
     context_.advance_to(begin);
     if (id >= 0 && id < NUM_ARGS) return parse_funcs_[id](context_);
-    while (begin != end && *begin != '}') ++begin;
+
+    // If id is out of range, it means we do not know the type and cannot parse
+    // the format at compile time. Instead, skip over content until we finish
+    // the format spec, accounting for any nested replacements.
+    for (int bracket_count = 0;
+         begin != end && (bracket_count > 0 || *begin != '}'); ++begin) {
+      if (*begin == '{')
+        ++bracket_count;
+      else if (*begin == '}')
+        --bracket_count;
+    }
     return begin;
   }
 
@@ -1728,9 +1754,10 @@ template <typename T> class buffer {
 
  protected:
   // Don't initialize ptr_ since it is not accessed to save a few cycles.
-  FMT_MSC_WARNING(suppress : 26495)
   FMT_CONSTEXPR buffer(grow_fun grow, size_t sz) noexcept
-      : size_(sz), capacity_(sz), grow_(grow) {}
+      : size_(sz), capacity_(sz), grow_(grow) {
+    if (FMT_MSC_VERSION != 0) ptr_ = nullptr;  // Suppress warning 26495.
+  }
 
   constexpr buffer(grow_fun grow, T* p = nullptr, size_t sz = 0,
                    size_t cap = 0) noexcept
@@ -1793,21 +1820,21 @@ template <typename T> class buffer {
 
   /// Appends data to the end of the buffer.
   template <typename U>
-// Workaround for MSVC2019 to fix error C2893: Failed to specialize function
-// template 'void fmt::v11::detail::buffer<T>::append(const U *,const U *)'.
-#if !FMT_MSC_VERSION || FMT_MSC_VERSION >= 1940
-  FMT_CONSTEXPR20
-#endif
-      void
-      append(const U* begin, const U* end) {
+  FMT_CONSTEXPR20 void append(const U* begin, const U* end) {
+    static_assert(std::is_same<T, U>() || std::is_same<U, char>(), "");
     while (begin != end) {
+      auto size = size_;
+      auto free_cap = capacity_ - size;
       auto count = to_unsigned(end - begin);
-      try_reserve(size_ + count);
-      auto free_cap = capacity_ - size_;
-      if (free_cap < count) count = free_cap;
+      if (free_cap < count) {
+        grow_(*this, size + count);
+        size = size_;
+        free_cap = capacity_ - size;
+        count = count < free_cap ? count : free_cap;
+      }
       // A loop is faster than memcpy on small sizes.
-      T* out = ptr_ + size_;
-      for (size_t i = 0; i < count; ++i) out[i] = begin[i];
+      T* out = ptr_ + size;
+      for (size_t i = 0; i < count; ++i) out[i] = static_cast<T>(begin[i]);
       size_ += count;
       begin += count;
     }
@@ -1817,7 +1844,7 @@ template <typename T> class buffer {
     return ptr_[index];
   }
   template <typename Idx>
-  FMT_CONSTEXPR auto operator[](Idx index) const -> const T& {
+  constexpr auto operator[](Idx index) const -> const T& {
     return ptr_[index];
   }
 };
@@ -1843,6 +1870,61 @@ class fixed_buffer_traits {
   }
 };
 
+template <typename OutputIt, typename InputIt, typename = void>
+struct has_append : std::false_type {};
+
+template <typename OutputIt, typename InputIt>
+struct has_append<OutputIt, InputIt,
+                  void_t<decltype(get_container(std::declval<OutputIt>())
+                                      .append(std::declval<InputIt>(),
+                                              std::declval<InputIt>()))>>
+    : std::true_type {};
+
+template <typename OutputIt, typename T, typename = void>
+struct has_insert : std::false_type {};
+
+template <typename OutputIt, typename T>
+struct has_insert<
+    OutputIt, T,
+    void_t<decltype(get_container(std::declval<OutputIt>())
+                        .insert({}, std::declval<T>(), std::declval<T>()))>>
+    : std::true_type {};
+
+// An optimized version of std::copy with the output value type (T).
+template <typename T, typename InputIt, typename OutputIt,
+          FMT_ENABLE_IF(is_back_insert_iterator<OutputIt>() &&
+                        has_append<OutputIt, InputIt>())>
+FMT_CONSTEXPR auto copy(InputIt begin, InputIt end, OutputIt out) -> OutputIt {
+  get_container(out).append(begin, end);
+  return out;
+}
+
+template <typename T, typename InputIt, typename OutputIt,
+          FMT_ENABLE_IF(is_back_insert_iterator<OutputIt>() &&
+                        !has_append<OutputIt, InputIt>() &&
+                        has_insert<OutputIt, InputIt>())>
+FMT_CONSTEXPR auto copy(InputIt begin, InputIt end, OutputIt out) -> OutputIt {
+  auto& c = get_container(out);
+  c.insert(c.end(), begin, end);
+  return out;
+}
+
+template <typename T, typename InputIt, typename OutputIt,
+          FMT_ENABLE_IF(!is_back_insert_iterator<OutputIt>() ||
+                        !(has_append<OutputIt, InputIt>() ||
+                          has_insert<OutputIt, InputIt>()))>
+FMT_CONSTEXPR auto copy(InputIt begin, InputIt end, OutputIt out) -> OutputIt {
+#if defined(__GNUC__) && !(defined(__clang__))
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+  while (begin != end) *out++ = static_cast<T>(*begin++);
+#if defined(__GNUC__) && !(defined(__clang__))
+#  pragma GCC diagnostic pop
+#endif
+  return out;
+}
+
 // A buffer that writes to an output iterator when flushed.
 template <typename OutputIt, typename T, typename Traits = buffer_traits>
 class iterator_buffer : public Traits, public buffer<T> {
@@ -1860,7 +1942,7 @@ class iterator_buffer : public Traits, public buffer<T> {
     this->clear();
     const T* begin = data_;
     const T* end = begin + this->limit(size);
-    while (begin != end) *out_++ = *begin++;
+    out_ = copy<T>(begin, end, out_);
   }
 
  public:
@@ -1987,7 +2069,7 @@ template <typename T = char> class counting_buffer : public buffer<T> {
   }
 
  public:
-  FMT_CONSTEXPR counting_buffer() : buffer<T>(grow, data_, 0, buffer_size) {}
+  constexpr counting_buffer() : buffer<T>(grow, data_, 0, buffer_size) {}
 
   constexpr auto count() const noexcept -> size_t {
     return count_ + this->size();
@@ -1996,56 +2078,6 @@ template <typename T = char> class counting_buffer : public buffer<T> {
 
 template <typename T>
 struct is_back_insert_iterator<basic_appender<T>> : std::true_type {};
-
-template <typename OutputIt, typename InputIt, typename = void>
-struct has_back_insert_iterator_container_append : std::false_type {};
-template <typename OutputIt, typename InputIt>
-struct has_back_insert_iterator_container_append<
-    OutputIt, InputIt,
-    void_t<decltype(get_container(std::declval<OutputIt>())
-                        .append(std::declval<InputIt>(),
-                                std::declval<InputIt>()))>> : std::true_type {};
-
-// An optimized version of std::copy with the output value type (T).
-template <typename T, typename InputIt, typename OutputIt,
-          FMT_ENABLE_IF(is_back_insert_iterator<OutputIt>::value&&
-                            has_back_insert_iterator_container_append<
-                                OutputIt, InputIt>::value)>
-FMT_CONSTEXPR20 auto copy(InputIt begin, InputIt end, OutputIt out)
-    -> OutputIt {
-  get_container(out).append(begin, end);
-  return out;
-}
-
-template <typename T, typename InputIt, typename OutputIt,
-          FMT_ENABLE_IF(is_back_insert_iterator<OutputIt>::value &&
-                        !has_back_insert_iterator_container_append<
-                            OutputIt, InputIt>::value)>
-FMT_CONSTEXPR20 auto copy(InputIt begin, InputIt end, OutputIt out)
-    -> OutputIt {
-  auto& c = get_container(out);
-  c.insert(c.end(), begin, end);
-  return out;
-}
-
-template <typename T, typename InputIt, typename OutputIt,
-          FMT_ENABLE_IF(!is_back_insert_iterator<OutputIt>::value)>
-FMT_CONSTEXPR auto copy(InputIt begin, InputIt end, OutputIt out) -> OutputIt {
-#if defined(__GNUC__) && !(defined(__clang__))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-  while (begin != end) *out++ = static_cast<T>(*begin++);
-#if defined(__GNUC__) && !(defined(__clang__))
-#pragma GCC diagnostic pop
-#endif
-  return out;
-}
-
-template <typename T, typename V, typename OutputIt>
-FMT_CONSTEXPR auto copy(basic_string_view<V> s, OutputIt out) -> OutputIt {
-  return copy<T>(s.begin(), s.end(), out);
-}
 
 template <typename It, typename Enable = std::true_type>
 struct is_buffer_appender : std::false_type {};
@@ -2116,9 +2148,9 @@ template <typename Context> class value {
     int int_value;
     unsigned uint_value;
     long long long_long_value;
-    unsigned long long ulong_long_value;
-    int128_opt int128_value;
-    uint128_opt uint128_value;
+    ullong ulong_long_value;
+    native_int128 int128_value;
+    native_uint128 uint128_value;
     bool bool_value;
     char_type char_value;
     float float_value;
@@ -2137,26 +2169,16 @@ template <typename Context> class value {
   constexpr FMT_INLINE value(unsigned short x FMT_BUILTIN) : uint_value(x) {}
   constexpr FMT_INLINE value(int x) : int_value(x) {}
   constexpr FMT_INLINE value(unsigned x FMT_BUILTIN) : uint_value(x) {}
-  FMT_CONSTEXPR FMT_INLINE value(long x FMT_BUILTIN) : value(long_type(x)) {}
-  FMT_CONSTEXPR FMT_INLINE value(unsigned long x FMT_BUILTIN)
+  constexpr FMT_INLINE value(long x FMT_BUILTIN) : value(long_type(x)) {}
+  constexpr FMT_INLINE value(unsigned long x FMT_BUILTIN)
       : value(ulong_type(x)) {}
   constexpr FMT_INLINE value(long long x FMT_BUILTIN) : long_long_value(x) {}
-  constexpr FMT_INLINE value(unsigned long long x FMT_BUILTIN)
-      : ulong_long_value(x) {}
-  FMT_INLINE value(int128_opt x FMT_BUILTIN) : int128_value(x) {}
-  FMT_INLINE value(uint128_opt x FMT_BUILTIN) : uint128_value(x) {}
+  constexpr FMT_INLINE value(ullong x FMT_BUILTIN) : ulong_long_value(x) {}
+  FMT_INLINE value(native_int128 x FMT_BUILTIN) : int128_value(x) {}
+  FMT_INLINE value(native_uint128 x FMT_BUILTIN) : uint128_value(x) {}
   constexpr FMT_INLINE value(bool x FMT_BUILTIN) : bool_value(x) {}
 
-  template <int N>
-  constexpr FMT_INLINE value(bitint<N> x FMT_BUILTIN) : long_long_value(x) {
-    static_assert(N <= 64, "unsupported _BitInt");
-  }
-  template <int N>
-  constexpr FMT_INLINE value(ubitint<N> x FMT_BUILTIN) : ulong_long_value(x) {
-    static_assert(N <= 64, "unsupported _BitInt");
-  }
-
-  template <typename T, FMT_ENABLE_IF(is_char<T>::value)>
+  template <typename T, FMT_ENABLE_IF(is_code_unit<T>::value)>
   constexpr FMT_INLINE value(T x FMT_BUILTIN) : char_value(x) {
     static_assert(
         std::is_same<T, char>::value || std::is_same<T, char_type>::value,
@@ -2184,17 +2206,20 @@ template <typename Context> class value {
     string.data = sv.data();
     string.size = sv.size();
   }
-  FMT_INLINE value(void* x FMT_BUILTIN) : pointer(x) {}
-  FMT_INLINE value(const void* x FMT_BUILTIN) : pointer(x) {}
-  FMT_INLINE value(volatile void* x FMT_BUILTIN)
+  constexpr FMT_INLINE value(void* x FMT_BUILTIN) : pointer(x) {}
+  constexpr FMT_INLINE value(const void* x FMT_BUILTIN) : pointer(x) {}
+  constexpr FMT_INLINE value(volatile void* x FMT_BUILTIN)
       : pointer(const_cast<const void*>(x)) {}
-  FMT_INLINE value(const volatile void* x FMT_BUILTIN)
+  constexpr FMT_INLINE value(const volatile void* x FMT_BUILTIN)
       : pointer(const_cast<const void*>(x)) {}
-  FMT_INLINE value(nullptr_t) : pointer(nullptr) {}
+  constexpr FMT_INLINE value(nullptr_t) : pointer(nullptr) {}
 
-  template <typename T, FMT_ENABLE_IF(std::is_pointer<T>::value ||
-                                      std::is_member_pointer<T>::value)>
-  value(const T&) {
+  template <typename T,
+            FMT_ENABLE_IF(
+                (std::is_pointer<T>::value ||
+                 std::is_member_pointer<T>::value) &&
+                !std::is_void<typename std::remove_pointer<T>::type>::value)>
+  constexpr value(const T&) {
     // Formatting of arbitrary pointers is disallowed. If you want to format a
     // pointer cast it to `void*` or `const void*`. In particular, this forbids
     // formatting of `[const] volatile char*` printed as bool by iostreams.
@@ -2203,16 +2228,16 @@ template <typename Context> class value {
   }
 
   template <typename T, FMT_ENABLE_IF(use_format_as<T>::value)>
-  value(const T& x) : value(format_as(x)) {}
+  constexpr value(const T& x) : value(format_as(x)) {}
   template <typename T, FMT_ENABLE_IF(use_format_as_member<T>::value)>
-  value(const T& x) : value(formatter<T>::format_as(x)) {}
+  constexpr value(const T& x) : value(formatter<T>::format_as(x)) {}
 
   template <typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
-  value(const T& named_arg) : value(named_arg.value) {}
+  constexpr value(const T& named_arg) : value(named_arg.value) {}
 
   template <typename T,
             FMT_ENABLE_IF(use_formatter<T>::value || !FMT_BUILTIN_TYPES)>
-  FMT_CONSTEXPR20 FMT_INLINE value(T& x) : value(x, custom_tag()) {}
+  FMT_CONSTEXPR FMT_INLINE value(T& x) : value(x, custom_tag()) {}
 
   FMT_ALWAYS_INLINE value(const named_arg_info<char_type>* args, size_t size)
       : named_args{args, size} {}
@@ -2232,21 +2257,21 @@ template <typename Context> class value {
         custom.value = const_cast<value_type*>(&x);
 #endif
     }
-    custom.format = format_custom<value_type, formatter<value_type, char_type>>;
+    custom.format = format_custom<value_type>;
   }
 
   template <typename T, FMT_ENABLE_IF(!has_formatter<T, char_type>())>
   FMT_CONSTEXPR value(const T&, custom_tag) {
     // Cannot format an argument; to make type T formattable provide a
-    // formatter<T> specialization: https://fmt.dev/latest/api.html#udt.
+    // formatter<T> specialization: https://fmt.dev/latest/api#udt.
     type_is_unformattable_for<T, char_type> _;
   }
 
   // Formats an argument of a custom type, such as a user-defined class.
-  template <typename T, typename Formatter>
+  template <typename T>
   static void format_custom(void* arg, parse_context<char_type>& parse_ctx,
                             Context& ctx) {
-    auto f = Formatter();
+    auto f = formatter<T, char_type>();
     parse_ctx.advance_to(f.parse(parse_ctx));
     using qualified_type =
         conditional_t<has_formatter<const T, char_type>(), const T, T>;
@@ -2259,8 +2284,8 @@ template <typename Context> class value {
 enum { packed_arg_bits = 4 };
 // Maximum number of arguments with packed types.
 enum { max_packed_args = 62 / packed_arg_bits };
-enum : unsigned long long { is_unpacked_bit = 1ULL << 63 };
-enum : unsigned long long { has_named_args_bit = 1ULL << 62 };
+enum : ullong { is_unpacked_bit = 1ULL << 63 };
+enum : ullong { has_named_args_bit = 1ULL << 62 };
 
 template <typename It, typename T, typename Enable = void>
 struct is_output_iterator : std::false_type {};
@@ -2270,41 +2295,19 @@ template <> struct is_output_iterator<appender, char> : std::true_type {};
 template <typename It, typename T>
 struct is_output_iterator<
     It, T,
-    void_t<decltype(*std::declval<decay_t<It>&>()++ = std::declval<T>())>>
-    : std::true_type {};
+    enable_if_t<std::is_assignable<decltype(*std::declval<decay_t<It>&>()++),
+                                   T>::value>> : std::true_type {};
 
-#ifndef FMT_USE_LOCALE
-#  define FMT_USE_LOCALE (FMT_OPTIMIZE_SIZE <= 1)
-#endif
+template <typename> constexpr auto encode_types() -> ullong { return 0; }
 
-// A type-erased reference to an std::locale to avoid a heavy <locale> include.
-struct locale_ref {
-#if FMT_USE_LOCALE
- private:
-  const void* locale_;  // A type-erased pointer to std::locale.
-
- public:
-  constexpr locale_ref() : locale_(nullptr) {}
-  template <typename Locale> locale_ref(const Locale& loc);
-
-  inline explicit operator bool() const noexcept { return locale_ != nullptr; }
-#endif  // FMT_USE_LOCALE
-
-  template <typename Locale> auto get() const -> Locale;
-};
-
-template <typename> constexpr auto encode_types() -> unsigned long long {
-  return 0;
-}
-
-template <typename Context, typename Arg, typename... Args>
-constexpr auto encode_types() -> unsigned long long {
-  return static_cast<unsigned>(stored_type_constant<Arg, Context>::value) |
-         (encode_types<Context, Args...>() << packed_arg_bits);
+template <typename Context, typename First, typename... T>
+constexpr auto encode_types() -> ullong {
+  return unsigned(stored_type_constant<First, Context>::value) |
+         (encode_types<Context, T...>() << packed_arg_bits);
 }
 
 template <typename Context, typename... T, size_t NUM_ARGS = sizeof...(T)>
-constexpr auto make_descriptor() -> unsigned long long {
+constexpr auto make_descriptor() -> ullong {
   return NUM_ARGS <= max_packed_args ? encode_types<Context, T...>()
                                      : is_unpacked_bit | NUM_ARGS;
 }
@@ -2313,12 +2316,11 @@ template <typename Context, int NUM_ARGS>
 using arg_t = conditional_t<NUM_ARGS <= max_packed_args, value<Context>,
                             basic_format_arg<Context>>;
 
-template <typename Context, int NUM_ARGS, int NUM_NAMED_ARGS,
-          unsigned long long DESC>
+template <typename Context, int NUM_ARGS, int NUM_NAMED_ARGS, ullong DESC>
 struct named_arg_store {
   // args_[0].named_args points to named_args to avoid bloating format_args.
-  arg_t<Context, NUM_ARGS> args[1 + NUM_ARGS];
-  named_arg_info<typename Context::char_type> named_args[NUM_NAMED_ARGS];
+  arg_t<Context, NUM_ARGS> args[NUM_ARGS + 1u];
+  named_arg_info<typename Context::char_type> named_args[NUM_NAMED_ARGS + 0u];
 
   template <typename... T>
   FMT_CONSTEXPR FMT_ALWAYS_INLINE named_arg_store(T&... values)
@@ -2337,21 +2339,20 @@ struct named_arg_store {
   }
 
   named_arg_store(const named_arg_store& rhs) = delete;
-  named_arg_store& operator=(const named_arg_store& rhs) = delete;
-  named_arg_store& operator=(named_arg_store&& rhs) = delete;
+  auto operator=(const named_arg_store& rhs) -> named_arg_store& = delete;
+  auto operator=(named_arg_store&& rhs) -> named_arg_store& = delete;
   operator const arg_t<Context, NUM_ARGS>*() const { return args + 1; }
 };
 
 // An array of references to arguments. It can be implicitly converted to
 // `basic_format_args` for passing into type-erased formatting functions
 // such as `vformat`. It is a plain struct to reduce binary size in debug mode.
-template <typename Context, int NUM_ARGS, int NUM_NAMED_ARGS,
-          unsigned long long DESC>
+template <typename Context, int NUM_ARGS, int NUM_NAMED_ARGS, ullong DESC>
 struct format_arg_store {
   // +1 to workaround a bug in gcc 7.5 that causes duplicated-branches warning.
   using type =
       conditional_t<NUM_NAMED_ARGS == 0,
-                    arg_t<Context, NUM_ARGS>[max_of(1, NUM_ARGS)],
+                    arg_t<Context, NUM_ARGS>[max_of<size_t>(1, NUM_ARGS)],
                     named_arg_store<Context, NUM_ARGS, NUM_NAMED_ARGS, DESC>>;
   type args;
 };
@@ -2362,12 +2363,10 @@ template <typename T, typename Char, type TYPE> struct native_formatter {
   dynamic_format_specs<Char> specs_;
 
  public:
-  using nonlocking = void;
-
   FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {
     if (ctx.begin() == ctx.end() || *ctx.begin() == '}') return ctx.begin();
     auto end = parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, TYPE);
-    if (const_check(TYPE == type::char_type)) check_char_specs(specs_);
+    if FMT_CONSTEXPR20 (TYPE == type::char_type) check_char_specs(specs_);
     return end;
   }
 
@@ -2378,25 +2377,26 @@ template <typename T, typename Char, type TYPE> struct native_formatter {
     specs_.set_type(set ? presentation_type::debug : presentation_type::none);
   }
 
-  FMT_PRAGMA_CLANG(diagnostic ignored "-Wundefined-inline")
   template <typename FormatContext>
   FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const
       -> decltype(ctx.out());
 };
 
-template <typename T, typename Enable = void>
-struct locking
-    : bool_constant<mapped_type_constant<T>::value == type::custom_type> {};
-template <typename T>
-struct locking<T, void_t<typename formatter<remove_cvref_t<T>>::nonlocking>>
-    : std::false_type {};
+template <bool B> constexpr bool enforce_compile_checks() {
+#ifdef FMT_ENFORCE_COMPILE_STRING
+  static_assert(
+      FMT_USE_CONSTEVAL && B,
+      "FMT_ENFORCE_COMPILE_STRING requires format strings to use FMT_STRING");
+#endif
+  return true;
+}
 
-template <typename T = int> FMT_CONSTEXPR inline auto is_locking() -> bool {
-  return locking<T>::value;
+template <typename T = int> constexpr auto is_locking() -> bool {
+  return locking<remove_cvref_t<T>>::value;
 }
 template <typename T1, typename T2, typename... Tail>
-FMT_CONSTEXPR inline auto is_locking() -> bool {
-  return locking<T1>::value || is_locking<T2, Tail...>();
+constexpr auto is_locking() -> bool {
+  return locking<remove_cvref_t<T1>>::value || is_locking<T2, Tail...>();
 }
 
 FMT_API void vformat_to(buffer<char>& buf, string_view fmt, format_args args,
@@ -2410,6 +2410,9 @@ inline void vprint_mojibake(FILE*, string_view, const format_args&, bool) {}
 }  // namespace detail
 
 // The main public API.
+
+template <typename T, typename Char = char>
+using named_arg = detail::named_arg<T, Char>;
 
 template <typename Char>
 FMT_CONSTEXPR void parse_context<Char>::do_check_arg_id(int arg_id) {
@@ -2439,15 +2442,15 @@ template <typename T> class basic_appender {
  public:
   using container_type = detail::buffer<T>;
 
-  FMT_CONSTEXPR basic_appender(detail::buffer<T>& buf) : container(&buf) {}
+  constexpr basic_appender(detail::buffer<T>& buf) : container(&buf) {}
 
-  FMT_CONSTEXPR20 auto operator=(T c) -> basic_appender& {
+  FMT_CONSTEXPR auto operator=(T c) -> basic_appender& {
     container->push_back(c);
     return *this;
   }
-  FMT_CONSTEXPR20 auto operator*() -> basic_appender& { return *this; }
-  FMT_CONSTEXPR20 auto operator++() -> basic_appender& { return *this; }
-  FMT_CONSTEXPR20 auto operator++(int) -> basic_appender { return *this; }
+  FMT_CONSTEXPR auto operator*() -> basic_appender& { return *this; }
+  FMT_CONSTEXPR auto operator++() -> basic_appender& { return *this; }
+  FMT_CONSTEXPR auto operator++(int) -> basic_appender { return *this; }
 };
 
 // A formatting argument. Context is a template parameter for the compiled API
@@ -2539,7 +2542,7 @@ template <typename Context> class basic_format_args {
   // If the number of arguments is less or equal to max_packed_args then
   // argument types are passed in the descriptor. This reduces binary code size
   // per formatting function call.
-  unsigned long long desc_;
+  ullong desc_;
   union {
     // If is_packed() returns true then argument values are stored in values_;
     // otherwise they are stored in args_. This is done to improve cache
@@ -2563,7 +2566,7 @@ template <typename Context> class basic_format_args {
     return static_cast<detail::type>((desc_ >> shift) & mask);
   }
 
-  template <int NUM_ARGS, int NUM_NAMED_ARGS, unsigned long long DESC>
+  template <int NUM_ARGS, int NUM_NAMED_ARGS, ullong DESC>
   using store =
       detail::format_arg_store<Context, NUM_ARGS, NUM_NAMED_ARGS, DESC>;
 
@@ -2573,14 +2576,14 @@ template <typename Context> class basic_format_args {
   constexpr basic_format_args() : desc_(0), args_(nullptr) {}
 
   /// Constructs a `basic_format_args` object from `format_arg_store`.
-  template <int NUM_ARGS, int NUM_NAMED_ARGS, unsigned long long DESC,
+  template <int NUM_ARGS, int NUM_NAMED_ARGS, ullong DESC,
             FMT_ENABLE_IF(NUM_ARGS <= detail::max_packed_args)>
   constexpr FMT_ALWAYS_INLINE basic_format_args(
       const store<NUM_ARGS, NUM_NAMED_ARGS, DESC>& s)
       : desc_(DESC | (NUM_NAMED_ARGS != 0 ? +detail::has_named_args_bit : 0)),
         values_(s.args) {}
 
-  template <int NUM_ARGS, int NUM_NAMED_ARGS, unsigned long long DESC,
+  template <int NUM_ARGS, int NUM_NAMED_ARGS, ullong DESC,
             FMT_ENABLE_IF(NUM_ARGS > detail::max_packed_args)>
   constexpr basic_format_args(const store<NUM_ARGS, NUM_NAMED_ARGS, DESC>& s)
       : desc_(DESC | (NUM_NAMED_ARGS != 0 ? +detail::has_named_args_bit : 0)),
@@ -2597,10 +2600,10 @@ template <typename Context> class basic_format_args {
   FMT_CONSTEXPR auto get(int id) const -> format_arg {
     auto arg = format_arg();
     if (!is_packed()) {
-      if (id < max_size()) arg = args_[id];
+      if (unsigned(id) < unsigned(max_size())) arg = args_[id];
       return arg;
     }
-    if (static_cast<unsigned>(id) >= detail::max_packed_args) return arg;
+    if (unsigned(id) >= detail::max_packed_args) return arg;
     arg.type_ = type(id);
     if (arg.type_ != detail::type::none_type) arg.value_ = values_[id];
     return arg;
@@ -2624,9 +2627,8 @@ template <typename Context> class basic_format_args {
   }
 
   auto max_size() const -> int {
-    unsigned long long max_packed = detail::max_packed_args;
-    return static_cast<int>(is_packed() ? max_packed
-                                        : desc_ & ~detail::is_unpacked_bit);
+    return int(is_packed() ? ullong(detail::max_packed_args)
+                           : desc_ & ~detail::is_unpacked_bit);
   }
 };
 
@@ -2635,22 +2637,17 @@ class context {
  private:
   appender out_;
   format_args args_;
-  FMT_NO_UNIQUE_ADDRESS detail::locale_ref loc_;
+  FMT_NO_UNIQUE_ADDRESS locale_ref loc_;
 
  public:
-  /// The character type for the output.
-  using char_type = char;
-
+  using char_type = char;  ///< The character type for the output.
   using iterator = appender;
   using format_arg = basic_format_arg<context>;
-  using parse_context_type FMT_DEPRECATED = parse_context<>;
-  template <typename T> using formatter_type FMT_DEPRECATED = formatter<T>;
   enum { builtin_types = FMT_BUILTIN_TYPES };
 
   /// Constructs a `context` object. References to the arguments are stored
   /// in the object so make sure they have appropriate lifetimes.
-  FMT_CONSTEXPR context(iterator out, format_args args,
-                        detail::locale_ref loc = {})
+  constexpr context(iterator out, format_args args, locale_ref loc = {})
       : out_(out), args_(args), loc_(loc) {}
   context(context&&) = default;
   context(const context&) = delete;
@@ -2666,12 +2663,12 @@ class context {
   auto args() const -> const format_args& { return args_; }
 
   // Returns an iterator to the beginning of the output range.
-  FMT_CONSTEXPR auto out() const -> iterator { return out_; }
+  constexpr auto out() const -> iterator { return out_; }
 
   // Advances the begin iterator to `it`.
   FMT_CONSTEXPR void advance_to(iterator) {}
 
-  FMT_CONSTEXPR auto locale() const -> detail::locale_ref { return loc_; }
+  constexpr auto locale() const -> locale_ref { return loc_; }
 };
 
 template <typename Char = char> struct runtime_format_string {
@@ -2696,7 +2693,7 @@ template <typename... T> struct fstring {
       detail::count_static_named_args<T...>();
 
   using checker = detail::format_string_checker<
-      char, static_cast<int>(sizeof...(T)), num_static_named_args,
+      char, int(sizeof...(T)), num_static_named_args,
       num_static_named_args != detail::count_named_args<T...>()>;
 
   using arg_pack = detail::arg_pack<T...>;
@@ -2709,41 +2706,33 @@ template <typename... T> struct fstring {
   template <size_t N>
   FMT_CONSTEVAL FMT_ALWAYS_INLINE fstring(const char (&s)[N]) : str(s, N - 1) {
     using namespace detail;
-    static_assert(count<(std::is_base_of<view, remove_reference_t<T>>::value &&
+    static_assert(count<(is_view<remove_cvref_t<T>>::value &&
                          std::is_reference<T>::value)...>() == 0,
                   "passing views as lvalues is disallowed");
-    if (FMT_USE_CONSTEVAL) parse_format_string<char>(s, checker(s, arg_pack()));
-#ifdef FMT_ENFORCE_COMPILE_STRING
-    static_assert(
-        FMT_USE_CONSTEVAL && sizeof(s) != 0,
-        "FMT_ENFORCE_COMPILE_STRING requires format strings to use FMT_STRING");
-#endif
+    if (FMT_USE_CONSTEVAL)
+      parse_format_string<char>(str, checker(str, arg_pack()));
+    constexpr bool unused = detail::enforce_compile_checks<sizeof(s) != 0>();
+    (void)unused;
   }
   template <typename S,
             FMT_ENABLE_IF(std::is_convertible<const S&, string_view>::value)>
   FMT_CONSTEVAL FMT_ALWAYS_INLINE fstring(const S& s) : str(s) {
-    auto sv = string_view(str);
     if (FMT_USE_CONSTEVAL)
-      detail::parse_format_string<char>(sv, checker(sv, arg_pack()));
-#ifdef FMT_ENFORCE_COMPILE_STRING
-    static_assert(
-        FMT_USE_CONSTEVAL && sizeof(s) != 0,
-        "FMT_ENFORCE_COMPILE_STRING requires format strings to use FMT_STRING");
-#endif
+      detail::parse_format_string<char>(str, checker(str, arg_pack()));
+    constexpr bool unused = detail::enforce_compile_checks<sizeof(s) != 0>();
+    (void)unused;
   }
   template <typename S,
             FMT_ENABLE_IF(std::is_base_of<detail::compile_string, S>::value&&
                               std::is_same<typename S::char_type, char>::value)>
   FMT_ALWAYS_INLINE fstring(const S&) : str(S()) {
     FMT_CONSTEXPR auto sv = string_view(S());
-    FMT_CONSTEXPR int ignore =
-        (parse_format_string(sv, checker(sv, arg_pack())), 0);
-    detail::ignore_unused(ignore);
+    FMT_CONSTEXPR int x = (parse_format_string(sv, checker(sv, arg_pack())), 0);
+    detail::ignore_unused(x);
   }
   fstring(runtime_format_string<> fmt) : str(fmt.str) {}
 
-  // Returning by reference generates better code in debug mode.
-  FMT_ALWAYS_INLINE operator const string_view&() const { return str; }
+  FMT_DEPRECATED operator const string_view&() const { return str; }
   auto get() const -> string_view { return str; }
 };
 
@@ -2753,13 +2742,10 @@ template <typename T, typename Char = char>
 using is_formattable = bool_constant<!std::is_same<
     detail::mapped_t<conditional_t<std::is_void<T>::value, int*, T>, Char>,
     void>::value>;
-#ifdef __cpp_concepts
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
 template <typename T, typename Char = char>
 concept formattable = is_formattable<remove_reference_t<T>, Char>::value;
 #endif
-
-template <typename T, typename Char>
-using has_formatter FMT_DEPRECATED = std::is_constructible<formatter<T, Char>>;
 
 // A formatter specialization for natively supported types.
 template <typename T, typename Char>
@@ -2777,19 +2763,17 @@ struct formatter<T, Char,
 // Take arguments by lvalue references to avoid some lifetime issues, e.g.
 //   auto args = make_format_args(std::string());
 template <typename Context = context, typename... T,
-          int NUM_ARGS = sizeof...(T),
+          int NUM_ARGS = int(sizeof...(T)),
           int NUM_NAMED_ARGS = detail::count_named_args<T...>(),
-          unsigned long long DESC = detail::make_descriptor<Context, T...>()>
+          ullong DESC = detail::make_descriptor<Context, T...>()>
 constexpr FMT_ALWAYS_INLINE auto make_format_args(T&... args)
     -> detail::format_arg_store<Context, NUM_ARGS, NUM_NAMED_ARGS, DESC> {
-  // Suppress warnings for pathological types convertible to detail::value.
-  FMT_PRAGMA_GCC(diagnostic ignored "-Wconversion")
   return {{args...}};
 }
 
 template <typename... T>
 using vargs =
-    detail::format_arg_store<context, sizeof...(T),
+    detail::format_arg_store<context, int(sizeof...(T)),
                              detail::count_named_args<T...>(),
                              detail::make_descriptor<context, T...>()>;
 
@@ -2800,9 +2784,13 @@ using vargs =
  * **Example**:
  *
  *     fmt::print("The answer is {answer}.", fmt::arg("answer", 42));
+ *
+ * Named arguments passed with `fmt::arg` are not supported
+ * in compile-time checks, but `"answer"_a=42` are compile-time checked in
+ * sufficiently new compilers. See `operator""_a()`.
  */
-template <typename Char, typename T>
-inline auto arg(const Char* name, const T& arg) -> detail::named_arg<Char, T> {
+template <typename T>
+inline auto arg(const char* name, const T& arg) -> named_arg<T> {
   return {name, arg};
 }
 
@@ -2810,6 +2798,7 @@ inline auto arg(const Char* name, const T& arg) -> detail::named_arg<Char, T> {
 template <typename OutputIt,
           FMT_ENABLE_IF(detail::is_output_iterator<remove_cvref_t<OutputIt>,
                                                    char>::value)>
+// DEPRECATED! Passing out as a forwarding reference.
 auto vformat_to(OutputIt&& out, string_view fmt, format_args args)
     -> remove_cvref_t<OutputIt> {
   auto&& buf = detail::get_buffer<char>(out);
@@ -2836,10 +2825,8 @@ FMT_INLINE auto format_to(OutputIt&& out, format_string<T...> fmt, T&&... args)
 }
 
 template <typename OutputIt> struct format_to_n_result {
-  /// Iterator past the end of the output range.
-  OutputIt out;
-  /// Total (not truncated) output size.
-  size_t size;
+  OutputIt out;  ///< Iterator past the end of the output range.
+  size_t size;   ///< Total (not truncated) output size.
 };
 
 template <typename OutputIt, typename... T,
@@ -2866,10 +2853,8 @@ FMT_INLINE auto format_to_n(OutputIt out, size_t n, format_string<T...> fmt,
 }
 
 struct format_to_result {
-  /// Pointer to just after the last successful write in the array.
-  char* out;
-  /// Specifies if the output was truncated.
-  bool truncated;
+  char* out;       ///< Pointer to just after the last successful write.
+  bool truncated;  ///< Specifies if the output was truncated.
 
   FMT_CONSTEXPR operator char*() const {
     // Report truncation to prevent silent data loss.
@@ -2879,8 +2864,8 @@ struct format_to_result {
 };
 
 template <size_t N>
-auto vformat_to(char (&out)[N], string_view fmt, format_args args)
-    -> format_to_result {
+FMT_DEPRECATED auto vformat_to(char (&out)[N], string_view fmt,
+                               format_args args) -> format_to_result {
   auto result = vformat_to_n(out, N, fmt, args);
   return {result.out, result.size > N};
 }
@@ -2917,10 +2902,10 @@ FMT_API void vprint_buffered(FILE* f, string_view fmt, format_args args);
 template <typename... T>
 FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
   vargs<T...> va = {{args...}};
-  if (detail::const_check(!detail::use_utf8))
+  if FMT_CONSTEXPR20 (!detail::use_utf8)
     return detail::vprint_mojibake(stdout, fmt.str, va, false);
-  return detail::is_locking<T...>() ? vprint_buffered(stdout, fmt.str, va)
-                                    : vprint(fmt.str, va);
+  detail::is_locking<T...>() ? vprint_buffered(stdout, fmt.str, va)
+                             : vprint(fmt.str, va);
 }
 
 /**
@@ -2934,10 +2919,10 @@ FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
 template <typename... T>
 FMT_INLINE void print(FILE* f, format_string<T...> fmt, T&&... args) {
   vargs<T...> va = {{args...}};
-  if (detail::const_check(!detail::use_utf8))
+  if FMT_CONSTEXPR20 (!detail::use_utf8)
     return detail::vprint_mojibake(f, fmt.str, va, false);
-  return detail::is_locking<T...>() ? vprint_buffered(f, fmt.str, va)
-                                    : vprint(f, fmt.str, va);
+  detail::is_locking<T...>() ? vprint_buffered(f, fmt.str, va)
+                             : vprint(f, fmt.str, va);
 }
 
 /// Formats `args` according to specifications in `fmt` and writes the output
@@ -2945,21 +2930,19 @@ FMT_INLINE void print(FILE* f, format_string<T...> fmt, T&&... args) {
 template <typename... T>
 FMT_INLINE void println(FILE* f, format_string<T...> fmt, T&&... args) {
   vargs<T...> va = {{args...}};
-  return detail::const_check(detail::use_utf8)
-             ? vprintln(f, fmt.str, va)
-             : detail::vprint_mojibake(f, fmt.str, va, true);
+  if FMT_CONSTEXPR20 (detail::use_utf8) return vprintln(f, fmt.str, va);
+  detail::vprint_mojibake(f, fmt.str, va, true);
 }
 
 /// Formats `args` according to specifications in `fmt` and writes the output
 /// to `stdout` followed by a newline.
 template <typename... T>
 FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
-  return fmt::println(stdout, fmt, static_cast<T&&>(args)...);
+  fmt::println(stdout, fmt, static_cast<T&&>(args)...);
 }
 
-FMT_END_EXPORT
-FMT_PRAGMA_CLANG(diagnostic pop)
 FMT_PRAGMA_GCC(pop_options)
+FMT_END_EXPORT
 FMT_END_NAMESPACE
 
 #ifdef FMT_HEADER_ONLY

--- a/lib/fmt/include/fmt-vt/chrono.h
+++ b/lib/fmt/include/fmt-vt/chrono.h
@@ -1,6 +1,6 @@
 // Formatting library for C++ - chrono support
 //
-// Copyright (c) 2012 - present, Victor Zverovich
+// Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
 // All rights reserved.
 //
 // For the license information refer to format.h.
@@ -22,21 +22,6 @@
 
 #include "format.h"
 
-namespace fmt_detail {
-struct time_zone {
-  template <typename Duration, typename T>
-  auto to_sys(T)
-      -> std::chrono::time_point<std::chrono::system_clock, Duration> {
-    return {};
-  }
-};
-template <typename... T> inline auto current_zone(T...) -> time_zone* {
-  return nullptr;
-}
-
-template <typename... T> inline void _tzset(T...) {}
-}  // namespace fmt_detail
-
 FMT_BEGIN_NAMESPACE
 
 // Enable safe chrono durations, unless explicitly disabled.
@@ -53,6 +38,7 @@ FMT_BEGIN_NAMESPACE
 // Copyright Paul Dreik 2019
 namespace safe_duration_cast {
 
+// DEPRECATED!
 template <typename To, typename From,
           FMT_ENABLE_IF(!std::is_same<From, To>::value &&
                         std::numeric_limits<From>::is_signed ==
@@ -66,7 +52,7 @@ FMT_CONSTEXPR auto lossless_integral_conversion(const From from, int& ec)
   static_assert(T::is_integer, "To must be integral");
 
   // A and B are both signed, or both unsigned.
-  if (detail::const_check(F::digits <= T::digits)) {
+  if FMT_CONSTEXPR20 (F::digits <= T::digits) {
     // From fits in To without any problem.
   } else {
     // From does not always fit in To, resort to a dynamic check.
@@ -93,22 +79,21 @@ FMT_CONSTEXPR auto lossless_integral_conversion(const From from, int& ec)
   static_assert(F::is_integer, "From must be integral");
   static_assert(T::is_integer, "To must be integral");
 
-  if (detail::const_check(F::is_signed && !T::is_signed)) {
+  if FMT_CONSTEXPR20 (F::is_signed && !T::is_signed) {
     // From may be negative, not allowed!
     if (fmt::detail::is_negative(from)) {
       ec = 1;
       return {};
     }
     // From is positive. Can it always fit in To?
-    if (detail::const_check(F::digits > T::digits) &&
+    if (F::digits > T::digits &&
         from > static_cast<From>(detail::max_value<To>())) {
       ec = 1;
       return {};
     }
   }
 
-  if (detail::const_check(!F::is_signed && T::is_signed &&
-                          F::digits >= T::digits) &&
+  if (!F::is_signed && T::is_signed && F::digits >= T::digits &&
       from > static_cast<From>(detail::max_value<To>())) {
     ec = 1;
     return {};
@@ -176,17 +161,6 @@ auto safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
                         int& ec) -> To {
   using From = std::chrono::duration<FromRep, FromPeriod>;
   ec = 0;
-  if (std::isnan(from.count())) {
-    // nan in, gives nan out. easy.
-    return To{std::numeric_limits<typename To::rep>::quiet_NaN()};
-  }
-  // maybe we should also check if from is denormal, and decide what to do about
-  // it.
-
-  // +-inf should be preserved.
-  if (std::isinf(from.count())) {
-    return To{from.count()};
-  }
 
   // the basic idea is that we need to convert from count() in the from type
   // to count() in the To type, by multiplying it with this:
@@ -213,7 +187,7 @@ auto safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
   }
 
   // multiply with Factor::num without overflow or underflow
-  if (detail::const_check(Factor::num != 1)) {
+  if FMT_CONSTEXPR20 (Factor::num != 1) {
     constexpr auto max1 = detail::max_value<IntermediateRep>() /
                           static_cast<IntermediateRep>(Factor::num);
     if (count > max1) {
@@ -230,7 +204,7 @@ auto safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
   }
 
   // this can't go wrong, right? den>0 is checked earlier.
-  if (detail::const_check(Factor::den != 1)) {
+  if FMT_CONSTEXPR20 (Factor::den != 1) {
     using common_t = typename std::common_type<IntermediateRep, intmax_t>::type;
     count /= static_cast<common_t>(Factor::den);
   }
@@ -297,8 +271,6 @@ namespace detail {
 #define FMT_NOMACRO
 
 template <typename T = void> struct null {};
-inline auto localtime_r FMT_NOMACRO(...) -> null<> { return null<>(); }
-inline auto localtime_s(...) -> null<> { return null<>(); }
 inline auto gmtime_r(...) -> null<> { return null<>(); }
 inline auto gmtime_s(...) -> null<> { return null<>(); }
 
@@ -341,7 +313,7 @@ inline auto get_classic_locale() -> const std::locale& {
 }
 
 template <typename CodeUnit> struct codecvt_result {
-  static constexpr const size_t max_size = 32;
+  static constexpr size_t max_size = 32;
   CodeUnit buf[max_size];
   CodeUnit* end;
 };
@@ -364,7 +336,7 @@ void write_codecvt(codecvt_result<CodeUnit>& out, string_view in,
 template <typename OutputIt>
 auto write_encoded_tm_str(OutputIt out, string_view in, const std::locale& loc)
     -> OutputIt {
-  if (const_check(detail::use_utf8) && loc != get_classic_locale()) {
+  if (detail::use_utf8 && loc != get_classic_locale()) {
     // char16_t and char32_t codecvts are broken in MSVC (linkage errors) and
     // gcc-4.
 #if FMT_MSC_VERSION != 0 ||  \
@@ -435,14 +407,11 @@ auto write(OutputIt out, const std::tm& time, const std::locale& loc,
   return write_encoded_tm_str(out, string_view(buf.data(), buf.size()), loc);
 }
 
-template <typename Rep1, typename Rep2>
-struct is_same_arithmetic_type
-    : public std::integral_constant<bool,
-                                    (std::is_integral<Rep1>::value &&
-                                     std::is_integral<Rep2>::value) ||
-                                        (std::is_floating_point<Rep1>::value &&
-                                         std::is_floating_point<Rep2>::value)> {
-};
+template <typename T, typename U>
+using is_similar_arithmetic_type =
+    bool_constant<(std::is_integral<T>::value && std::is_integral<U>::value) ||
+                  (std::is_floating_point<T>::value &&
+                   std::is_floating_point<U>::value)>;
 
 FMT_NORETURN inline void throw_duration_error() {
   FMT_THROW(format_error("cannot format duration"));
@@ -461,21 +430,18 @@ auto duration_cast(std::chrono::duration<FromRep, FromPeriod> from) -> To {
 
   using common_rep = typename std::common_type<FromRep, typename To::rep,
                                                decltype(factor::num)>::type;
-
-  int ec = 0;
-  auto count = safe_duration_cast::lossless_integral_conversion<common_rep>(
-      from.count(), ec);
-  if (ec) throw_duration_error();
+  common_rep count = from.count();  // This conversion is lossless.
 
   // Multiply from.count() by factor and check for overflow.
-  if (const_check(factor::num != 1)) {
+  if FMT_CONSTEXPR20 (factor::num != 1) {
     if (count > max_value<common_rep>() / factor::num) throw_duration_error();
     const auto min = (std::numeric_limits<common_rep>::min)() / factor::num;
-    if (const_check(!std::is_unsigned<common_rep>::value) && count < min)
+    if (!std::is_unsigned<common_rep>::value && count < min)
       throw_duration_error();
     count *= factor::num;
   }
-  if (const_check(factor::den != 1)) count /= factor::den;
+  if FMT_CONSTEXPR20 (factor::den != 1) count /= factor::den;
+  int ec = 0;
   auto to =
       To(safe_duration_cast::lossless_integral_conversion<typename To::rep>(
           count, ec));
@@ -489,6 +455,8 @@ template <typename To, typename FromRep, typename FromPeriod,
                             std::is_floating_point<typename To::rep>::value)>
 auto duration_cast(std::chrono::duration<FromRep, FromPeriod> from) -> To {
 #if FMT_SAFE_DURATION_CAST
+  // Preserve infinity and NaN.
+  if (!isfinite(from.count())) return static_cast<To>(from.count());
   // Throwing version of safe_duration_cast is only available for
   // integer to integer or float to float casts.
   int ec;
@@ -501,11 +469,11 @@ auto duration_cast(std::chrono::duration<FromRep, FromPeriod> from) -> To {
 #endif
 }
 
-template <
-    typename To, typename FromRep, typename FromPeriod,
-    FMT_ENABLE_IF(!is_same_arithmetic_type<FromRep, typename To::rep>::value)>
+template <typename To, typename FromRep, typename FromPeriod,
+          FMT_ENABLE_IF(
+              !is_similar_arithmetic_type<FromRep, typename To::rep>::value)>
 auto duration_cast(std::chrono::duration<FromRep, FromPeriod> from) -> To {
-  // Mixed integer <-> float cast is not supported by safe_duration_cast.
+  // Mixed integer <-> float cast is not supported by safe duration_cast.
   return std::chrono::duration_cast<To>(from);
 }
 
@@ -519,67 +487,9 @@ auto to_time_t(sys_time<Duration> time_point) -> std::time_t {
       .count();
 }
 
-// Workaround a bug in libstdc++ which sets __cpp_lib_chrono to 201907 without
-// providing current_zone(): https://github.com/fmtlib/fmt/issues/4160.
-template <typename T> FMT_CONSTEXPR auto has_current_zone() -> bool {
-  using namespace std::chrono;
-  using namespace fmt_detail;
-  return !std::is_same<decltype(current_zone()), fmt_detail::time_zone*>::value;
-}
 }  // namespace detail
 
 FMT_BEGIN_EXPORT
-
-/**
- * Converts given time since epoch as `std::time_t` value into calendar time,
- * expressed in local time. Unlike `std::localtime`, this function is
- * thread-safe on most platforms.
- */
-inline auto localtime(std::time_t time) -> std::tm {
-  struct dispatcher {
-    std::time_t time_;
-    std::tm tm_;
-
-    inline dispatcher(std::time_t t) : time_(t) {}
-
-    inline auto run() -> bool {
-      using namespace fmt::detail;
-      return handle(localtime_r(&time_, &tm_));
-    }
-
-    inline auto handle(std::tm* tm) -> bool { return tm != nullptr; }
-
-    inline auto handle(detail::null<>) -> bool {
-      using namespace fmt::detail;
-      return fallback(localtime_s(&tm_, &time_));
-    }
-
-    inline auto fallback(int res) -> bool { return res == 0; }
-
-#if !FMT_MSC_VERSION
-    inline auto fallback(detail::null<>) -> bool {
-      using namespace fmt::detail;
-      std::tm* tm = std::localtime(&time_);
-      if (tm) tm_ = *tm;
-      return tm != nullptr;
-    }
-#endif
-  };
-  dispatcher lt(time);
-  // Too big time values may be unsupported.
-  if (!lt.run()) FMT_THROW(format_error("time_t value out of range"));
-  return lt.tm_;
-}
-
-#if FMT_USE_LOCAL_TIME
-template <typename Duration,
-          FMT_ENABLE_IF(detail::has_current_zone<Duration>())>
-inline auto localtime(std::chrono::local_time<Duration> time) -> std::tm {
-  using namespace std::chrono;
-  using namespace fmt_detail;
-  return localtime(detail::to_time_t(current_zone()->to_sys<Duration>(time)));
-}
-#endif
 
 /**
  * Converts given time since epoch as `std::time_t` value into calendar time,
@@ -633,8 +543,7 @@ namespace detail {
 // https://johnnylee-sde.github.io/Fast-unsigned-integer-to-time-string/.
 inline void write_digit2_separated(char* buf, unsigned a, unsigned b,
                                    unsigned c, char sep) {
-  unsigned long long digits =
-      a | (b << 24) | (static_cast<unsigned long long>(c) << 48);
+  ullong digits = a | (b << 24) | (static_cast<ullong>(c) << 48);
   // Convert each value to BCD.
   // We have x = a * 10 + b and we want to convert it to BCD y = a * 16 + b.
   // The difference is
@@ -648,12 +557,12 @@ inline void write_digit2_separated(char* buf, unsigned a, unsigned b,
   // Put low nibbles to high bytes and high nibbles to low bytes.
   digits = ((digits & 0x00f00000f00000f0) >> 4) |
            ((digits & 0x000f00000f00000f) << 8);
-  auto usep = static_cast<unsigned long long>(sep);
+  auto usep = static_cast<ullong>(sep);
   // Add ASCII '0' to each digit byte and insert separators.
   digits |= 0x3030003030003030 | (usep << 16) | (usep << 40);
 
-  constexpr const size_t len = 8;
-  if (const_check(is_big_endian())) {
+  constexpr size_t len = 8;
+  if (is_big_endian()) {
     char tmp[len];
     std::memcpy(tmp, &digits, len);
     std::reverse_copy(tmp, tmp + len, buf);
@@ -911,7 +820,14 @@ template <typename Derived> struct null_chrono_spec_handler {
   FMT_CONSTEXPR void on_tz_name() { unsupported(); }
 };
 
-struct tm_format_checker : null_chrono_spec_handler<tm_format_checker> {
+class tm_format_checker : public null_chrono_spec_handler<tm_format_checker> {
+ private:
+  bool has_timezone_ = false;
+
+ public:
+  constexpr explicit tm_format_checker(bool has_timezone)
+      : has_timezone_(has_timezone) {}
+
   FMT_NORETURN inline void unsupported() {
     FMT_THROW(format_error("no format"));
   }
@@ -949,8 +865,12 @@ struct tm_format_checker : null_chrono_spec_handler<tm_format_checker> {
   FMT_CONSTEXPR void on_24_hour_time() {}
   FMT_CONSTEXPR void on_iso_time() {}
   FMT_CONSTEXPR void on_am_pm() {}
-  FMT_CONSTEXPR void on_utc_offset(numeric_system) {}
-  FMT_CONSTEXPR void on_tz_name() {}
+  FMT_CONSTEXPR void on_utc_offset(numeric_system) {
+    if (!has_timezone_) FMT_THROW(format_error("no timezone"));
+  }
+  FMT_CONSTEXPR void on_tz_name() {
+    if (!has_timezone_) FMT_THROW(format_error("no timezone"));
+  }
 };
 
 inline auto tm_wday_full_name(int wday) -> const char* {
@@ -980,24 +900,27 @@ inline auto tm_mon_short_name(int mon) -> const char* {
 }
 
 template <typename T, typename = void>
-struct has_member_data_tm_gmtoff : std::false_type {};
+struct has_tm_gmtoff : std::false_type {};
 template <typename T>
-struct has_member_data_tm_gmtoff<T, void_t<decltype(T::tm_gmtoff)>>
-    : std::true_type {};
+struct has_tm_gmtoff<T, void_t<decltype(T::tm_gmtoff)>> : std::true_type {};
 
-template <typename T, typename = void>
-struct has_member_data_tm_zone : std::false_type {};
+template <typename T, typename = void> struct has_tm_zone : std::false_type {};
 template <typename T>
-struct has_member_data_tm_zone<T, void_t<decltype(T::tm_zone)>>
-    : std::true_type {};
+struct has_tm_zone<T, void_t<decltype(T::tm_zone)>> : std::true_type {};
 
-inline void tzset_once() {
-  static bool init = []() {
-    using namespace fmt_detail;
-    _tzset();
-    return false;
-  }();
-  ignore_unused(init);
+template <typename T, FMT_ENABLE_IF(has_tm_zone<T>::value)>
+auto set_tm_zone(T& time, char* tz) -> bool {
+  time.tm_zone = tz;
+  return true;
+}
+template <typename T, FMT_ENABLE_IF(!has_tm_zone<T>::value)>
+auto set_tm_zone(T&, char*) -> bool {
+  return false;
+}
+
+inline auto utc() -> char* {
+  static char tz[] = "UTC";
+  return tz;
 }
 
 // Converts value to Int and checks that it's in the range [0, upper).
@@ -1005,7 +928,7 @@ template <typename T, typename Int, FMT_ENABLE_IF(std::is_integral<T>::value)>
 inline auto to_nonnegative_int(T value, Int upper) -> Int {
   if (!std::is_unsigned<Int>::value &&
       (value < 0 || to_unsigned(value) > to_unsigned(upper))) {
-    FMT_THROW(fmt::format_error("chrono value is out of range"));
+    FMT_THROW(format_error("chrono value is out of range"));
   }
   return static_cast<Int>(value);
 }
@@ -1090,7 +1013,7 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
 
 // Format subseconds which are given as a floating point type with an
 // appropriate number of digits. We cannot pass the Duration here, as we
-// explicitly need to pass the Rep value in the chrono_formatter.
+// explicitly need to pass the Rep value in the duration_formatter.
 template <typename Duration>
 void write_floating_seconds(memory_buffer& buf, Duration duration,
                             int num_fractional_digits = -1) {
@@ -1124,7 +1047,7 @@ class tm_writer {
   static constexpr int days_per_week = 7;
 
   const std::locale& loc_;
-  const bool is_classic_;
+  bool is_classic_;
   OutputIt out_;
   const Duration* subsecs_;
   const std::tm& tm_;
@@ -1160,8 +1083,8 @@ class tm_writer {
   }
 
   auto tm_hour12() const noexcept -> int {
-    const auto h = tm_hour();
-    const auto z = h < 12 ? h : h - 12;
+    auto h = tm_hour();
+    auto z = h < 12 ? h : h - 12;
     return z == 0 ? 12 : z;
   }
 
@@ -1177,11 +1100,11 @@ class tm_writer {
 
   // Algorithm: https://en.wikipedia.org/wiki/ISO_week_date.
   auto iso_year_weeks(long long curr_year) const noexcept -> int {
-    const auto prev_year = curr_year - 1;
-    const auto curr_p =
+    auto prev_year = curr_year - 1;
+    auto curr_p =
         (curr_year + curr_year / 4 - curr_year / 100 + curr_year / 400) %
         days_per_week;
-    const auto prev_p =
+    auto prev_p =
         (prev_year + prev_year / 4 - prev_year / 100 + prev_year / 400) %
         days_per_week;
     return 52 + ((curr_p == 4 || prev_p == 3) ? 1 : 0);
@@ -1191,15 +1114,15 @@ class tm_writer {
            days_per_week;
   }
   auto tm_iso_week_year() const noexcept -> long long {
-    const auto year = tm_year();
-    const auto w = iso_week_num(tm_yday(), tm_wday());
+    auto year = tm_year();
+    auto w = iso_week_num(tm_yday(), tm_wday());
     if (w < 1) return year - 1;
     if (w > iso_year_weeks(year)) return year + 1;
     return year;
   }
   auto tm_iso_week_of_year() const noexcept -> int {
-    const auto year = tm_year();
-    const auto w = iso_week_num(tm_yday(), tm_wday());
+    auto year = tm_year();
+    auto w = iso_week_num(tm_yday(), tm_wday());
     if (w < 1) return iso_year_weeks(year - 1);
     if (w > iso_year_weeks(year)) return 1;
     return w;
@@ -1236,9 +1159,8 @@ class tm_writer {
     uint32_or_64_or_128_t<long long> n = to_unsigned(year);
     const int num_digits = count_digits(n);
     if (negative && pad == pad_type::zero) *out_++ = '-';
-    if (width > num_digits) {
+    if (width > num_digits)
       out_ = detail::write_padding(out_, pad, width - num_digits);
-    }
     if (negative && pad != pad_type::zero) *out_++ = '-';
     out_ = format_decimal<Char>(out_, n, num_digits);
   }
@@ -1259,45 +1181,23 @@ class tm_writer {
     write2(static_cast<int>(offset % 60));
   }
 
-  template <typename T, FMT_ENABLE_IF(has_member_data_tm_gmtoff<T>::value)>
-  void format_utc_offset_impl(const T& tm, numeric_system ns) {
+  template <typename T, FMT_ENABLE_IF(has_tm_gmtoff<T>::value)>
+  void format_utc_offset(const T& tm, numeric_system ns) {
     write_utc_offset(tm.tm_gmtoff, ns);
   }
-  template <typename T, FMT_ENABLE_IF(!has_member_data_tm_gmtoff<T>::value)>
-  void format_utc_offset_impl(const T& tm, numeric_system ns) {
-#if defined(_WIN32) && defined(_UCRT)
-    tzset_once();
-    long offset = 0;
-    _get_timezone(&offset);
-    if (tm.tm_isdst) {
-      long dstbias = 0;
-      _get_dstbias(&dstbias);
-      offset += dstbias;
-    }
-    write_utc_offset(-offset, ns);
-#else
-    if (ns == numeric_system::standard) return format_localized('z');
-
-    // Extract timezone offset from timezone conversion functions.
-    std::tm gtm = tm;
-    std::time_t gt = std::mktime(&gtm);
-    std::tm ltm = gmtime(gt);
-    std::time_t lt = std::mktime(&ltm);
-    long long offset = gt - lt;
-    write_utc_offset(offset, ns);
-#endif
+  template <typename T, FMT_ENABLE_IF(!has_tm_gmtoff<T>::value)>
+  void format_utc_offset(const T&, numeric_system ns) {
+    write_utc_offset(0, ns);
   }
 
-  template <typename T, FMT_ENABLE_IF(has_member_data_tm_zone<T>::value)>
-  void format_tz_name_impl(const T& tm) {
-    if (is_classic_)
-      out_ = write_tm_str<Char>(out_, tm.tm_zone, loc_);
-    else
-      format_localized('Z');
+  template <typename T, FMT_ENABLE_IF(has_tm_zone<T>::value)>
+  void format_tz_name(const T& tm) {
+    if (!tm.tm_zone) FMT_THROW(format_error("no timezone"));
+    out_ = write_tm_str<Char>(out_, tm.tm_zone, loc_);
   }
-  template <typename T, FMT_ENABLE_IF(!has_member_data_tm_zone<T>::value)>
-  void format_tz_name_impl(const T&) {
-    format_localized('Z');
+  template <typename T, FMT_ENABLE_IF(!has_tm_zone<T>::value)>
+  void format_tz_name(const T&) {
+    out_ = std::copy_n(utc(), 3, out_);
   }
 
   void format_localized(char format, char modifier = 0) {
@@ -1408,8 +1308,8 @@ class tm_writer {
     out_ = copy<Char>(std::begin(buf) + offset, std::end(buf), out_);
   }
 
-  void on_utc_offset(numeric_system ns) { format_utc_offset_impl(tm_, ns); }
-  void on_tz_name() { format_tz_name_impl(tm_); }
+  void on_utc_offset(numeric_system ns) { format_utc_offset(tm_, ns); }
+  void on_tz_name() { format_tz_name(tm_); }
 
   void on_year(numeric_system ns, pad_type pad) {
     if (is_classic_ || ns == numeric_system::standard)
@@ -1483,11 +1383,10 @@ class tm_writer {
   void on_day_of_year(pad_type pad) {
     auto yday = tm_yday() + 1;
     auto digit1 = yday / 100;
-    if (digit1 != 0) {
+    if (digit1 != 0)
       write1(digit1);
-    } else {
+    else
       out_ = detail::write_padding(out_, pad);
-    }
     write2(yday % 100, pad);
   }
 
@@ -1624,18 +1523,16 @@ template <typename Rep, typename Period,
           FMT_ENABLE_IF(std::is_integral<Rep>::value)>
 inline auto get_milliseconds(std::chrono::duration<Rep, Period> d)
     -> std::chrono::duration<Rep, std::milli> {
-  // this may overflow and/or the result may not fit in the
-  // target type.
+  // This may overflow and/or the result may not fit in the target type.
 #if FMT_SAFE_DURATION_CAST
-  using CommonSecondsType =
+  using common_seconds_type =
       typename std::common_type<decltype(d), std::chrono::seconds>::type;
-  const auto d_as_common = detail::duration_cast<CommonSecondsType>(d);
-  const auto d_as_whole_seconds =
+  auto d_as_common = detail::duration_cast<common_seconds_type>(d);
+  auto d_as_whole_seconds =
       detail::duration_cast<std::chrono::seconds>(d_as_common);
-  // this conversion should be nonproblematic
-  const auto diff = d_as_common - d_as_whole_seconds;
-  const auto ms =
-      detail::duration_cast<std::chrono::duration<Rep, std::milli>>(diff);
+  // This conversion should be nonproblematic.
+  auto diff = d_as_common - d_as_whole_seconds;
+  auto ms = detail::duration_cast<std::chrono::duration<Rep, std::milli>>(diff);
   return ms;
 #else
   auto s = detail::duration_cast<std::chrono::seconds>(d);
@@ -1678,7 +1575,7 @@ auto format_duration_unit(OutputIt out) -> OutputIt {
     return copy_unit(string_view(unit), out, Char());
   *out++ = '[';
   out = write<Char>(out, Period::num);
-  if (const_check(Period::den != 1)) {
+  if FMT_CONSTEXPR20 (Period::den != 1) {
     *out++ = '/';
     out = write<Char>(out, Period::den);
   }
@@ -1696,8 +1593,13 @@ class get_locale {
 
  public:
   inline get_locale(bool localized, locale_ref loc) : has_locale_(localized) {
-    if (localized)
-      ::new (&locale_) std::locale(loc.template get<std::locale>());
+    if (!localized) return;
+    ignore_unused(loc);
+    ::new (&locale_) std::locale(
+#if FMT_USE_LOCALE
+        loc.template get<std::locale>()
+#endif
+    );
   }
   inline ~get_locale() {
     if (has_locale_) locale_.~locale();
@@ -1707,32 +1609,28 @@ class get_locale {
   }
 };
 
-template <typename FormatContext, typename OutputIt, typename Rep,
-          typename Period>
-struct chrono_formatter {
-  FormatContext& context;
-  OutputIt out;
-  int precision;
-  bool localized = false;
+template <typename Char, typename Rep, typename Period>
+struct duration_formatter {
+  using iterator = basic_appender<Char>;
+  iterator out;
   // rep is unsigned to avoid overflow.
   using rep =
       conditional_t<std::is_integral<Rep>::value && sizeof(Rep) < sizeof(int),
                     unsigned, typename make_unsigned_or_unchanged<Rep>::type>;
   rep val;
+  int precision;
+  locale_ref locale;
+  bool localized = false;
   using seconds = std::chrono::duration<rep>;
   seconds s;
   using milliseconds = std::chrono::duration<rep, std::milli>;
   bool negative;
 
-  using char_type = typename FormatContext::char_type;
-  using tm_writer_type = tm_writer<OutputIt, char_type>;
+  using tm_writer_type = tm_writer<iterator, Char>;
 
-  chrono_formatter(FormatContext& ctx, OutputIt o,
-                   std::chrono::duration<Rep, Period> d)
-      : context(ctx),
-        out(o),
-        val(static_cast<rep>(d.count())),
-        negative(false) {
+  duration_formatter(iterator o, std::chrono::duration<Rep, Period> d,
+                     locale_ref loc)
+      : out(o), val(static_cast<rep>(d.count())), locale(loc), negative(false) {
     if (d.count() < 0) {
       val = 0 - val;
       negative = true;
@@ -1746,19 +1644,16 @@ struct chrono_formatter {
 
   // returns true if nan or inf, writes to out.
   auto handle_nan_inf() -> bool {
-    if (isfinite(val)) {
-      return false;
-    }
+    if (isfinite(val)) return false;
     if (isnan(val)) {
       write_nan();
       return true;
     }
     // must be +-inf
-    if (val > 0) {
-      write_pinf();
-    } else {
-      write_ninf();
-    }
+    if (val > 0)
+      std::copy_n("inf", 3, out);
+    else
+      std::copy_n("-inf", 4, out);
     return true;
   }
 
@@ -1786,10 +1681,9 @@ struct chrono_formatter {
   }
 
   void write_sign() {
-    if (negative) {
-      *out++ = '-';
-      negative = false;
-    }
+    if (!negative) return;
+    *out++ = '-';
+    negative = false;
   }
 
   void write(Rep value, int width, pad_type pad = pad_type::zero) {
@@ -1801,24 +1695,22 @@ struct chrono_formatter {
     if (width > num_digits) {
       out = detail::write_padding(out, pad, width - num_digits);
     }
-    out = format_decimal<char_type>(out, n, num_digits);
+    out = format_decimal<Char>(out, n, num_digits);
   }
 
   void write_nan() { std::copy_n("nan", 3, out); }
-  void write_pinf() { std::copy_n("inf", 3, out); }
-  void write_ninf() { std::copy_n("-inf", 4, out); }
 
   template <typename Callback, typename... Args>
   void format_tm(const tm& time, Callback cb, Args... args) {
     if (isnan(val)) return write_nan();
-    get_locale loc(localized, context.locale());
+    get_locale loc(localized, locale);
     auto w = tm_writer_type(loc, out, time);
     (w.*cb)(args...);
     out = w.out();
   }
 
-  void on_text(const char_type* begin, const char_type* end) {
-    copy<char_type>(begin, end, out);
+  void on_text(const Char* begin, const Char* end) {
+    copy<Char>(begin, end, out);
   }
 
   // These are not implemented because durations don't have date information.
@@ -1888,13 +1780,12 @@ struct chrono_formatter {
         write_floating_seconds(buf, std::chrono::duration<rep, Period>(val),
                                precision);
         if (negative) *out++ = '-';
-        if (buf.size() < 2 || buf[1] == '.') {
+        if (buf.size() < 2 || buf[1] == '.')
           out = detail::write_padding(out, pad);
-        }
-        out = copy<char_type>(buf.begin(), buf.end(), out);
+        out = copy<Char>(buf.begin(), buf.end(), out);
       } else {
         write(second(), 2, pad);
-        write_fractional_seconds<char_type>(
+        write_fractional_seconds<Char>(
             out, std::chrono::duration<rep, Period>(val), precision);
       }
       return;
@@ -1936,12 +1827,10 @@ struct chrono_formatter {
   void on_duration_value() {
     if (handle_nan_inf()) return;
     write_sign();
-    out = format_duration_value<char_type>(out, val, precision);
+    out = format_duration_value<Char>(out, val, precision);
   }
 
-  void on_duration_unit() {
-    out = format_duration_unit<char_type, Period>(out);
-  }
+  void on_duration_unit() { out = format_duration_unit<Char, Period>(out); }
 };
 
 }  // namespace detail
@@ -2011,12 +1900,11 @@ class year_month_day {
   constexpr auto month() const noexcept -> fmt::month { return month_; }
   constexpr auto day() const noexcept -> fmt::day { return day_; }
 };
-#endif
+#endif  // __cpp_lib_chrono >= 201907
 
 template <typename Char>
 struct formatter<weekday, Char> : private formatter<std::tm, Char> {
  private:
-  bool localized_ = false;
   bool use_tm_formatter_ = false;
 
  public:
@@ -2024,8 +1912,7 @@ struct formatter<weekday, Char> : private formatter<std::tm, Char> {
     auto it = ctx.begin(), end = ctx.end();
     if (it != end && *it == 'L') {
       ++it;
-      localized_ = true;
-      return it;
+      this->set_localized();
     }
     use_tm_formatter_ = it != end && *it != '}';
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
@@ -2036,7 +1923,7 @@ struct formatter<weekday, Char> : private formatter<std::tm, Char> {
     auto time = std::tm();
     time.tm_wday = static_cast<int>(wd.c_encoding());
     if (use_tm_formatter_) return formatter<std::tm, Char>::format(time, ctx);
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(this->localized(), ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_weekday();
     return w.out();
@@ -2070,7 +1957,6 @@ struct formatter<day, Char> : private formatter<std::tm, Char> {
 template <typename Char>
 struct formatter<month, Char> : private formatter<std::tm, Char> {
  private:
-  bool localized_ = false;
   bool use_tm_formatter_ = false;
 
  public:
@@ -2078,8 +1964,7 @@ struct formatter<month, Char> : private formatter<std::tm, Char> {
     auto it = ctx.begin(), end = ctx.end();
     if (it != end && *it == 'L') {
       ++it;
-      localized_ = true;
-      return it;
+      this->set_localized();
     }
     use_tm_formatter_ = it != end && *it != '}';
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
@@ -2090,7 +1975,7 @@ struct formatter<month, Char> : private formatter<std::tm, Char> {
     auto time = std::tm();
     time.tm_mon = static_cast<int>(static_cast<unsigned>(m)) - 1;
     if (use_tm_formatter_) return formatter<std::tm, Char>::format(time, ctx);
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(this->localized(), ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_month();
     return w.out();
@@ -2154,7 +2039,6 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
   format_specs specs_;
   detail::arg_ref<Char> width_ref_;
   detail::arg_ref<Char> precision_ref_;
-  bool localized_ = false;
   basic_string_view<Char> fmt_;
 
  public:
@@ -2177,7 +2061,7 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
       it = detail::parse_precision(it, end, specs_, precision_ref_, ctx);
     }
     if (it != end && *it == 'L') {
-      localized_ = true;
+      specs_.set_localized();
       ++it;
     }
     end = detail::parse_chrono_format(it, end, checker);
@@ -2204,11 +2088,10 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
       out = detail::format_duration_value<Char>(out, d.count(), precision);
       detail::format_duration_unit<Char, Period>(out);
     } else {
-      using chrono_formatter =
-          detail::chrono_formatter<FormatContext, decltype(out), Rep, Period>;
-      auto f = chrono_formatter(ctx, out, d);
+      auto f =
+          detail::duration_formatter<Char, Rep, Period>(out, d, ctx.locale());
       f.precision = precision;
-      f.localized = localized_;
+      f.localized = specs_.localized();
       detail::parse_chrono_format(begin, end, f);
     }
     return detail::write(
@@ -2220,30 +2103,15 @@ template <typename Char> struct formatter<std::tm, Char> {
  private:
   format_specs specs_;
   detail::arg_ref<Char> width_ref_;
+  basic_string_view<Char> fmt_ =
+      detail::string_literal<Char, '%', 'F', ' ', '%', 'T'>();
 
  protected:
-  basic_string_view<Char> fmt_;
+  auto localized() const -> bool { return specs_.localized(); }
+  FMT_CONSTEXPR void set_localized() { specs_.set_localized(); }
 
-  template <typename Duration, typename FormatContext>
-  auto do_format(const std::tm& tm, FormatContext& ctx,
-                 const Duration* subsecs) const -> decltype(ctx.out()) {
-    auto specs = specs_;
-    auto buf = basic_memory_buffer<Char>();
-    auto out = basic_appender<Char>(buf);
-    detail::handle_dynamic_spec(specs.dynamic_width(), specs.width, width_ref_,
-                                ctx);
-
-    auto loc_ref = ctx.locale();
-    detail::get_locale loc(static_cast<bool>(loc_ref), loc_ref);
-    auto w =
-        detail::tm_writer<decltype(out), Char, Duration>(loc, out, tm, subsecs);
-    detail::parse_chrono_format(fmt_.begin(), fmt_.end(), w);
-    return detail::write(
-        ctx.out(), basic_string_view<Char>(buf.data(), buf.size()), specs);
-  }
-
- public:
-  FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {
+  FMT_CONSTEXPR auto do_parse(parse_context<Char>& ctx, bool has_timezone)
+      -> const Char* {
     auto it = ctx.begin(), end = ctx.end();
     if (it == end || *it == '}') return it;
 
@@ -2256,10 +2124,39 @@ template <typename Char> struct formatter<std::tm, Char> {
       if (it == end) return it;
     }
 
-    end = detail::parse_chrono_format(it, end, detail::tm_format_checker());
+    if (*it == 'L') {
+      specs_.set_localized();
+      ++it;
+    }
+
+    end = detail::parse_chrono_format(it, end,
+                                      detail::tm_format_checker(has_timezone));
     // Replace the default format string only if the new spec is not empty.
     if (end != it) fmt_ = {it, detail::to_unsigned(end - it)};
     return end;
+  }
+
+  template <typename Duration, typename FormatContext>
+  auto do_format(const std::tm& tm, FormatContext& ctx,
+                 const Duration* subsecs) const -> decltype(ctx.out()) {
+    auto specs = specs_;
+    auto buf = basic_memory_buffer<Char>();
+    auto out = basic_appender<Char>(buf);
+    detail::handle_dynamic_spec(specs.dynamic_width(), specs.width, width_ref_,
+                                ctx);
+
+    auto loc_ref = specs.localized() ? ctx.locale() : locale_ref();
+    detail::get_locale loc(static_cast<bool>(loc_ref), loc_ref);
+    auto w = detail::tm_writer<basic_appender<Char>, Char, Duration>(
+        loc, out, tm, subsecs);
+    detail::parse_chrono_format(fmt_.begin(), fmt_.end(), w);
+    return detail::write(
+        ctx.out(), basic_string_view<Char>(buf.data(), buf.size()), specs);
+  }
+
+ public:
+  FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {
+    return do_parse(ctx, detail::has_tm_gmtoff<std::tm>::value);
   }
 
   template <typename FormatContext>
@@ -2269,10 +2166,11 @@ template <typename Char> struct formatter<std::tm, Char> {
   }
 };
 
+// DEPRECATED! Reversed order of template parameters.
 template <typename Char, typename Duration>
-struct formatter<sys_time<Duration>, Char> : formatter<std::tm, Char> {
-  FMT_CONSTEXPR formatter() {
-    this->fmt_ = detail::string_literal<Char, '%', 'F', ' ', '%', 'T'>();
+struct formatter<sys_time<Duration>, Char> : private formatter<std::tm, Char> {
+  FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {
+    return this->do_parse(ctx, true);
   }
 
   template <typename FormatContext>
@@ -2280,9 +2178,10 @@ struct formatter<sys_time<Duration>, Char> : formatter<std::tm, Char> {
       -> decltype(ctx.out()) {
     std::tm tm = gmtime(val);
     using period = typename Duration::period;
-    if (detail::const_check(
-            period::num == 1 && period::den == 1 &&
-            !std::is_floating_point<typename Duration::rep>::value)) {
+    if FMT_CONSTEXPR20 (period::num == 1 && period::den == 1 &&
+                        !std::is_floating_point<
+                            typename Duration::rep>::value) {
+      detail::set_tm_zone(tm, detail::utc());
       return formatter<std::tm, Char>::format(tm, ctx);
     }
     Duration epoch = val.time_since_epoch();
@@ -2290,11 +2189,13 @@ struct formatter<sys_time<Duration>, Char> : formatter<std::tm, Char> {
         epoch - detail::duration_cast<std::chrono::seconds>(epoch));
     if (subsecs.count() < 0) {
       auto second = detail::duration_cast<Duration>(std::chrono::seconds(1));
-      if (tm.tm_sec != 0)
+      if (tm.tm_sec != 0) {
         --tm.tm_sec;
-      else
+      } else {
         tm = gmtime(val - second);
-      subsecs += detail::duration_cast<Duration>(std::chrono::seconds(1));
+        detail::set_tm_zone(tm, detail::utc());
+      }
+      subsecs += second;
     }
     return formatter<std::tm, Char>::do_format(tm, ctx, &subsecs);
   }
@@ -2312,23 +2213,29 @@ struct formatter<utc_time<Duration>, Char>
 };
 
 template <typename Duration, typename Char>
-struct formatter<local_time<Duration>, Char> : formatter<std::tm, Char> {
-  FMT_CONSTEXPR formatter() {
-    this->fmt_ = detail::string_literal<Char, '%', 'F', ' ', '%', 'T'>();
+struct formatter<local_time<Duration>, Char>
+    : private formatter<std::tm, Char> {
+  FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {
+    return this->do_parse(ctx, false);
   }
 
   template <typename FormatContext>
   auto format(local_time<Duration> val, FormatContext& ctx) const
       -> decltype(ctx.out()) {
+    auto time_since_epoch = val.time_since_epoch();
+    auto seconds_since_epoch =
+        detail::duration_cast<std::chrono::seconds>(time_since_epoch);
+    // Use gmtime to prevent time zone conversion since local_time has an
+    // unspecified time zone.
+    std::tm t = gmtime(seconds_since_epoch.count());
     using period = typename Duration::period;
     if (period::num == 1 && period::den == 1 &&
         !std::is_floating_point<typename Duration::rep>::value) {
-      return formatter<std::tm, Char>::format(localtime(val), ctx);
+      return formatter<std::tm, Char>::format(t, ctx);
     }
-    auto epoch = val.time_since_epoch();
-    auto subsecs = detail::duration_cast<Duration>(
-        epoch - detail::duration_cast<std::chrono::seconds>(epoch));
-    return formatter<std::tm, Char>::do_format(localtime(val), ctx, &subsecs);
+    auto subsecs =
+        detail::duration_cast<Duration>(time_since_epoch - seconds_since_epoch);
+    return formatter<std::tm, Char>::do_format(t, ctx, &subsecs);
   }
 };
 

--- a/lib/fmt/include/fmt-vt/core.h
+++ b/lib/fmt/include/fmt-vt/core.h
@@ -1,5 +1,14 @@
-// This file is only provided for compatibility and may be removed in future
-// versions. Use fmt/base.h if you don't need fmt::format and fmt/format.h
-// otherwise.
+// Formatting library for C++ - core API
+//
+// Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+// All rights reserved.
+//
+// For the license information refer to format.h.
 
-#include "format.h"
+#include "base.h"
+
+// Using fmt::format via fmt/core.h has been deprecated since version 11
+// and now requires an explicit opt in.
+#ifdef FMT_DEPRECATED_HEAVY_CORE
+#  include "format.h"
+#endif

--- a/lib/fmt/include/fmt-vt/format-inl.h
+++ b/lib/fmt/include/fmt-vt/format-inl.h
@@ -1,6 +1,6 @@
 // Formatting library for C++ - implementation
 //
-// Copyright (c) 2012 - 2016, Victor Zverovich
+// Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
 // All rights reserved.
 //
 // For the license information refer to format.h.
@@ -8,12 +8,17 @@
 #ifndef FMT_FORMAT_INL_H_
 #define FMT_FORMAT_INL_H_
 
+#ifdef __SANITIZE_THREAD__
+extern "C" void __tsan_acquire(void*);
+extern "C" void __tsan_release(void*);
+#endif
+
 #ifndef FMT_MODULE
+#  include <stddef.h>  // ptrdiff_t
+
 #  include <algorithm>
 #  include <cerrno>  // errno
-#  include <climits>
-#  include <cmath>
-#  include <exception>
+#  include <new>     // std::bad_alloc
 #endif
 
 #if defined(_WIN32) && !defined(FMT_USE_WRITE_CONSOLE)
@@ -22,7 +27,7 @@
 
 #include "format.h"
 
-#if FMT_USE_LOCALE
+#if FMT_USE_LOCALE && !defined(FMT_MODULE)
 #  include <locale>
 #endif
 
@@ -30,24 +35,67 @@
 #  define FMT_FUNC
 #endif
 
-FMT_BEGIN_NAMESPACE
-namespace detail {
+#if defined(FMT_USE_FULL_CACHE_DRAGONBOX)
+// Use the provided definition.
+#elif defined(__OPTIMIZE_SIZE__)
+#  define FMT_USE_FULL_CACHE_DRAGONBOX 0
+#else
+#  define FMT_USE_FULL_CACHE_DRAGONBOX 1
+#endif
 
+FMT_BEGIN_NAMESPACE
+
+#ifndef FMT_CUSTOM_ASSERT_FAIL
 FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   // Use unchecked std::fprintf to avoid triggering another assertion when
   // writing to stderr fails.
-  fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
+  std::fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
   abort();
+}
+#endif
+
+#if FMT_USE_LOCALE
+namespace detail {
+using std::locale;
+using std::numpunct;
+using std::use_facet;
+}  // namespace detail
+#else
+namespace detail {
+struct locale {};
+template <typename Char> struct numpunct {
+  auto grouping() const -> std::string { return "\03"; }
+  auto thousands_sep() const -> Char { return ','; }
+  auto decimal_point() const -> Char { return '.'; }
+};
+template <typename Facet> Facet use_facet(locale) { return {}; }
+}  // namespace detail
+#endif  // FMT_USE_LOCALE
+
+template <typename Locale> auto locale_ref::get() const -> Locale {
+  using namespace detail;
+  static_assert(std::is_same<Locale, locale>::value, "");
+#if FMT_USE_LOCALE
+  if (locale_) return *static_cast<const locale*>(locale_);
+#endif
+  return locale();
+}
+
+namespace detail {
+
+FMT_FUNC auto allocate(size_t size) -> void* {
+  void* p = malloc(size);
+  if (!p) FMT_THROW(std::bad_alloc());
+  return p;
 }
 
 FMT_FUNC void format_error_code(detail::buffer<char>& out, int error_code,
                                 string_view message) noexcept {
-  // Report error code making sure that the output fits into
-  // inline_buffer_size to avoid dynamic memory allocation and potential
-  // bad_alloc.
+  // Report error code making sure that the output fits into inline_buffer_size
+  // to avoid dynamic memory allocation and potential bad_alloc.
   out.try_resize(0);
-  static const char SEP[] = ": ";
-  static const char ERROR_STR[] = "error ";
+  static constexpr char SEP[] = ": ";
+  static constexpr char ERROR_STR[] = "error ";
   // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
   size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
   auto abs_value = static_cast<uint32_or_64_or_128_t<int>>(error_code);
@@ -79,33 +127,6 @@ inline void fwrite_all(const void* ptr, size_t count, FILE* stream) {
     FMT_THROW(system_error(errno, FMT_STRING("cannot write to file")));
 }
 
-#if FMT_USE_LOCALE
-using std::locale;
-using std::numpunct;
-using std::use_facet;
-
-template <typename Locale>
-locale_ref::locale_ref(const Locale& loc) : locale_(&loc) {
-  static_assert(std::is_same<Locale, locale>::value, "");
-}
-#else
-struct locale {};
-template <typename Char> struct numpunct {
-  auto grouping() const -> std::string { return "\03"; }
-  auto thousands_sep() const -> Char { return ','; }
-  auto decimal_point() const -> Char { return '.'; }
-};
-template <typename Facet> Facet use_facet(locale) { return {}; }
-#endif  // FMT_USE_LOCALE
-
-template <typename Locale> auto locale_ref::get() const -> Locale {
-  static_assert(std::is_same<Locale, locale>::value, "");
-#if FMT_USE_LOCALE
-  if (locale_) return *static_cast<const locale*>(locale_);
-#endif
-  return locale();
-}
-
 template <typename Char>
 FMT_FUNC auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char> {
   auto&& facet = use_facet<numpunct<Char>>(loc.get<locale>());
@@ -133,14 +154,13 @@ FMT_FUNC auto write_loc(appender out, loc_value value,
 }  // namespace detail
 
 FMT_FUNC void report_error(const char* message) {
-#if FMT_USE_EXCEPTIONS
-  // Use FMT_THROW instead of throw to avoid bogus unreachable code warnings
-  // from MSVC.
-  FMT_THROW(format_error(message));
-#else
-  fputs(message, stderr);
-  abort();
+#if FMT_MSC_VERSION || defined(__NVCC__)
+  // Silence unreachable code warnings in MSVC and NVCC because these
+  // are nearly impossible to fix in a generic code.
+  volatile bool b = true;
+  if (!b) return;
 #endif
+  FMT_THROW(format_error(message));
 }
 
 template <typename Locale> typename Locale::id format_facet<Locale>::id;
@@ -174,11 +194,11 @@ inline auto operator==(basic_fp<F> x, basic_fp<F> y) -> bool {
 }
 
 // Compilers should be able to optimize this into the ror instruction.
-FMT_CONSTEXPR inline auto rotr(uint32_t n, uint32_t r) noexcept -> uint32_t {
+FMT_INLINE auto rotr(uint32_t n, uint32_t r) noexcept -> uint32_t {
   r &= 31;
   return (n >> r) | (n << (32 - r));
 }
-FMT_CONSTEXPR inline auto rotr(uint64_t n, uint32_t r) noexcept -> uint64_t {
+FMT_INLINE auto rotr(uint64_t n, uint32_t r) noexcept -> uint64_t {
   r &= 63;
   return (n >> r) | (n << (64 - r));
 }
@@ -193,10 +213,9 @@ inline auto umul96_upper64(uint32_t x, uint64_t y) noexcept -> uint64_t {
 
 // Computes lower 128 bits of multiplication of a 64-bit unsigned integer and a
 // 128-bit unsigned integer.
-inline auto umul192_lower128(uint64_t x, uint128_fallback y) noexcept
-    -> uint128_fallback {
+inline auto umul192_lower128(uint64_t x, uint128 y) noexcept -> uint128 {
   uint64_t high = x * y.high();
-  uint128_fallback high_low = umul128(x, y.low());
+  uint128 high_low = umul128(x, y.low());
   return {high + high_low.high(), high_low.low()};
 }
 
@@ -212,7 +231,7 @@ inline auto floor_log10_pow2_minus_log10_4_over_3(int e) noexcept -> int {
   return (e * 631305 - 261663) >> 21;
 }
 
-FMT_INLINE_VARIABLE constexpr struct {
+FMT_INLINE_VARIABLE constexpr struct div_small_pow10_infos_struct {
   uint32_t divisor;
   int shift_amount;
 } div_small_pow10_infos[] = {{10, 16}, {100, 16}};
@@ -275,7 +294,7 @@ template <> struct cache_accessor<float> {
   static auto get_cached_power(int k) noexcept -> uint64_t {
     FMT_ASSERT(k >= float_info<float>::min_k && k <= float_info<float>::max_k,
                "k is out of range");
-    static constexpr const uint64_t pow10_significands[] = {
+    static constexpr uint64_t pow10_significands[] = {
         0x81ceb32c4b43fcf5, 0xa2425ff75e14fc32, 0xcad2f7f5359a3b3f,
         0xfd87b5f28300ca0e, 0x9e74d1b791e07e49, 0xc612062576589ddb,
         0xf79687aed3eec552, 0x9abe14cd44753b53, 0xc16d9a0095928a28,
@@ -364,680 +383,680 @@ template <> struct cache_accessor<float> {
 
 template <> struct cache_accessor<double> {
   using carrier_uint = float_info<double>::carrier_uint;
-  using cache_entry_type = uint128_fallback;
+  using cache_entry_type = uint128;
 
-  static auto get_cached_power(int k) noexcept -> uint128_fallback {
+  static auto get_cached_power(int k) noexcept -> uint128 {
     FMT_ASSERT(k >= float_info<double>::min_k && k <= float_info<double>::max_k,
                "k is out of range");
 
-    static constexpr const uint128_fallback pow10_significands[] = {
+    static constexpr uint128 pow10_significands[] = {
 #if FMT_USE_FULL_CACHE_DRAGONBOX
-      {0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7b},
-      {0x9faacf3df73609b1, 0x77b191618c54e9ad},
-      {0xc795830d75038c1d, 0xd59df5b9ef6a2418},
-      {0xf97ae3d0d2446f25, 0x4b0573286b44ad1e},
-      {0x9becce62836ac577, 0x4ee367f9430aec33},
-      {0xc2e801fb244576d5, 0x229c41f793cda740},
-      {0xf3a20279ed56d48a, 0x6b43527578c11110},
-      {0x9845418c345644d6, 0x830a13896b78aaaa},
-      {0xbe5691ef416bd60c, 0x23cc986bc656d554},
-      {0xedec366b11c6cb8f, 0x2cbfbe86b7ec8aa9},
-      {0x94b3a202eb1c3f39, 0x7bf7d71432f3d6aa},
-      {0xb9e08a83a5e34f07, 0xdaf5ccd93fb0cc54},
-      {0xe858ad248f5c22c9, 0xd1b3400f8f9cff69},
-      {0x91376c36d99995be, 0x23100809b9c21fa2},
-      {0xb58547448ffffb2d, 0xabd40a0c2832a78b},
-      {0xe2e69915b3fff9f9, 0x16c90c8f323f516d},
-      {0x8dd01fad907ffc3b, 0xae3da7d97f6792e4},
-      {0xb1442798f49ffb4a, 0x99cd11cfdf41779d},
-      {0xdd95317f31c7fa1d, 0x40405643d711d584},
-      {0x8a7d3eef7f1cfc52, 0x482835ea666b2573},
-      {0xad1c8eab5ee43b66, 0xda3243650005eed0},
-      {0xd863b256369d4a40, 0x90bed43e40076a83},
-      {0x873e4f75e2224e68, 0x5a7744a6e804a292},
-      {0xa90de3535aaae202, 0x711515d0a205cb37},
-      {0xd3515c2831559a83, 0x0d5a5b44ca873e04},
-      {0x8412d9991ed58091, 0xe858790afe9486c3},
-      {0xa5178fff668ae0b6, 0x626e974dbe39a873},
-      {0xce5d73ff402d98e3, 0xfb0a3d212dc81290},
-      {0x80fa687f881c7f8e, 0x7ce66634bc9d0b9a},
-      {0xa139029f6a239f72, 0x1c1fffc1ebc44e81},
-      {0xc987434744ac874e, 0xa327ffb266b56221},
-      {0xfbe9141915d7a922, 0x4bf1ff9f0062baa9},
-      {0x9d71ac8fada6c9b5, 0x6f773fc3603db4aa},
-      {0xc4ce17b399107c22, 0xcb550fb4384d21d4},
-      {0xf6019da07f549b2b, 0x7e2a53a146606a49},
-      {0x99c102844f94e0fb, 0x2eda7444cbfc426e},
-      {0xc0314325637a1939, 0xfa911155fefb5309},
-      {0xf03d93eebc589f88, 0x793555ab7eba27cb},
-      {0x96267c7535b763b5, 0x4bc1558b2f3458df},
-      {0xbbb01b9283253ca2, 0x9eb1aaedfb016f17},
-      {0xea9c227723ee8bcb, 0x465e15a979c1cadd},
-      {0x92a1958a7675175f, 0x0bfacd89ec191eca},
-      {0xb749faed14125d36, 0xcef980ec671f667c},
-      {0xe51c79a85916f484, 0x82b7e12780e7401b},
-      {0x8f31cc0937ae58d2, 0xd1b2ecb8b0908811},
-      {0xb2fe3f0b8599ef07, 0x861fa7e6dcb4aa16},
-      {0xdfbdcece67006ac9, 0x67a791e093e1d49b},
-      {0x8bd6a141006042bd, 0xe0c8bb2c5c6d24e1},
-      {0xaecc49914078536d, 0x58fae9f773886e19},
-      {0xda7f5bf590966848, 0xaf39a475506a899f},
-      {0x888f99797a5e012d, 0x6d8406c952429604},
-      {0xaab37fd7d8f58178, 0xc8e5087ba6d33b84},
-      {0xd5605fcdcf32e1d6, 0xfb1e4a9a90880a65},
-      {0x855c3be0a17fcd26, 0x5cf2eea09a550680},
-      {0xa6b34ad8c9dfc06f, 0xf42faa48c0ea481f},
-      {0xd0601d8efc57b08b, 0xf13b94daf124da27},
-      {0x823c12795db6ce57, 0x76c53d08d6b70859},
-      {0xa2cb1717b52481ed, 0x54768c4b0c64ca6f},
-      {0xcb7ddcdda26da268, 0xa9942f5dcf7dfd0a},
-      {0xfe5d54150b090b02, 0xd3f93b35435d7c4d},
-      {0x9efa548d26e5a6e1, 0xc47bc5014a1a6db0},
-      {0xc6b8e9b0709f109a, 0x359ab6419ca1091c},
-      {0xf867241c8cc6d4c0, 0xc30163d203c94b63},
-      {0x9b407691d7fc44f8, 0x79e0de63425dcf1e},
-      {0xc21094364dfb5636, 0x985915fc12f542e5},
-      {0xf294b943e17a2bc4, 0x3e6f5b7b17b2939e},
-      {0x979cf3ca6cec5b5a, 0xa705992ceecf9c43},
-      {0xbd8430bd08277231, 0x50c6ff782a838354},
-      {0xece53cec4a314ebd, 0xa4f8bf5635246429},
-      {0x940f4613ae5ed136, 0x871b7795e136be9a},
-      {0xb913179899f68584, 0x28e2557b59846e40},
-      {0xe757dd7ec07426e5, 0x331aeada2fe589d0},
-      {0x9096ea6f3848984f, 0x3ff0d2c85def7622},
-      {0xb4bca50b065abe63, 0x0fed077a756b53aa},
-      {0xe1ebce4dc7f16dfb, 0xd3e8495912c62895},
-      {0x8d3360f09cf6e4bd, 0x64712dd7abbbd95d},
-      {0xb080392cc4349dec, 0xbd8d794d96aacfb4},
-      {0xdca04777f541c567, 0xecf0d7a0fc5583a1},
-      {0x89e42caaf9491b60, 0xf41686c49db57245},
-      {0xac5d37d5b79b6239, 0x311c2875c522ced6},
-      {0xd77485cb25823ac7, 0x7d633293366b828c},
-      {0x86a8d39ef77164bc, 0xae5dff9c02033198},
-      {0xa8530886b54dbdeb, 0xd9f57f830283fdfd},
-      {0xd267caa862a12d66, 0xd072df63c324fd7c},
-      {0x8380dea93da4bc60, 0x4247cb9e59f71e6e},
-      {0xa46116538d0deb78, 0x52d9be85f074e609},
-      {0xcd795be870516656, 0x67902e276c921f8c},
-      {0x806bd9714632dff6, 0x00ba1cd8a3db53b7},
-      {0xa086cfcd97bf97f3, 0x80e8a40eccd228a5},
-      {0xc8a883c0fdaf7df0, 0x6122cd128006b2ce},
-      {0xfad2a4b13d1b5d6c, 0x796b805720085f82},
-      {0x9cc3a6eec6311a63, 0xcbe3303674053bb1},
-      {0xc3f490aa77bd60fc, 0xbedbfc4411068a9d},
-      {0xf4f1b4d515acb93b, 0xee92fb5515482d45},
-      {0x991711052d8bf3c5, 0x751bdd152d4d1c4b},
-      {0xbf5cd54678eef0b6, 0xd262d45a78a0635e},
-      {0xef340a98172aace4, 0x86fb897116c87c35},
-      {0x9580869f0e7aac0e, 0xd45d35e6ae3d4da1},
-      {0xbae0a846d2195712, 0x8974836059cca10a},
-      {0xe998d258869facd7, 0x2bd1a438703fc94c},
-      {0x91ff83775423cc06, 0x7b6306a34627ddd0},
-      {0xb67f6455292cbf08, 0x1a3bc84c17b1d543},
-      {0xe41f3d6a7377eeca, 0x20caba5f1d9e4a94},
-      {0x8e938662882af53e, 0x547eb47b7282ee9d},
-      {0xb23867fb2a35b28d, 0xe99e619a4f23aa44},
-      {0xdec681f9f4c31f31, 0x6405fa00e2ec94d5},
-      {0x8b3c113c38f9f37e, 0xde83bc408dd3dd05},
-      {0xae0b158b4738705e, 0x9624ab50b148d446},
-      {0xd98ddaee19068c76, 0x3badd624dd9b0958},
-      {0x87f8a8d4cfa417c9, 0xe54ca5d70a80e5d7},
-      {0xa9f6d30a038d1dbc, 0x5e9fcf4ccd211f4d},
-      {0xd47487cc8470652b, 0x7647c32000696720},
-      {0x84c8d4dfd2c63f3b, 0x29ecd9f40041e074},
-      {0xa5fb0a17c777cf09, 0xf468107100525891},
-      {0xcf79cc9db955c2cc, 0x7182148d4066eeb5},
-      {0x81ac1fe293d599bf, 0xc6f14cd848405531},
-      {0xa21727db38cb002f, 0xb8ada00e5a506a7d},
-      {0xca9cf1d206fdc03b, 0xa6d90811f0e4851d},
-      {0xfd442e4688bd304a, 0x908f4a166d1da664},
-      {0x9e4a9cec15763e2e, 0x9a598e4e043287ff},
-      {0xc5dd44271ad3cdba, 0x40eff1e1853f29fe},
-      {0xf7549530e188c128, 0xd12bee59e68ef47d},
-      {0x9a94dd3e8cf578b9, 0x82bb74f8301958cf},
-      {0xc13a148e3032d6e7, 0xe36a52363c1faf02},
-      {0xf18899b1bc3f8ca1, 0xdc44e6c3cb279ac2},
-      {0x96f5600f15a7b7e5, 0x29ab103a5ef8c0ba},
-      {0xbcb2b812db11a5de, 0x7415d448f6b6f0e8},
-      {0xebdf661791d60f56, 0x111b495b3464ad22},
-      {0x936b9fcebb25c995, 0xcab10dd900beec35},
-      {0xb84687c269ef3bfb, 0x3d5d514f40eea743},
-      {0xe65829b3046b0afa, 0x0cb4a5a3112a5113},
-      {0x8ff71a0fe2c2e6dc, 0x47f0e785eaba72ac},
-      {0xb3f4e093db73a093, 0x59ed216765690f57},
-      {0xe0f218b8d25088b8, 0x306869c13ec3532d},
-      {0x8c974f7383725573, 0x1e414218c73a13fc},
-      {0xafbd2350644eeacf, 0xe5d1929ef90898fb},
-      {0xdbac6c247d62a583, 0xdf45f746b74abf3a},
-      {0x894bc396ce5da772, 0x6b8bba8c328eb784},
-      {0xab9eb47c81f5114f, 0x066ea92f3f326565},
-      {0xd686619ba27255a2, 0xc80a537b0efefebe},
-      {0x8613fd0145877585, 0xbd06742ce95f5f37},
-      {0xa798fc4196e952e7, 0x2c48113823b73705},
-      {0xd17f3b51fca3a7a0, 0xf75a15862ca504c6},
-      {0x82ef85133de648c4, 0x9a984d73dbe722fc},
-      {0xa3ab66580d5fdaf5, 0xc13e60d0d2e0ebbb},
-      {0xcc963fee10b7d1b3, 0x318df905079926a9},
-      {0xffbbcfe994e5c61f, 0xfdf17746497f7053},
-      {0x9fd561f1fd0f9bd3, 0xfeb6ea8bedefa634},
-      {0xc7caba6e7c5382c8, 0xfe64a52ee96b8fc1},
-      {0xf9bd690a1b68637b, 0x3dfdce7aa3c673b1},
-      {0x9c1661a651213e2d, 0x06bea10ca65c084f},
-      {0xc31bfa0fe5698db8, 0x486e494fcff30a63},
-      {0xf3e2f893dec3f126, 0x5a89dba3c3efccfb},
-      {0x986ddb5c6b3a76b7, 0xf89629465a75e01d},
-      {0xbe89523386091465, 0xf6bbb397f1135824},
-      {0xee2ba6c0678b597f, 0x746aa07ded582e2d},
-      {0x94db483840b717ef, 0xa8c2a44eb4571cdd},
-      {0xba121a4650e4ddeb, 0x92f34d62616ce414},
-      {0xe896a0d7e51e1566, 0x77b020baf9c81d18},
-      {0x915e2486ef32cd60, 0x0ace1474dc1d122f},
-      {0xb5b5ada8aaff80b8, 0x0d819992132456bb},
-      {0xe3231912d5bf60e6, 0x10e1fff697ed6c6a},
-      {0x8df5efabc5979c8f, 0xca8d3ffa1ef463c2},
-      {0xb1736b96b6fd83b3, 0xbd308ff8a6b17cb3},
-      {0xddd0467c64bce4a0, 0xac7cb3f6d05ddbdf},
-      {0x8aa22c0dbef60ee4, 0x6bcdf07a423aa96c},
-      {0xad4ab7112eb3929d, 0x86c16c98d2c953c7},
-      {0xd89d64d57a607744, 0xe871c7bf077ba8b8},
-      {0x87625f056c7c4a8b, 0x11471cd764ad4973},
-      {0xa93af6c6c79b5d2d, 0xd598e40d3dd89bd0},
-      {0xd389b47879823479, 0x4aff1d108d4ec2c4},
-      {0x843610cb4bf160cb, 0xcedf722a585139bb},
-      {0xa54394fe1eedb8fe, 0xc2974eb4ee658829},
-      {0xce947a3da6a9273e, 0x733d226229feea33},
-      {0x811ccc668829b887, 0x0806357d5a3f5260},
-      {0xa163ff802a3426a8, 0xca07c2dcb0cf26f8},
-      {0xc9bcff6034c13052, 0xfc89b393dd02f0b6},
-      {0xfc2c3f3841f17c67, 0xbbac2078d443ace3},
-      {0x9d9ba7832936edc0, 0xd54b944b84aa4c0e},
-      {0xc5029163f384a931, 0x0a9e795e65d4df12},
-      {0xf64335bcf065d37d, 0x4d4617b5ff4a16d6},
-      {0x99ea0196163fa42e, 0x504bced1bf8e4e46},
-      {0xc06481fb9bcf8d39, 0xe45ec2862f71e1d7},
-      {0xf07da27a82c37088, 0x5d767327bb4e5a4d},
-      {0x964e858c91ba2655, 0x3a6a07f8d510f870},
-      {0xbbe226efb628afea, 0x890489f70a55368c},
-      {0xeadab0aba3b2dbe5, 0x2b45ac74ccea842f},
-      {0x92c8ae6b464fc96f, 0x3b0b8bc90012929e},
-      {0xb77ada0617e3bbcb, 0x09ce6ebb40173745},
-      {0xe55990879ddcaabd, 0xcc420a6a101d0516},
-      {0x8f57fa54c2a9eab6, 0x9fa946824a12232e},
-      {0xb32df8e9f3546564, 0x47939822dc96abfa},
-      {0xdff9772470297ebd, 0x59787e2b93bc56f8},
-      {0x8bfbea76c619ef36, 0x57eb4edb3c55b65b},
-      {0xaefae51477a06b03, 0xede622920b6b23f2},
-      {0xdab99e59958885c4, 0xe95fab368e45ecee},
-      {0x88b402f7fd75539b, 0x11dbcb0218ebb415},
-      {0xaae103b5fcd2a881, 0xd652bdc29f26a11a},
-      {0xd59944a37c0752a2, 0x4be76d3346f04960},
-      {0x857fcae62d8493a5, 0x6f70a4400c562ddc},
-      {0xa6dfbd9fb8e5b88e, 0xcb4ccd500f6bb953},
-      {0xd097ad07a71f26b2, 0x7e2000a41346a7a8},
-      {0x825ecc24c873782f, 0x8ed400668c0c28c9},
-      {0xa2f67f2dfa90563b, 0x728900802f0f32fb},
-      {0xcbb41ef979346bca, 0x4f2b40a03ad2ffba},
-      {0xfea126b7d78186bc, 0xe2f610c84987bfa9},
-      {0x9f24b832e6b0f436, 0x0dd9ca7d2df4d7ca},
-      {0xc6ede63fa05d3143, 0x91503d1c79720dbc},
-      {0xf8a95fcf88747d94, 0x75a44c6397ce912b},
-      {0x9b69dbe1b548ce7c, 0xc986afbe3ee11abb},
-      {0xc24452da229b021b, 0xfbe85badce996169},
-      {0xf2d56790ab41c2a2, 0xfae27299423fb9c4},
-      {0x97c560ba6b0919a5, 0xdccd879fc967d41b},
-      {0xbdb6b8e905cb600f, 0x5400e987bbc1c921},
-      {0xed246723473e3813, 0x290123e9aab23b69},
-      {0x9436c0760c86e30b, 0xf9a0b6720aaf6522},
-      {0xb94470938fa89bce, 0xf808e40e8d5b3e6a},
-      {0xe7958cb87392c2c2, 0xb60b1d1230b20e05},
-      {0x90bd77f3483bb9b9, 0xb1c6f22b5e6f48c3},
-      {0xb4ecd5f01a4aa828, 0x1e38aeb6360b1af4},
-      {0xe2280b6c20dd5232, 0x25c6da63c38de1b1},
-      {0x8d590723948a535f, 0x579c487e5a38ad0f},
-      {0xb0af48ec79ace837, 0x2d835a9df0c6d852},
-      {0xdcdb1b2798182244, 0xf8e431456cf88e66},
-      {0x8a08f0f8bf0f156b, 0x1b8e9ecb641b5900},
-      {0xac8b2d36eed2dac5, 0xe272467e3d222f40},
-      {0xd7adf884aa879177, 0x5b0ed81dcc6abb10},
-      {0x86ccbb52ea94baea, 0x98e947129fc2b4ea},
-      {0xa87fea27a539e9a5, 0x3f2398d747b36225},
-      {0xd29fe4b18e88640e, 0x8eec7f0d19a03aae},
-      {0x83a3eeeef9153e89, 0x1953cf68300424ad},
-      {0xa48ceaaab75a8e2b, 0x5fa8c3423c052dd8},
-      {0xcdb02555653131b6, 0x3792f412cb06794e},
-      {0x808e17555f3ebf11, 0xe2bbd88bbee40bd1},
-      {0xa0b19d2ab70e6ed6, 0x5b6aceaeae9d0ec5},
-      {0xc8de047564d20a8b, 0xf245825a5a445276},
-      {0xfb158592be068d2e, 0xeed6e2f0f0d56713},
-      {0x9ced737bb6c4183d, 0x55464dd69685606c},
-      {0xc428d05aa4751e4c, 0xaa97e14c3c26b887},
-      {0xf53304714d9265df, 0xd53dd99f4b3066a9},
-      {0x993fe2c6d07b7fab, 0xe546a8038efe402a},
-      {0xbf8fdb78849a5f96, 0xde98520472bdd034},
-      {0xef73d256a5c0f77c, 0x963e66858f6d4441},
-      {0x95a8637627989aad, 0xdde7001379a44aa9},
-      {0xbb127c53b17ec159, 0x5560c018580d5d53},
-      {0xe9d71b689dde71af, 0xaab8f01e6e10b4a7},
-      {0x9226712162ab070d, 0xcab3961304ca70e9},
-      {0xb6b00d69bb55c8d1, 0x3d607b97c5fd0d23},
-      {0xe45c10c42a2b3b05, 0x8cb89a7db77c506b},
-      {0x8eb98a7a9a5b04e3, 0x77f3608e92adb243},
-      {0xb267ed1940f1c61c, 0x55f038b237591ed4},
-      {0xdf01e85f912e37a3, 0x6b6c46dec52f6689},
-      {0x8b61313bbabce2c6, 0x2323ac4b3b3da016},
-      {0xae397d8aa96c1b77, 0xabec975e0a0d081b},
-      {0xd9c7dced53c72255, 0x96e7bd358c904a22},
-      {0x881cea14545c7575, 0x7e50d64177da2e55},
-      {0xaa242499697392d2, 0xdde50bd1d5d0b9ea},
-      {0xd4ad2dbfc3d07787, 0x955e4ec64b44e865},
-      {0x84ec3c97da624ab4, 0xbd5af13bef0b113f},
-      {0xa6274bbdd0fadd61, 0xecb1ad8aeacdd58f},
-      {0xcfb11ead453994ba, 0x67de18eda5814af3},
-      {0x81ceb32c4b43fcf4, 0x80eacf948770ced8},
-      {0xa2425ff75e14fc31, 0xa1258379a94d028e},
-      {0xcad2f7f5359a3b3e, 0x096ee45813a04331},
-      {0xfd87b5f28300ca0d, 0x8bca9d6e188853fd},
-      {0x9e74d1b791e07e48, 0x775ea264cf55347e},
-      {0xc612062576589dda, 0x95364afe032a819e},
-      {0xf79687aed3eec551, 0x3a83ddbd83f52205},
-      {0x9abe14cd44753b52, 0xc4926a9672793543},
-      {0xc16d9a0095928a27, 0x75b7053c0f178294},
-      {0xf1c90080baf72cb1, 0x5324c68b12dd6339},
-      {0x971da05074da7bee, 0xd3f6fc16ebca5e04},
-      {0xbce5086492111aea, 0x88f4bb1ca6bcf585},
-      {0xec1e4a7db69561a5, 0x2b31e9e3d06c32e6},
-      {0x9392ee8e921d5d07, 0x3aff322e62439fd0},
-      {0xb877aa3236a4b449, 0x09befeb9fad487c3},
-      {0xe69594bec44de15b, 0x4c2ebe687989a9b4},
-      {0x901d7cf73ab0acd9, 0x0f9d37014bf60a11},
-      {0xb424dc35095cd80f, 0x538484c19ef38c95},
-      {0xe12e13424bb40e13, 0x2865a5f206b06fba},
-      {0x8cbccc096f5088cb, 0xf93f87b7442e45d4},
-      {0xafebff0bcb24aafe, 0xf78f69a51539d749},
-      {0xdbe6fecebdedd5be, 0xb573440e5a884d1c},
-      {0x89705f4136b4a597, 0x31680a88f8953031},
-      {0xabcc77118461cefc, 0xfdc20d2b36ba7c3e},
-      {0xd6bf94d5e57a42bc, 0x3d32907604691b4d},
-      {0x8637bd05af6c69b5, 0xa63f9a49c2c1b110},
-      {0xa7c5ac471b478423, 0x0fcf80dc33721d54},
-      {0xd1b71758e219652b, 0xd3c36113404ea4a9},
-      {0x83126e978d4fdf3b, 0x645a1cac083126ea},
-      {0xa3d70a3d70a3d70a, 0x3d70a3d70a3d70a4},
-      {0xcccccccccccccccc, 0xcccccccccccccccd},
-      {0x8000000000000000, 0x0000000000000000},
-      {0xa000000000000000, 0x0000000000000000},
-      {0xc800000000000000, 0x0000000000000000},
-      {0xfa00000000000000, 0x0000000000000000},
-      {0x9c40000000000000, 0x0000000000000000},
-      {0xc350000000000000, 0x0000000000000000},
-      {0xf424000000000000, 0x0000000000000000},
-      {0x9896800000000000, 0x0000000000000000},
-      {0xbebc200000000000, 0x0000000000000000},
-      {0xee6b280000000000, 0x0000000000000000},
-      {0x9502f90000000000, 0x0000000000000000},
-      {0xba43b74000000000, 0x0000000000000000},
-      {0xe8d4a51000000000, 0x0000000000000000},
-      {0x9184e72a00000000, 0x0000000000000000},
-      {0xb5e620f480000000, 0x0000000000000000},
-      {0xe35fa931a0000000, 0x0000000000000000},
-      {0x8e1bc9bf04000000, 0x0000000000000000},
-      {0xb1a2bc2ec5000000, 0x0000000000000000},
-      {0xde0b6b3a76400000, 0x0000000000000000},
-      {0x8ac7230489e80000, 0x0000000000000000},
-      {0xad78ebc5ac620000, 0x0000000000000000},
-      {0xd8d726b7177a8000, 0x0000000000000000},
-      {0x878678326eac9000, 0x0000000000000000},
-      {0xa968163f0a57b400, 0x0000000000000000},
-      {0xd3c21bcecceda100, 0x0000000000000000},
-      {0x84595161401484a0, 0x0000000000000000},
-      {0xa56fa5b99019a5c8, 0x0000000000000000},
-      {0xcecb8f27f4200f3a, 0x0000000000000000},
-      {0x813f3978f8940984, 0x4000000000000000},
-      {0xa18f07d736b90be5, 0x5000000000000000},
-      {0xc9f2c9cd04674ede, 0xa400000000000000},
-      {0xfc6f7c4045812296, 0x4d00000000000000},
-      {0x9dc5ada82b70b59d, 0xf020000000000000},
-      {0xc5371912364ce305, 0x6c28000000000000},
-      {0xf684df56c3e01bc6, 0xc732000000000000},
-      {0x9a130b963a6c115c, 0x3c7f400000000000},
-      {0xc097ce7bc90715b3, 0x4b9f100000000000},
-      {0xf0bdc21abb48db20, 0x1e86d40000000000},
-      {0x96769950b50d88f4, 0x1314448000000000},
-      {0xbc143fa4e250eb31, 0x17d955a000000000},
-      {0xeb194f8e1ae525fd, 0x5dcfab0800000000},
-      {0x92efd1b8d0cf37be, 0x5aa1cae500000000},
-      {0xb7abc627050305ad, 0xf14a3d9e40000000},
-      {0xe596b7b0c643c719, 0x6d9ccd05d0000000},
-      {0x8f7e32ce7bea5c6f, 0xe4820023a2000000},
-      {0xb35dbf821ae4f38b, 0xdda2802c8a800000},
-      {0xe0352f62a19e306e, 0xd50b2037ad200000},
-      {0x8c213d9da502de45, 0x4526f422cc340000},
-      {0xaf298d050e4395d6, 0x9670b12b7f410000},
-      {0xdaf3f04651d47b4c, 0x3c0cdd765f114000},
-      {0x88d8762bf324cd0f, 0xa5880a69fb6ac800},
-      {0xab0e93b6efee0053, 0x8eea0d047a457a00},
-      {0xd5d238a4abe98068, 0x72a4904598d6d880},
-      {0x85a36366eb71f041, 0x47a6da2b7f864750},
-      {0xa70c3c40a64e6c51, 0x999090b65f67d924},
-      {0xd0cf4b50cfe20765, 0xfff4b4e3f741cf6d},
-      {0x82818f1281ed449f, 0xbff8f10e7a8921a5},
-      {0xa321f2d7226895c7, 0xaff72d52192b6a0e},
-      {0xcbea6f8ceb02bb39, 0x9bf4f8a69f764491},
-      {0xfee50b7025c36a08, 0x02f236d04753d5b5},
-      {0x9f4f2726179a2245, 0x01d762422c946591},
-      {0xc722f0ef9d80aad6, 0x424d3ad2b7b97ef6},
-      {0xf8ebad2b84e0d58b, 0xd2e0898765a7deb3},
-      {0x9b934c3b330c8577, 0x63cc55f49f88eb30},
-      {0xc2781f49ffcfa6d5, 0x3cbf6b71c76b25fc},
-      {0xf316271c7fc3908a, 0x8bef464e3945ef7b},
-      {0x97edd871cfda3a56, 0x97758bf0e3cbb5ad},
-      {0xbde94e8e43d0c8ec, 0x3d52eeed1cbea318},
-      {0xed63a231d4c4fb27, 0x4ca7aaa863ee4bde},
-      {0x945e455f24fb1cf8, 0x8fe8caa93e74ef6b},
-      {0xb975d6b6ee39e436, 0xb3e2fd538e122b45},
-      {0xe7d34c64a9c85d44, 0x60dbbca87196b617},
-      {0x90e40fbeea1d3a4a, 0xbc8955e946fe31ce},
-      {0xb51d13aea4a488dd, 0x6babab6398bdbe42},
-      {0xe264589a4dcdab14, 0xc696963c7eed2dd2},
-      {0x8d7eb76070a08aec, 0xfc1e1de5cf543ca3},
-      {0xb0de65388cc8ada8, 0x3b25a55f43294bcc},
-      {0xdd15fe86affad912, 0x49ef0eb713f39ebf},
-      {0x8a2dbf142dfcc7ab, 0x6e3569326c784338},
-      {0xacb92ed9397bf996, 0x49c2c37f07965405},
-      {0xd7e77a8f87daf7fb, 0xdc33745ec97be907},
-      {0x86f0ac99b4e8dafd, 0x69a028bb3ded71a4},
-      {0xa8acd7c0222311bc, 0xc40832ea0d68ce0d},
-      {0xd2d80db02aabd62b, 0xf50a3fa490c30191},
-      {0x83c7088e1aab65db, 0x792667c6da79e0fb},
-      {0xa4b8cab1a1563f52, 0x577001b891185939},
-      {0xcde6fd5e09abcf26, 0xed4c0226b55e6f87},
-      {0x80b05e5ac60b6178, 0x544f8158315b05b5},
-      {0xa0dc75f1778e39d6, 0x696361ae3db1c722},
-      {0xc913936dd571c84c, 0x03bc3a19cd1e38ea},
-      {0xfb5878494ace3a5f, 0x04ab48a04065c724},
-      {0x9d174b2dcec0e47b, 0x62eb0d64283f9c77},
-      {0xc45d1df942711d9a, 0x3ba5d0bd324f8395},
-      {0xf5746577930d6500, 0xca8f44ec7ee3647a},
-      {0x9968bf6abbe85f20, 0x7e998b13cf4e1ecc},
-      {0xbfc2ef456ae276e8, 0x9e3fedd8c321a67f},
-      {0xefb3ab16c59b14a2, 0xc5cfe94ef3ea101f},
-      {0x95d04aee3b80ece5, 0xbba1f1d158724a13},
-      {0xbb445da9ca61281f, 0x2a8a6e45ae8edc98},
-      {0xea1575143cf97226, 0xf52d09d71a3293be},
-      {0x924d692ca61be758, 0x593c2626705f9c57},
-      {0xb6e0c377cfa2e12e, 0x6f8b2fb00c77836d},
-      {0xe498f455c38b997a, 0x0b6dfb9c0f956448},
-      {0x8edf98b59a373fec, 0x4724bd4189bd5ead},
-      {0xb2977ee300c50fe7, 0x58edec91ec2cb658},
-      {0xdf3d5e9bc0f653e1, 0x2f2967b66737e3ee},
-      {0x8b865b215899f46c, 0xbd79e0d20082ee75},
-      {0xae67f1e9aec07187, 0xecd8590680a3aa12},
-      {0xda01ee641a708de9, 0xe80e6f4820cc9496},
-      {0x884134fe908658b2, 0x3109058d147fdcde},
-      {0xaa51823e34a7eede, 0xbd4b46f0599fd416},
-      {0xd4e5e2cdc1d1ea96, 0x6c9e18ac7007c91b},
-      {0x850fadc09923329e, 0x03e2cf6bc604ddb1},
-      {0xa6539930bf6bff45, 0x84db8346b786151d},
-      {0xcfe87f7cef46ff16, 0xe612641865679a64},
-      {0x81f14fae158c5f6e, 0x4fcb7e8f3f60c07f},
-      {0xa26da3999aef7749, 0xe3be5e330f38f09e},
-      {0xcb090c8001ab551c, 0x5cadf5bfd3072cc6},
-      {0xfdcb4fa002162a63, 0x73d9732fc7c8f7f7},
-      {0x9e9f11c4014dda7e, 0x2867e7fddcdd9afb},
-      {0xc646d63501a1511d, 0xb281e1fd541501b9},
-      {0xf7d88bc24209a565, 0x1f225a7ca91a4227},
-      {0x9ae757596946075f, 0x3375788de9b06959},
-      {0xc1a12d2fc3978937, 0x0052d6b1641c83af},
-      {0xf209787bb47d6b84, 0xc0678c5dbd23a49b},
-      {0x9745eb4d50ce6332, 0xf840b7ba963646e1},
-      {0xbd176620a501fbff, 0xb650e5a93bc3d899},
-      {0xec5d3fa8ce427aff, 0xa3e51f138ab4cebf},
-      {0x93ba47c980e98cdf, 0xc66f336c36b10138},
-      {0xb8a8d9bbe123f017, 0xb80b0047445d4185},
-      {0xe6d3102ad96cec1d, 0xa60dc059157491e6},
-      {0x9043ea1ac7e41392, 0x87c89837ad68db30},
-      {0xb454e4a179dd1877, 0x29babe4598c311fc},
-      {0xe16a1dc9d8545e94, 0xf4296dd6fef3d67b},
-      {0x8ce2529e2734bb1d, 0x1899e4a65f58660d},
-      {0xb01ae745b101e9e4, 0x5ec05dcff72e7f90},
-      {0xdc21a1171d42645d, 0x76707543f4fa1f74},
-      {0x899504ae72497eba, 0x6a06494a791c53a9},
-      {0xabfa45da0edbde69, 0x0487db9d17636893},
-      {0xd6f8d7509292d603, 0x45a9d2845d3c42b7},
-      {0x865b86925b9bc5c2, 0x0b8a2392ba45a9b3},
-      {0xa7f26836f282b732, 0x8e6cac7768d7141f},
-      {0xd1ef0244af2364ff, 0x3207d795430cd927},
-      {0x8335616aed761f1f, 0x7f44e6bd49e807b9},
-      {0xa402b9c5a8d3a6e7, 0x5f16206c9c6209a7},
-      {0xcd036837130890a1, 0x36dba887c37a8c10},
-      {0x802221226be55a64, 0xc2494954da2c978a},
-      {0xa02aa96b06deb0fd, 0xf2db9baa10b7bd6d},
-      {0xc83553c5c8965d3d, 0x6f92829494e5acc8},
-      {0xfa42a8b73abbf48c, 0xcb772339ba1f17fa},
-      {0x9c69a97284b578d7, 0xff2a760414536efc},
-      {0xc38413cf25e2d70d, 0xfef5138519684abb},
-      {0xf46518c2ef5b8cd1, 0x7eb258665fc25d6a},
-      {0x98bf2f79d5993802, 0xef2f773ffbd97a62},
-      {0xbeeefb584aff8603, 0xaafb550ffacfd8fb},
-      {0xeeaaba2e5dbf6784, 0x95ba2a53f983cf39},
-      {0x952ab45cfa97a0b2, 0xdd945a747bf26184},
-      {0xba756174393d88df, 0x94f971119aeef9e5},
-      {0xe912b9d1478ceb17, 0x7a37cd5601aab85e},
-      {0x91abb422ccb812ee, 0xac62e055c10ab33b},
-      {0xb616a12b7fe617aa, 0x577b986b314d600a},
-      {0xe39c49765fdf9d94, 0xed5a7e85fda0b80c},
-      {0x8e41ade9fbebc27d, 0x14588f13be847308},
-      {0xb1d219647ae6b31c, 0x596eb2d8ae258fc9},
-      {0xde469fbd99a05fe3, 0x6fca5f8ed9aef3bc},
-      {0x8aec23d680043bee, 0x25de7bb9480d5855},
-      {0xada72ccc20054ae9, 0xaf561aa79a10ae6b},
-      {0xd910f7ff28069da4, 0x1b2ba1518094da05},
-      {0x87aa9aff79042286, 0x90fb44d2f05d0843},
-      {0xa99541bf57452b28, 0x353a1607ac744a54},
-      {0xd3fa922f2d1675f2, 0x42889b8997915ce9},
-      {0x847c9b5d7c2e09b7, 0x69956135febada12},
-      {0xa59bc234db398c25, 0x43fab9837e699096},
-      {0xcf02b2c21207ef2e, 0x94f967e45e03f4bc},
-      {0x8161afb94b44f57d, 0x1d1be0eebac278f6},
-      {0xa1ba1ba79e1632dc, 0x6462d92a69731733},
-      {0xca28a291859bbf93, 0x7d7b8f7503cfdcff},
-      {0xfcb2cb35e702af78, 0x5cda735244c3d43f},
-      {0x9defbf01b061adab, 0x3a0888136afa64a8},
-      {0xc56baec21c7a1916, 0x088aaa1845b8fdd1},
-      {0xf6c69a72a3989f5b, 0x8aad549e57273d46},
-      {0x9a3c2087a63f6399, 0x36ac54e2f678864c},
-      {0xc0cb28a98fcf3c7f, 0x84576a1bb416a7de},
-      {0xf0fdf2d3f3c30b9f, 0x656d44a2a11c51d6},
-      {0x969eb7c47859e743, 0x9f644ae5a4b1b326},
-      {0xbc4665b596706114, 0x873d5d9f0dde1fef},
-      {0xeb57ff22fc0c7959, 0xa90cb506d155a7eb},
-      {0x9316ff75dd87cbd8, 0x09a7f12442d588f3},
-      {0xb7dcbf5354e9bece, 0x0c11ed6d538aeb30},
-      {0xe5d3ef282a242e81, 0x8f1668c8a86da5fb},
-      {0x8fa475791a569d10, 0xf96e017d694487bd},
-      {0xb38d92d760ec4455, 0x37c981dcc395a9ad},
-      {0xe070f78d3927556a, 0x85bbe253f47b1418},
-      {0x8c469ab843b89562, 0x93956d7478ccec8f},
-      {0xaf58416654a6babb, 0x387ac8d1970027b3},
-      {0xdb2e51bfe9d0696a, 0x06997b05fcc0319f},
-      {0x88fcf317f22241e2, 0x441fece3bdf81f04},
-      {0xab3c2fddeeaad25a, 0xd527e81cad7626c4},
-      {0xd60b3bd56a5586f1, 0x8a71e223d8d3b075},
-      {0x85c7056562757456, 0xf6872d5667844e4a},
-      {0xa738c6bebb12d16c, 0xb428f8ac016561dc},
-      {0xd106f86e69d785c7, 0xe13336d701beba53},
-      {0x82a45b450226b39c, 0xecc0024661173474},
-      {0xa34d721642b06084, 0x27f002d7f95d0191},
-      {0xcc20ce9bd35c78a5, 0x31ec038df7b441f5},
-      {0xff290242c83396ce, 0x7e67047175a15272},
-      {0x9f79a169bd203e41, 0x0f0062c6e984d387},
-      {0xc75809c42c684dd1, 0x52c07b78a3e60869},
-      {0xf92e0c3537826145, 0xa7709a56ccdf8a83},
-      {0x9bbcc7a142b17ccb, 0x88a66076400bb692},
-      {0xc2abf989935ddbfe, 0x6acff893d00ea436},
-      {0xf356f7ebf83552fe, 0x0583f6b8c4124d44},
-      {0x98165af37b2153de, 0xc3727a337a8b704b},
-      {0xbe1bf1b059e9a8d6, 0x744f18c0592e4c5d},
-      {0xeda2ee1c7064130c, 0x1162def06f79df74},
-      {0x9485d4d1c63e8be7, 0x8addcb5645ac2ba9},
-      {0xb9a74a0637ce2ee1, 0x6d953e2bd7173693},
-      {0xe8111c87c5c1ba99, 0xc8fa8db6ccdd0438},
-      {0x910ab1d4db9914a0, 0x1d9c9892400a22a3},
-      {0xb54d5e4a127f59c8, 0x2503beb6d00cab4c},
-      {0xe2a0b5dc971f303a, 0x2e44ae64840fd61e},
-      {0x8da471a9de737e24, 0x5ceaecfed289e5d3},
-      {0xb10d8e1456105dad, 0x7425a83e872c5f48},
-      {0xdd50f1996b947518, 0xd12f124e28f7771a},
-      {0x8a5296ffe33cc92f, 0x82bd6b70d99aaa70},
-      {0xace73cbfdc0bfb7b, 0x636cc64d1001550c},
-      {0xd8210befd30efa5a, 0x3c47f7e05401aa4f},
-      {0x8714a775e3e95c78, 0x65acfaec34810a72},
-      {0xa8d9d1535ce3b396, 0x7f1839a741a14d0e},
-      {0xd31045a8341ca07c, 0x1ede48111209a051},
-      {0x83ea2b892091e44d, 0x934aed0aab460433},
-      {0xa4e4b66b68b65d60, 0xf81da84d56178540},
-      {0xce1de40642e3f4b9, 0x36251260ab9d668f},
-      {0x80d2ae83e9ce78f3, 0xc1d72b7c6b42601a},
-      {0xa1075a24e4421730, 0xb24cf65b8612f820},
-      {0xc94930ae1d529cfc, 0xdee033f26797b628},
-      {0xfb9b7cd9a4a7443c, 0x169840ef017da3b2},
-      {0x9d412e0806e88aa5, 0x8e1f289560ee864f},
-      {0xc491798a08a2ad4e, 0xf1a6f2bab92a27e3},
-      {0xf5b5d7ec8acb58a2, 0xae10af696774b1dc},
-      {0x9991a6f3d6bf1765, 0xacca6da1e0a8ef2a},
-      {0xbff610b0cc6edd3f, 0x17fd090a58d32af4},
-      {0xeff394dcff8a948e, 0xddfc4b4cef07f5b1},
-      {0x95f83d0a1fb69cd9, 0x4abdaf101564f98f},
-      {0xbb764c4ca7a4440f, 0x9d6d1ad41abe37f2},
-      {0xea53df5fd18d5513, 0x84c86189216dc5ee},
-      {0x92746b9be2f8552c, 0x32fd3cf5b4e49bb5},
-      {0xb7118682dbb66a77, 0x3fbc8c33221dc2a2},
-      {0xe4d5e82392a40515, 0x0fabaf3feaa5334b},
-      {0x8f05b1163ba6832d, 0x29cb4d87f2a7400f},
-      {0xb2c71d5bca9023f8, 0x743e20e9ef511013},
-      {0xdf78e4b2bd342cf6, 0x914da9246b255417},
-      {0x8bab8eefb6409c1a, 0x1ad089b6c2f7548f},
-      {0xae9672aba3d0c320, 0xa184ac2473b529b2},
-      {0xda3c0f568cc4f3e8, 0xc9e5d72d90a2741f},
-      {0x8865899617fb1871, 0x7e2fa67c7a658893},
-      {0xaa7eebfb9df9de8d, 0xddbb901b98feeab8},
-      {0xd51ea6fa85785631, 0x552a74227f3ea566},
-      {0x8533285c936b35de, 0xd53a88958f872760},
-      {0xa67ff273b8460356, 0x8a892abaf368f138},
-      {0xd01fef10a657842c, 0x2d2b7569b0432d86},
-      {0x8213f56a67f6b29b, 0x9c3b29620e29fc74},
-      {0xa298f2c501f45f42, 0x8349f3ba91b47b90},
-      {0xcb3f2f7642717713, 0x241c70a936219a74},
-      {0xfe0efb53d30dd4d7, 0xed238cd383aa0111},
-      {0x9ec95d1463e8a506, 0xf4363804324a40ab},
-      {0xc67bb4597ce2ce48, 0xb143c6053edcd0d6},
-      {0xf81aa16fdc1b81da, 0xdd94b7868e94050b},
-      {0x9b10a4e5e9913128, 0xca7cf2b4191c8327},
-      {0xc1d4ce1f63f57d72, 0xfd1c2f611f63a3f1},
-      {0xf24a01a73cf2dccf, 0xbc633b39673c8ced},
-      {0x976e41088617ca01, 0xd5be0503e085d814},
-      {0xbd49d14aa79dbc82, 0x4b2d8644d8a74e19},
-      {0xec9c459d51852ba2, 0xddf8e7d60ed1219f},
-      {0x93e1ab8252f33b45, 0xcabb90e5c942b504},
-      {0xb8da1662e7b00a17, 0x3d6a751f3b936244},
-      {0xe7109bfba19c0c9d, 0x0cc512670a783ad5},
-      {0x906a617d450187e2, 0x27fb2b80668b24c6},
-      {0xb484f9dc9641e9da, 0xb1f9f660802dedf7},
-      {0xe1a63853bbd26451, 0x5e7873f8a0396974},
-      {0x8d07e33455637eb2, 0xdb0b487b6423e1e9},
-      {0xb049dc016abc5e5f, 0x91ce1a9a3d2cda63},
-      {0xdc5c5301c56b75f7, 0x7641a140cc7810fc},
-      {0x89b9b3e11b6329ba, 0xa9e904c87fcb0a9e},
-      {0xac2820d9623bf429, 0x546345fa9fbdcd45},
-      {0xd732290fbacaf133, 0xa97c177947ad4096},
-      {0x867f59a9d4bed6c0, 0x49ed8eabcccc485e},
-      {0xa81f301449ee8c70, 0x5c68f256bfff5a75},
-      {0xd226fc195c6a2f8c, 0x73832eec6fff3112},
-      {0x83585d8fd9c25db7, 0xc831fd53c5ff7eac},
-      {0xa42e74f3d032f525, 0xba3e7ca8b77f5e56},
-      {0xcd3a1230c43fb26f, 0x28ce1bd2e55f35ec},
-      {0x80444b5e7aa7cf85, 0x7980d163cf5b81b4},
-      {0xa0555e361951c366, 0xd7e105bcc3326220},
-      {0xc86ab5c39fa63440, 0x8dd9472bf3fefaa8},
-      {0xfa856334878fc150, 0xb14f98f6f0feb952},
-      {0x9c935e00d4b9d8d2, 0x6ed1bf9a569f33d4},
-      {0xc3b8358109e84f07, 0x0a862f80ec4700c9},
-      {0xf4a642e14c6262c8, 0xcd27bb612758c0fb},
-      {0x98e7e9cccfbd7dbd, 0x8038d51cb897789d},
-      {0xbf21e44003acdd2c, 0xe0470a63e6bd56c4},
-      {0xeeea5d5004981478, 0x1858ccfce06cac75},
-      {0x95527a5202df0ccb, 0x0f37801e0c43ebc9},
-      {0xbaa718e68396cffd, 0xd30560258f54e6bb},
-      {0xe950df20247c83fd, 0x47c6b82ef32a206a},
-      {0x91d28b7416cdd27e, 0x4cdc331d57fa5442},
-      {0xb6472e511c81471d, 0xe0133fe4adf8e953},
-      {0xe3d8f9e563a198e5, 0x58180fddd97723a7},
-      {0x8e679c2f5e44ff8f, 0x570f09eaa7ea7649},
-      {0xb201833b35d63f73, 0x2cd2cc6551e513db},
-      {0xde81e40a034bcf4f, 0xf8077f7ea65e58d2},
-      {0x8b112e86420f6191, 0xfb04afaf27faf783},
-      {0xadd57a27d29339f6, 0x79c5db9af1f9b564},
-      {0xd94ad8b1c7380874, 0x18375281ae7822bd},
-      {0x87cec76f1c830548, 0x8f2293910d0b15b6},
-      {0xa9c2794ae3a3c69a, 0xb2eb3875504ddb23},
-      {0xd433179d9c8cb841, 0x5fa60692a46151ec},
-      {0x849feec281d7f328, 0xdbc7c41ba6bcd334},
-      {0xa5c7ea73224deff3, 0x12b9b522906c0801},
-      {0xcf39e50feae16bef, 0xd768226b34870a01},
-      {0x81842f29f2cce375, 0xe6a1158300d46641},
-      {0xa1e53af46f801c53, 0x60495ae3c1097fd1},
-      {0xca5e89b18b602368, 0x385bb19cb14bdfc5},
-      {0xfcf62c1dee382c42, 0x46729e03dd9ed7b6},
-      {0x9e19db92b4e31ba9, 0x6c07a2c26a8346d2},
-      {0xc5a05277621be293, 0xc7098b7305241886},
-      {0xf70867153aa2db38, 0xb8cbee4fc66d1ea8},
-      {0x9a65406d44a5c903, 0x737f74f1dc043329},
-      {0xc0fe908895cf3b44, 0x505f522e53053ff3},
-      {0xf13e34aabb430a15, 0x647726b9e7c68ff0},
-      {0x96c6e0eab509e64d, 0x5eca783430dc19f6},
-      {0xbc789925624c5fe0, 0xb67d16413d132073},
-      {0xeb96bf6ebadf77d8, 0xe41c5bd18c57e890},
-      {0x933e37a534cbaae7, 0x8e91b962f7b6f15a},
-      {0xb80dc58e81fe95a1, 0x723627bbb5a4adb1},
-      {0xe61136f2227e3b09, 0xcec3b1aaa30dd91d},
-      {0x8fcac257558ee4e6, 0x213a4f0aa5e8a7b2},
-      {0xb3bd72ed2af29e1f, 0xa988e2cd4f62d19e},
-      {0xe0accfa875af45a7, 0x93eb1b80a33b8606},
-      {0x8c6c01c9498d8b88, 0xbc72f130660533c4},
-      {0xaf87023b9bf0ee6a, 0xeb8fad7c7f8680b5},
-      {0xdb68c2ca82ed2a05, 0xa67398db9f6820e2},
+        {0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7b},
+        {0x9faacf3df73609b1, 0x77b191618c54e9ad},
+        {0xc795830d75038c1d, 0xd59df5b9ef6a2418},
+        {0xf97ae3d0d2446f25, 0x4b0573286b44ad1e},
+        {0x9becce62836ac577, 0x4ee367f9430aec33},
+        {0xc2e801fb244576d5, 0x229c41f793cda740},
+        {0xf3a20279ed56d48a, 0x6b43527578c11110},
+        {0x9845418c345644d6, 0x830a13896b78aaaa},
+        {0xbe5691ef416bd60c, 0x23cc986bc656d554},
+        {0xedec366b11c6cb8f, 0x2cbfbe86b7ec8aa9},
+        {0x94b3a202eb1c3f39, 0x7bf7d71432f3d6aa},
+        {0xb9e08a83a5e34f07, 0xdaf5ccd93fb0cc54},
+        {0xe858ad248f5c22c9, 0xd1b3400f8f9cff69},
+        {0x91376c36d99995be, 0x23100809b9c21fa2},
+        {0xb58547448ffffb2d, 0xabd40a0c2832a78b},
+        {0xe2e69915b3fff9f9, 0x16c90c8f323f516d},
+        {0x8dd01fad907ffc3b, 0xae3da7d97f6792e4},
+        {0xb1442798f49ffb4a, 0x99cd11cfdf41779d},
+        {0xdd95317f31c7fa1d, 0x40405643d711d584},
+        {0x8a7d3eef7f1cfc52, 0x482835ea666b2573},
+        {0xad1c8eab5ee43b66, 0xda3243650005eed0},
+        {0xd863b256369d4a40, 0x90bed43e40076a83},
+        {0x873e4f75e2224e68, 0x5a7744a6e804a292},
+        {0xa90de3535aaae202, 0x711515d0a205cb37},
+        {0xd3515c2831559a83, 0x0d5a5b44ca873e04},
+        {0x8412d9991ed58091, 0xe858790afe9486c3},
+        {0xa5178fff668ae0b6, 0x626e974dbe39a873},
+        {0xce5d73ff402d98e3, 0xfb0a3d212dc81290},
+        {0x80fa687f881c7f8e, 0x7ce66634bc9d0b9a},
+        {0xa139029f6a239f72, 0x1c1fffc1ebc44e81},
+        {0xc987434744ac874e, 0xa327ffb266b56221},
+        {0xfbe9141915d7a922, 0x4bf1ff9f0062baa9},
+        {0x9d71ac8fada6c9b5, 0x6f773fc3603db4aa},
+        {0xc4ce17b399107c22, 0xcb550fb4384d21d4},
+        {0xf6019da07f549b2b, 0x7e2a53a146606a49},
+        {0x99c102844f94e0fb, 0x2eda7444cbfc426e},
+        {0xc0314325637a1939, 0xfa911155fefb5309},
+        {0xf03d93eebc589f88, 0x793555ab7eba27cb},
+        {0x96267c7535b763b5, 0x4bc1558b2f3458df},
+        {0xbbb01b9283253ca2, 0x9eb1aaedfb016f17},
+        {0xea9c227723ee8bcb, 0x465e15a979c1cadd},
+        {0x92a1958a7675175f, 0x0bfacd89ec191eca},
+        {0xb749faed14125d36, 0xcef980ec671f667c},
+        {0xe51c79a85916f484, 0x82b7e12780e7401b},
+        {0x8f31cc0937ae58d2, 0xd1b2ecb8b0908811},
+        {0xb2fe3f0b8599ef07, 0x861fa7e6dcb4aa16},
+        {0xdfbdcece67006ac9, 0x67a791e093e1d49b},
+        {0x8bd6a141006042bd, 0xe0c8bb2c5c6d24e1},
+        {0xaecc49914078536d, 0x58fae9f773886e19},
+        {0xda7f5bf590966848, 0xaf39a475506a899f},
+        {0x888f99797a5e012d, 0x6d8406c952429604},
+        {0xaab37fd7d8f58178, 0xc8e5087ba6d33b84},
+        {0xd5605fcdcf32e1d6, 0xfb1e4a9a90880a65},
+        {0x855c3be0a17fcd26, 0x5cf2eea09a550680},
+        {0xa6b34ad8c9dfc06f, 0xf42faa48c0ea481f},
+        {0xd0601d8efc57b08b, 0xf13b94daf124da27},
+        {0x823c12795db6ce57, 0x76c53d08d6b70859},
+        {0xa2cb1717b52481ed, 0x54768c4b0c64ca6f},
+        {0xcb7ddcdda26da268, 0xa9942f5dcf7dfd0a},
+        {0xfe5d54150b090b02, 0xd3f93b35435d7c4d},
+        {0x9efa548d26e5a6e1, 0xc47bc5014a1a6db0},
+        {0xc6b8e9b0709f109a, 0x359ab6419ca1091c},
+        {0xf867241c8cc6d4c0, 0xc30163d203c94b63},
+        {0x9b407691d7fc44f8, 0x79e0de63425dcf1e},
+        {0xc21094364dfb5636, 0x985915fc12f542e5},
+        {0xf294b943e17a2bc4, 0x3e6f5b7b17b2939e},
+        {0x979cf3ca6cec5b5a, 0xa705992ceecf9c43},
+        {0xbd8430bd08277231, 0x50c6ff782a838354},
+        {0xece53cec4a314ebd, 0xa4f8bf5635246429},
+        {0x940f4613ae5ed136, 0x871b7795e136be9a},
+        {0xb913179899f68584, 0x28e2557b59846e40},
+        {0xe757dd7ec07426e5, 0x331aeada2fe589d0},
+        {0x9096ea6f3848984f, 0x3ff0d2c85def7622},
+        {0xb4bca50b065abe63, 0x0fed077a756b53aa},
+        {0xe1ebce4dc7f16dfb, 0xd3e8495912c62895},
+        {0x8d3360f09cf6e4bd, 0x64712dd7abbbd95d},
+        {0xb080392cc4349dec, 0xbd8d794d96aacfb4},
+        {0xdca04777f541c567, 0xecf0d7a0fc5583a1},
+        {0x89e42caaf9491b60, 0xf41686c49db57245},
+        {0xac5d37d5b79b6239, 0x311c2875c522ced6},
+        {0xd77485cb25823ac7, 0x7d633293366b828c},
+        {0x86a8d39ef77164bc, 0xae5dff9c02033198},
+        {0xa8530886b54dbdeb, 0xd9f57f830283fdfd},
+        {0xd267caa862a12d66, 0xd072df63c324fd7c},
+        {0x8380dea93da4bc60, 0x4247cb9e59f71e6e},
+        {0xa46116538d0deb78, 0x52d9be85f074e609},
+        {0xcd795be870516656, 0x67902e276c921f8c},
+        {0x806bd9714632dff6, 0x00ba1cd8a3db53b7},
+        {0xa086cfcd97bf97f3, 0x80e8a40eccd228a5},
+        {0xc8a883c0fdaf7df0, 0x6122cd128006b2ce},
+        {0xfad2a4b13d1b5d6c, 0x796b805720085f82},
+        {0x9cc3a6eec6311a63, 0xcbe3303674053bb1},
+        {0xc3f490aa77bd60fc, 0xbedbfc4411068a9d},
+        {0xf4f1b4d515acb93b, 0xee92fb5515482d45},
+        {0x991711052d8bf3c5, 0x751bdd152d4d1c4b},
+        {0xbf5cd54678eef0b6, 0xd262d45a78a0635e},
+        {0xef340a98172aace4, 0x86fb897116c87c35},
+        {0x9580869f0e7aac0e, 0xd45d35e6ae3d4da1},
+        {0xbae0a846d2195712, 0x8974836059cca10a},
+        {0xe998d258869facd7, 0x2bd1a438703fc94c},
+        {0x91ff83775423cc06, 0x7b6306a34627ddd0},
+        {0xb67f6455292cbf08, 0x1a3bc84c17b1d543},
+        {0xe41f3d6a7377eeca, 0x20caba5f1d9e4a94},
+        {0x8e938662882af53e, 0x547eb47b7282ee9d},
+        {0xb23867fb2a35b28d, 0xe99e619a4f23aa44},
+        {0xdec681f9f4c31f31, 0x6405fa00e2ec94d5},
+        {0x8b3c113c38f9f37e, 0xde83bc408dd3dd05},
+        {0xae0b158b4738705e, 0x9624ab50b148d446},
+        {0xd98ddaee19068c76, 0x3badd624dd9b0958},
+        {0x87f8a8d4cfa417c9, 0xe54ca5d70a80e5d7},
+        {0xa9f6d30a038d1dbc, 0x5e9fcf4ccd211f4d},
+        {0xd47487cc8470652b, 0x7647c32000696720},
+        {0x84c8d4dfd2c63f3b, 0x29ecd9f40041e074},
+        {0xa5fb0a17c777cf09, 0xf468107100525891},
+        {0xcf79cc9db955c2cc, 0x7182148d4066eeb5},
+        {0x81ac1fe293d599bf, 0xc6f14cd848405531},
+        {0xa21727db38cb002f, 0xb8ada00e5a506a7d},
+        {0xca9cf1d206fdc03b, 0xa6d90811f0e4851d},
+        {0xfd442e4688bd304a, 0x908f4a166d1da664},
+        {0x9e4a9cec15763e2e, 0x9a598e4e043287ff},
+        {0xc5dd44271ad3cdba, 0x40eff1e1853f29fe},
+        {0xf7549530e188c128, 0xd12bee59e68ef47d},
+        {0x9a94dd3e8cf578b9, 0x82bb74f8301958cf},
+        {0xc13a148e3032d6e7, 0xe36a52363c1faf02},
+        {0xf18899b1bc3f8ca1, 0xdc44e6c3cb279ac2},
+        {0x96f5600f15a7b7e5, 0x29ab103a5ef8c0ba},
+        {0xbcb2b812db11a5de, 0x7415d448f6b6f0e8},
+        {0xebdf661791d60f56, 0x111b495b3464ad22},
+        {0x936b9fcebb25c995, 0xcab10dd900beec35},
+        {0xb84687c269ef3bfb, 0x3d5d514f40eea743},
+        {0xe65829b3046b0afa, 0x0cb4a5a3112a5113},
+        {0x8ff71a0fe2c2e6dc, 0x47f0e785eaba72ac},
+        {0xb3f4e093db73a093, 0x59ed216765690f57},
+        {0xe0f218b8d25088b8, 0x306869c13ec3532d},
+        {0x8c974f7383725573, 0x1e414218c73a13fc},
+        {0xafbd2350644eeacf, 0xe5d1929ef90898fb},
+        {0xdbac6c247d62a583, 0xdf45f746b74abf3a},
+        {0x894bc396ce5da772, 0x6b8bba8c328eb784},
+        {0xab9eb47c81f5114f, 0x066ea92f3f326565},
+        {0xd686619ba27255a2, 0xc80a537b0efefebe},
+        {0x8613fd0145877585, 0xbd06742ce95f5f37},
+        {0xa798fc4196e952e7, 0x2c48113823b73705},
+        {0xd17f3b51fca3a7a0, 0xf75a15862ca504c6},
+        {0x82ef85133de648c4, 0x9a984d73dbe722fc},
+        {0xa3ab66580d5fdaf5, 0xc13e60d0d2e0ebbb},
+        {0xcc963fee10b7d1b3, 0x318df905079926a9},
+        {0xffbbcfe994e5c61f, 0xfdf17746497f7053},
+        {0x9fd561f1fd0f9bd3, 0xfeb6ea8bedefa634},
+        {0xc7caba6e7c5382c8, 0xfe64a52ee96b8fc1},
+        {0xf9bd690a1b68637b, 0x3dfdce7aa3c673b1},
+        {0x9c1661a651213e2d, 0x06bea10ca65c084f},
+        {0xc31bfa0fe5698db8, 0x486e494fcff30a63},
+        {0xf3e2f893dec3f126, 0x5a89dba3c3efccfb},
+        {0x986ddb5c6b3a76b7, 0xf89629465a75e01d},
+        {0xbe89523386091465, 0xf6bbb397f1135824},
+        {0xee2ba6c0678b597f, 0x746aa07ded582e2d},
+        {0x94db483840b717ef, 0xa8c2a44eb4571cdd},
+        {0xba121a4650e4ddeb, 0x92f34d62616ce414},
+        {0xe896a0d7e51e1566, 0x77b020baf9c81d18},
+        {0x915e2486ef32cd60, 0x0ace1474dc1d122f},
+        {0xb5b5ada8aaff80b8, 0x0d819992132456bb},
+        {0xe3231912d5bf60e6, 0x10e1fff697ed6c6a},
+        {0x8df5efabc5979c8f, 0xca8d3ffa1ef463c2},
+        {0xb1736b96b6fd83b3, 0xbd308ff8a6b17cb3},
+        {0xddd0467c64bce4a0, 0xac7cb3f6d05ddbdf},
+        {0x8aa22c0dbef60ee4, 0x6bcdf07a423aa96c},
+        {0xad4ab7112eb3929d, 0x86c16c98d2c953c7},
+        {0xd89d64d57a607744, 0xe871c7bf077ba8b8},
+        {0x87625f056c7c4a8b, 0x11471cd764ad4973},
+        {0xa93af6c6c79b5d2d, 0xd598e40d3dd89bd0},
+        {0xd389b47879823479, 0x4aff1d108d4ec2c4},
+        {0x843610cb4bf160cb, 0xcedf722a585139bb},
+        {0xa54394fe1eedb8fe, 0xc2974eb4ee658829},
+        {0xce947a3da6a9273e, 0x733d226229feea33},
+        {0x811ccc668829b887, 0x0806357d5a3f5260},
+        {0xa163ff802a3426a8, 0xca07c2dcb0cf26f8},
+        {0xc9bcff6034c13052, 0xfc89b393dd02f0b6},
+        {0xfc2c3f3841f17c67, 0xbbac2078d443ace3},
+        {0x9d9ba7832936edc0, 0xd54b944b84aa4c0e},
+        {0xc5029163f384a931, 0x0a9e795e65d4df12},
+        {0xf64335bcf065d37d, 0x4d4617b5ff4a16d6},
+        {0x99ea0196163fa42e, 0x504bced1bf8e4e46},
+        {0xc06481fb9bcf8d39, 0xe45ec2862f71e1d7},
+        {0xf07da27a82c37088, 0x5d767327bb4e5a4d},
+        {0x964e858c91ba2655, 0x3a6a07f8d510f870},
+        {0xbbe226efb628afea, 0x890489f70a55368c},
+        {0xeadab0aba3b2dbe5, 0x2b45ac74ccea842f},
+        {0x92c8ae6b464fc96f, 0x3b0b8bc90012929e},
+        {0xb77ada0617e3bbcb, 0x09ce6ebb40173745},
+        {0xe55990879ddcaabd, 0xcc420a6a101d0516},
+        {0x8f57fa54c2a9eab6, 0x9fa946824a12232e},
+        {0xb32df8e9f3546564, 0x47939822dc96abfa},
+        {0xdff9772470297ebd, 0x59787e2b93bc56f8},
+        {0x8bfbea76c619ef36, 0x57eb4edb3c55b65b},
+        {0xaefae51477a06b03, 0xede622920b6b23f2},
+        {0xdab99e59958885c4, 0xe95fab368e45ecee},
+        {0x88b402f7fd75539b, 0x11dbcb0218ebb415},
+        {0xaae103b5fcd2a881, 0xd652bdc29f26a11a},
+        {0xd59944a37c0752a2, 0x4be76d3346f04960},
+        {0x857fcae62d8493a5, 0x6f70a4400c562ddc},
+        {0xa6dfbd9fb8e5b88e, 0xcb4ccd500f6bb953},
+        {0xd097ad07a71f26b2, 0x7e2000a41346a7a8},
+        {0x825ecc24c873782f, 0x8ed400668c0c28c9},
+        {0xa2f67f2dfa90563b, 0x728900802f0f32fb},
+        {0xcbb41ef979346bca, 0x4f2b40a03ad2ffba},
+        {0xfea126b7d78186bc, 0xe2f610c84987bfa9},
+        {0x9f24b832e6b0f436, 0x0dd9ca7d2df4d7ca},
+        {0xc6ede63fa05d3143, 0x91503d1c79720dbc},
+        {0xf8a95fcf88747d94, 0x75a44c6397ce912b},
+        {0x9b69dbe1b548ce7c, 0xc986afbe3ee11abb},
+        {0xc24452da229b021b, 0xfbe85badce996169},
+        {0xf2d56790ab41c2a2, 0xfae27299423fb9c4},
+        {0x97c560ba6b0919a5, 0xdccd879fc967d41b},
+        {0xbdb6b8e905cb600f, 0x5400e987bbc1c921},
+        {0xed246723473e3813, 0x290123e9aab23b69},
+        {0x9436c0760c86e30b, 0xf9a0b6720aaf6522},
+        {0xb94470938fa89bce, 0xf808e40e8d5b3e6a},
+        {0xe7958cb87392c2c2, 0xb60b1d1230b20e05},
+        {0x90bd77f3483bb9b9, 0xb1c6f22b5e6f48c3},
+        {0xb4ecd5f01a4aa828, 0x1e38aeb6360b1af4},
+        {0xe2280b6c20dd5232, 0x25c6da63c38de1b1},
+        {0x8d590723948a535f, 0x579c487e5a38ad0f},
+        {0xb0af48ec79ace837, 0x2d835a9df0c6d852},
+        {0xdcdb1b2798182244, 0xf8e431456cf88e66},
+        {0x8a08f0f8bf0f156b, 0x1b8e9ecb641b5900},
+        {0xac8b2d36eed2dac5, 0xe272467e3d222f40},
+        {0xd7adf884aa879177, 0x5b0ed81dcc6abb10},
+        {0x86ccbb52ea94baea, 0x98e947129fc2b4ea},
+        {0xa87fea27a539e9a5, 0x3f2398d747b36225},
+        {0xd29fe4b18e88640e, 0x8eec7f0d19a03aae},
+        {0x83a3eeeef9153e89, 0x1953cf68300424ad},
+        {0xa48ceaaab75a8e2b, 0x5fa8c3423c052dd8},
+        {0xcdb02555653131b6, 0x3792f412cb06794e},
+        {0x808e17555f3ebf11, 0xe2bbd88bbee40bd1},
+        {0xa0b19d2ab70e6ed6, 0x5b6aceaeae9d0ec5},
+        {0xc8de047564d20a8b, 0xf245825a5a445276},
+        {0xfb158592be068d2e, 0xeed6e2f0f0d56713},
+        {0x9ced737bb6c4183d, 0x55464dd69685606c},
+        {0xc428d05aa4751e4c, 0xaa97e14c3c26b887},
+        {0xf53304714d9265df, 0xd53dd99f4b3066a9},
+        {0x993fe2c6d07b7fab, 0xe546a8038efe402a},
+        {0xbf8fdb78849a5f96, 0xde98520472bdd034},
+        {0xef73d256a5c0f77c, 0x963e66858f6d4441},
+        {0x95a8637627989aad, 0xdde7001379a44aa9},
+        {0xbb127c53b17ec159, 0x5560c018580d5d53},
+        {0xe9d71b689dde71af, 0xaab8f01e6e10b4a7},
+        {0x9226712162ab070d, 0xcab3961304ca70e9},
+        {0xb6b00d69bb55c8d1, 0x3d607b97c5fd0d23},
+        {0xe45c10c42a2b3b05, 0x8cb89a7db77c506b},
+        {0x8eb98a7a9a5b04e3, 0x77f3608e92adb243},
+        {0xb267ed1940f1c61c, 0x55f038b237591ed4},
+        {0xdf01e85f912e37a3, 0x6b6c46dec52f6689},
+        {0x8b61313bbabce2c6, 0x2323ac4b3b3da016},
+        {0xae397d8aa96c1b77, 0xabec975e0a0d081b},
+        {0xd9c7dced53c72255, 0x96e7bd358c904a22},
+        {0x881cea14545c7575, 0x7e50d64177da2e55},
+        {0xaa242499697392d2, 0xdde50bd1d5d0b9ea},
+        {0xd4ad2dbfc3d07787, 0x955e4ec64b44e865},
+        {0x84ec3c97da624ab4, 0xbd5af13bef0b113f},
+        {0xa6274bbdd0fadd61, 0xecb1ad8aeacdd58f},
+        {0xcfb11ead453994ba, 0x67de18eda5814af3},
+        {0x81ceb32c4b43fcf4, 0x80eacf948770ced8},
+        {0xa2425ff75e14fc31, 0xa1258379a94d028e},
+        {0xcad2f7f5359a3b3e, 0x096ee45813a04331},
+        {0xfd87b5f28300ca0d, 0x8bca9d6e188853fd},
+        {0x9e74d1b791e07e48, 0x775ea264cf55347e},
+        {0xc612062576589dda, 0x95364afe032a819e},
+        {0xf79687aed3eec551, 0x3a83ddbd83f52205},
+        {0x9abe14cd44753b52, 0xc4926a9672793543},
+        {0xc16d9a0095928a27, 0x75b7053c0f178294},
+        {0xf1c90080baf72cb1, 0x5324c68b12dd6339},
+        {0x971da05074da7bee, 0xd3f6fc16ebca5e04},
+        {0xbce5086492111aea, 0x88f4bb1ca6bcf585},
+        {0xec1e4a7db69561a5, 0x2b31e9e3d06c32e6},
+        {0x9392ee8e921d5d07, 0x3aff322e62439fd0},
+        {0xb877aa3236a4b449, 0x09befeb9fad487c3},
+        {0xe69594bec44de15b, 0x4c2ebe687989a9b4},
+        {0x901d7cf73ab0acd9, 0x0f9d37014bf60a11},
+        {0xb424dc35095cd80f, 0x538484c19ef38c95},
+        {0xe12e13424bb40e13, 0x2865a5f206b06fba},
+        {0x8cbccc096f5088cb, 0xf93f87b7442e45d4},
+        {0xafebff0bcb24aafe, 0xf78f69a51539d749},
+        {0xdbe6fecebdedd5be, 0xb573440e5a884d1c},
+        {0x89705f4136b4a597, 0x31680a88f8953031},
+        {0xabcc77118461cefc, 0xfdc20d2b36ba7c3e},
+        {0xd6bf94d5e57a42bc, 0x3d32907604691b4d},
+        {0x8637bd05af6c69b5, 0xa63f9a49c2c1b110},
+        {0xa7c5ac471b478423, 0x0fcf80dc33721d54},
+        {0xd1b71758e219652b, 0xd3c36113404ea4a9},
+        {0x83126e978d4fdf3b, 0x645a1cac083126ea},
+        {0xa3d70a3d70a3d70a, 0x3d70a3d70a3d70a4},
+        {0xcccccccccccccccc, 0xcccccccccccccccd},
+        {0x8000000000000000, 0x0000000000000000},
+        {0xa000000000000000, 0x0000000000000000},
+        {0xc800000000000000, 0x0000000000000000},
+        {0xfa00000000000000, 0x0000000000000000},
+        {0x9c40000000000000, 0x0000000000000000},
+        {0xc350000000000000, 0x0000000000000000},
+        {0xf424000000000000, 0x0000000000000000},
+        {0x9896800000000000, 0x0000000000000000},
+        {0xbebc200000000000, 0x0000000000000000},
+        {0xee6b280000000000, 0x0000000000000000},
+        {0x9502f90000000000, 0x0000000000000000},
+        {0xba43b74000000000, 0x0000000000000000},
+        {0xe8d4a51000000000, 0x0000000000000000},
+        {0x9184e72a00000000, 0x0000000000000000},
+        {0xb5e620f480000000, 0x0000000000000000},
+        {0xe35fa931a0000000, 0x0000000000000000},
+        {0x8e1bc9bf04000000, 0x0000000000000000},
+        {0xb1a2bc2ec5000000, 0x0000000000000000},
+        {0xde0b6b3a76400000, 0x0000000000000000},
+        {0x8ac7230489e80000, 0x0000000000000000},
+        {0xad78ebc5ac620000, 0x0000000000000000},
+        {0xd8d726b7177a8000, 0x0000000000000000},
+        {0x878678326eac9000, 0x0000000000000000},
+        {0xa968163f0a57b400, 0x0000000000000000},
+        {0xd3c21bcecceda100, 0x0000000000000000},
+        {0x84595161401484a0, 0x0000000000000000},
+        {0xa56fa5b99019a5c8, 0x0000000000000000},
+        {0xcecb8f27f4200f3a, 0x0000000000000000},
+        {0x813f3978f8940984, 0x4000000000000000},
+        {0xa18f07d736b90be5, 0x5000000000000000},
+        {0xc9f2c9cd04674ede, 0xa400000000000000},
+        {0xfc6f7c4045812296, 0x4d00000000000000},
+        {0x9dc5ada82b70b59d, 0xf020000000000000},
+        {0xc5371912364ce305, 0x6c28000000000000},
+        {0xf684df56c3e01bc6, 0xc732000000000000},
+        {0x9a130b963a6c115c, 0x3c7f400000000000},
+        {0xc097ce7bc90715b3, 0x4b9f100000000000},
+        {0xf0bdc21abb48db20, 0x1e86d40000000000},
+        {0x96769950b50d88f4, 0x1314448000000000},
+        {0xbc143fa4e250eb31, 0x17d955a000000000},
+        {0xeb194f8e1ae525fd, 0x5dcfab0800000000},
+        {0x92efd1b8d0cf37be, 0x5aa1cae500000000},
+        {0xb7abc627050305ad, 0xf14a3d9e40000000},
+        {0xe596b7b0c643c719, 0x6d9ccd05d0000000},
+        {0x8f7e32ce7bea5c6f, 0xe4820023a2000000},
+        {0xb35dbf821ae4f38b, 0xdda2802c8a800000},
+        {0xe0352f62a19e306e, 0xd50b2037ad200000},
+        {0x8c213d9da502de45, 0x4526f422cc340000},
+        {0xaf298d050e4395d6, 0x9670b12b7f410000},
+        {0xdaf3f04651d47b4c, 0x3c0cdd765f114000},
+        {0x88d8762bf324cd0f, 0xa5880a69fb6ac800},
+        {0xab0e93b6efee0053, 0x8eea0d047a457a00},
+        {0xd5d238a4abe98068, 0x72a4904598d6d880},
+        {0x85a36366eb71f041, 0x47a6da2b7f864750},
+        {0xa70c3c40a64e6c51, 0x999090b65f67d924},
+        {0xd0cf4b50cfe20765, 0xfff4b4e3f741cf6d},
+        {0x82818f1281ed449f, 0xbff8f10e7a8921a5},
+        {0xa321f2d7226895c7, 0xaff72d52192b6a0e},
+        {0xcbea6f8ceb02bb39, 0x9bf4f8a69f764491},
+        {0xfee50b7025c36a08, 0x02f236d04753d5b5},
+        {0x9f4f2726179a2245, 0x01d762422c946591},
+        {0xc722f0ef9d80aad6, 0x424d3ad2b7b97ef6},
+        {0xf8ebad2b84e0d58b, 0xd2e0898765a7deb3},
+        {0x9b934c3b330c8577, 0x63cc55f49f88eb30},
+        {0xc2781f49ffcfa6d5, 0x3cbf6b71c76b25fc},
+        {0xf316271c7fc3908a, 0x8bef464e3945ef7b},
+        {0x97edd871cfda3a56, 0x97758bf0e3cbb5ad},
+        {0xbde94e8e43d0c8ec, 0x3d52eeed1cbea318},
+        {0xed63a231d4c4fb27, 0x4ca7aaa863ee4bde},
+        {0x945e455f24fb1cf8, 0x8fe8caa93e74ef6b},
+        {0xb975d6b6ee39e436, 0xb3e2fd538e122b45},
+        {0xe7d34c64a9c85d44, 0x60dbbca87196b617},
+        {0x90e40fbeea1d3a4a, 0xbc8955e946fe31ce},
+        {0xb51d13aea4a488dd, 0x6babab6398bdbe42},
+        {0xe264589a4dcdab14, 0xc696963c7eed2dd2},
+        {0x8d7eb76070a08aec, 0xfc1e1de5cf543ca3},
+        {0xb0de65388cc8ada8, 0x3b25a55f43294bcc},
+        {0xdd15fe86affad912, 0x49ef0eb713f39ebf},
+        {0x8a2dbf142dfcc7ab, 0x6e3569326c784338},
+        {0xacb92ed9397bf996, 0x49c2c37f07965405},
+        {0xd7e77a8f87daf7fb, 0xdc33745ec97be907},
+        {0x86f0ac99b4e8dafd, 0x69a028bb3ded71a4},
+        {0xa8acd7c0222311bc, 0xc40832ea0d68ce0d},
+        {0xd2d80db02aabd62b, 0xf50a3fa490c30191},
+        {0x83c7088e1aab65db, 0x792667c6da79e0fb},
+        {0xa4b8cab1a1563f52, 0x577001b891185939},
+        {0xcde6fd5e09abcf26, 0xed4c0226b55e6f87},
+        {0x80b05e5ac60b6178, 0x544f8158315b05b5},
+        {0xa0dc75f1778e39d6, 0x696361ae3db1c722},
+        {0xc913936dd571c84c, 0x03bc3a19cd1e38ea},
+        {0xfb5878494ace3a5f, 0x04ab48a04065c724},
+        {0x9d174b2dcec0e47b, 0x62eb0d64283f9c77},
+        {0xc45d1df942711d9a, 0x3ba5d0bd324f8395},
+        {0xf5746577930d6500, 0xca8f44ec7ee3647a},
+        {0x9968bf6abbe85f20, 0x7e998b13cf4e1ecc},
+        {0xbfc2ef456ae276e8, 0x9e3fedd8c321a67f},
+        {0xefb3ab16c59b14a2, 0xc5cfe94ef3ea101f},
+        {0x95d04aee3b80ece5, 0xbba1f1d158724a13},
+        {0xbb445da9ca61281f, 0x2a8a6e45ae8edc98},
+        {0xea1575143cf97226, 0xf52d09d71a3293be},
+        {0x924d692ca61be758, 0x593c2626705f9c57},
+        {0xb6e0c377cfa2e12e, 0x6f8b2fb00c77836d},
+        {0xe498f455c38b997a, 0x0b6dfb9c0f956448},
+        {0x8edf98b59a373fec, 0x4724bd4189bd5ead},
+        {0xb2977ee300c50fe7, 0x58edec91ec2cb658},
+        {0xdf3d5e9bc0f653e1, 0x2f2967b66737e3ee},
+        {0x8b865b215899f46c, 0xbd79e0d20082ee75},
+        {0xae67f1e9aec07187, 0xecd8590680a3aa12},
+        {0xda01ee641a708de9, 0xe80e6f4820cc9496},
+        {0x884134fe908658b2, 0x3109058d147fdcde},
+        {0xaa51823e34a7eede, 0xbd4b46f0599fd416},
+        {0xd4e5e2cdc1d1ea96, 0x6c9e18ac7007c91b},
+        {0x850fadc09923329e, 0x03e2cf6bc604ddb1},
+        {0xa6539930bf6bff45, 0x84db8346b786151d},
+        {0xcfe87f7cef46ff16, 0xe612641865679a64},
+        {0x81f14fae158c5f6e, 0x4fcb7e8f3f60c07f},
+        {0xa26da3999aef7749, 0xe3be5e330f38f09e},
+        {0xcb090c8001ab551c, 0x5cadf5bfd3072cc6},
+        {0xfdcb4fa002162a63, 0x73d9732fc7c8f7f7},
+        {0x9e9f11c4014dda7e, 0x2867e7fddcdd9afb},
+        {0xc646d63501a1511d, 0xb281e1fd541501b9},
+        {0xf7d88bc24209a565, 0x1f225a7ca91a4227},
+        {0x9ae757596946075f, 0x3375788de9b06959},
+        {0xc1a12d2fc3978937, 0x0052d6b1641c83af},
+        {0xf209787bb47d6b84, 0xc0678c5dbd23a49b},
+        {0x9745eb4d50ce6332, 0xf840b7ba963646e1},
+        {0xbd176620a501fbff, 0xb650e5a93bc3d899},
+        {0xec5d3fa8ce427aff, 0xa3e51f138ab4cebf},
+        {0x93ba47c980e98cdf, 0xc66f336c36b10138},
+        {0xb8a8d9bbe123f017, 0xb80b0047445d4185},
+        {0xe6d3102ad96cec1d, 0xa60dc059157491e6},
+        {0x9043ea1ac7e41392, 0x87c89837ad68db30},
+        {0xb454e4a179dd1877, 0x29babe4598c311fc},
+        {0xe16a1dc9d8545e94, 0xf4296dd6fef3d67b},
+        {0x8ce2529e2734bb1d, 0x1899e4a65f58660d},
+        {0xb01ae745b101e9e4, 0x5ec05dcff72e7f90},
+        {0xdc21a1171d42645d, 0x76707543f4fa1f74},
+        {0x899504ae72497eba, 0x6a06494a791c53a9},
+        {0xabfa45da0edbde69, 0x0487db9d17636893},
+        {0xd6f8d7509292d603, 0x45a9d2845d3c42b7},
+        {0x865b86925b9bc5c2, 0x0b8a2392ba45a9b3},
+        {0xa7f26836f282b732, 0x8e6cac7768d7141f},
+        {0xd1ef0244af2364ff, 0x3207d795430cd927},
+        {0x8335616aed761f1f, 0x7f44e6bd49e807b9},
+        {0xa402b9c5a8d3a6e7, 0x5f16206c9c6209a7},
+        {0xcd036837130890a1, 0x36dba887c37a8c10},
+        {0x802221226be55a64, 0xc2494954da2c978a},
+        {0xa02aa96b06deb0fd, 0xf2db9baa10b7bd6d},
+        {0xc83553c5c8965d3d, 0x6f92829494e5acc8},
+        {0xfa42a8b73abbf48c, 0xcb772339ba1f17fa},
+        {0x9c69a97284b578d7, 0xff2a760414536efc},
+        {0xc38413cf25e2d70d, 0xfef5138519684abb},
+        {0xf46518c2ef5b8cd1, 0x7eb258665fc25d6a},
+        {0x98bf2f79d5993802, 0xef2f773ffbd97a62},
+        {0xbeeefb584aff8603, 0xaafb550ffacfd8fb},
+        {0xeeaaba2e5dbf6784, 0x95ba2a53f983cf39},
+        {0x952ab45cfa97a0b2, 0xdd945a747bf26184},
+        {0xba756174393d88df, 0x94f971119aeef9e5},
+        {0xe912b9d1478ceb17, 0x7a37cd5601aab85e},
+        {0x91abb422ccb812ee, 0xac62e055c10ab33b},
+        {0xb616a12b7fe617aa, 0x577b986b314d600a},
+        {0xe39c49765fdf9d94, 0xed5a7e85fda0b80c},
+        {0x8e41ade9fbebc27d, 0x14588f13be847308},
+        {0xb1d219647ae6b31c, 0x596eb2d8ae258fc9},
+        {0xde469fbd99a05fe3, 0x6fca5f8ed9aef3bc},
+        {0x8aec23d680043bee, 0x25de7bb9480d5855},
+        {0xada72ccc20054ae9, 0xaf561aa79a10ae6b},
+        {0xd910f7ff28069da4, 0x1b2ba1518094da05},
+        {0x87aa9aff79042286, 0x90fb44d2f05d0843},
+        {0xa99541bf57452b28, 0x353a1607ac744a54},
+        {0xd3fa922f2d1675f2, 0x42889b8997915ce9},
+        {0x847c9b5d7c2e09b7, 0x69956135febada12},
+        {0xa59bc234db398c25, 0x43fab9837e699096},
+        {0xcf02b2c21207ef2e, 0x94f967e45e03f4bc},
+        {0x8161afb94b44f57d, 0x1d1be0eebac278f6},
+        {0xa1ba1ba79e1632dc, 0x6462d92a69731733},
+        {0xca28a291859bbf93, 0x7d7b8f7503cfdcff},
+        {0xfcb2cb35e702af78, 0x5cda735244c3d43f},
+        {0x9defbf01b061adab, 0x3a0888136afa64a8},
+        {0xc56baec21c7a1916, 0x088aaa1845b8fdd1},
+        {0xf6c69a72a3989f5b, 0x8aad549e57273d46},
+        {0x9a3c2087a63f6399, 0x36ac54e2f678864c},
+        {0xc0cb28a98fcf3c7f, 0x84576a1bb416a7de},
+        {0xf0fdf2d3f3c30b9f, 0x656d44a2a11c51d6},
+        {0x969eb7c47859e743, 0x9f644ae5a4b1b326},
+        {0xbc4665b596706114, 0x873d5d9f0dde1fef},
+        {0xeb57ff22fc0c7959, 0xa90cb506d155a7eb},
+        {0x9316ff75dd87cbd8, 0x09a7f12442d588f3},
+        {0xb7dcbf5354e9bece, 0x0c11ed6d538aeb30},
+        {0xe5d3ef282a242e81, 0x8f1668c8a86da5fb},
+        {0x8fa475791a569d10, 0xf96e017d694487bd},
+        {0xb38d92d760ec4455, 0x37c981dcc395a9ad},
+        {0xe070f78d3927556a, 0x85bbe253f47b1418},
+        {0x8c469ab843b89562, 0x93956d7478ccec8f},
+        {0xaf58416654a6babb, 0x387ac8d1970027b3},
+        {0xdb2e51bfe9d0696a, 0x06997b05fcc0319f},
+        {0x88fcf317f22241e2, 0x441fece3bdf81f04},
+        {0xab3c2fddeeaad25a, 0xd527e81cad7626c4},
+        {0xd60b3bd56a5586f1, 0x8a71e223d8d3b075},
+        {0x85c7056562757456, 0xf6872d5667844e4a},
+        {0xa738c6bebb12d16c, 0xb428f8ac016561dc},
+        {0xd106f86e69d785c7, 0xe13336d701beba53},
+        {0x82a45b450226b39c, 0xecc0024661173474},
+        {0xa34d721642b06084, 0x27f002d7f95d0191},
+        {0xcc20ce9bd35c78a5, 0x31ec038df7b441f5},
+        {0xff290242c83396ce, 0x7e67047175a15272},
+        {0x9f79a169bd203e41, 0x0f0062c6e984d387},
+        {0xc75809c42c684dd1, 0x52c07b78a3e60869},
+        {0xf92e0c3537826145, 0xa7709a56ccdf8a83},
+        {0x9bbcc7a142b17ccb, 0x88a66076400bb692},
+        {0xc2abf989935ddbfe, 0x6acff893d00ea436},
+        {0xf356f7ebf83552fe, 0x0583f6b8c4124d44},
+        {0x98165af37b2153de, 0xc3727a337a8b704b},
+        {0xbe1bf1b059e9a8d6, 0x744f18c0592e4c5d},
+        {0xeda2ee1c7064130c, 0x1162def06f79df74},
+        {0x9485d4d1c63e8be7, 0x8addcb5645ac2ba9},
+        {0xb9a74a0637ce2ee1, 0x6d953e2bd7173693},
+        {0xe8111c87c5c1ba99, 0xc8fa8db6ccdd0438},
+        {0x910ab1d4db9914a0, 0x1d9c9892400a22a3},
+        {0xb54d5e4a127f59c8, 0x2503beb6d00cab4c},
+        {0xe2a0b5dc971f303a, 0x2e44ae64840fd61e},
+        {0x8da471a9de737e24, 0x5ceaecfed289e5d3},
+        {0xb10d8e1456105dad, 0x7425a83e872c5f48},
+        {0xdd50f1996b947518, 0xd12f124e28f7771a},
+        {0x8a5296ffe33cc92f, 0x82bd6b70d99aaa70},
+        {0xace73cbfdc0bfb7b, 0x636cc64d1001550c},
+        {0xd8210befd30efa5a, 0x3c47f7e05401aa4f},
+        {0x8714a775e3e95c78, 0x65acfaec34810a72},
+        {0xa8d9d1535ce3b396, 0x7f1839a741a14d0e},
+        {0xd31045a8341ca07c, 0x1ede48111209a051},
+        {0x83ea2b892091e44d, 0x934aed0aab460433},
+        {0xa4e4b66b68b65d60, 0xf81da84d56178540},
+        {0xce1de40642e3f4b9, 0x36251260ab9d668f},
+        {0x80d2ae83e9ce78f3, 0xc1d72b7c6b42601a},
+        {0xa1075a24e4421730, 0xb24cf65b8612f820},
+        {0xc94930ae1d529cfc, 0xdee033f26797b628},
+        {0xfb9b7cd9a4a7443c, 0x169840ef017da3b2},
+        {0x9d412e0806e88aa5, 0x8e1f289560ee864f},
+        {0xc491798a08a2ad4e, 0xf1a6f2bab92a27e3},
+        {0xf5b5d7ec8acb58a2, 0xae10af696774b1dc},
+        {0x9991a6f3d6bf1765, 0xacca6da1e0a8ef2a},
+        {0xbff610b0cc6edd3f, 0x17fd090a58d32af4},
+        {0xeff394dcff8a948e, 0xddfc4b4cef07f5b1},
+        {0x95f83d0a1fb69cd9, 0x4abdaf101564f98f},
+        {0xbb764c4ca7a4440f, 0x9d6d1ad41abe37f2},
+        {0xea53df5fd18d5513, 0x84c86189216dc5ee},
+        {0x92746b9be2f8552c, 0x32fd3cf5b4e49bb5},
+        {0xb7118682dbb66a77, 0x3fbc8c33221dc2a2},
+        {0xe4d5e82392a40515, 0x0fabaf3feaa5334b},
+        {0x8f05b1163ba6832d, 0x29cb4d87f2a7400f},
+        {0xb2c71d5bca9023f8, 0x743e20e9ef511013},
+        {0xdf78e4b2bd342cf6, 0x914da9246b255417},
+        {0x8bab8eefb6409c1a, 0x1ad089b6c2f7548f},
+        {0xae9672aba3d0c320, 0xa184ac2473b529b2},
+        {0xda3c0f568cc4f3e8, 0xc9e5d72d90a2741f},
+        {0x8865899617fb1871, 0x7e2fa67c7a658893},
+        {0xaa7eebfb9df9de8d, 0xddbb901b98feeab8},
+        {0xd51ea6fa85785631, 0x552a74227f3ea566},
+        {0x8533285c936b35de, 0xd53a88958f872760},
+        {0xa67ff273b8460356, 0x8a892abaf368f138},
+        {0xd01fef10a657842c, 0x2d2b7569b0432d86},
+        {0x8213f56a67f6b29b, 0x9c3b29620e29fc74},
+        {0xa298f2c501f45f42, 0x8349f3ba91b47b90},
+        {0xcb3f2f7642717713, 0x241c70a936219a74},
+        {0xfe0efb53d30dd4d7, 0xed238cd383aa0111},
+        {0x9ec95d1463e8a506, 0xf4363804324a40ab},
+        {0xc67bb4597ce2ce48, 0xb143c6053edcd0d6},
+        {0xf81aa16fdc1b81da, 0xdd94b7868e94050b},
+        {0x9b10a4e5e9913128, 0xca7cf2b4191c8327},
+        {0xc1d4ce1f63f57d72, 0xfd1c2f611f63a3f1},
+        {0xf24a01a73cf2dccf, 0xbc633b39673c8ced},
+        {0x976e41088617ca01, 0xd5be0503e085d814},
+        {0xbd49d14aa79dbc82, 0x4b2d8644d8a74e19},
+        {0xec9c459d51852ba2, 0xddf8e7d60ed1219f},
+        {0x93e1ab8252f33b45, 0xcabb90e5c942b504},
+        {0xb8da1662e7b00a17, 0x3d6a751f3b936244},
+        {0xe7109bfba19c0c9d, 0x0cc512670a783ad5},
+        {0x906a617d450187e2, 0x27fb2b80668b24c6},
+        {0xb484f9dc9641e9da, 0xb1f9f660802dedf7},
+        {0xe1a63853bbd26451, 0x5e7873f8a0396974},
+        {0x8d07e33455637eb2, 0xdb0b487b6423e1e9},
+        {0xb049dc016abc5e5f, 0x91ce1a9a3d2cda63},
+        {0xdc5c5301c56b75f7, 0x7641a140cc7810fc},
+        {0x89b9b3e11b6329ba, 0xa9e904c87fcb0a9e},
+        {0xac2820d9623bf429, 0x546345fa9fbdcd45},
+        {0xd732290fbacaf133, 0xa97c177947ad4096},
+        {0x867f59a9d4bed6c0, 0x49ed8eabcccc485e},
+        {0xa81f301449ee8c70, 0x5c68f256bfff5a75},
+        {0xd226fc195c6a2f8c, 0x73832eec6fff3112},
+        {0x83585d8fd9c25db7, 0xc831fd53c5ff7eac},
+        {0xa42e74f3d032f525, 0xba3e7ca8b77f5e56},
+        {0xcd3a1230c43fb26f, 0x28ce1bd2e55f35ec},
+        {0x80444b5e7aa7cf85, 0x7980d163cf5b81b4},
+        {0xa0555e361951c366, 0xd7e105bcc3326220},
+        {0xc86ab5c39fa63440, 0x8dd9472bf3fefaa8},
+        {0xfa856334878fc150, 0xb14f98f6f0feb952},
+        {0x9c935e00d4b9d8d2, 0x6ed1bf9a569f33d4},
+        {0xc3b8358109e84f07, 0x0a862f80ec4700c9},
+        {0xf4a642e14c6262c8, 0xcd27bb612758c0fb},
+        {0x98e7e9cccfbd7dbd, 0x8038d51cb897789d},
+        {0xbf21e44003acdd2c, 0xe0470a63e6bd56c4},
+        {0xeeea5d5004981478, 0x1858ccfce06cac75},
+        {0x95527a5202df0ccb, 0x0f37801e0c43ebc9},
+        {0xbaa718e68396cffd, 0xd30560258f54e6bb},
+        {0xe950df20247c83fd, 0x47c6b82ef32a206a},
+        {0x91d28b7416cdd27e, 0x4cdc331d57fa5442},
+        {0xb6472e511c81471d, 0xe0133fe4adf8e953},
+        {0xe3d8f9e563a198e5, 0x58180fddd97723a7},
+        {0x8e679c2f5e44ff8f, 0x570f09eaa7ea7649},
+        {0xb201833b35d63f73, 0x2cd2cc6551e513db},
+        {0xde81e40a034bcf4f, 0xf8077f7ea65e58d2},
+        {0x8b112e86420f6191, 0xfb04afaf27faf783},
+        {0xadd57a27d29339f6, 0x79c5db9af1f9b564},
+        {0xd94ad8b1c7380874, 0x18375281ae7822bd},
+        {0x87cec76f1c830548, 0x8f2293910d0b15b6},
+        {0xa9c2794ae3a3c69a, 0xb2eb3875504ddb23},
+        {0xd433179d9c8cb841, 0x5fa60692a46151ec},
+        {0x849feec281d7f328, 0xdbc7c41ba6bcd334},
+        {0xa5c7ea73224deff3, 0x12b9b522906c0801},
+        {0xcf39e50feae16bef, 0xd768226b34870a01},
+        {0x81842f29f2cce375, 0xe6a1158300d46641},
+        {0xa1e53af46f801c53, 0x60495ae3c1097fd1},
+        {0xca5e89b18b602368, 0x385bb19cb14bdfc5},
+        {0xfcf62c1dee382c42, 0x46729e03dd9ed7b6},
+        {0x9e19db92b4e31ba9, 0x6c07a2c26a8346d2},
+        {0xc5a05277621be293, 0xc7098b7305241886},
+        {0xf70867153aa2db38, 0xb8cbee4fc66d1ea8},
+        {0x9a65406d44a5c903, 0x737f74f1dc043329},
+        {0xc0fe908895cf3b44, 0x505f522e53053ff3},
+        {0xf13e34aabb430a15, 0x647726b9e7c68ff0},
+        {0x96c6e0eab509e64d, 0x5eca783430dc19f6},
+        {0xbc789925624c5fe0, 0xb67d16413d132073},
+        {0xeb96bf6ebadf77d8, 0xe41c5bd18c57e890},
+        {0x933e37a534cbaae7, 0x8e91b962f7b6f15a},
+        {0xb80dc58e81fe95a1, 0x723627bbb5a4adb1},
+        {0xe61136f2227e3b09, 0xcec3b1aaa30dd91d},
+        {0x8fcac257558ee4e6, 0x213a4f0aa5e8a7b2},
+        {0xb3bd72ed2af29e1f, 0xa988e2cd4f62d19e},
+        {0xe0accfa875af45a7, 0x93eb1b80a33b8606},
+        {0x8c6c01c9498d8b88, 0xbc72f130660533c4},
+        {0xaf87023b9bf0ee6a, 0xeb8fad7c7f8680b5},
+        {0xdb68c2ca82ed2a05, 0xa67398db9f6820e2},
 #else
-      {0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7b},
-      {0xce5d73ff402d98e3, 0xfb0a3d212dc81290},
-      {0xa6b34ad8c9dfc06f, 0xf42faa48c0ea481f},
-      {0x86a8d39ef77164bc, 0xae5dff9c02033198},
-      {0xd98ddaee19068c76, 0x3badd624dd9b0958},
-      {0xafbd2350644eeacf, 0xe5d1929ef90898fb},
-      {0x8df5efabc5979c8f, 0xca8d3ffa1ef463c2},
-      {0xe55990879ddcaabd, 0xcc420a6a101d0516},
-      {0xb94470938fa89bce, 0xf808e40e8d5b3e6a},
-      {0x95a8637627989aad, 0xdde7001379a44aa9},
-      {0xf1c90080baf72cb1, 0x5324c68b12dd6339},
-      {0xc350000000000000, 0x0000000000000000},
-      {0x9dc5ada82b70b59d, 0xf020000000000000},
-      {0xfee50b7025c36a08, 0x02f236d04753d5b5},
-      {0xcde6fd5e09abcf26, 0xed4c0226b55e6f87},
-      {0xa6539930bf6bff45, 0x84db8346b786151d},
-      {0x865b86925b9bc5c2, 0x0b8a2392ba45a9b3},
-      {0xd910f7ff28069da4, 0x1b2ba1518094da05},
-      {0xaf58416654a6babb, 0x387ac8d1970027b3},
-      {0x8da471a9de737e24, 0x5ceaecfed289e5d3},
-      {0xe4d5e82392a40515, 0x0fabaf3feaa5334b},
-      {0xb8da1662e7b00a17, 0x3d6a751f3b936244},
-      {0x95527a5202df0ccb, 0x0f37801e0c43ebc9},
-      {0xf13e34aabb430a15, 0x647726b9e7c68ff0}
+        {0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7b},
+        {0xce5d73ff402d98e3, 0xfb0a3d212dc81290},
+        {0xa6b34ad8c9dfc06f, 0xf42faa48c0ea481f},
+        {0x86a8d39ef77164bc, 0xae5dff9c02033198},
+        {0xd98ddaee19068c76, 0x3badd624dd9b0958},
+        {0xafbd2350644eeacf, 0xe5d1929ef90898fb},
+        {0x8df5efabc5979c8f, 0xca8d3ffa1ef463c2},
+        {0xe55990879ddcaabd, 0xcc420a6a101d0516},
+        {0xb94470938fa89bce, 0xf808e40e8d5b3e6a},
+        {0x95a8637627989aad, 0xdde7001379a44aa9},
+        {0xf1c90080baf72cb1, 0x5324c68b12dd6339},
+        {0xc350000000000000, 0x0000000000000000},
+        {0x9dc5ada82b70b59d, 0xf020000000000000},
+        {0xfee50b7025c36a08, 0x02f236d04753d5b5},
+        {0xcde6fd5e09abcf26, 0xed4c0226b55e6f87},
+        {0xa6539930bf6bff45, 0x84db8346b786151d},
+        {0x865b86925b9bc5c2, 0x0b8a2392ba45a9b3},
+        {0xd910f7ff28069da4, 0x1b2ba1518094da05},
+        {0xaf58416654a6babb, 0x387ac8d1970027b3},
+        {0x8da471a9de737e24, 0x5ceaecfed289e5d3},
+        {0xe4d5e82392a40515, 0x0fabaf3feaa5334b},
+        {0xb8da1662e7b00a17, 0x3d6a751f3b936244},
+        {0x95527a5202df0ccb, 0x0f37801e0c43ebc9},
+        {0xf13e34aabb430a15, 0x647726b9e7c68ff0}
 #endif
     };
 
 #if FMT_USE_FULL_CACHE_DRAGONBOX
     return pow10_significands[k - float_info<double>::min_k];
 #else
-    static constexpr const uint64_t powers_of_5_64[] = {
+    static constexpr uint64_t powers_of_5_64[] = {
         0x0000000000000001, 0x0000000000000005, 0x0000000000000019,
         0x000000000000007d, 0x0000000000000271, 0x0000000000000c35,
         0x0000000000003d09, 0x000000000001312d, 0x000000000005f5e1,
@@ -1056,7 +1075,7 @@ template <> struct cache_accessor<double> {
     int offset = k - kb;
 
     // Get base cache.
-    uint128_fallback base_cache = pow10_significands[cache_index];
+    uint128 base_cache = pow10_significands[cache_index];
     if (offset == 0) return base_cache;
 
     // Compute the required amount of bit-shift.
@@ -1065,17 +1084,16 @@ template <> struct cache_accessor<double> {
 
     // Try to recover the real cache.
     uint64_t pow5 = powers_of_5_64[offset];
-    uint128_fallback recovered_cache = umul128(base_cache.high(), pow5);
-    uint128_fallback middle_low = umul128(base_cache.low(), pow5);
+    uint128 recovered_cache = umul128(base_cache.high(), pow5);
+    uint128 middle_low = umul128(base_cache.low(), pow5);
 
     recovered_cache += middle_low.high();
 
     uint64_t high_to_middle = recovered_cache.high() << (64 - alpha);
     uint64_t middle_to_low = recovered_cache.low() << (64 - alpha);
 
-    recovered_cache =
-        uint128_fallback{(recovered_cache.low() >> alpha) | high_to_middle,
-                         ((middle_low.low() >> alpha) | middle_to_low)};
+    recovered_cache = uint128{(recovered_cache.low() >> alpha) | high_to_middle,
+                              ((middle_low.low() >> alpha) | middle_to_low)};
     FMT_ASSERT(recovered_cache.low() + 1 != 0, "");
     return {recovered_cache.high(), recovered_cache.low() + 1};
 #endif
@@ -1097,7 +1115,7 @@ template <> struct cache_accessor<double> {
     return {r.high(), r.low() == 0};
   }
 
-  static auto compute_delta(cache_entry_type const& cache, int beta) noexcept
+  static auto compute_delta(const cache_entry_type& cache, int beta) noexcept
       -> uint32_t {
     return static_cast<uint32_t>(cache.high() >> (64 - 1 - beta));
   }
@@ -1136,7 +1154,7 @@ template <> struct cache_accessor<double> {
   }
 };
 
-FMT_FUNC auto get_cached_power(int k) noexcept -> uint128_fallback {
+FMT_FUNC auto get_cached_power(int k) noexcept -> uint128 {
   return cache_accessor<double>::get_cached_power(k);
 }
 
@@ -1149,8 +1167,8 @@ auto is_left_endpoint_integer_shorter_interval(int exponent) noexcept -> bool {
          exponent <= case_shorter_interval_left_endpoint_upper_threshold;
 }
 
-// Remove trailing zeros from n and return the number of zeros removed (float)
-FMT_INLINE int remove_trailing_zeros(uint32_t& n, int s = 0) noexcept {
+// Remove trailing zeros from n and return the number of zeros removed (float).
+FMT_INLINE auto remove_trailing_zeros(uint32_t& n, int s = 0) noexcept -> int {
   FMT_ASSERT(n != 0, "");
   // Modular inverse of 5 (mod 2^32): (mod_inv_5 * 5) mod 2^32 = 1.
   constexpr uint32_t mod_inv_5 = 0xcccccccd;
@@ -1170,22 +1188,19 @@ FMT_INLINE int remove_trailing_zeros(uint32_t& n, int s = 0) noexcept {
   return s;
 }
 
-// Removes trailing zeros and returns the number of zeros removed (double)
-FMT_INLINE int remove_trailing_zeros(uint64_t& n) noexcept {
+// Removes trailing zeros and returns the number of zeros removed (double).
+FMT_INLINE auto remove_trailing_zeros(uint64_t& n) noexcept -> int {
   FMT_ASSERT(n != 0, "");
 
-  // This magic number is ceil(2^90 / 10^8).
-  constexpr uint64_t magic_number = 12379400392853802749ull;
-  auto nm = umul128(n, magic_number);
-
   // Is n is divisible by 10^8?
-  if ((nm.high() & ((1ull << (90 - 64)) - 1)) == 0 && nm.low() < magic_number) {
+  constexpr uint32_t ten_pow_8 = 100000000u;
+  if ((n % ten_pow_8) == 0) {
     // If yes, work with the quotient...
-    auto n32 = static_cast<uint32_t>(nm.high() >> (90 - 64));
+    auto n32 = static_cast<uint32_t>(n / ten_pow_8);
     // ... and use the 32 bit variant of the function
-    int s = remove_trailing_zeros(n32, 8);
+    int num_zeros = remove_trailing_zeros(n32, 8);
     n = n32;
-    return s;
+    return num_zeros;
   }
 
   // If n is not divisible by 10^8, work with n itself.
@@ -1210,7 +1225,7 @@ FMT_INLINE int remove_trailing_zeros(uint64_t& n) noexcept {
 
 // The main algorithm for shorter interval case
 template <typename T>
-FMT_INLINE decimal_fp<T> shorter_interval_case(int exponent) noexcept {
+FMT_INLINE auto shorter_interval_case(int exponent) noexcept -> decimal_fp<T> {
   decimal_fp<T> ret_value;
   // Compute k and beta
   const int minus_k = floor_log10_pow2_minus_log10_4_over_3(exponent);
@@ -1454,8 +1469,8 @@ FMT_FUNC void vformat_to(buffer<char>& buf, string_view fmt, format_args args,
   auto out = appender(buf);
   if (fmt.size() == 2 && equal2(fmt.data(), "{}"))
     return args.get(0).visit(default_arg_formatter<char>{out});
-  parse_format_string(
-      fmt, format_handler<char>{parse_context<char>(fmt), {out, args, loc}});
+  parse_format_string(fmt,
+                      format_handler<>{parse_context<>(fmt), {out, args, loc}});
 }
 
 template <typename T> struct span {
@@ -1464,10 +1479,10 @@ template <typename T> struct span {
 };
 
 template <typename F> auto flockfile(F* f) -> decltype(_lock_file(f)) {
-  _lock_file(f);
+  return _lock_file(f);
 }
 template <typename F> auto funlockfile(F* f) -> decltype(_unlock_file(f)) {
-  _unlock_file(f);
+  return _unlock_file(f);
 }
 
 #ifndef getc_unlocked
@@ -1476,12 +1491,16 @@ template <typename F> auto getc_unlocked(F* f) -> decltype(_fgetc_nolock(f)) {
 }
 #endif
 
+#ifndef FMT_USE_FLOCKFILE
+#  define FMT_USE_FLOCKFILE 1
+#endif
+
 template <typename F = FILE, typename Enable = void>
 struct has_flockfile : std::false_type {};
 
 template <typename F>
 struct has_flockfile<F, void_t<decltype(flockfile(&std::declval<F&>()))>>
-    : std::true_type {};
+    : bool_constant<FMT_USE_FLOCKFILE != 0> {};
 
 // A FILE wrapper. F is FILE defined as a template parameter to make system API
 // detection work.
@@ -1526,9 +1545,8 @@ template <typename F> class glibc_file : public file_base<F> {
   }
 
   void init_buffer() {
-    if (this->file_->_IO_write_ptr) return;
+    if (this->file_->_IO_write_ptr < this->file_->_IO_write_end) return;
     // Force buffer initialization by placing and removing a char in a buffer.
-    assume(this->file_->_IO_write_ptr >= this->file_->_IO_write_end);
     putc_unlocked(0, this->file_);
     --this->file_->_IO_write_ptr;
   }
@@ -1547,10 +1565,11 @@ template <typename F> class glibc_file : public file_base<F> {
 
   void advance_write_buffer(size_t size) { this->file_->_IO_write_ptr += size; }
 
-  bool needs_flush() const {
+  auto needs_flush() const -> bool {
     if ((this->file_->_flags & line_buffered) == 0) return false;
     char* end = this->file_->_IO_write_end;
-    return memchr(end, '\n', to_unsigned(this->file_->_IO_write_ptr - end));
+    auto size = max_of<ptrdiff_t>(this->file_->_IO_write_ptr - end, 0);
+    return memchr(end, '\n', static_cast<size_t>(size));
   }
 
   void flush() { fflush_unlocked(this->file_); }
@@ -1574,7 +1593,7 @@ template <typename F> class apple_file : public file_base<F> {
   void init_buffer() {
     if (this->file_->_p) return;
     // Force buffer initialization by placing and removing a char in a buffer.
-    putc_unlocked(0, this->file_);
+    if (!FMT_CLANG_ANALYZER) putc_unlocked(0, this->file_);
     --this->file_->_p;
     ++this->file_->_w;
   }
@@ -1595,7 +1614,7 @@ template <typename F> class apple_file : public file_base<F> {
     this->file_->_w -= size;
   }
 
-  bool needs_flush() const {
+  auto needs_flush() const -> bool {
     if ((this->file_->_flags & line_buffered) == 0) return false;
     return memchr(this->file_->_p + this->file_->_w, '\n',
                   to_unsigned(-this->file_->_w));
@@ -1679,6 +1698,9 @@ class file_print_buffer<F, enable_if_t<has_flockfile<F>::value>>
  public:
   explicit file_print_buffer(F* f) : buffer(grow, size_t()), file_(f) {
     flockfile(f);
+#ifdef __SANITIZE_THREAD__
+    __tsan_acquire(f);
+#endif
     file_.init_buffer();
     auto buf = file_.get_write_buffer();
     set(buf.data, buf.size);
@@ -1686,7 +1708,10 @@ class file_print_buffer<F, enable_if_t<has_flockfile<F>::value>>
   ~file_print_buffer() {
     file_.advance_write_buffer(size());
     bool flush = file_.needs_flush();
-    F* f = file_;    // Make funlockfile depend on the template parameter F
+    F* f = file_;  // Make funlockfile depend on the template parameter F.
+#ifdef __SANITIZE_THREAD__
+    __tsan_release(f);
+#endif
     funlockfile(f);  // for the system API detection to work.
     if (flush) fflush(file_);
   }

--- a/lib/fmt/include/fmt-vt/format.h
+++ b/lib/fmt/include/fmt-vt/format.h
@@ -326,6 +326,9 @@ class uint128 {
       -> uint128 {
     return {lhs.hi_ & rhs.hi_, lhs.lo_ & rhs.lo_};
   }
+  friend constexpr auto operator~(const uint128& n) -> uint128 {
+    return {~n.hi_, ~n.lo_};
+  }
   friend FMT_CONSTEXPR auto operator+(const uint128& lhs, const uint128& rhs)
       -> uint128 {
     auto result = uint128(lhs);

--- a/lib/fmt/include/fmt-vt/format.h
+++ b/lib/fmt/include/fmt-vt/format.h
@@ -1,7 +1,7 @@
 /*
   Formatting library for C++
 
-  Copyright (c) 2012 - present, Victor Zverovich
+  Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the
@@ -40,13 +40,19 @@
 
 #include "base.h"
 
+// libc++ supports string_view in pre-c++17.
+#if FMT_HAS_INCLUDE(<string_view>) && \
+    (FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
+#  define FMT_USE_STRING_VIEW
+#endif
+
 #ifndef FMT_MODULE
-#  include <cmath>    // std::signbit
-#  include <cstddef>  // std::byte
-#  include <cstdint>  // uint32_t
-#  include <cstring>  // std::memcpy
-#  include <limits>   // std::numeric_limits
-#  include <new>      // std::bad_alloc
+#  include <stdint.h>  // uint32_t
+#  include <stdlib.h>  // malloc, free
+#  include <string.h>  // memcpy
+
+#  include <cmath>   // std::signbit
+#  include <limits>  // std::numeric_limits
 #  if defined(__GLIBCXX__) && !defined(_GLIBCXX_USE_DUAL_ABI)
 // Workaround for pre gcc 5 libstdc++.
 #    include <memory>  // std::allocator_traits
@@ -60,11 +66,8 @@
 #    include <bit>  // std::bit_cast
 #  endif
 
-// libc++ supports string_view in pre-c++17.
-#  if FMT_HAS_INCLUDE(<string_view>) && \
-      (FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
+#  if defined(FMT_USE_STRING_VIEW)
 #    include <string_view>
-#    define FMT_USE_STRING_VIEW
 #  endif
 
 #  if FMT_MSC_VERSION
@@ -117,6 +120,34 @@
 #  define FMT_NOINLINE
 #endif
 
+// Detect constexpr std::string.
+#if !FMT_USE_CONSTEVAL
+#  define FMT_USE_CONSTEXPR_STRING 0
+#elif defined(__cpp_lib_constexpr_string) && \
+    __cpp_lib_constexpr_string >= 201907L
+#  if FMT_CLANG_VERSION && FMT_GLIBCXX_RELEASE
+// clang + libstdc++ are able to work only starting with gcc13.3
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=113294
+#    if FMT_GLIBCXX_RELEASE < 13
+#      define FMT_USE_CONSTEXPR_STRING 0
+#    elif FMT_GLIBCXX_RELEASE == 13 && __GLIBCXX__ < 20240521
+#      define FMT_USE_CONSTEXPR_STRING 0
+#    else
+#      define FMT_USE_CONSTEXPR_STRING 1
+#    endif
+#  else
+#    define FMT_USE_CONSTEXPR_STRING 1
+#  endif
+#else
+#  define FMT_USE_CONSTEXPR_STRING 0
+#endif
+#if FMT_USE_CONSTEXPR_STRING
+#  define FMT_CONSTEXPR_STRING constexpr
+#else
+#  define FMT_CONSTEXPR_STRING
+#endif
+
+// GCC 4.9 doesn't support qualified names in specializations.
 namespace std {
 template <typename T> struct iterator_traits<fmt::basic_appender<T>> {
   using iterator_category = output_iterator_tag;
@@ -128,28 +159,19 @@ template <typename T> struct iterator_traits<fmt::basic_appender<T>> {
 };
 }  // namespace std
 
-#ifndef FMT_THROW
-#  if FMT_USE_EXCEPTIONS
-#    if FMT_MSC_VERSION || defined(__NVCC__)
-FMT_BEGIN_NAMESPACE
-namespace detail {
-template <typename Exception> inline void do_throw(const Exception& x) {
-  // Silence unreachable code warnings in MSVC and NVCC because these
-  // are nearly impossible to fix in a generic code.
-  volatile bool b = true;
-  if (b) throw x;
-}
-}  // namespace detail
-FMT_END_NAMESPACE
-#      define FMT_THROW(x) detail::do_throw(x)
-#    else
-#      define FMT_THROW(x) throw x
-#    endif
-#  else
-#    define FMT_THROW(x) \
-      ::fmt::detail::assert_fail(__FILE__, __LINE__, (x).what())
-#  endif  // FMT_USE_EXCEPTIONS
-#endif    // FMT_THROW
+#ifdef FMT_THROW
+// Use the provided definition.
+#elif FMT_USE_EXCEPTIONS
+#  define FMT_THROW(x) throw x
+#else
+#  define FMT_THROW(x) ::fmt::assert_fail(__FILE__, __LINE__, (x).what())
+#endif
+
+#ifdef __clang_analyzer__
+#  define FMT_CLANG_ANALYZER 1
+#else
+#  define FMT_CLANG_ANALYZER 0
+#endif
 
 // Defining FMT_REDUCE_INT_INSTANTIATIONS to 1, will reduce the number of
 // integer formatter template instantiations to just one by only using the
@@ -192,7 +214,6 @@ namespace detail {
 
 inline auto clz(uint32_t x) -> int {
   FMT_ASSERT(x != 0, "");
-  FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
   unsigned long r = 0;
   _BitScanReverse(&r, x);
   return 31 ^ static_cast<int>(r);
@@ -201,7 +222,6 @@ inline auto clz(uint32_t x) -> int {
 
 inline auto clzll(uint64_t x) -> int {
   FMT_ASSERT(x != 0, "");
-  FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
   unsigned long r = 0;
 #  ifdef _WIN64
   _BitScanReverse64(&r, x);
@@ -251,7 +271,7 @@ FMT_CONSTEXPR20 auto bit_cast(const From& from) -> To {
 #endif
   auto to = To();
   // The cast suppresses a bogus -Wclass-memaccess on GCC.
-  std::memcpy(static_cast<void*>(&to), &from, sizeof(to));
+  memcpy(static_cast<void*>(&to), &from, sizeof(to));
   return to;
 }
 
@@ -270,13 +290,13 @@ inline auto is_big_endian() -> bool {
 #endif
 }
 
-class uint128_fallback {
+class uint128 {
  private:
   uint64_t lo_, hi_;
 
  public:
-  constexpr uint128_fallback(uint64_t hi, uint64_t lo) : lo_(lo), hi_(hi) {}
-  constexpr uint128_fallback(uint64_t value = 0) : lo_(value), hi_(0) {}
+  constexpr uint128(uint64_t hi, uint64_t lo) : lo_(lo), hi_(hi) {}
+  constexpr uint128(uint64_t value = 0) : lo_(value), hi_(0) {}
 
   constexpr auto high() const noexcept -> uint64_t { return hi_; }
   constexpr auto low() const noexcept -> uint64_t { return lo_; }
@@ -286,92 +306,84 @@ class uint128_fallback {
     return static_cast<T>(lo_);
   }
 
-  friend constexpr auto operator==(const uint128_fallback& lhs,
-                                   const uint128_fallback& rhs) -> bool {
+  friend constexpr auto operator==(const uint128& lhs, const uint128& rhs)
+      -> bool {
     return lhs.hi_ == rhs.hi_ && lhs.lo_ == rhs.lo_;
   }
-  friend constexpr auto operator!=(const uint128_fallback& lhs,
-                                   const uint128_fallback& rhs) -> bool {
+  friend constexpr auto operator!=(const uint128& lhs, const uint128& rhs)
+      -> bool {
     return !(lhs == rhs);
   }
-  friend constexpr auto operator>(const uint128_fallback& lhs,
-                                  const uint128_fallback& rhs) -> bool {
+  friend constexpr auto operator>(const uint128& lhs, const uint128& rhs)
+      -> bool {
     return lhs.hi_ != rhs.hi_ ? lhs.hi_ > rhs.hi_ : lhs.lo_ > rhs.lo_;
   }
-  friend constexpr auto operator|(const uint128_fallback& lhs,
-                                  const uint128_fallback& rhs)
-      -> uint128_fallback {
+  friend constexpr auto operator|(const uint128& lhs, const uint128& rhs)
+      -> uint128 {
     return {lhs.hi_ | rhs.hi_, lhs.lo_ | rhs.lo_};
   }
-  friend constexpr auto operator&(const uint128_fallback& lhs,
-                                  const uint128_fallback& rhs)
-      -> uint128_fallback {
+  friend constexpr auto operator&(const uint128& lhs, const uint128& rhs)
+      -> uint128 {
     return {lhs.hi_ & rhs.hi_, lhs.lo_ & rhs.lo_};
   }
-  friend constexpr auto operator~(const uint128_fallback& n)
-      -> uint128_fallback {
-    return {~n.hi_, ~n.lo_};
-  }
-  friend FMT_CONSTEXPR auto operator+(const uint128_fallback& lhs,
-                                      const uint128_fallback& rhs)
-      -> uint128_fallback {
-    auto result = uint128_fallback(lhs);
+  friend FMT_CONSTEXPR auto operator+(const uint128& lhs, const uint128& rhs)
+      -> uint128 {
+    auto result = uint128(lhs);
     result += rhs;
     return result;
   }
-  friend FMT_CONSTEXPR auto operator*(const uint128_fallback& lhs, uint32_t rhs)
-      -> uint128_fallback {
+  friend FMT_CONSTEXPR auto operator*(const uint128& lhs, uint32_t rhs)
+      -> uint128 {
     FMT_ASSERT(lhs.hi_ == 0, "");
     uint64_t hi = (lhs.lo_ >> 32) * rhs;
     uint64_t lo = (lhs.lo_ & ~uint32_t()) * rhs;
     uint64_t new_lo = (hi << 32) + lo;
     return {(hi >> 32) + (new_lo < lo ? 1 : 0), new_lo};
   }
-  friend constexpr auto operator-(const uint128_fallback& lhs, uint64_t rhs)
-      -> uint128_fallback {
+  friend constexpr auto operator-(const uint128& lhs, uint64_t rhs) -> uint128 {
     return {lhs.hi_ - (lhs.lo_ < rhs ? 1 : 0), lhs.lo_ - rhs};
   }
-  FMT_CONSTEXPR auto operator>>(int shift) const -> uint128_fallback {
+  FMT_CONSTEXPR auto operator>>(int shift) const -> uint128 {
     if (shift == 64) return {0, hi_};
-    if (shift > 64) return uint128_fallback(0, hi_) >> (shift - 64);
+    if (shift > 64) return uint128(0, hi_) >> (shift - 64);
     return {hi_ >> shift, (hi_ << (64 - shift)) | (lo_ >> shift)};
   }
-  FMT_CONSTEXPR auto operator<<(int shift) const -> uint128_fallback {
+  FMT_CONSTEXPR auto operator<<(int shift) const -> uint128 {
     if (shift == 64) return {lo_, 0};
-    if (shift > 64) return uint128_fallback(lo_, 0) << (shift - 64);
+    if (shift > 64) return uint128(lo_, 0) << (shift - 64);
     return {hi_ << shift | (lo_ >> (64 - shift)), (lo_ << shift)};
   }
-  FMT_CONSTEXPR auto operator>>=(int shift) -> uint128_fallback& {
+  FMT_CONSTEXPR auto operator>>=(int shift) -> uint128& {
     return *this = *this >> shift;
   }
-  FMT_CONSTEXPR void operator+=(uint128_fallback n) {
+  FMT_CONSTEXPR void operator+=(uint128 n) {
     uint64_t new_lo = lo_ + n.lo_;
     uint64_t new_hi = hi_ + n.hi_ + (new_lo < lo_ ? 1 : 0);
     FMT_ASSERT(new_hi >= hi_, "");
     lo_ = new_lo;
     hi_ = new_hi;
   }
-  FMT_CONSTEXPR void operator&=(uint128_fallback n) {
+  FMT_CONSTEXPR void operator&=(uint128 n) {
     lo_ &= n.lo_;
     hi_ &= n.hi_;
   }
 
-  FMT_CONSTEXPR20 auto operator+=(uint64_t n) noexcept -> uint128_fallback& {
+  FMT_CONSTEXPR20 auto operator+=(uint64_t n) noexcept -> uint128& {
     if (is_constant_evaluated()) {
       lo_ += n;
       hi_ += (lo_ < n ? 1 : 0);
       return *this;
     }
 #if FMT_HAS_BUILTIN(__builtin_addcll) && !defined(__ibmxl__)
-    unsigned long long carry;
+    ullong carry;
     lo_ = __builtin_addcll(lo_, n, 0, &carry);
     hi_ += carry;
 #elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64) && !defined(__ibmxl__)
-    unsigned long long result;
+    ullong result;
     auto carry = __builtin_ia32_addcarryx_u64(0, lo_, n, &result);
     lo_ = result;
     hi_ += carry;
-#elif defined(_MSC_VER) && defined(_M_X64)
+#elif defined(_MSC_VER) && defined(_M_AMD64)
     auto carry = _addcarry_u64(0, lo_, n, &lo_);
     _addcarry_u64(carry, hi_, 0, &hi_);
 #else
@@ -382,7 +394,7 @@ class uint128_fallback {
   }
 };
 
-using uint128_t = conditional_t<FMT_USE_INT128, uint128_opt, uint128_fallback>;
+using uint128_t = conditional_t<FMT_USE_INT128, native_uint128, uint128>;
 
 #ifdef UINTPTR_MAX
 using uintptr_t = ::uintptr_t;
@@ -399,12 +411,12 @@ template <typename T> constexpr auto num_bits() -> int {
   return std::numeric_limits<T>::digits;
 }
 // std::numeric_limits<T>::digits may return 0 for 128-bit ints.
-template <> constexpr auto num_bits<int128_opt>() -> int { return 128; }
-template <> constexpr auto num_bits<uint128_opt>() -> int { return 128; }
-template <> constexpr auto num_bits<uint128_fallback>() -> int { return 128; }
+template <> constexpr auto num_bits<native_int128>() -> int { return 128; }
+template <> constexpr auto num_bits<native_uint128>() -> int { return 128; }
+template <> constexpr auto num_bits<uint128>() -> int { return 128; }
 
 // A heterogeneous bit_cast used for converting 96-bit long double to uint128_t
-// and 128-bit pointers to uint128_fallback.
+// and 128-bit pointers to uint128.
 template <typename To, typename From, FMT_ENABLE_IF(sizeof(To) > sizeof(From))>
 inline auto bit_cast(const From& from) -> To {
   constexpr auto size = static_cast<int>(sizeof(From) / sizeof(unsigned short));
@@ -412,7 +424,7 @@ inline auto bit_cast(const From& from) -> To {
     unsigned short value[static_cast<unsigned>(size)];
   } data = bit_cast<data_t>(from);
   auto result = To();
-  if (const_check(is_big_endian())) {
+  if (is_big_endian()) {
     for (int i = 0; i < size; ++i)
       result = (result << num_bits<unsigned short>()) | data.value[i];
   } else {
@@ -461,8 +473,8 @@ template <typename OutputIt,
 #if FMT_CLANG_VERSION >= 307 && !FMT_ICC_VERSION
 __attribute__((no_sanitize("undefined")))
 #endif
-FMT_CONSTEXPR20 inline auto
-reserve(OutputIt it, size_t n) -> typename OutputIt::value_type* {
+FMT_CONSTEXPR20 inline auto reserve(OutputIt it, size_t n) ->
+    typename OutputIt::value_type* {
   auto& c = get_container(it);
   size_t size = c.size();
   c.resize(size + n);
@@ -489,6 +501,11 @@ using reserve_iterator =
 template <typename T, typename OutputIt>
 constexpr auto to_pointer(OutputIt, size_t) -> T* {
   return nullptr;
+}
+template <typename T> FMT_CONSTEXPR auto to_pointer(T*& ptr, size_t n) -> T* {
+  T* begin = ptr;
+  ptr += n;
+  return begin;
 }
 template <typename T>
 FMT_CONSTEXPR20 auto to_pointer(basic_appender<T> it, size_t n) -> T* {
@@ -525,8 +542,15 @@ FMT_CONSTEXPR auto fill_n(OutputIt out, Size count, const T& value)
 template <typename T, typename Size>
 FMT_CONSTEXPR20 auto fill_n(T* out, Size count, char value) -> T* {
   if (is_constant_evaluated()) return fill_n<T*, Size, T>(out, count, value);
-  std::memset(out, value, to_unsigned(count));
+  static_assert(sizeof(T) == 1,
+                "sizeof(T) must be 1 to use char for initialization");
+  memset(out, value, to_unsigned(count));
   return out + count;
+}
+
+template <typename T, typename V, typename OutputIt>
+FMT_CONSTEXPR auto copy(basic_string_view<V> s, OutputIt out) -> OutputIt {
+  return copy<T>(s.begin(), s.end(), out);
 }
 
 template <typename OutChar, typename InputIt, typename OutputIt>
@@ -554,10 +578,10 @@ FMT_CONSTEXPR FMT_NOINLINE auto copy_noinline(InputIt begin, InputIt end,
  */
 FMT_CONSTEXPR inline auto utf8_decode(const char* s, uint32_t* c, int* e)
     -> const char* {
-  constexpr const int masks[] = {0x00, 0x7f, 0x1f, 0x0f, 0x07};
-  constexpr const uint32_t mins[] = {4194304, 0, 128, 2048, 65536};
-  constexpr const int shiftc[] = {0, 18, 12, 6, 0};
-  constexpr const int shifte[] = {0, 6, 4, 2, 0};
+  constexpr int masks[] = {0x00, 0x7f, 0x1f, 0x0f, 0x07};
+  constexpr uint32_t mins[] = {4194304, 0, 128, 2048, 65536};
+  constexpr int shiftc[] = {0, 18, 12, 6, 0};
+  constexpr int shifte[] = {0, 6, 4, 2, 0};
 
   int len = "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0\0\0\2\2\2\2\3\3\4"
       [static_cast<unsigned char>(*s) >> 3];
@@ -628,21 +652,9 @@ FMT_CONSTEXPR void for_each_codepoint(string_view s, F f) {
   } while (buf_ptr < buf + num_chars_left);
 }
 
-template <typename Char>
-inline auto compute_width(basic_string_view<Char> s) -> size_t {
-  return s.size();
-}
-
-// Computes approximate display width of a UTF-8 string.
-FMT_CONSTEXPR inline auto compute_width(string_view s) -> size_t {
-  size_t num_code_points = 0;
-  // It is not a lambda for compatibility with C++14.
-  struct count_code_points {
-    size_t* count;
-    FMT_CONSTEXPR auto operator()(uint32_t cp, string_view) const -> bool {
-      *count += to_unsigned(
-          1 +
-          (cp >= 0x1100 &&
+FMT_CONSTEXPR inline auto display_width_of(uint32_t cp) noexcept -> size_t {
+  return to_unsigned(
+      1 + (cp >= 0x1100 &&
            (cp <= 0x115f ||  // Hangul Jamo init. consonants
             cp == 0x2329 ||  // LEFT-POINTING ANGLE BRACKET
             cp == 0x232a ||  // RIGHT-POINTING ANGLE BRACKET
@@ -660,42 +672,16 @@ FMT_CONSTEXPR inline auto compute_width(string_view s) -> size_t {
             (cp >= 0x1f300 && cp <= 0x1f64f) ||
             // Supplemental Symbols and Pictographs:
             (cp >= 0x1f900 && cp <= 0x1f9ff))));
-      return true;
-    }
-  };
-  // We could avoid branches by using utf8_decode directly.
-  for_each_codepoint(s, count_code_points{&num_code_points});
-  return num_code_points;
-}
-
-template <typename Char>
-inline auto code_point_index(basic_string_view<Char> s, size_t n) -> size_t {
-  return min_of(n, s.size());
-}
-
-// Calculates the index of the nth code point in a UTF-8 string.
-inline auto code_point_index(string_view s, size_t n) -> size_t {
-  size_t result = s.size();
-  const char* begin = s.begin();
-  for_each_codepoint(s, [begin, &n, &result](uint32_t, string_view sv) {
-    if (n != 0) {
-      --n;
-      return true;
-    }
-    result = to_unsigned(sv.begin() - begin);
-    return false;
-  });
-  return result;
 }
 
 template <typename T> struct is_integral : std::is_integral<T> {};
-template <> struct is_integral<int128_opt> : std::true_type {};
+template <> struct is_integral<native_int128> : std::true_type {};
 template <> struct is_integral<uint128_t> : std::true_type {};
 
 template <typename T>
 using is_signed =
     std::integral_constant<bool, std::numeric_limits<T>::is_signed ||
-                                     std::is_same<T, int128_opt>::value>;
+                                     std::is_same<T, native_int128>::value>;
 
 template <typename T>
 using is_integer =
@@ -705,7 +691,7 @@ using is_integer =
 
 #if defined(FMT_USE_FLOAT128)
 // Use the provided definition.
-#elif FMT_CLANG_VERSION && FMT_HAS_INCLUDE(<quadmath.h>)
+#elif FMT_CLANG_VERSION >= 309 && FMT_HAS_INCLUDE(<quadmath.h>)
 #  define FMT_USE_FLOAT128 1
 #elif FMT_GCC_VERSION && defined(_GLIBCXX_USE_FLOAT128) && \
     !defined(__STRICT_ANSI__)
@@ -721,36 +707,50 @@ struct float128 {};
 
 template <typename T> using is_float128 = std::is_same<T, float128>;
 
-template <typename T>
-using is_floating_point =
-    bool_constant<std::is_floating_point<T>::value || is_float128<T>::value>;
+template <typename T> struct is_floating_point : std::is_floating_point<T> {};
+template <> struct is_floating_point<float128> : std::true_type {};
 
-template <typename T, bool = std::is_floating_point<T>::value>
+template <typename T, bool = is_floating_point<T>::value>
 struct is_fast_float : bool_constant<std::numeric_limits<T>::is_iec559 &&
                                      sizeof(T) <= sizeof(double)> {};
 template <typename T> struct is_fast_float<T, false> : std::false_type {};
 
 template <typename T>
+using fast_float_t = conditional_t<sizeof(T) == sizeof(double), double, float>;
+
+template <typename T>
 using is_double_double = bool_constant<std::numeric_limits<T>::digits == 106>;
 
-#ifndef FMT_USE_FULL_CACHE_DRAGONBOX
-#  define FMT_USE_FULL_CACHE_DRAGONBOX 0
-#endif
+FMT_API auto allocate(size_t size) -> void*;
 
 // An allocator that uses malloc/free to allow removing dependency on the C++
-// standard libary runtime.
-template <typename T> struct allocator {
+// standard library runtime. std::decay is used for back_inserter to be found by
+// ADL when applied to memory_buffer.
+template <typename T> struct allocator : private std::decay<void> {
   using value_type = T;
 
-  T* allocate(size_t n) {
+  auto allocate(size_t n) -> T* {
     FMT_ASSERT(n <= max_value<size_t>() / sizeof(T), "");
-    T* p = static_cast<T*>(malloc(n * sizeof(T)));
-    if (!p) FMT_THROW(std::bad_alloc());
-    return p;
+    return static_cast<T*>(detail::allocate(n * sizeof(T)));
   }
 
   void deallocate(T* p, size_t) { free(p); }
+
+  constexpr friend auto operator==(allocator, allocator) noexcept -> bool {
+    return true;  // All instances of this allocator are equivalent.
+  }
+  constexpr friend auto operator!=(allocator, allocator) noexcept -> bool {
+    return false;
+  }
 };
+
+template <typename Formatter>
+FMT_CONSTEXPR auto maybe_set_debug_format(Formatter& f, bool set)
+    -> decltype(f.set_debug_format(set)) {
+  f.set_debug_format(set);
+}
+template <typename Formatter>
+FMT_CONSTEXPR void maybe_set_debug_format(Formatter&, ...) {}
 
 }  // namespace detail
 
@@ -825,11 +825,32 @@ class basic_memory_buffer : public detail::buffer<T> {
   FMT_CONSTEXPR20 ~basic_memory_buffer() { deallocate(); }
 
  private:
+  template <typename Alloc = Allocator,
+            FMT_ENABLE_IF(std::allocator_traits<Alloc>::
+                              propagate_on_container_move_assignment::value)>
+  FMT_CONSTEXPR20 auto move_alloc(basic_memory_buffer& other) -> bool {
+    alloc_ = std::move(other.alloc_);
+    return true;
+  }
+  // If the allocator does not propagate then copy the data from other.
+  template <typename Alloc = Allocator,
+            FMT_ENABLE_IF(!std::allocator_traits<Alloc>::
+                              propagate_on_container_move_assignment::value)>
+  FMT_CONSTEXPR20 auto move_alloc(basic_memory_buffer& other) -> bool {
+    T* data = other.data();
+    if (alloc_ == other.alloc_ || data == other.store_) return true;
+    size_t size = other.size();
+    // Perform copy operation, allocators are different.
+    this->resize(size);
+    detail::copy<T>(data, data + size, this->data());
+    return false;
+  }
+
   // Move data from other to this buffer.
   FMT_CONSTEXPR20 void move(basic_memory_buffer& other) {
-    alloc_ = std::move(other.alloc_);
     T* data = other.data();
     size_t size = other.size(), capacity = other.capacity();
+    if (!move_alloc(other)) return;
     if (data == other.store_) {
       this->set(store_, capacity);
       detail::copy<T>(other.store_, other.store_ + size, store_);
@@ -918,7 +939,7 @@ class string_buffer {
   inline string_buffer() : buf_(str_) {}
 
   inline operator writer() { return buf_; }
-  inline std::string& str() { return str_; }
+  inline auto str() -> std::string& { return str_; }
 };
 
 template <typename T, size_t SIZE, typename Allocator>
@@ -944,7 +965,7 @@ FMT_API void print(FILE*, string_view);
 
 namespace detail {
 template <typename Char, size_t N> struct fixed_string {
-  FMT_CONSTEXPR20 fixed_string(const Char (&s)[N]) {
+  FMT_CONSTEXPR fixed_string(const Char (&s)[N]) {
     detail::copy<Char, const Char*, Char*>(static_cast<const Char*>(s), s + N,
                                            data);
   }
@@ -991,12 +1012,12 @@ using uint64_or_128_t = conditional_t<num_bits<T>() <= 64, uint64_t, uint128_t>;
       (factor) * 100000, (factor) * 1000000, (factor) * 10000000, \
       (factor) * 100000000, (factor) * 1000000000
 
-// Converts value in the range [0, 100) to a string.
-// GCC generates slightly better code when value is pointer-size.
-inline auto digits2(size_t value) -> const char* {
+// Converts value in the range [0, 100) to a string. GCC generates a bit better
+// code when value is pointer-size (https://www.godbolt.org/z/5fEPMT1cc).
+inline auto digits2(size_t value) noexcept -> const char* {
   // Align data since unaligned access may be slower when crossing a
   // hardware-specific boundary.
-  alignas(2) static const char data[] =
+  alignas(2) static constexpr char data[] =
       "0001020304050607080910111213141516171819"
       "2021222324252627282930313233343536373839"
       "4041424344454647484950515253545556575859"
@@ -1005,9 +1026,25 @@ inline auto digits2(size_t value) -> const char* {
   return &data[value * 2];
 }
 
+// Given i in [0, 100), let x be the first 7 digits after
+// the decimal point of i / 100 in base 2, the first 2 bytes
+// after digits2_i(x) is the string representation of i.
+inline auto digits2_i(size_t value) noexcept -> const char* {
+  alignas(2) static constexpr char data[] =
+      "00010203  0405060707080910  1112"
+      "131414151617  18192021  222324  "
+      "25262728  2930313232333435  3637"
+      "383939404142  43444546  474849  "
+      "50515253  5455565757585960  6162"
+      "636464656667  68697071  727374  "
+      "75767778  7980818282838485  8687"
+      "888989909192  93949596  979899  ";
+  return &data[value * 2];
+}
+
 template <typename Char> constexpr auto getsign(sign s) -> Char {
-  return static_cast<char>(((' ' << 24) | ('+' << 16) | ('-' << 8)) >>
-                           (static_cast<int>(s) * 8));
+  return static_cast<Char>(static_cast<char>(
+      ((' ' << 24) | ('+' << 16) | ('-' << 8)) >> (static_cast<int>(s) * 8)));
 }
 
 template <typename T> FMT_CONSTEXPR auto count_digits_fallback(T n) -> int {
@@ -1025,7 +1062,7 @@ template <typename T> FMT_CONSTEXPR auto count_digits_fallback(T n) -> int {
   }
 }
 #if FMT_USE_INT128
-FMT_CONSTEXPR inline auto count_digits(uint128_opt n) -> int {
+FMT_CONSTEXPR inline auto count_digits(native_uint128 n) -> int {
   return count_digits_fallback(n);
 }
 #endif
@@ -1044,7 +1081,7 @@ inline auto do_count_digits(uint64_t n) -> int {
       10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15, 15,
       15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 19, 20};
   auto t = bsr2log10[FMT_BUILTIN_CLZLL(n | 1) ^ 63];
-  static constexpr const uint64_t zero_or_powers_of_10[] = {
+  static constexpr uint64_t zero_or_powers_of_10[] = {
       0, 0, FMT_POWERS_OF_10(1U), FMT_POWERS_OF_10(1000000000ULL),
       10000000000000000000ULL};
   return t - (n < zero_or_powers_of_10[t]);
@@ -1113,7 +1150,9 @@ FMT_CONSTEXPR20 inline auto count_digits(uint32_t n) -> int {
 template <typename Int> constexpr auto digits10() noexcept -> int {
   return std::numeric_limits<Int>::digits10;
 }
-template <> constexpr auto digits10<int128_opt>() noexcept -> int { return 38; }
+template <> constexpr auto digits10<native_int128>() noexcept -> int {
+  return 38;
+}
 template <> constexpr auto digits10<uint128_t>() noexcept -> int { return 38; }
 
 template <typename Char> struct thousands_sep_result {
@@ -1126,7 +1165,7 @@ FMT_API auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char>;
 template <typename Char>
 inline auto thousands_sep(locale_ref loc) -> thousands_sep_result<Char> {
   auto result = thousands_sep_impl<char>(loc);
-  return {result.grouping, Char(result.thousands_sep)};
+  return {std::move(result.grouping), Char(result.thousands_sep)};
 }
 template <>
 inline auto thousands_sep(locale_ref loc) -> thousands_sep_result<wchar_t> {
@@ -1173,6 +1212,16 @@ FMT_CONSTEXPR20 FMT_INLINE void write2digits(Char* out, size_t value) {
   *out = static_cast<Char>('0' + value % 10);
 }
 
+template <typename Char>
+FMT_INLINE void write2digits_i(Char* out, size_t value) {
+  if (std::is_same<Char, char>::value && !FMT_OPTIMIZE_SIZE) {
+    memcpy(out, digits2_i(value), 2);
+    return;
+  }
+  *out++ = static_cast<Char>(digits2_i(value)[0]);
+  *out = static_cast<Char>(digits2_i(value)[1]);
+}
+
 // Formats a decimal unsigned integer value writing to out pointing to a buffer
 // of specified size. The caller must ensure that the buffer is large enough.
 template <typename Char, typename UInt>
@@ -1181,12 +1230,19 @@ FMT_CONSTEXPR20 auto do_format_decimal(Char* out, UInt value, int size)
   FMT_ASSERT(size >= count_digits(value), "invalid digit count");
   unsigned n = to_unsigned(size);
   while (value >= 100) {
-    // Integer division is slow so do it for a group of two digits instead
-    // of for every digit. The idea comes from the talk by Alexandrescu
-    // "Three Optimization Tips for C++". See speed-test for a comparison.
     n -= 2;
-    write2digits(out + n, static_cast<unsigned>(value % 100));
-    value /= 100;
+    if (!is_constant_evaluated() && sizeof(UInt) == 4) {
+      auto p = value * static_cast<uint64_t>((1ull << 39) / 100 + 1);
+      write2digits_i(out + n, p >> (39 - 7) & ((1 << 7) - 1));
+      value = static_cast<UInt>(p >> 39) +
+              (static_cast<UInt>(value >= (100u << 25)) << 25);
+    } else {
+      // Integer division is slow so do it for a group of two digits instead
+      // of for every digit. The idea comes from the talk by Alexandrescu
+      // "Three Optimization Tips for C++". See speed-test for a comparison.
+      write2digits(out + n, static_cast<unsigned>(value % 100));
+      value /= 100;
+    }
   }
   if (value >= 10) {
     n -= 2;
@@ -1225,7 +1281,7 @@ FMT_CONSTEXPR auto do_format_base2e(int base_bits, Char* out, UInt value,
   out += size;
   do {
     const char* digits = upper ? "0123456789ABCDEF" : "0123456789abcdef";
-    unsigned digit = static_cast<unsigned>(value & ((1 << base_bits) - 1));
+    unsigned digit = static_cast<unsigned>(value & ((1u << base_bits) - 1));
     *--out = static_cast<Char>(base_bits < 4 ? static_cast<char>('0' + digit)
                                              : digits[digit]);
   } while ((value >>= base_bits) != 0);
@@ -1271,7 +1327,13 @@ class utf8_to_utf16 {
   inline auto str() const -> std::wstring { return {&buffer_[0], size()}; }
 };
 
-enum class to_utf8_error_policy { abort, replace };
+enum class to_utf8_error_policy { abort, replace, wtf };
+
+inline void to_utf8_3bytes(buffer<char>& buf, uint32_t cp) {
+  buf.push_back(static_cast<char>(0xe0 | (cp >> 12)));
+  buf.push_back(static_cast<char>(0x80 | ((cp & 0xfff) >> 6)));
+  buf.push_back(static_cast<char>(0x80 | (cp & 0x3f)));
+}
 
 // A converter from UTF-16/UTF-32 (host endian) to UTF-8.
 template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
@@ -1283,10 +1345,11 @@ template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
   explicit to_utf8(basic_string_view<WChar> s,
                    to_utf8_error_policy policy = to_utf8_error_policy::abort) {
     static_assert(sizeof(WChar) == 2 || sizeof(WChar) == 4,
-                  "Expect utf16 or utf32");
-    if (!convert(s, policy))
+                  "expected utf16 or utf32");
+    if (!convert(s, policy)) {
       FMT_THROW(std::runtime_error(sizeof(WChar) == 2 ? "invalid utf16"
                                                       : "invalid utf32"));
+    }
   }
   operator string_view() const { return string_view(&buffer_[0], size()); }
   auto size() const -> size_t { return buffer_.size() - 1; }
@@ -1312,13 +1375,17 @@ template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
         // Handle a surrogate pair.
         ++p;
         if (p == s.end() || (c & 0xfc00) != 0xd800 || (*p & 0xfc00) != 0xdc00) {
-          if (policy == to_utf8_error_policy::abort) return false;
-          buf.append(string_view("\xEF\xBF\xBD"));
+          switch (policy) {
+          case to_utf8_error_policy::abort: return false;
+          case to_utf8_error_policy::replace:
+            buf.append(string_view("\xEF\xBF\xBD"));
+            break;
+          case to_utf8_error_policy::wtf: to_utf8_3bytes(buf, c); break;
+          }
           --p;
           continue;
-        } else {
-          c = (c << 10) + static_cast<uint32_t>(*p) - 0x35fdc00;
         }
+        c = (c << 10) + static_cast<uint32_t>(*p) - 0x35fdc00;
       }
       if (c < 0x80) {
         buf.push_back(static_cast<char>(c));
@@ -1326,9 +1393,7 @@ template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
         buf.push_back(static_cast<char>(0xc0 | (c >> 6)));
         buf.push_back(static_cast<char>(0x80 | (c & 0x3f)));
       } else if ((c >= 0x800 && c <= 0xd7ff) || (c >= 0xe000 && c <= 0xffff)) {
-        buf.push_back(static_cast<char>(0xe0 | (c >> 12)));
-        buf.push_back(static_cast<char>(0x80 | ((c & 0xfff) >> 6)));
-        buf.push_back(static_cast<char>(0x80 | (c & 0x3f)));
+        to_utf8_3bytes(buf, c);
       } else if (c >= 0x10000 && c <= 0x10ffff) {
         buf.push_back(static_cast<char>(0xf0 | (c >> 18)));
         buf.push_back(static_cast<char>(0x80 | ((c & 0x3ffff) >> 12)));
@@ -1343,11 +1408,11 @@ template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
 };
 
 // Computes 128-bit result of multiplication of two 64-bit unsigned integers.
-inline auto umul128(uint64_t x, uint64_t y) noexcept -> uint128_fallback {
+FMT_INLINE auto umul128(uint64_t x, uint64_t y) noexcept -> uint128 {
 #if FMT_USE_INT128
-  auto p = static_cast<uint128_opt>(x) * static_cast<uint128_opt>(y);
+  auto p = static_cast<native_uint128>(x) * static_cast<native_uint128>(y);
   return {static_cast<uint64_t>(p >> 64), static_cast<uint64_t>(p)};
-#elif defined(_MSC_VER) && defined(_M_X64)
+#elif defined(_MSC_VER) && defined(_M_AMD64)
   auto hi = uint64_t();
   auto lo = _umul128(x, y, &hi);
   return {hi, lo};
@@ -1388,9 +1453,9 @@ inline auto floor_log2_pow10(int e) noexcept -> int {
 // Computes upper 64 bits of multiplication of two 64-bit unsigned integers.
 inline auto umul128_upper64(uint64_t x, uint64_t y) noexcept -> uint64_t {
 #if FMT_USE_INT128
-  auto p = static_cast<uint128_opt>(x) * static_cast<uint128_opt>(y);
+  auto p = static_cast<native_uint128>(x) * static_cast<native_uint128>(y);
   return static_cast<uint64_t>(p >> 64);
-#elif defined(_MSC_VER) && defined(_M_X64)
+#elif defined(_MSC_VER) && defined(_M_AMD64)
   return __umulh(x, y);
 #else
   return umul128(x, y).high();
@@ -1399,40 +1464,39 @@ inline auto umul128_upper64(uint64_t x, uint64_t y) noexcept -> uint64_t {
 
 // Computes upper 128 bits of multiplication of a 64-bit unsigned integer and a
 // 128-bit unsigned integer.
-inline auto umul192_upper128(uint64_t x, uint128_fallback y) noexcept
-    -> uint128_fallback {
-  uint128_fallback r = umul128(x, y.high());
+inline auto umul192_upper128(uint64_t x, uint128 y) noexcept -> uint128 {
+  uint128 r = umul128(x, y.high());
   r += umul128_upper64(x, y.low());
   return r;
 }
 
-FMT_API auto get_cached_power(int k) noexcept -> uint128_fallback;
+FMT_API auto get_cached_power(int k) noexcept -> uint128;
 
 // Type-specific information that Dragonbox uses.
 template <typename T, typename Enable = void> struct float_info;
 
 template <> struct float_info<float> {
   using carrier_uint = uint32_t;
-  static const int exponent_bits = 8;
-  static const int kappa = 1;
-  static const int big_divisor = 100;
-  static const int small_divisor = 10;
-  static const int min_k = -31;
-  static const int max_k = 46;
-  static const int shorter_interval_tie_lower_threshold = -35;
-  static const int shorter_interval_tie_upper_threshold = -35;
+  static constexpr int exponent_bits = 8;
+  static constexpr int kappa = 1;
+  static constexpr int big_divisor = 100;
+  static constexpr int small_divisor = 10;
+  static constexpr int min_k = -31;
+  enum { max_k = 46 };
+  static constexpr int shorter_interval_tie_lower_threshold = -35;
+  static constexpr int shorter_interval_tie_upper_threshold = -35;
 };
 
 template <> struct float_info<double> {
   using carrier_uint = uint64_t;
-  static const int exponent_bits = 11;
-  static const int kappa = 2;
-  static const int big_divisor = 1000;
-  static const int small_divisor = 100;
-  static const int min_k = -292;
-  static const int max_k = 341;
-  static const int shorter_interval_tie_lower_threshold = -77;
-  static const int shorter_interval_tie_upper_threshold = -77;
+  static constexpr int exponent_bits = 11;
+  static constexpr int kappa = 2;
+  static constexpr int big_divisor = 1000;
+  static constexpr int small_divisor = 100;
+  static constexpr int min_k = -292;
+  enum { max_k = 341 };
+  static constexpr int shorter_interval_tie_lower_threshold = -77;
+  static constexpr int shorter_interval_tie_upper_threshold = -77;
 };
 
 // An 80- or 128-bit floating point number.
@@ -1487,6 +1551,13 @@ template <typename Float> constexpr auto exponent_bias() -> int {
                               : std::numeric_limits<Float>::max_exponent - 1;
 }
 
+FMT_CONSTEXPR inline auto compute_exp_size(int exp) -> int {
+  auto prefix_size = 2;  // sign + 'e'
+  auto abs_exp = exp >= 0 ? exp : -exp;
+  if (abs_exp < 100) return prefix_size + 2;
+  return prefix_size + (abs_exp >= 1000 ? 4 : 3);
+}
+
 // Writes the exponent exp in the form "[+-]d{2,3}" to buffer.
 template <typename Char, typename OutputIt>
 FMT_CONSTEXPR auto write_exponent(int exp, OutputIt out) -> OutputIt {
@@ -1519,7 +1590,7 @@ template <typename F> struct basic_fp {
   F f;
   int e;
 
-  static constexpr const int num_significand_bits =
+  static constexpr int num_significand_bits =
       static_cast<int>(sizeof(F) * num_bits<unsigned char>());
 
   constexpr basic_fp() : f(0), e(0) {}
@@ -1561,7 +1632,7 @@ template <typename F> struct basic_fp {
   }
 };
 
-using fp = basic_fp<unsigned long long>;
+using fp = basic_fp<ullong>;
 
 // Normalizes the value converted from double and multiplied by (1 << SHIFT).
 template <int SHIFT = 0, typename F>
@@ -1612,8 +1683,17 @@ constexpr auto convert_float(T value) -> convert_float_result<T> {
   return static_cast<convert_float_result<T>>(value);
 }
 
+template <bool C, typename T, typename F, FMT_ENABLE_IF(C)>
+auto select(T true_value, F) -> T {
+  return true_value;
+}
+template <bool C, typename T, typename F, FMT_ENABLE_IF(!C)>
+auto select(T, F false_value) -> F {
+  return false_value;
+}
+
 template <typename Char, typename OutputIt>
-FMT_NOINLINE FMT_CONSTEXPR auto fill(OutputIt it, size_t n,
+FMT_CONSTEXPR FMT_NOINLINE auto fill(OutputIt it, size_t n,
                                      const basic_specs& specs) -> OutputIt {
   auto fill_size = specs.fill_size();
   if (fill_size == 1) return detail::fill_n(it, n, specs.fill_unit<Char>());
@@ -1683,7 +1763,7 @@ FMT_API auto is_printable(uint32_t cp) -> bool;
 
 inline auto needs_escape(uint32_t cp) -> bool {
   if (cp < 0x20 || cp == 0x7f || cp == '"' || cp == '\\') return true;
-  if (const_check(FMT_OPTIMIZE_SIZE > 1)) return false;
+  if FMT_CONSTEXPR20 (FMT_OPTIMIZE_SIZE > 1) return false;
   return !is_printable(cp);
 }
 
@@ -1698,7 +1778,7 @@ auto find_escape(const Char* begin, const Char* end)
     -> find_escape_result<Char> {
   for (; begin != end; ++begin) {
     uint32_t cp = static_cast<unsigned_char<Char>>(*begin);
-    if (const_check(sizeof(Char) == 1) && cp >= 0x80) continue;
+    if (sizeof(Char) == 1 && cp >= 0x80) continue;
     if (needs_escape(cp)) return {begin, begin + 1, cp};
   }
   return {begin, nullptr, 0};
@@ -1706,7 +1786,7 @@ auto find_escape(const Char* begin, const Char* end)
 
 inline auto find_escape(const char* begin, const char* end)
     -> find_escape_result<char> {
-  if (const_check(!use_utf8)) return find_escape<char>(begin, end);
+  if FMT_CONSTEXPR20 (!use_utf8) return find_escape<char>(begin, end);
   auto result = find_escape_result<char>{end, nullptr, 0};
   for_each_codepoint(string_view(begin, to_unsigned(end - begin)),
                      [&](uint32_t cp, string_view sv) {
@@ -1808,16 +1888,6 @@ FMT_CONSTEXPR auto write_char(OutputIt out, Char value,
     return it;
   });
 }
-template <typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write(OutputIt out, Char value, const format_specs& specs,
-                         locale_ref loc = {}) -> OutputIt {
-  // char is formatted as unsigned char for consistency across platforms.
-  using unsigned_type =
-      conditional_t<std::is_same<Char, char>::value, unsigned char, unsigned>;
-  return check_char_specs(specs)
-             ? write_char<Char>(out, value, specs)
-             : write<Char>(out, static_cast<unsigned_type>(value), specs, loc);
-}
 
 template <typename Char> class digit_grouping {
  private:
@@ -1841,12 +1911,10 @@ template <typename Char> class digit_grouping {
   }
 
  public:
-  template <typename Locale,
-            FMT_ENABLE_IF(std::is_same<Locale, locale_ref>::value)>
-  explicit digit_grouping(Locale loc, bool localized = true) {
+  explicit digit_grouping(locale_ref loc, bool localized = true) {
     if (!localized) return;
     auto sep = thousands_sep<Char>(loc);
-    grouping_ = sep.grouping;
+    grouping_ = std::move(sep.grouping);
     if (sep.thousands_sep) thousands_sep_.assign(1, sep.thousands_sep);
   }
   digit_grouping(std::string grouping, std::basic_string<Char> sep)
@@ -1861,7 +1929,7 @@ template <typename Char> class digit_grouping {
     return count;
   }
 
-  // Applies grouping to digits and write the output to out.
+  // Applies grouping to digits and writes the output to out.
   template <typename Out, typename C>
   auto apply(Out out, basic_string_view<C> digits) const -> Out {
     auto num_digits = static_cast<int>(digits.size());
@@ -1943,6 +2011,8 @@ auto write_int(OutputIt out, UInt value, unsigned prefix,
 // Writes a localized value.
 FMT_API auto write_loc(appender out, loc_value value, const format_specs& specs,
                        locale_ref loc) -> bool;
+auto write_loc(basic_appender<wchar_t> out, loc_value value,
+               const format_specs& specs, locale_ref loc) -> bool;
 #endif
 template <typename OutputIt>
 inline auto write_loc(OutputIt, const loc_value&, const format_specs&,
@@ -1964,8 +2034,7 @@ FMT_CONSTEXPR auto make_write_int_arg(T value, sign s)
     prefix = 0x01000000 | '-';
     abs_value = 0 - abs_value;
   } else {
-    constexpr const unsigned prefixes[4] = {0, 0, 0x1000000u | '+',
-                                            0x1000000u | ' '};
+    constexpr unsigned prefixes[4] = {0, 0, 0x1000000u | '+', 0x1000000u | ' '};
     prefix = prefixes[static_cast<int>(s)];
   }
   return {abs_value, prefix};
@@ -2018,7 +2087,7 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
                                         const format_specs& specs) -> OutputIt {
   static_assert(std::is_same<T, uint32_or_64_or_128_t<T>>::value, "");
 
-  constexpr int buffer_size = num_bits<T>();
+  constexpr size_t buffer_size = num_bits<T>();
   char buffer[buffer_size];
   if (is_constant_evaluated()) fill_n(buffer, buffer_size, '\0');
   const char* begin = nullptr;
@@ -2111,12 +2180,108 @@ FMT_CONSTEXPR FMT_INLINE auto write(OutputIt out, T value,
 }
 
 template <typename Char, typename OutputIt>
+FMT_CONSTEXPR auto write(OutputIt out, Char value, const format_specs& specs,
+                         locale_ref loc = {}) -> OutputIt {
+  // char is formatted as unsigned char for consistency across platforms.
+  using unsigned_type =
+      conditional_t<std::is_same<Char, char>::value, unsigned char, unsigned>;
+  return check_char_specs(specs)
+             ? write_char<Char>(out, value, specs)
+             : write<Char>(out, static_cast<unsigned_type>(value), specs, loc);
+}
+
+template <typename Char, typename OutputIt,
+          FMT_ENABLE_IF(std::is_same<Char, char>::value)>
+FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s,
+                         const format_specs& specs) -> OutputIt {
+  bool is_debug = specs.type() == presentation_type::debug;
+  if (specs.precision < 0 && specs.width == 0) {
+    auto&& it = reserve(out, s.size());
+    return is_debug ? write_escaped_string(it, s) : copy<char>(s, it);
+  }
+
+  size_t display_width_limit =
+      specs.precision < 0 ? SIZE_MAX : to_unsigned(specs.precision);
+  size_t display_width =
+      !is_debug || specs.precision == 0 ? 0 : 1;  // Account for opening '"'.
+  size_t size = !is_debug || specs.precision == 0 ? 0 : 1;
+  for_each_codepoint(s, [&](uint32_t cp, string_view sv) {
+    if (is_debug && needs_escape(cp)) {
+      counting_buffer<char> buf;
+      write_escaped_cp(basic_appender<char>(buf),
+                       find_escape_result<char>{sv.begin(), sv.end(), cp});
+      // We're reinterpreting bytes as display width. That's okay
+      // because write_escaped_cp() only writes ASCII characters.
+      size_t cp_width = buf.count();
+      if (display_width + cp_width <= display_width_limit) {
+        display_width += cp_width;
+        size += cp_width;
+        // If this is the end of the string, account for closing '"'.
+        if (display_width < display_width_limit && sv.end() == s.end()) {
+          ++display_width;
+          ++size;
+        }
+        return true;
+      }
+
+      size += display_width_limit - display_width;
+      display_width = display_width_limit;
+      return false;
+    }
+
+    size_t cp_width = display_width_of(cp);
+    if (cp_width + display_width <= display_width_limit) {
+      display_width += cp_width;
+      size += sv.size();
+      // If this is the end of the string, account for closing '"'.
+      if (is_debug && display_width < display_width_limit &&
+          sv.end() == s.end()) {
+        ++display_width;
+        ++size;
+      }
+      return true;
+    }
+
+    return false;
+  });
+
+  struct bounded_output_iterator {
+    reserve_iterator<OutputIt> underlying_iterator;
+    size_t bound;
+
+    FMT_CONSTEXPR auto operator*() -> bounded_output_iterator& { return *this; }
+    FMT_CONSTEXPR auto operator++() -> bounded_output_iterator& {
+      return *this;
+    }
+    FMT_CONSTEXPR auto operator++(int) -> bounded_output_iterator& {
+      return *this;
+    }
+    FMT_CONSTEXPR auto operator=(char c) -> bounded_output_iterator& {
+      if (bound > 0) {
+        *underlying_iterator++ = c;
+        --bound;
+      }
+      return *this;
+    }
+  };
+
+  return write_padded<char>(
+      out, specs, size, display_width, [=](reserve_iterator<OutputIt> it) {
+        return is_debug
+                   ? write_escaped_string(bounded_output_iterator{it, size}, s)
+                         .underlying_iterator
+                   : copy<char>(s.data(), s.data() + size, it);
+      });
+}
+
+template <typename Char, typename OutputIt,
+          FMT_ENABLE_IF(!std::is_same<Char, char>::value)>
 FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s,
                          const format_specs& specs) -> OutputIt {
   auto data = s.data();
   auto size = s.size();
   if (specs.precision >= 0 && to_unsigned(specs.precision) < size)
-    size = code_point_index(s, to_unsigned(specs.precision));
+    size = to_unsigned(specs.precision);
 
   bool is_debug = specs.type() == presentation_type::debug;
   if (is_debug) {
@@ -2125,22 +2290,19 @@ FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s,
     size = buf.count();
   }
 
-  size_t width = 0;
-  if (specs.width != 0) {
-    width =
-        is_debug ? size : compute_width(basic_string_view<Char>(data, size));
-  }
   return write_padded<Char>(
-      out, specs, size, width, [=](reserve_iterator<OutputIt> it) {
+      out, specs, size, [=](reserve_iterator<OutputIt> it) {
         return is_debug ? write_escaped_string(it, s)
                         : copy<Char>(data, data + size, it);
       });
 }
+
 template <typename Char, typename OutputIt>
 FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s,
                          const format_specs& specs, locale_ref) -> OutputIt {
   return write<Char>(out, s, specs);
 }
+
 template <typename Char, typename OutputIt>
 FMT_CONSTEXPR auto write(OutputIt out, const Char* s, const format_specs& specs,
                          locale_ref) -> OutputIt {
@@ -2197,9 +2359,8 @@ FMT_CONSTEXPR auto parse_align(const Char* begin, const Char* end,
         ++begin;
       }
       break;
-    } else if (p == begin) {
-      break;
     }
+    if (p == begin) break;
     p = begin;
   }
   specs.set_align(alignment);
@@ -2274,7 +2435,7 @@ inline auto write_significand(Char* out, UInt significand, int significand_size,
   int floating_size = significand_size - integral_size;
   for (int i = floating_size / 2; i > 0; --i) {
     out -= 2;
-    write2digits(out, static_cast<std::size_t>(significand % 100));
+    write2digits(out, static_cast<size_t>(significand % 100));
     significand /= 100;
   }
   if (floating_size % 2 != 0) {
@@ -2328,110 +2489,18 @@ FMT_CONSTEXPR20 auto write_significand(OutputIt out, T significand,
                                      buffer.end(), out);
 }
 
-template <typename Char, typename OutputIt, typename DecimalFP,
-          typename Grouping = digit_grouping<Char>>
-FMT_CONSTEXPR20 auto do_write_float(OutputIt out, const DecimalFP& f,
-                                    const format_specs& specs, sign s,
-                                    locale_ref loc) -> OutputIt {
-  auto significand = f.significand;
-  int significand_size = get_significand_size(f);
-  const Char zero = static_cast<Char>('0');
-  size_t size = to_unsigned(significand_size) + (s != sign::none ? 1 : 0);
-  using iterator = reserve_iterator<OutputIt>;
+// Numbers with exponents greater or equal to the returned value will use
+// the exponential notation.
+template <typename T> FMT_CONSTEVAL auto exp_upper() -> int {
+  return std::numeric_limits<T>::digits10 != 0
+             ? min_of(16, std::numeric_limits<T>::digits10 + 1)
+             : 16;
+}
 
-  Char decimal_point = specs.localized() ? detail::decimal_point<Char>(loc)
-                                         : static_cast<Char>('.');
-
-  int output_exp = f.exponent + significand_size - 1;
-  auto use_exp_format = [=]() {
-    if (specs.type() == presentation_type::exp) return true;
-    if (specs.type() == presentation_type::fixed) return false;
-    // Use the fixed notation if the exponent is in [exp_lower, exp_upper),
-    // e.g. 0.0001 instead of 1e-04. Otherwise use the exponent notation.
-    const int exp_lower = -4, exp_upper = 16;
-    return output_exp < exp_lower ||
-           output_exp >= (specs.precision > 0 ? specs.precision : exp_upper);
-  };
-  if (use_exp_format()) {
-    int num_zeros = 0;
-    if (specs.alt()) {
-      num_zeros = specs.precision - significand_size;
-      if (num_zeros < 0) num_zeros = 0;
-      size += to_unsigned(num_zeros);
-    } else if (significand_size == 1) {
-      decimal_point = Char();
-    }
-    auto abs_output_exp = output_exp >= 0 ? output_exp : -output_exp;
-    int exp_digits = 2;
-    if (abs_output_exp >= 100) exp_digits = abs_output_exp >= 1000 ? 4 : 3;
-
-    size += to_unsigned((decimal_point ? 1 : 0) + 2 + exp_digits);
-    char exp_char = specs.upper() ? 'E' : 'e';
-    auto write = [=](iterator it) {
-      if (s != sign::none) *it++ = detail::getsign<Char>(s);
-      // Insert a decimal point after the first digit and add an exponent.
-      it = write_significand(it, significand, significand_size, 1,
-                             decimal_point);
-      if (num_zeros > 0) it = detail::fill_n(it, num_zeros, zero);
-      *it++ = static_cast<Char>(exp_char);
-      return write_exponent<Char>(output_exp, it);
-    };
-    return specs.width > 0
-               ? write_padded<Char, align::right>(out, specs, size, write)
-               : base_iterator(out, write(reserve(out, size)));
-  }
-
-  int exp = f.exponent + significand_size;
-  if (f.exponent >= 0) {
-    // 1234e5 -> 123400000[.0+]
-    size += to_unsigned(f.exponent);
-    int num_zeros = specs.precision - exp;
-    abort_fuzzing_if(num_zeros > 5000);
-    if (specs.alt()) {
-      ++size;
-      if (num_zeros <= 0 && specs.type() != presentation_type::fixed)
-        num_zeros = 0;
-      if (num_zeros > 0) size += to_unsigned(num_zeros);
-    }
-    auto grouping = Grouping(loc, specs.localized());
-    size += to_unsigned(grouping.count_separators(exp));
-    return write_padded<Char, align::right>(out, specs, size, [&](iterator it) {
-      if (s != sign::none) *it++ = detail::getsign<Char>(s);
-      it = write_significand<Char>(it, significand, significand_size,
-                                   f.exponent, grouping);
-      if (!specs.alt()) return it;
-      *it++ = decimal_point;
-      return num_zeros > 0 ? detail::fill_n(it, num_zeros, zero) : it;
-    });
-  } else if (exp > 0) {
-    // 1234e-2 -> 12.34[0+]
-    int num_zeros = specs.alt() ? specs.precision - significand_size : 0;
-    size += 1 + static_cast<unsigned>(max_of(num_zeros, 0));
-    auto grouping = Grouping(loc, specs.localized());
-    size += to_unsigned(grouping.count_separators(exp));
-    return write_padded<Char, align::right>(out, specs, size, [&](iterator it) {
-      if (s != sign::none) *it++ = detail::getsign<Char>(s);
-      it = write_significand(it, significand, significand_size, exp,
-                             decimal_point, grouping);
-      return num_zeros > 0 ? detail::fill_n(it, num_zeros, zero) : it;
-    });
-  }
-  // 1234e-6 -> 0.001234
-  int num_zeros = -exp;
-  if (significand_size == 0 && specs.precision >= 0 &&
-      specs.precision < num_zeros) {
-    num_zeros = specs.precision;
-  }
-  bool pointy = num_zeros != 0 || significand_size != 0 || specs.alt();
-  size += 1 + (pointy ? 1 : 0) + to_unsigned(num_zeros);
-  return write_padded<Char, align::right>(out, specs, size, [&](iterator it) {
-    if (s != sign::none) *it++ = detail::getsign<Char>(s);
-    *it++ = zero;
-    if (!pointy) return it;
-    *it++ = decimal_point;
-    it = detail::fill_n(it, num_zeros, zero);
-    return write_significand<Char>(it, significand, significand_size);
-  });
+// Use the fixed notation if the exponent is in [-4, exp_upper),
+// e.g. 0.0001 instead of 1e-04. Otherwise use the exponent notation.
+constexpr auto use_fixed(int exp, int exp_upper) -> bool {
+  return exp >= -4 && exp < exp_upper;
 }
 
 template <typename Char> class fallback_digit_grouping {
@@ -2448,15 +2517,122 @@ template <typename Char> class fallback_digit_grouping {
   }
 };
 
+template <typename Char, typename Grouping, typename OutputIt,
+          typename DecimalFP>
+FMT_CONSTEXPR20 auto write_fixed(OutputIt out, const DecimalFP& f,
+                                 int significand_size, Char decimal_point,
+                                 const format_specs& specs, sign s,
+                                 locale_ref loc = {}) -> OutputIt {
+  using iterator = reserve_iterator<OutputIt>;
+
+  int exp = f.exponent + significand_size;
+  long long size = significand_size + (s != sign::none ? 1 : 0);
+  if (f.exponent >= 0) {
+    // 1234e5 -> 123400000[.0+]
+    size += f.exponent;
+    int num_zeros = specs.precision - exp;
+    abort_fuzzing_if(num_zeros > 5000);
+    if (specs.alt()) {
+      ++size;
+      if (num_zeros <= 0 && specs.type() != presentation_type::fixed)
+        num_zeros = 0;
+      if (num_zeros > 0) size += num_zeros;
+    }
+    auto grouping = Grouping(loc, specs.localized());
+    size += grouping.count_separators(exp);
+    return write_padded<Char, align::right>(
+        out, specs, static_cast<size_t>(size), [&](iterator it) {
+          if (s != sign::none) *it++ = detail::getsign<Char>(s);
+          it = write_significand<Char>(it, f.significand, significand_size,
+                                       f.exponent, grouping);
+          if (!specs.alt()) return it;
+          *it++ = decimal_point;
+          return num_zeros > 0 ? detail::fill_n(it, num_zeros, Char('0')) : it;
+        });
+  }
+  if (exp > 0) {
+    // 1234e-2 -> 12.34[0+]
+    int num_zeros = specs.alt() ? specs.precision - significand_size : 0;
+    size += 1 + max_of(num_zeros, 0);
+    auto grouping = Grouping(loc, specs.localized());
+    size += grouping.count_separators(exp);
+    return write_padded<Char, align::right>(
+        out, specs, static_cast<size_t>(size), [&](iterator it) {
+          if (s != sign::none) *it++ = detail::getsign<Char>(s);
+          it = write_significand(it, f.significand, significand_size, exp,
+                                 decimal_point, grouping);
+          return num_zeros > 0 ? detail::fill_n(it, num_zeros, Char('0')) : it;
+        });
+  }
+  // 1234e-6 -> 0.001234
+  int num_zeros = -exp;
+  if (significand_size == 0 && specs.precision >= 0 &&
+      specs.precision < num_zeros) {
+    num_zeros = specs.precision;
+  }
+  bool pointy = num_zeros != 0 || significand_size != 0 || specs.alt();
+  size += 1 + (pointy ? 1 : 0) + num_zeros;
+  return write_padded<Char, align::right>(
+      out, specs, static_cast<size_t>(size), [&](iterator it) {
+        if (s != sign::none) *it++ = detail::getsign<Char>(s);
+        *it++ = Char('0');
+        if (!pointy) return it;
+        *it++ = decimal_point;
+        it = detail::fill_n(it, num_zeros, Char('0'));
+        return write_significand<Char>(it, f.significand, significand_size);
+      });
+}
+
+template <typename Char, typename Grouping, typename OutputIt,
+          typename DecimalFP>
+FMT_CONSTEXPR20 auto do_write_float(OutputIt out, const DecimalFP& f,
+                                    const format_specs& specs, sign s,
+                                    int exp_upper, locale_ref loc) -> OutputIt {
+  Char point = specs.localized() ? detail::decimal_point<Char>(loc) : Char('.');
+  int significand_size = get_significand_size(f);
+  int exp = f.exponent + significand_size - 1;
+  if (specs.type() == presentation_type::fixed ||
+      (specs.type() != presentation_type::exp &&
+       use_fixed(exp, specs.precision > 0 ? specs.precision : exp_upper))) {
+    return write_fixed<Char, Grouping>(out, f, significand_size, point, specs,
+                                       s, loc);
+  }
+
+  // Write value in the exponential format.
+  int num_zeros = 0;
+  long long size = significand_size + (s != sign::none ? 1 : 0);
+  if (specs.alt()) {
+    num_zeros = max_of(specs.precision - significand_size, 0);
+    size += num_zeros;
+  } else if (significand_size == 1) {
+    point = Char();
+  }
+  size += (point ? 1 : 0) + compute_exp_size(exp);
+  char exp_char = specs.upper() ? 'E' : 'e';
+  auto write = [=](reserve_iterator<OutputIt> it) {
+    if (s != sign::none) *it++ = detail::getsign<Char>(s);
+    // Insert a decimal point after the first digit and add an exponent.
+    it = write_significand(it, f.significand, significand_size, 1, point);
+    if (num_zeros > 0) it = detail::fill_n(it, num_zeros, Char('0'));
+    *it++ = Char(exp_char);
+    return write_exponent<Char>(exp, it);
+  };
+  size_t usize = static_cast<size_t>(size);
+  return specs.width > 0
+             ? write_padded<Char, align::right>(out, specs, usize, write)
+             : base_iterator(out, write(reserve(out, usize)));
+}
+
 template <typename Char, typename OutputIt, typename DecimalFP>
 FMT_CONSTEXPR20 auto write_float(OutputIt out, const DecimalFP& f,
                                  const format_specs& specs, sign s,
-                                 locale_ref loc) -> OutputIt {
+                                 int exp_upper, locale_ref loc) -> OutputIt {
   if (is_constant_evaluated()) {
-    return do_write_float<Char, OutputIt, DecimalFP,
-                          fallback_digit_grouping<Char>>(out, f, specs, s, loc);
+    return do_write_float<Char, fallback_digit_grouping<Char>>(out, f, specs, s,
+                                                               exp_upper, loc);
   } else {
-    return do_write_float<Char>(out, f, specs, s, loc);
+    return do_write_float<Char, digit_grouping<Char>>(out, f, specs, s,
+                                                      exp_upper, loc);
   }
 }
 
@@ -2471,8 +2647,8 @@ template <typename T>
 struct has_isfinite<T, enable_if_t<sizeof(std::isfinite(T())) != 0>>
     : std::true_type {};
 
-template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value&&
-                                        has_isfinite<T>::value)>
+template <typename T,
+          FMT_ENABLE_IF(is_floating_point<T>::value&& has_isfinite<T>::value)>
 FMT_CONSTEXPR20 auto isfinite(T value) -> bool {
   constexpr T inf = T(std::numeric_limits<double>::infinity());
   if (is_constant_evaluated())
@@ -2487,7 +2663,7 @@ FMT_CONSTEXPR auto isfinite(T value) -> bool {
 }
 
 template <typename T, FMT_ENABLE_IF(is_floating_point<T>::value)>
-FMT_INLINE FMT_CONSTEXPR bool signbit(T value) {
+FMT_INLINE FMT_CONSTEXPR auto signbit(T value) -> bool {
   if (is_constant_evaluated()) {
 #ifdef __cpp_if_constexpr
     if constexpr (std::numeric_limits<double>::is_iec559) {
@@ -2727,7 +2903,7 @@ class bigint {
     bigits_.resize(to_unsigned(num_bigits + exp_difference));
     for (int i = num_bigits - 1, j = i + exp_difference; i >= 0; --i, --j)
       bigits_[j] = bigits_[i];
-    memset(bigits_.data(), 0, to_unsigned(exp_difference) * sizeof(bigit));
+    fill_n(bigits_.data(), to_unsigned(exp_difference), 0U);
     exp_ -= exp_difference;
   }
 
@@ -2985,8 +3161,9 @@ constexpr auto fractional_part_rounding_thresholds(int index) -> uint32_t {
   // It is equal to ceil(2^31 + 2^32/10^(k + 1)).
   // These are stored in a string literal because we cannot have static arrays
   // in constexpr functions and non-static ones are poorly optimized.
-  return U"\x9999999a\x828f5c29\x80418938\x80068db9\x8000a7c6\x800010c7"
-         U"\x800001ae\x8000002b"[index];
+  return uint32_t(u"\x9999\x828f\x8041\x8006\x8000\x8000\x8000\x8000"[index])
+             << 16u |
+         uint32_t(u"\x999a\x5c29\x8938\x8db9\xa7c6\x10c7\x01ae\x002b"[index]);
 }
 
 template <typename Float>
@@ -3288,9 +3465,12 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision,
   return exp;
 }
 
-template <typename Char, typename OutputIt, typename T>
-FMT_CONSTEXPR20 auto write_float(OutputIt out, T value, format_specs specs,
-                                 locale_ref loc) -> OutputIt {
+template <typename Char, typename OutputIt, typename T,
+          FMT_ENABLE_IF(is_floating_point<T>::value)>
+FMT_CONSTEXPR20 auto write(OutputIt out, T value, format_specs specs,
+                           locale_ref loc = {}) -> OutputIt {
+  if (specs.localized() && write_loc(out, value, specs, loc)) return out;
+
   // Use signbit because value < 0 is false for NaN.
   sign s = detail::signbit(value) ? sign::minus : specs.sign();
 
@@ -3303,15 +3483,15 @@ FMT_CONSTEXPR20 auto write_float(OutputIt out, T value, format_specs specs,
     if (specs.width != 0) --specs.width;
   }
 
+  const int exp_upper = detail::exp_upper<T>();
   int precision = specs.precision;
   if (precision < 0) {
     if (specs.type() != presentation_type::none) {
       precision = 6;
     } else if (is_fast_float<T>::value && !is_constant_evaluated()) {
       // Use Dragonbox for the shortest format.
-      using floaty = conditional_t<sizeof(T) >= sizeof(double), double, float>;
-      auto dec = dragonbox::to_decimal(static_cast<floaty>(value));
-      return write_float<Char>(out, dec, specs, s, loc);
+      auto dec = dragonbox::to_decimal(static_cast<fast_float_t<T>>(value));
+      return write_float<Char>(out, dec, specs, s, exp_upper, loc);
     }
   }
 
@@ -3339,16 +3519,7 @@ FMT_CONSTEXPR20 auto write_float(OutputIt out, T value, format_specs specs,
 
   specs.precision = precision;
   auto f = big_decimal_fp{buffer.data(), static_cast<int>(buffer.size()), exp};
-  return write_float<Char>(out, f, specs, s, loc);
-}
-
-template <typename Char, typename OutputIt, typename T,
-          FMT_ENABLE_IF(is_floating_point<T>::value)>
-FMT_CONSTEXPR20 auto write(OutputIt out, T value, format_specs specs,
-                           locale_ref loc = {}) -> OutputIt {
-  return specs.localized() && write_loc(out, value, specs, loc)
-             ? out
-             : write_float<Char>(out, value, specs, loc);
+  return write_float<Char>(out, f, specs, s, exp_upper, loc);
 }
 
 template <typename Char, typename OutputIt, typename T,
@@ -3357,23 +3528,71 @@ FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
   if (is_constant_evaluated()) return write<Char>(out, value, format_specs());
 
   auto s = detail::signbit(value) ? sign::minus : sign::none;
+  auto mask = exponent_mask<fast_float_t<T>>();
+  if ((bit_cast<decltype(mask)>(value) & mask) == mask)
+    return write_nonfinite<Char>(out, std::isnan(value), {}, s);
 
-  constexpr auto specs = format_specs();
-  using floaty = conditional_t<sizeof(T) >= sizeof(double), double, float>;
-  using floaty_uint = typename dragonbox::float_info<floaty>::carrier_uint;
-  floaty_uint mask = exponent_mask<floaty>();
-  if ((bit_cast<floaty_uint>(value) & mask) == mask)
-    return write_nonfinite<Char>(out, std::isnan(value), specs, s);
+  auto dec = dragonbox::to_decimal(static_cast<fast_float_t<T>>(value));
+  auto significand = dec.significand;
+  int significand_size = count_digits(significand);
+  int exponent = dec.exponent + significand_size - 1;
+  if (use_fixed(exponent, detail::exp_upper<T>())) {
+    return write_fixed<Char, fallback_digit_grouping<Char>>(
+        out, dec, significand_size, Char('.'), {}, s);
+  }
 
-  auto dec = dragonbox::to_decimal(static_cast<floaty>(value));
-  return write_float<Char>(out, dec, specs, s, {});
+  // Write value in the exponential format.
+  const char* prefix = "e+";
+  int abs_exponent = exponent;
+  if (exponent < 0) {
+    abs_exponent = -exponent;
+    prefix = "e-";
+  }
+  auto has_decimal_point = significand_size != 1;
+  size_t size = std::is_pointer<OutputIt>::value
+                    ? 0u
+                    : to_unsigned((s != sign::none ? 1 : 0) + significand_size +
+                                  (has_decimal_point ? 1 : 0) +
+                                  (abs_exponent >= 100 ? 5 : 4));
+  if (auto ptr = to_pointer<Char>(out, size)) {
+    if (s != sign::none) *ptr++ = Char('-');
+    if (has_decimal_point) {
+      auto begin = ptr;
+      ptr = format_decimal<Char>(ptr, significand, significand_size + 1);
+      *begin = begin[1];
+      begin[1] = '.';
+    } else {
+      *ptr++ = static_cast<Char>('0' + significand);
+    }
+    if (std::is_same<Char, char>::value) {
+      memcpy(ptr, prefix, 2);
+      ptr += 2;
+    } else {
+      *ptr++ = static_cast<Char>(prefix[0]);
+      *ptr++ = static_cast<Char>(prefix[1]);
+    }
+    if (abs_exponent >= 100) {
+      *ptr++ = static_cast<Char>('0' + abs_exponent / 100);
+      abs_exponent %= 100;
+    }
+    write2digits(ptr, static_cast<unsigned>(abs_exponent));
+    return select<std::is_pointer<OutputIt>::value>(ptr + 2, out);
+  }
+  auto it = reserve(out, size);
+  if (s != sign::none) *it++ = Char('-');
+  // Insert a decimal point after the first digit and add an exponent.
+  it = write_significand(it, significand, significand_size, 1,
+                         has_decimal_point ? Char('.') : Char());
+  *it++ = Char('e');
+  it = write_exponent<Char>(exponent, it);
+  return base_iterator(out, it);
 }
 
 template <typename Char, typename OutputIt, typename T,
           FMT_ENABLE_IF(is_floating_point<T>::value &&
                         !is_fast_float<T>::value)>
 inline auto write(OutputIt out, T value) -> OutputIt {
-  return write<Char>(out, value, format_specs());
+  return write<Char>(out, value, {});
 }
 
 template <typename Char, typename OutputIt>
@@ -3502,43 +3721,29 @@ template <typename Char> struct arg_formatter {
 
 struct dynamic_spec_getter {
   template <typename T, FMT_ENABLE_IF(is_integer<T>::value)>
-  FMT_CONSTEXPR auto operator()(T value) -> unsigned long long {
-    return is_negative(value) ? ~0ull : static_cast<unsigned long long>(value);
+  FMT_CONSTEXPR auto operator()(T value) -> ullong {
+    return is_negative(value) ? ~0ull : static_cast<ullong>(value);
   }
 
   template <typename T, FMT_ENABLE_IF(!is_integer<T>::value)>
-  FMT_CONSTEXPR auto operator()(T) -> unsigned long long {
+  FMT_CONSTEXPR auto operator()(T) -> ullong {
     report_error("width/precision is not integer");
     return 0;
   }
 };
 
-template <typename Context, typename ID>
-FMT_CONSTEXPR auto get_arg(Context& ctx, ID id) -> basic_format_arg<Context> {
-  auto arg = ctx.arg(id);
-  if (!arg) report_error("argument not found");
-  return arg;
-}
-
-template <typename Context>
-FMT_CONSTEXPR int get_dynamic_spec(
-    arg_id_kind kind, const arg_ref<typename Context::char_type>& ref,
-    Context& ctx) {
-  FMT_ASSERT(kind != arg_id_kind::none, "");
-  auto arg =
-      kind == arg_id_kind::index ? ctx.arg(ref.index) : ctx.arg(ref.name);
-  if (!arg) report_error("argument not found");
-  unsigned long long value = arg.visit(dynamic_spec_getter());
-  if (value > to_unsigned(max_value<int>()))
-    report_error("width/precision is out of range");
-  return static_cast<int>(value);
-}
-
 template <typename Context>
 FMT_CONSTEXPR void handle_dynamic_spec(
     arg_id_kind kind, int& value,
     const arg_ref<typename Context::char_type>& ref, Context& ctx) {
-  if (kind != arg_id_kind::none) value = get_dynamic_spec(kind, ref, ctx);
+  if (kind == arg_id_kind::none) return;
+  auto arg =
+      kind == arg_id_kind::index ? ctx.arg(ref.index) : ctx.arg(ref.name);
+  if (!arg) report_error("argument not found");
+  ullong result = arg.visit(dynamic_spec_getter());
+  if (result > to_unsigned(max_value<int>()))
+    report_error("width/precision is out of range");
+  value = static_cast<int>(result);
 }
 
 #if FMT_USE_NONTYPE_TEMPLATE_ARGS
@@ -3570,13 +3775,13 @@ struct udl_arg {
 template <typename Char> struct udl_arg {
   const Char* str;
 
-  template <typename T> auto operator=(T&& value) const -> named_arg<Char, T> {
+  template <typename T> auto operator=(T&& value) const -> named_arg<T, Char> {
     return {str, std::forward<T>(value)};
   }
 };
 #endif  // FMT_USE_NONTYPE_TEMPLATE_ARGS
 
-template <typename Char> struct format_handler {
+template <typename Char = char> struct format_handler {
   parse_context<Char> parse_ctx;
   buffered_context<Char> ctx;
 
@@ -3602,7 +3807,8 @@ template <typename Char> struct format_handler {
 
   auto on_format_specs(int id, const Char* begin, const Char* end)
       -> const Char* {
-    auto arg = get_arg(ctx, id);
+    auto arg = ctx.arg(id);
+    if (!arg) report_error("argument not found");
     // Not using a visitor for custom types gives better codegen.
     if (arg.format_custom(begin, parse_ctx, ctx)) return parse_ctx.begin();
 
@@ -3622,6 +3828,7 @@ template <typename Char> struct format_handler {
   FMT_NORETURN void on_error(const char* message) { report_error(message); }
 };
 
+// It is used in format-inl.h and os.cc.
 using format_func = void (*)(detail::buffer<char>&, int, const char*);
 FMT_API void do_report_error(format_func func, int error_code,
                              const char* message) noexcept;
@@ -3642,28 +3849,6 @@ FMT_CONSTEXPR auto native_formatter<T, Char, TYPE>::format(
                       specs_.precision_ref, ctx);
   return write<Char>(ctx.out(), val, specs, ctx.locale());
 }
-
-// DEPRECATED! https://github.com/fmtlib/fmt/issues/4292.
-template <typename T, typename Enable = void>
-struct is_locale : std::false_type {};
-template <typename T>
-struct is_locale<T, void_t<decltype(T::classic())>> : std::true_type {};
-
-// DEPRECATED!
-template <typename Char = char> struct vformat_args {
-  using type = basic_format_args<buffered_context<Char>>;
-};
-template <> struct vformat_args<char> {
-  using type = format_args;
-};
-
-template <typename Char>
-void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
-                typename vformat_args<Char>::type args, locale_ref loc = {}) {
-  auto out = basic_appender<Char>(buf);
-  parse_format_string(
-      fmt, format_handler<Char>{parse_context<Char>(fmt), {out, args, loc}});
-}
 }  // namespace detail
 
 FMT_BEGIN_EXPORT
@@ -3675,19 +3860,16 @@ template <typename OutputIt, typename Char> class generic_context {
  private:
   OutputIt out_;
   basic_format_args<generic_context> args_;
-  detail::locale_ref loc_;
+  locale_ref loc_;
 
  public:
   using char_type = Char;
   using iterator = OutputIt;
-  using parse_context_type FMT_DEPRECATED = parse_context<Char>;
-  template <typename T>
-  using formatter_type FMT_DEPRECATED = formatter<T, Char>;
   enum { builtin_types = FMT_BUILTIN_TYPES };
 
   constexpr generic_context(OutputIt out,
                             basic_format_args<generic_context> args,
-                            detail::locale_ref loc = {})
+                            locale_ref loc = {})
       : out_(out), args_(args), loc_(loc) {}
   generic_context(generic_context&&) = default;
   generic_context(const generic_context&) = delete;
@@ -3706,11 +3888,11 @@ template <typename OutputIt, typename Char> class generic_context {
 
   constexpr auto out() const -> iterator { return out_; }
 
-  void advance_to(iterator it) {
+  FMT_CONSTEXPR void advance_to(iterator it) {
     if (!detail::is_back_insert_iterator<iterator>()) out_ = it;
   }
 
-  constexpr auto locale() const -> detail::locale_ref { return loc_; }
+  constexpr auto locale() const -> locale_ref { return loc_; }
 };
 
 class loc_value {
@@ -3748,8 +3930,8 @@ template <typename Locale> class format_facet : public Locale::facet {
   explicit format_facet(string_view sep = "", std::string grouping = "\3",
                         std::string decimal_point = ".")
       : separator_(sep.data(), sep.size()),
-        grouping_(grouping),
-        decimal_point_(decimal_point) {}
+        grouping_(std::move(grouping)),
+        decimal_point_(std::move(decimal_point)) {}
 
   auto put(appender out, loc_value val, const format_specs& specs) const
       -> bool {
@@ -3785,12 +3967,6 @@ template <typename Char, typename Traits, typename Allocator>
 class formatter<std::basic_string<Char, Traits, Allocator>, Char>
     : public formatter<basic_string_view<Char>, Char> {};
 
-template <int N, typename Char>
-struct formatter<detail::bitint<N>, Char> : formatter<long long, Char> {};
-template <int N, typename Char>
-struct formatter<detail::ubitint<N>, Char>
-    : formatter<unsigned long long, Char> {};
-
 template <typename Char>
 struct formatter<detail::float128, Char>
     : detail::native_formatter<detail::float128, Char,
@@ -3815,7 +3991,7 @@ struct formatter<T, Char, void_t<detail::format_as_result<T>>>
  *     auto s = fmt::format("{}", fmt::ptr(p));
  */
 template <typename T> auto ptr(T p) -> const void* {
-  static_assert(std::is_pointer<T>::value, "");
+  static_assert(std::is_pointer<T>::value, "fmt::ptr used with non-pointer");
   return detail::bit_cast<const void*>(p);
 }
 
@@ -3838,18 +4014,6 @@ constexpr auto format_as(Enum e) noexcept -> underlying_t<Enum> {
   return static_cast<underlying_t<Enum>>(e);
 }
 }  // namespace enums
-
-#ifdef __cpp_lib_byte
-template <> struct formatter<std::byte> : formatter<unsigned> {
-  static auto format_as(std::byte b) -> unsigned char {
-    return static_cast<unsigned char>(b);
-  }
-  template <typename Context>
-  auto format(std::byte b, Context& ctx) const -> decltype(ctx.out()) {
-    return formatter<unsigned>::format(format_as(b), ctx);
-  }
-};
-#endif
 
 struct bytes {
   string_view data;
@@ -3983,6 +4147,14 @@ template <typename T, typename Char = char> struct nested_formatter {
 
 inline namespace literals {
 #if FMT_USE_NONTYPE_TEMPLATE_ARGS
+/**
+ * User-defined literal equivalent of `fmt::arg`, but with compile-time checks.
+ *
+ * **Example**:
+ *
+ *     using namespace fmt::literals;
+ *     fmt::print("The answer is {answer}.", "answer"_a=42);
+ */
 template <detail::fixed_string S> constexpr auto operator""_a() {
   using char_t = remove_cvref_t<decltype(*S.data)>;
   return detail::udl_arg<char_t, sizeof(S.data) / sizeof(char_t), S>();
@@ -4007,7 +4179,7 @@ class format_int {
  private:
   // Buffer should be large enough to hold all digits (digits10 + 1),
   // a sign and a null character.
-  enum { buffer_size = std::numeric_limits<unsigned long long>::digits10 + 3 };
+  enum { buffer_size = std::numeric_limits<ullong>::digits10 + 3 };
   mutable char buffer_[buffer_size];
   char* str_;
 
@@ -4037,7 +4209,7 @@ class format_int {
       : str_(format_unsigned(value)) {}
   FMT_CONSTEXPR20 explicit format_int(unsigned long value)
       : str_(format_unsigned(value)) {}
-  FMT_CONSTEXPR20 explicit format_int(unsigned long long value)
+  FMT_CONSTEXPR20 explicit format_int(ullong value)
       : str_(format_unsigned(value)) {}
 
   /// Returns the number of characters written to the output buffer.
@@ -4060,21 +4232,26 @@ class format_int {
   inline auto str() const -> std::string { return {str_, size()}; }
 };
 
-#define FMT_STRING_IMPL(s, base)                                              \
-  [] {                                                                        \
-    /* Use the hidden visibility as a workaround for a GCC bug (#1973). */    \
-    /* Use a macro-like name to avoid shadowing warnings. */                  \
-    struct FMT_VISIBILITY("hidden") FMT_COMPILE_STRING : base {               \
-      using char_type = fmt::remove_cvref_t<decltype(s[0])>;                  \
-      constexpr explicit operator fmt::basic_string_view<char_type>() const { \
-        return fmt::detail::compile_string_to_view<char_type>(s);             \
-      }                                                                       \
-    };                                                                        \
-    using FMT_STRING_VIEW =                                                   \
-        fmt::basic_string_view<typename FMT_COMPILE_STRING::char_type>;       \
-    fmt::detail::ignore_unused(FMT_STRING_VIEW(FMT_COMPILE_STRING()));        \
-    return FMT_COMPILE_STRING();                                              \
-  }()
+#if FMT_CLANG_ANALYZER
+#  define FMT_STRING_IMPL(s, base) s
+#else
+#  define FMT_STRING_IMPL(s, base)                                           \
+    [] {                                                                     \
+      /* Use the hidden visibility as a workaround for a GCC bug (#1973). */ \
+      /* Use a macro-like name to avoid shadowing warnings. */               \
+      struct FMT_VISIBILITY("hidden") FMT_COMPILE_STRING : base {            \
+        using char_type = fmt::remove_cvref_t<decltype(s[0])>;               \
+        constexpr explicit operator fmt::basic_string_view<char_type>()      \
+            const {                                                          \
+          return fmt::detail::compile_string_to_view<char_type>(s);          \
+        }                                                                    \
+      };                                                                     \
+      using FMT_STRING_VIEW =                                                \
+          fmt::basic_string_view<typename FMT_COMPILE_STRING::char_type>;    \
+      fmt::detail::ignore_unused(FMT_STRING_VIEW(FMT_COMPILE_STRING()));     \
+      return FMT_COMPILE_STRING();                                           \
+    }()
+#endif  // FMT_CLANG_ANALYZER
 
 /**
  * Constructs a legacy compile-time format string from a string literal `s`.
@@ -4084,7 +4261,11 @@ class format_int {
  *     // A compile-time error because 'd' is an invalid specifier for strings.
  *     std::string s = fmt::format(FMT_STRING("{:d}"), "foo");
  */
-#define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string)
+#if FMT_USE_CONSTEVAL
+#  define FMT_STRING(s) s
+#else
+#  define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string)
+#endif  // FMT_USE_CONSTEVAL
 
 FMT_API auto vsystem_error(int error_code, string_view fmt, format_args args)
     -> std::system_error;
@@ -4130,46 +4311,41 @@ FMT_API void format_system_error(detail::buffer<char>& out, int error_code,
 // Can be used to report errors from destructors.
 FMT_API void report_system_error(int error_code, const char* message) noexcept;
 
-template <typename Locale, FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
-inline auto vformat(const Locale& loc, string_view fmt, format_args args)
+inline auto vformat(locale_ref loc, string_view fmt, format_args args)
     -> std::string {
   auto buf = memory_buffer();
-  detail::vformat_to(buf, fmt, args, detail::locale_ref(loc));
+  detail::vformat_to(buf, fmt, args, loc);
   return {buf.data(), buf.size()};
 }
 
-template <typename Locale, typename... T,
-          FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
-FMT_INLINE auto format(const Locale& loc, format_string<T...> fmt, T&&... args)
+template <typename... T>
+FMT_INLINE auto format(locale_ref loc, format_string<T...> fmt, T&&... args)
     -> std::string {
   return vformat(loc, fmt.str, vargs<T...>{{args...}});
 }
 
-template <typename OutputIt, typename Locale,
+template <typename OutputIt,
           FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
-auto vformat_to(OutputIt out, const Locale& loc, string_view fmt,
-                format_args args) -> OutputIt {
+auto vformat_to(OutputIt out, locale_ref loc, string_view fmt, format_args args)
+    -> OutputIt {
   auto&& buf = detail::get_buffer<char>(out);
-  detail::vformat_to(buf, fmt, args, detail::locale_ref(loc));
+  detail::vformat_to(buf, fmt, args, loc);
   return detail::get_iterator(buf, out);
 }
 
-template <typename OutputIt, typename Locale, typename... T,
-          FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value&&
-                            detail::is_locale<Locale>::value)>
-FMT_INLINE auto format_to(OutputIt out, const Locale& loc,
-                          format_string<T...> fmt, T&&... args) -> OutputIt {
+template <typename OutputIt, typename... T,
+          FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
+FMT_INLINE auto format_to(OutputIt out, locale_ref loc, format_string<T...> fmt,
+                          T&&... args) -> OutputIt {
   return fmt::vformat_to(out, loc, fmt.str, vargs<T...>{{args...}});
 }
 
-template <typename Locale, typename... T,
-          FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
-FMT_NODISCARD FMT_INLINE auto formatted_size(const Locale& loc,
+template <typename... T>
+FMT_NODISCARD FMT_INLINE auto formatted_size(locale_ref loc,
                                              format_string<T...> fmt,
                                              T&&... args) -> size_t {
   auto buf = detail::counting_buffer<>();
-  detail::vformat_to(buf, fmt.str, vargs<T...>{{args...}},
-                     detail::locale_ref(loc));
+  detail::vformat_to(buf, fmt.str, vargs<T...>{{args...}}, loc);
   return buf.count();
 }
 
@@ -4198,7 +4374,7 @@ FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args)
  *     std::string answer = fmt::to_string(42);
  */
 template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
-FMT_NODISCARD auto to_string(T value) -> std::string {
+FMT_NODISCARD FMT_CONSTEXPR_STRING auto to_string(T value) -> std::string {
   // The buffer should be large enough to store the number including the sign
   // or "false" for bool.
   char buffer[max_of(detail::digits10<T>() + 2, 5)];
@@ -4206,13 +4382,15 @@ FMT_NODISCARD auto to_string(T value) -> std::string {
 }
 
 template <typename T, FMT_ENABLE_IF(detail::use_format_as<T>::value)>
-FMT_NODISCARD auto to_string(const T& value) -> std::string {
+FMT_NODISCARD FMT_CONSTEXPR_STRING auto to_string(const T& value)
+    -> std::string {
   return to_string(format_as(value));
 }
 
 template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value &&
                                     !detail::use_format_as<T>::value)>
-FMT_NODISCARD auto to_string(const T& value) -> std::string {
+FMT_NODISCARD FMT_CONSTEXPR_STRING auto to_string(const T& value)
+    -> std::string {
   auto buffer = memory_buffer();
   detail::write<char>(appender(buffer), value);
   return {buffer.data(), buffer.size()};

--- a/lib/fmt/include/fmt-vt/ostream.h
+++ b/lib/fmt/include/fmt-vt/ostream.h
@@ -1,6 +1,6 @@
 // Formatting library for C++ - std::ostream support
 //
-// Copyright (c) 2012 - present, Victor Zverovich
+// Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
 // All rights reserved.
 //
 // For the license information refer to format.h.
@@ -33,12 +33,12 @@
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
-// Generate a unique explicit instantion in every translation unit using a tag
-// type in an anonymous namespace.
+// Generate a unique explicit instantiation in every translation unit using a
+// tag type in an anonymous namespace.
 namespace {
 struct file_access_tag {};
 }  // namespace
-template <typename Tag, typename BufType, FILE* BufType::*FileMemberPtr>
+template <typename Tag, typename BufType, FILE* BufType::* FileMemberPtr>
 class file_access {
   friend auto get_file(BufType& obj) -> FILE* { return obj.*FileMemberPtr; }
 };
@@ -150,7 +150,7 @@ inline void vprint(std::ostream& os, string_view fmt, format_args args) {
 FMT_EXPORT template <typename... T>
 void print(std::ostream& os, format_string<T...> fmt, T&&... args) {
   fmt::vargs<T...> vargs = {{args...}};
-  if (detail::const_check(detail::use_utf8)) return vprint(os, fmt.str, vargs);
+  if FMT_CONSTEXPR20 (detail::use_utf8) return vprint(os, fmt.str, vargs);
   auto buffer = memory_buffer();
   detail::vformat_to(buffer, fmt.str, vargs);
   detail::write_buffer(os, buffer);
@@ -158,7 +158,8 @@ void print(std::ostream& os, format_string<T...> fmt, T&&... args) {
 
 FMT_EXPORT template <typename... T>
 void println(std::ostream& os, format_string<T...> fmt, T&&... args) {
-  fmt::print(os, "{}\n", fmt::format(fmt, std::forward<T>(args)...));
+  fmt::print(os, FMT_STRING("{}\n"),
+             fmt::format(fmt, std::forward<T>(args)...));
 }
 
 FMT_END_NAMESPACE

--- a/lib/fmt/src/format.cc
+++ b/lib/fmt/src/format.cc
@@ -1,6 +1,6 @@
 // Formatting library for C++
 //
-// Copyright (c) 2012 - 2016, Victor Zverovich
+// Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
 // All rights reserved.
 //
 // For the license information refer to format.h.
@@ -8,18 +8,18 @@
 #include "fmt-vt/format-inl.h"
 
 FMT_BEGIN_NAMESPACE
+
+#if FMT_USE_LOCALE
+template FMT_API locale_ref::locale_ref(const std::locale& loc);  // DEPRECATED!
+template FMT_API auto locale_ref::get<std::locale>() const -> std::locale;
+#endif
+
 namespace detail {
 
 template FMT_API auto dragonbox::to_decimal(float x) noexcept
     -> dragonbox::decimal_fp<float>;
 template FMT_API auto dragonbox::to_decimal(double x) noexcept
     -> dragonbox::decimal_fp<double>;
-
-#if FMT_USE_LOCALE
-// DEPRECATED! locale_ref in the detail namespace
-template FMT_API locale_ref::locale_ref(const std::locale& loc);
-template FMT_API auto locale_ref::get<std::locale>() const -> std::locale;
-#endif
 
 // Explicit instantiations for char.
 
@@ -30,16 +30,13 @@ template FMT_API auto decimal_point_impl(locale_ref) -> char;
 // DEPRECATED!
 template FMT_API void buffer<char>::append(const char*, const char*);
 
-// DEPRECATED!
-template FMT_API void vformat_to(buffer<char>&, string_view,
-                                 typename vformat_args<>::type, locale_ref);
-
 // Explicit instantiations for wchar_t.
 
 template FMT_API auto thousands_sep_impl(locale_ref)
     -> thousands_sep_result<wchar_t>;
 template FMT_API auto decimal_point_impl(locale_ref) -> wchar_t;
 
+// DEPRECATED!
 template FMT_API void buffer<wchar_t>::append(const wchar_t*, const wchar_t*);
 
 }  // namespace detail

--- a/src/vt/configs/debug/debug_fmt.h
+++ b/src/vt/configs/debug/debug_fmt.h
@@ -46,7 +46,7 @@
 
 #include "vt/config.h"
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 #include <iosfwd>
 

--- a/src/vt/configs/debug/debug_print.h
+++ b/src/vt/configs/debug/debug_print.h
@@ -49,7 +49,7 @@
 #include "vt/configs/debug/debug_colorize.h"
 #include "vt/configs/debug/debug_var_unused.h"
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 /*
    === Debug file/line/func functionality ===

--- a/src/vt/configs/error/assert_out.impl.h
+++ b/src/vt/configs/error/assert_out.impl.h
@@ -56,7 +56,7 @@
 #include <string>
 #include <cassert>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace debug { namespace assert {
 

--- a/src/vt/configs/error/assert_out_info.impl.h
+++ b/src/vt/configs/error/assert_out_info.impl.h
@@ -57,7 +57,7 @@
 #include <string>
 #include <sstream>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace debug { namespace assert {
 

--- a/src/vt/configs/error/error.impl.h
+++ b/src/vt/configs/error/error.impl.h
@@ -55,7 +55,7 @@
 #include <tuple>
 #include <type_traits>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace error {
 

--- a/src/vt/configs/error/keyval_printer.impl.h
+++ b/src/vt/configs/error/keyval_printer.impl.h
@@ -53,7 +53,7 @@
 #include <string>
 #include <vector>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace util { namespace error {
 

--- a/src/vt/configs/error/pretty_print_message.cc
+++ b/src/vt/configs/error/pretty_print_message.cc
@@ -50,7 +50,7 @@
 #include <string>
 #include <unistd.h> // gethostname
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace debug {
 

--- a/src/vt/configs/error/soft_error.h
+++ b/src/vt/configs/error/soft_error.h
@@ -59,7 +59,7 @@
 
 #include <string>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt {
 

--- a/src/vt/runtime/component/diagnostic_value_format.h
+++ b/src/vt/runtime/component/diagnostic_value_format.h
@@ -49,7 +49,7 @@
 #include "vt/runtime/component/diagnostic_enum_format.h"
 #include "vt/utils/memory/memory_units.h"
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace runtime { namespace component { namespace detail {
 

--- a/src/vt/runtime/runtime_diagnostics.cc
+++ b/src/vt/runtime/runtime_diagnostics.cc
@@ -56,7 +56,7 @@
 #include <fort.hpp>
 #endif /*vt_check_enabled(libfort)*/
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 #include <map>
 #include <string>

--- a/src/vt/utils/adt/histogram_approx.h
+++ b/src/vt/utils/adt/histogram_approx.h
@@ -52,7 +52,7 @@
 #include <cmath>
 #include <algorithm>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace util { namespace adt {
 

--- a/src/vt/utils/json/json_appender.h
+++ b/src/vt/utils/json/json_appender.h
@@ -49,7 +49,7 @@
 
 #include <nlohmann-vt/json.hpp>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace util { namespace json {
 

--- a/src/vt/vrt/collection/manager.impl.h
+++ b/src/vt/vrt/collection/manager.impl.h
@@ -88,7 +88,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 #include INCLUDE_FMT_OSTREAM
 
 namespace vt { namespace vrt { namespace collection {

--- a/tests/perf/collection_local_send.cc
+++ b/tests/perf/collection_local_send.cc
@@ -43,7 +43,7 @@
 #include "common/test_harness.h"
 #include <vt/transport.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 using namespace vt;
 using namespace vt::tests::perf::common;

--- a/tests/perf/make_runnable_micro.cc
+++ b/tests/perf/make_runnable_micro.cc
@@ -46,7 +46,7 @@
 #include <vt/objgroup/manager.h>
 #include <vt/messaging/active.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 using namespace vt;
 using namespace vt::tests::perf::common;

--- a/tests/perf/objgroup_local_send.cc
+++ b/tests/perf/objgroup_local_send.cc
@@ -43,7 +43,7 @@
 #include "common/test_harness.h"
 #include <vt/transport.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 using namespace vt;
 using namespace vt::tests::perf::common;

--- a/tests/perf/ping_pong.cc
+++ b/tests/perf/ping_pong.cc
@@ -45,7 +45,7 @@
 #include <vt/objgroup/manager.h>
 #include <vt/messaging/active.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 using namespace vt;
 using namespace vt::tests::perf::common;

--- a/tests/perf/ping_pong_am.cc
+++ b/tests/perf/ping_pong_am.cc
@@ -46,7 +46,7 @@
 #include <vt/objgroup/manager.h>
 #include <vt/messaging/active.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 using namespace vt;
 using namespace vt::tests::perf::common;

--- a/tests/perf/reduce.cc
+++ b/tests/perf/reduce.cc
@@ -45,7 +45,7 @@
 #include <vt/objgroup/manager.h>
 #include <vt/messaging/active.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 using namespace vt;
 using namespace vt::tests::perf::common;

--- a/tests/unit/collection/test_collection_common.h
+++ b/tests/unit/collection/test_collection_common.h
@@ -47,7 +47,7 @@
 #include <vt/topos/index/index.h>
 #include <vt/context/context.h>
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 #include INCLUDE_FMT_OSTREAM
 
 #include <gtest/gtest.h>

--- a/tests/unit/collection/test_collection_construct_common.h
+++ b/tests/unit/collection/test_collection_construct_common.h
@@ -49,7 +49,7 @@
 #include "vt/vrt/collection/manager.h"
 #include "data_message.h"
 
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 #include INCLUDE_FMT_OSTREAM
 
 #include <gtest/gtest.h>

--- a/tests/unit/configs/test_stack_dumping.cc
+++ b/tests/unit/configs/test_stack_dumping.cc
@@ -45,7 +45,7 @@
 
 #include "test_parallel_harness.h"
 #include "vt/configs/error/stack_out.h"
-#include INCLUDE_FMT_CORE
+#include INCLUDE_FMT_FORMAT
 
 namespace vt { namespace tests { namespace unit {
 


### PR DESCRIPTION
Fixes #2519 

Changes:
- from fmt `10.2.1` to `12.2.0`
- updated vendored fmt sources in `lib/fmt`
- from `INCLUDE_FMT_CORE` to `INCLUDE_FMT_FORMAT`

